### PR TITLE
Add contact details to provider

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -5,4 +5,39 @@ class Provider < ApplicationRecord
 
   has_many :sites
   has_many :enrichments, foreign_key: :provider_code, primary_key: :provider_code, class_name: "ProviderEnrichment"
+
+  def address
+    if enrichments.present?
+      attrs = enrichments.last.json_data
+      {
+        "address1" => attrs["Address1"],
+        "address2" => attrs["Address2"],
+        "address3" => attrs["Address3"],
+        "address4" => attrs["Address4"],
+        "postcode" => attrs["Postcode"]
+      }
+    else
+      attributes
+    end
+  end
+
+  def address1
+    address["address1"]
+  end
+
+  def address2
+    address["address2"]
+  end
+
+  def address3
+    address["address3"]
+  end
+
+  def address4
+    address["address4"]
+  end
+
+  def postcode
+    address["postcode"]
+  end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -4,4 +4,5 @@ class Provider < ApplicationRecord
   has_and_belongs_to_many :organisations, join_table: :organisation_provider
 
   has_many :sites
+  has_many :enrichments, foreign_key: :provider_code, primary_key: :provider_code, class_name: "ProviderEnrichment"
 end

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -1,8 +1,8 @@
 class ProviderSerializer < ActiveModel::Serializer
   has_many :sites, key: :campuses
 
-  attributes :institution_code, :institution_name,
-             :institution_type, :accrediting_provider
+  attributes :institution_code, :institution_name, :institution_type, :accrediting_provider,
+             :address1, :address2, :address3, :address4, :postcode
 
   def institution_code
     object.provider_code
@@ -18,5 +18,45 @@ class ProviderSerializer < ActiveModel::Serializer
 
   def accrediting_provider
     # TODO: pull this thru from UCAS import
+  end
+
+  def address1
+    if object.enrichments.present?
+      object.enrichments.last.json_data["Address1"]
+    else
+      object.address1
+    end
+  end
+
+  def address2
+    if object.enrichments.present?
+      object.enrichments.last.json_data["Address2"]
+    else
+      object.address2
+    end
+  end
+
+  def address3
+    if object.enrichments.present?
+      object.enrichments.last.json_data["Address3"]
+    else
+      object.address3
+    end
+  end
+
+  def address4
+    if object.enrichments.present?
+      object.enrichments.last.json_data["Address4"]
+    else
+      object.address4
+    end
+  end
+
+  def postcode
+    if object.enrichments.present?
+      object.enrichments.last.json_data["Postcode"]
+    else
+      object.postcode
+    end
   end
 end

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -19,44 +19,4 @@ class ProviderSerializer < ActiveModel::Serializer
   def accrediting_provider
     # TODO: pull this thru from UCAS import
   end
-
-  def address1
-    if object.enrichments.present?
-      object.enrichments.last.json_data["Address1"]
-    else
-      object.address1
-    end
-  end
-
-  def address2
-    if object.enrichments.present?
-      object.enrichments.last.json_data["Address2"]
-    else
-      object.address2
-    end
-  end
-
-  def address3
-    if object.enrichments.present?
-      object.enrichments.last.json_data["Address3"]
-    else
-      object.address3
-    end
-  end
-
-  def address4
-    if object.enrichments.present?
-      object.enrichments.last.json_data["Address4"]
-    else
-      object.address4
-    end
-  end
-
-  def postcode
-    if object.enrichments.present?
-      object.enrichments.last.json_data["Postcode"]
-    else
-      object.postcode
-    end
-  end
 end

--- a/spec/factories/provider_enrichment.rb
+++ b/spec/factories/provider_enrichment.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :provider_enrichment do
+    sequence(:provider_code) { |n| "A#{n}" }
+    json_data {
+      { "Email" => Faker::Internet.email,
+        "Website" => Faker::Internet.url,
+        "Address1" => Faker::Address.street_address,
+        "Address2" => Faker::Address.community,
+        "Address3" => Faker::Address.city,
+        "Address4" => Faker::Address.state,
+        "Postcode" => Faker::Address.postcode,
+        "TrainWithUs" => Faker::Lorem.sentence.to_s,
+        "TrainWithDisability" => Faker::Lorem.sentence.to_s, }
+    }
+  end
+end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -11,13 +11,13 @@ FactoryBot.define do
     transient do
       site_count { 1 }
       course_count { 2 }
-      enrichment_count { 1 }
+      enrichments { build_list(:provider_enrichment, 1) }
     end
 
     after(:create) do |provider, evaluator|
       create_list(:course, evaluator.course_count, provider: provider)
       create_list(:site, evaluator.site_count, provider: provider)
-      create_list(:provider_enrichment, evaluator.enrichment_count, provider: provider)
+      provider.enrichments << evaluator.enrichments
     end
   end
 end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -2,15 +2,22 @@ FactoryBot.define do
   factory :provider do
     provider_name { 'ACME SCITT' + rand(1000000).to_s }
     sequence(:provider_code) { |n| "A#{n}" }
+    address1 { Faker::Address.street_address }
+    address2 { Faker::Address.community }
+    address3 { Faker::Address.city }
+    address4 { Faker::Address.state }
+    postcode { Faker::Address.postcode }
 
     transient do
       site_count { 1 }
       course_count { 2 }
+      enrichment_count { 1 }
     end
 
     after(:create) do |provider, evaluator|
       create_list(:course, evaluator.course_count, provider: provider)
       create_list(:site, evaluator.site_count, provider: provider)
+      create_list(:provider_enrichment, evaluator.enrichment_count, provider: provider)
     end
   end
 end

