### PR TITLE
Course and subject controller inherit from app controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@
 2. Run `rails db:setup` to create a development and testing database
 3. Run `bundle exec rails server` to launch the app on http://localhost:3000.
 
+## Accessing API
+
+Example using the command line using the development basic authentication credentials
+
+```bash
+curl --basic -u bat:beta http://localhost:3000/api/v1/subjects.json
+```
+
 ## Linting
 
 It's best to lint just your app directories and not those belonging to the framework, e.g.

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class CoursesController < ActionController::API
+    class CoursesController < ApplicationController
       def index
         @courses = Course.all
         paginate json: @courses

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class SubjectsController < ActionController::API
+    class SubjectsController < ApplicationController
       def index
         @subjects = Subject.all
         paginate json: @subjects

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -15,15 +15,21 @@ RSpec.describe "Courses API", type: :request do
         sites: [site],
         subjects: [subject1, subject2],
         provider: provider)
-
-      get "/api/v1/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials("bat", "beta") }
     end
 
     it "returns http success" do
+      get "/api/v1/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials("bat", "beta") }
       expect(response).to have_http_status(:success)
     end
 
+    it "returns http unauthorised" do
+      get "/api/v1/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials("foo", "bar") }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
     it "JSON body response contains expected course attributes" do
+      get "/api/v1/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials("bat", "beta") }
+
       json = JSON.parse(response.body)
       expect(json). to eq([
         {

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -12,15 +12,22 @@ RSpec.describe "Providers API", type: :request do
         location_name: "Main site",
         code: "-",
         provider: provider)
-
-      get "/api/v1/providers", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials("bat", "beta") }
     end
 
     it "returns http success" do
+      get "/api/v1/providers", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials("bat", "beta") }
       expect(response).to have_http_status(:success)
     end
 
+
+    it "returns http unauthorised" do
+      get "/api/v1/providers", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials("foo", "bar") }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
     it "JSON body response contains expected provider attributes" do
+      get "/api/v1/providers", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials("bat", "beta") }
+
       json = JSON.parse(response.body)
       expect(json). to eq(
         [

--- a/spec/requests/api/v1/subject_spec.rb
+++ b/spec/requests/api/v1/subject_spec.rb
@@ -9,15 +9,21 @@ RSpec.describe "Subjecs API", type: :request do
       FactoryBot.create(:subject,
         subject_name: "Biology",
         subject_code: "M4")
-
-      get "/api/v1/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials("bat", "beta") }
     end
 
     it "returns http success" do
+      get "/api/v1/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials("bat", "beta") }
       expect(response).to have_http_status(:success)
     end
 
+    it "returns http unauthorized" do
+      get "/api/v1/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials("foo", "bar") }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
     it "JSON body response contains expected provider attributes" do
+      get "/api/v1/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials("bat", "beta") }
+
       json = JSON.parse(response.body)
       expect(json).to eq([
         {


### PR DESCRIPTION
### Changes proposed in this pull request
Ensure `subjects` and `courses` inherit from correct controller

### Guidance to review
Basic auth should kick in for the `subjects` and `courses` endpoint as well as `providers`