### PR TITLE
Add rubocop configs from govuk-lint.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+inherit_gem:
+  govuk-lint: configs/rubocop/all.yml


### PR DESCRIPTION
### Context

This just makes it a lot easier to integrate with existing tools, such as
editor integrations with rubocop.

### Changes proposed in this pull request

Move the rubocop configs from [alphagov/govuk-lint](https://github.com/alphagov/govuk-lint) repo into our ours.

### Guidance to review

One reason against is that if `govuk-lint` is updated we'll miss those changes. If we continue to use `govuk-lint` in our CI, though, we'll catch those and be able to update the configs in the repo.