### PR TITLE
Add explicit start month string to course API

### DIFF
--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -5,10 +5,15 @@ class CourseSerializer < ActiveModel::Serializer
   has_one :accrediting_provider
 
   attributes :course_code, :start_month, :name, :study_mode, :copy_form_required, :profpost_flag,
-             :program_type, :modular, :english, :maths, :science, :qualification, :recruitment_cycle
+             :program_type, :modular, :english, :maths, :science, :qualification, :recruitment_cycle,
+             :start_month_string
 
   def start_month
     object.start_date.iso8601 if object.start_date
+  end
+
+  def start_month_string
+    object.start_date.strftime("%B") if object.start_date
   end
 
   def copy_form_required

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe "Courses API", type: :request do
         {
           "course_code" => "2HPF",
           "start_month" => "2019-09-01T00:00:00Z",
+          "start_month_string" => "September",
           "name" => "Religious Education",
           "study_mode" => "F",
           "copy_form_required" => "Y",


### PR DESCRIPTION
### Context
Downstream API consumer asked for the start date month to be included in the API.
