### PR TITLE
Correctly check presence of applications_accepted_from

### DIFF
--- a/app/serializers/site_status_serializer.rb
+++ b/app/serializers/site_status_serializer.rb
@@ -8,7 +8,7 @@ class SiteStatusSerializer < ActiveModel::Serializer
   # rubocop:disable Style/DateTime
   def course_open_date
     # TODO applications_accepted_from should be a timestamp, not a string
-    DateTime.parse(object.applications_accepted_from).iso8601 if object.applications_accepted_from
+    DateTime.parse(object.applications_accepted_from).iso8601 if object.applications_accepted_from.present?
   end
   # rubocop:enable Style/DateTime
 


### PR DESCRIPTION
### Context
Broken endpoint https://manage-courses-support.herokuapp.com/api/v1/courses?page=18

### Changes proposed in this pull request
Check presence of `applications_accepted_from` with `.present?`

### Guidance to review
`course_open_date` should return null when `applications_accepted_from` isn't present
