### PR TITLE
Dockerise the app, build the container on CI, and push it to Azure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.bundle
+log
+tmp
+.byebug_history
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
 deploy:
   provider: script
   script: bash docker-push.sh
+  skip_cleanup: true
   on:
     branch: master
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,17 @@
-language: ruby
-cache: bundler
+language: minimal
 git:
   depth: false
 services:
-  - postgresql
-addons:
-  postgresql: "9.6"
+  - docker
 before_script:
-  - bundle exec rake db:setup
-before_install:
-  - gem update --system
+  - docker-compose pull
+  - docker-compose build
+  - docker-compose up --no-build -d
+  - sleep 5 # Wait for the database to wake up, so we can set up the database and run the tests.
+  - docker-compose exec web /bin/sh -c "bundle exec rails db:setup"
 script:
-  - bundle exec rake spec
-  - bundle exec govuk-lint-ruby app config db lib spec --format clang
+  - docker-compose exec web /bin/sh -c "bundle exec rake spec"
+  - docker-compose exec web /bin/sh -c "bundle exec govuk-lint-ruby app config db lib spec --format clang"
+env:
+  global:
+    secure: p3cx6N2Fdv9UCNniQhdOokgZGeOw0fUgnUVD8+Adk9OvAYVmRIXjPY2EttHFlz/5GTZ11KZBcprUO/IeFxhqHG5LJWEaX+q1BKazECiJ3BzwLDLXFwQJ24XdKvRE1p3XulPSy9hioH7q6n9r6wpEf0i6KgelpLIWCCUjIDYM8udXsfNLsCkBuwMC3RMc0xY4XNPXhJX3VVZJxC8hp5egJn8X11mhiQXQNLjQzaKIPNXa5AOfegCXuL8oDIYKvazhLvDvsvRn4GisZfvZVIOO4AXYdV/YPzBmGO5QJYDL6tglZQ8plb4hd1KrHsrbw+Aw3h400uySsI/cWgdC8vSkCEkdobGp0Uz5KM0mqowOV8eMb2scplFUGNyajy9fZmwsQMgxNmpdyONPSZ1yLnYJaObWdj5qoe6vG7UUwLzL/v87erRKo12se5KK4ejbumkDWztzXb9xmWcEDe09ieAoDNuUIN74cwf92KtYna2uJIkCkK8wat5rRw9HuSun6GdDS7KAay7LL8xm+Qxu03yWTSLAssdWdtFpbQasWDoGWce3KrPjz8k14Ck58Ib+nI6+HVrUAoyH/5wYCJAOp3dCzAbp2TmAi1hayQuFmNX6NY9MoPC4MJ4moIiH6b97DiMJ4L33GOfeb3Iwfok/pj+uSSdFmQa7oWwZU4IdzbNWTa0=

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ git:
 services:
   - docker
 before_script:
+  - source ./config.sh
+  - ./docker-login.sh
   - docker-compose pull
   - docker-compose build
   - docker-compose up --no-build -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ deploy:
   script: bash docker-push.sh
   skip_cleanup: true
   on:
-    branch: master
+    all_branches: true
+    condition: $TRAVIS_BRANCH =~ ^master|staging|production$
 env:
   global:
     secure: p3cx6N2Fdv9UCNniQhdOokgZGeOw0fUgnUVD8+Adk9OvAYVmRIXjPY2EttHFlz/5GTZ11KZBcprUO/IeFxhqHG5LJWEaX+q1BKazECiJ3BzwLDLXFwQJ24XdKvRE1p3XulPSy9hioH7q6n9r6wpEf0i6KgelpLIWCCUjIDYM8udXsfNLsCkBuwMC3RMc0xY4XNPXhJX3VVZJxC8hp5egJn8X11mhiQXQNLjQzaKIPNXa5AOfegCXuL8oDIYKvazhLvDvsvRn4GisZfvZVIOO4AXYdV/YPzBmGO5QJYDL6tglZQ8plb4hd1KrHsrbw+Aw3h400uySsI/cWgdC8vSkCEkdobGp0Uz5KM0mqowOV8eMb2scplFUGNyajy9fZmwsQMgxNmpdyONPSZ1yLnYJaObWdj5qoe6vG7UUwLzL/v87erRKo12se5KK4ejbumkDWztzXb9xmWcEDe09ieAoDNuUIN74cwf92KtYna2uJIkCkK8wat5rRw9HuSun6GdDS7KAay7LL8xm+Qxu03yWTSLAssdWdtFpbQasWDoGWce3KrPjz8k14Ck58Ib+nI6+HVrUAoyH/5wYCJAOp3dCzAbp2TmAi1hayQuFmNX6NY9MoPC4MJ4moIiH6b97DiMJ4L33GOfeb3Iwfok/pj+uSSdFmQa7oWwZU4IdzbNWTa0=

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ before_script:
 script:
   - docker-compose exec web /bin/sh -c "bundle exec rake spec"
   - docker-compose exec web /bin/sh -c "bundle exec govuk-lint-ruby app config db lib spec --format clang"
