### PR TITLE
Define and use enum for profpost_flag on Course

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,6 +1,13 @@
 class Course < ApplicationRecord
   self.table_name = "course"
 
+  enum profpost_flag: {
+    "Recommendation for QTS" => "",
+    "Professional" => "PF",
+    "Postgraduate" => "PG",
+    "Professional/Postgraduate" => "BO",
+  }
+
   belongs_to :provider
   belongs_to :accrediting_provider, class_name: 'Provider', optional: true
   has_and_belongs_to_many :subjects

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -7,6 +7,10 @@ class CourseSerializer < ActiveModel::Serializer
   attributes :course_code, :start_month, :name, :study_mode, :copy_form_required, :profpost_flag,
              :program_type, :modular, :english, :maths, :science, :qualification, :recruitment_cycle
 
+  def profpost_flag
+    object.profpost_flag_before_type_cast
+  end
+
   def start_month
     object.start_date.iso8601 if object.start_date
   end

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Courses API", type: :request do
         study_mode: "F",
         english: 3,
         maths: 9,
-        profpost_flag: "PG",
+        profpost_flag: "Postgraduate",
         program_type: "SD",
         modular: "",
         provider: provider)


### PR DESCRIPTION
### Context
Some of the database fields (like `course.profpost_flag`) are abbreviated down to the point that it's hard to see what the values mean at first glance. This problem can be overcome with some Rails syntactic sugar which makes at least the code more readable.

### Changes proposed in this pull request
This allows us to keep the domain definitions of the field in the Course model, while still sending the more cryptic variants downstream to consumers of the API.

### Guidance to review
If we like this approach, I can do the same for other enums in the schema.