--- a/spec/factory_specs/providers_spec.rb
+++ b/spec/factory_specs/providers_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe "Provider Factory" do
+  let(:provider) { create(:provider) }
+
+  it "created provider" do
+    expect(provider).to be_instance_of(Provider)
+    expect(provider).to be_valid
+  end
+
+  it "creates a provider with enrichments" do
+    expect(provider.enrichments.count).to eq 1
+    expect(provider.enrichments.first).to be_instance_of(ProviderEnrichment)
+  end
+end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -6,4 +6,61 @@ RSpec.describe Provider, type: :model do
   describe 'associations' do
     it { should have_many(:sites) }
   end
+
+  describe '#address' do
+    it "returns attributes of the provider" do
+      provider = create(:provider, enrichments: [])
+      expect(provider.address).to eq provider.attributes
+    end
+
+    context "provider has enrichments" do
+      it "returns json_data from the last enrichment" do
+        enrichment = build(:provider_enrichment)
+        provider = create(:provider, enrichments: [enrichment])
+
+        expect(provider.address).to eq(
+          "address1" => enrichment.json_data["Address1"],
+          "address2" => enrichment.json_data["Address2"],
+          "address3" => enrichment.json_data["Address3"],
+          "address4" => enrichment.json_data["Address4"],
+          "postcode" => enrichment.json_data["Postcode"]
+        )
+      end
+    end
+  end
+
+  describe '#address1' do
+    it "returns address1 of the address" do
+      provider = create(:provider)
+      expect(provider.address1).to eq provider.address["address1"]
+    end
+  end
+
+  describe '#address2' do
+    it "returns address2 of the address" do
+      provider = create(:provider)
+      expect(provider.address2).to eq provider.address["address2"]
+    end
+  end
+
+  describe '#address3' do
+    it "returns address3 of the address" do
+      provider = create(:provider)
+      expect(provider.address3).to eq provider.address["address3"]
+    end
+  end
+
+  describe '#address4' do
+    it "returns address4 of the address" do
+      provider = create(:provider)
+      expect(provider.address4).to eq provider.address["address4"]
+    end
+  end
+
+  describe '#postcode' do
+    it "returns postcode of the address" do
+      provider = create(:provider)
+      expect(provider.postcode).to eq provider.address["postcode"]
+    end
+  end
 end

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -4,6 +4,16 @@ RSpec.describe "Courses API", type: :request do
   describe 'GET index' do
     before do
       provider = FactoryBot.create(:provider, provider_name: "ACME SCITT", provider_code: "2LD", site_count: 0, course_count: 0)
+      FactoryBot.create(:provider_enrichment,
+                        provider_code: "2LD",
+                        provider: provider,
+                        json_data: {
+                          "Address1" => "Sydney Russell School",
+                          "Address2" => "Parsloes Avenue",
+                          "Address3" => "Dagenham",
+                          "Address4" => "Essex",
+                          "Postcode" => "RM9 5QT"
+                        })
       site = FactoryBot.create(:site, code: "-", location_name: "Main Site", provider: provider)
       subject1 = FactoryBot.create(:subject, subject_code: "1", subject_name: "Secondary")
       subject2 = FactoryBot.create(:subject, subject_code: "2", subject_name: "Mathematics")
@@ -86,7 +96,12 @@ RSpec.describe "Courses API", type: :request do
             "institution_code" => "2LD",
             "institution_name" => "ACME SCITT",
             "institution_type" => "Y",
-            "accrediting_provider" => nil
+            "accrediting_provider" => nil,
+            "address1" => "Sydney Russell School",
+            "address2" => "Parsloes Avenue",
+            "address3" => "Dagenham",
+            "address4" => "Essex",
+            "postcode" => "RM9 5QT"
           },
           "accrediting_provider" => nil
         }

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -12,6 +12,13 @@ RSpec.describe "Providers API", type: :request do
         location_name: "Main site",
         code: "-",
         provider: provider)
+      FactoryBot.create(:provider_enrichment,
+                        provider_code: provider.provider_code,
+                        json_data: { "Address1" => "Sydney Russell School",
+                                    "Address2" => "Parsloes Avenue",
+                                    "Address3" => "Dagenham",
+                                    "Address4" => "Essex",
+                                    "Postcode" => "RM9 5QT" })
     end
 
     it "returns http success" do
@@ -43,6 +50,11 @@ RSpec.describe "Providers API", type: :request do
             "institution_code" => "A123",
             "institution_name" => "ACME SCITT",
             "institution_type" => "Y",
+            "address1" => "Sydney Russell School",
+            "address2" => "Parsloes Avenue",
+            "address3" => "Dagenham",
+            "address4" => "Essex",
+            "postcode" => "RM9 5QT"
           },
         ]
       )

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -4,5 +4,13 @@ RSpec.describe ProviderSerializer do
   let(:provider) { create :provider }
   subject { serialize(provider) }
 
-  it { is_expected.to include(institution_code: provider.provider_code, institution_name: provider.provider_name) }
+  it { should include(institution_code: provider.provider_code) }
+  it { should include(institution_name: provider.provider_name) }
+  it { should include(address1: provider.address1) }
+  it { should include(address2: provider.address2) }
+  it { should include(address3: provider.address3) }
+  it { should include(address4: provider.address4) }
+  it { should include(postcode: provider.postcode) }
+  it { should include(institution_type: "Y") }
+  it { should include(accrediting_provider: nil) }
 end


### PR DESCRIPTION
### Context
Providers endpoint

### Changes proposed in this pull request
Add contact details i.e. `address1`, `address2`, `address3`, `address4`, `postcode`

### Guidance to review
`/api/v1/providers`
