### PR TITLE
Update recruitment_cycle

### DIFF
--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -17,8 +17,6 @@ class CourseSerializer < ActiveModel::Serializer
 
   # TODO: make recruitment cycle dynamic
   def recruitment_cycle
-    {
-      "name" => "2019/20"
-    }
+    "2019"
   end
 end

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -11,8 +11,6 @@ class SiteSerializer < ActiveModel::Serializer
 
   # TODO: make recruitment cycle dynamic
   def recruitment_cycle
-    {
-      "name" => "2019/20"
-    }
+    "2019"
   end
 end

--- a/app/serializers/site_status_serializer.rb
+++ b/app/serializers/site_status_serializer.rb
@@ -18,8 +18,6 @@ class SiteStatusSerializer < ActiveModel::Serializer
 
   # TODO: make recruitment cycle dynamic
   def recruitment_cycle
-    {
-      "name" => "2019/20"
-    }
+    "2019"
   end
 end

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -39,9 +39,7 @@ RSpec.describe "Courses API", type: :request do
           "maths" => nil,
           "science" => nil,
           "qualification" => 1,
-          "recruitment_cycle" => {
-            "name" => "2019/20"
-          },
+          "recruitment_cycle" => "2019",
           "campus_statuses" => [
             {
               "campus_code" => "-",
@@ -50,9 +48,7 @@ RSpec.describe "Courses API", type: :request do
               "publish" => nil,
               "status" => nil,
               "course_open_date" => nil,
-              "recruitment_cycle" => {
-                "name" => "2019/20"
-              }
+              "recruitment_cycle" => "2019"
             }
           ],
           "subjects" => [

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -30,9 +30,7 @@ RSpec.describe "Providers API", type: :request do
               {
                 "campus_code" => "-",
                 "name" => "Main site",
-                "recruitment_cycle" => {
-                  "name" => "2019/20"
-                }
+                "recruitment_cycle" => "2019"
               }
             ],
             "institution_code" => "A123",


### PR DESCRIPTION
### Context
recruitment cycle

### Changes proposed in this pull request
Update `recruitment_cycle` to 4 digits. This needs to be dynamic eventually.

```
recruitment_cycle: {
    name: "2019/20"
}
```

to

```
recruitment_cycle: "2019"
```

### Guidance to review
`/api/v1/providers`