### PR TITLE
Provider type enum

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -1,6 +1,14 @@
 class Provider < ApplicationRecord
   self.table_name = "provider"
 
+  enum provider_type: {
+    "SCITT" => "B",
+    "Lead school" => "Y",
+    "University" => "O",
+    "??" => "",
+    "Invalid value" => "0", # there is only one of these in the data
+  }
+
   has_and_belongs_to_many :organisations, join_table: :organisation_provider
 
   has_many :sites

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -13,7 +13,7 @@ class ProviderSerializer < ActiveModel::Serializer
   end
 
   def institution_type
-    object.provider_type
+    object.provider_type_before_type_cast
   end
 
   def accrediting_provider

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Courses API", type: :request do
   describe 'GET index' do
     before do
-      provider = FactoryBot.create(:provider, provider_name: "ACME SCITT", provider_code: "2LD", provider_type: "Y", site_count: 0, course_count: 0)
+      provider = FactoryBot.create(:provider, provider_name: "ACME SCITT", provider_code: "2LD", provider_type: "SCITT", site_count: 0, course_count: 0)
       FactoryBot.create(:provider_enrichment,
                         provider_code: "2LD",
                         provider: provider,
@@ -97,7 +97,7 @@ RSpec.describe "Courses API", type: :request do
           "provider" => {
             "institution_code" => "2LD",
             "institution_name" => "ACME SCITT",
-            "institution_type" => "Y",
+            "institution_type" => "B",
             "accrediting_provider" => nil,
             "address1" => "Sydney Russell School",
             "address2" => "Parsloes Avenue",

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Providers API", type: :request do
       provider = FactoryBot.create(:provider,
         provider_name: "ACME SCITT",
         provider_code: "A123",
-        provider_type: 'Y',
+        provider_type: 'SCITT',
         site_count: 0)
       FactoryBot.create(:site,
         location_name: "Main site",
@@ -20,9 +20,9 @@ RSpec.describe "Providers API", type: :request do
                                     "Address4" => "Essex",
                                     "Postcode" => "RM9 5QT" })
       provider = FactoryBot.create(:provider,
-        provider_name: "BCME SCITT",
+        provider_name: "ACME University",
         provider_code: "B123",
-        provider_type: 'B',
+        provider_type: 'University',
         site_count: 0)
       FactoryBot.create(:site,
         location_name: "Main site",
@@ -65,7 +65,7 @@ RSpec.describe "Providers API", type: :request do
             ],
             "institution_code" => "A123",
             "institution_name" => "ACME SCITT",
-            "institution_type" => "Y",
+            "institution_type" => "B",
             "address1" => "Sydney Russell School",
             "address2" => "Parsloes Avenue",
             "address3" => "Dagenham",
@@ -82,8 +82,8 @@ RSpec.describe "Providers API", type: :request do
               }
             ],
             "institution_code" => "B123",
-            "institution_name" => "BCME SCITT",
-            "institution_type" => "B",
+            "institution_name" => "ACME University",
+            "institution_type" => "O",
             "address1" => "Bee School",
             "address2" => "Bee Avenue",
             "address3" => "Bee City",

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -23,18 +23,17 @@ RSpec.describe "Providers API", type: :request do
         provider_name: "ACME University",
         provider_code: "B123",
         provider_type: 'University',
+        address1: "Bee School",
+        address2: "Bee Avenue",
+        address3: "Bee City",
+        address4: "Bee Hive",
+        postcode: "B3 3BB",
+        enrichments: [],
         site_count: 0)
       FactoryBot.create(:site,
         location_name: "Main site",
         code: "-",
         provider: provider)
-      FactoryBot.create(:provider_enrichment,
-                        provider_code: provider.provider_code,
-                        json_data: { "Address1" => "Bee School",
-                                    "Address2" => "Bee Avenue",
-                                    "Address3" => "Bee City",
-                                    "Address4" => "Bee Hive",
-                                    "Postcode" => "B3 3BB" })
     end
 
     it "returns http success" do


### PR DESCRIPTION
### Context
The `provider.provider_type` attribute was wired up on #27.

### Changes proposed in this pull request
Introduce an enum to decode the attribute (similar to #21 and #22). Also fix up some test data for consistency.