+deploy:
+  provider: script
+  script: bash docker-push.sh
+  on:
+    branch: master
 env:
   global:
     secure: p3cx6N2Fdv9UCNniQhdOokgZGeOw0fUgnUVD8+Adk9OvAYVmRIXjPY2EttHFlz/5GTZ11KZBcprUO/IeFxhqHG5LJWEaX+q1BKazECiJ3BzwLDLXFwQJ24XdKvRE1p3XulPSy9hioH7q6n9r6wpEf0i6KgelpLIWCCUjIDYM8udXsfNLsCkBuwMC3RMc0xY4XNPXhJX3VVZJxC8hp5egJn8X11mhiQXQNLjQzaKIPNXa5AOfegCXuL8oDIYKvazhLvDvsvRn4GisZfvZVIOO4AXYdV/YPzBmGO5QJYDL6tglZQ8plb4hd1KrHsrbw+Aw3h400uySsI/cWgdC8vSkCEkdobGp0Uz5KM0mqowOV8eMb2scplFUGNyajy9fZmwsQMgxNmpdyONPSZ1yLnYJaObWdj5qoe6vG7UUwLzL/v87erRKo12se5KK4ejbumkDWztzXb9xmWcEDe09ieAoDNuUIN74cwf92KtYna2uJIkCkK8wat5rRw9HuSun6GdDS7KAay7LL8xm+Qxu03yWTSLAssdWdtFpbQasWDoGWce3KrPjz8k14Ck58Ib+nI6+HVrUAoyH/5wYCJAOp3dCzAbp2TmAi1hayQuFmNX6NY9MoPC4MJ4moIiH6b97DiMJ4L33GOfeb3Iwfok/pj+uSSdFmQa7oWwZU4IdzbNWTa0=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:2.5.3
+
+ENV APP_HOME /app
+RUN mkdir $APP_HOME
+WORKDIR $APP_HOME
+
+ADD Gemfile $APP_HOME/Gemfile
+ADD Gemfile.lock $APP_HOME/Gemfile.lock
+RUN bundle install
+
+ADD . $APP_HOME/
+
+CMD bundle exec rails server -b 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -4,17 +4,28 @@
 
 ## Prerequisites
 
-- Ruby 2.5.3
+- docker
+- docker-compose
 
 ## Setting up the app in development
 
-1. Run `bundle install` to install the gem dependencies
-2. Run `rails db:setup` to create a development and testing database
-3. Run `bundle exec rails server` to launch the app on http://localhost:3000.
+Run this in a shell and leave it running:
+
+```
+$ docker-compose up
+```
+
+The first time you run the app, you need to set up the databases. With the above command running separately, do:
+
+```
+$ docker-compose exec web /bin/sh -c "bundle exec rails db:setup"
+```
+
+Then open http://localhost:3000 to see the app.
 
 ## Accessing API
 
-Example using the command line using the development basic authentication credentials
+Example using the command line using the development basic authentication credentials:
 
 ```bash
 curl --basic -u bat:beta http://localhost:3000/api/v1/subjects.json
@@ -25,5 +36,5 @@ curl --basic -u bat:beta http://localhost:3000/api/v1/subjects.json
 It's best to lint just your app directories and not those belonging to the framework, e.g.
 
 ```bash
-bundle exec govuk-lint-ruby app config db lib spec --format clang
+$ docker-compose exec web /bin/sh -c "bundle exec govuk-lint-ruby app config db lib spec --format clang"
 ```

--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# source this file to set up environment for use by other scripts
+
+export DOCKER_REGISTRY_HOST="batdevcontainerregistry.azurecr.io"
+export DOCKER_REGISTRY_IMAGE="manage-courses-backend"
+
+export DOCKER_PATH="$DOCKER_REGISTRY_HOST/$DOCKER_REGISTRY_IMAGE"

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,6 +2,10 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: 5
+  username: <%= ENV['DB_USERNAME'] || 'postgres' %>
+  password: <%= ENV['DB_PASSWORD'] || '' %>
+  host: <%= ENV['DB_HOSTNAME'] || 'localhost' %>
+  port: <%= ENV['DB_PORT'] || '5432' %>
 
 development:
   <<: *default
@@ -14,7 +18,3 @@ test:
 production:
   <<: *default
   database: <%= ENV['DB_DATABASE'] %>
-  username: <%= ENV['DB_USERNAME'] %>
-  password: <%= ENV['DB_PASSWORD'] %>
-  host: <%= ENV['DB_HOSTNAME'] %>
-  port: <%= ENV['DB_PORT'] || '5432' %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,13 @@
 version: '3.2'
+volumes:
+  dbdata:
 services:
   db:
     image: postgres:9.6-alpine
     # To preserve data between runs of docker-compose, we mount a folder from the host machine.
+#    volumes:
     volumes:
-      - ./tmp/db:/var/lib/postgresql/data
+     - dbdata:/var/lib/postgresql/data
   web:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
   db:
     image: postgres:9.6-alpine
     # To preserve data between runs of docker-compose, we mount a folder from the host machine.
-#    volumes:
     volumes:
      - dbdata:/var/lib/postgresql/data
   web:
@@ -13,7 +12,7 @@ services:
       context: .
       cache_from:
         - batdevcontainerregistry.azurecr.io/manage-courses-backend:latest
-    image: batdevcontainerregistry.azurecr.io/manage-courses-backend
+    image: batdevcontainerregistry.azurecr.io/manage-courses-backend:latest
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails server -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.2'
+services:
+  db:
+    image: postgres:9.6-alpine
+    # To preserve data between runs of docker-compose, we mount a folder from the host machine.
+    volumes:
+      - ./tmp/db:/var/lib/postgresql/data
+  web:
+    build:
+      context: .
+      cache_from:
+        - batdevcontainerregistry.azurecr.io/manage-courses-backend:latest
+    image: batdevcontainerregistry.azurecr.io/manage-courses-backend
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails server -p 3000 -b '0.0.0.0'"
+    volumes:
+      - .:/app
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+    environment:
+      - DB_HOSTNAME=db

--- a/docker-login.sh
+++ b/docker-login.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+if [ -z "$AZURE_CR_PASSWORD" ];
+then
+  echo "AZURE_CR_PASSWORD environment variable is required"
+  exit 1
+fi
+
+echo "Logging in to docker host '$DOCKER_REGISTRY_HOST' ..."
+echo "$AZURE_CR_PASSWORD" | docker login "$DOCKER_REGISTRY_HOST" -u="batdevcontainerregistry" --password-stdin

--- a/docker-push.sh
+++ b/docker-push.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+if [ -z "$TRAVIS_BRANCH" ];
+then
+  echo "TRAVIS_BRANCH environment variable is required"
+  exit 1
+fi
+
+source config.sh
+
+DOCKER_REGISTRY_HOST=$DOCKER_REGISTRY_HOST ./docker-login.sh
+
+echo "Running docker push to $DOCKER_PATH:$TRAVIS_BRANCH ..."
+docker tag "$DOCKER_PATH:latest" "$DOCKER_PATH:$TRAVIS_BRANCH"
+docker push "$DOCKER_PATH"


### PR DESCRIPTION
### Context

This builds a docker image of the app when we push to CI, runs the tests inside, and then pushes it to the Azure Container Registry under the `master|staging|production` tags respectively.

Also includes instructions on running the app locally using `docker-compose` to better mimic the live environment, and simplify the setup by not requiring specific versions of Ruby of Postgres installed locally.

Paired with @defong.