### PR TITLE
Present multiple (truncated) provider name versions in API

### DIFF
--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -9,7 +9,11 @@ class ProviderSerializer < ActiveModel::Serializer
   end
 
   def institution_name
-    object.provider_name
+    {
+      "full" => object.provider_name,
+      "long" => object.provider_name[0..19],
+      "short" => object.provider_name[0..5],
+    }
   end
 
   def institution_type

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -98,7 +98,11 @@ RSpec.describe "Courses API", type: :request do
           ],
           "provider" => {
             "institution_code" => "2LD",
-            "institution_name" => "ACME SCITT",
+            "institution_name" => {
+              "full" => "ACME SCITT",
+              "long" => "ACME SCITT",
+              "short" => "ACME S",
+            },
             "institution_type" => "B",
             "accrediting_provider" => nil,
             "address1" => "Sydney Russell School",

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -32,7 +32,7 @@ describe 'Providers API', type: :request do
     end
     let(:provider2) do
       create(:provider,
-             provider_name: 'ACME University',
+             provider_name: 'ACME University of the North East',
              provider_code: 'B123',
              provider_type: 'University',
              address1: 'Bee School',
@@ -89,7 +89,11 @@ describe 'Providers API', type: :request do
                 }
               ],
               'institution_code' => 'A123',
-              'institution_name' => 'ACME SCITT',
+              'institution_name' => {
+                'full' => 'ACME SCITT',
+                'long' => 'ACME SCITT',
+                'short' => 'ACME S',
+              },
               'institution_type' => 'B',
               'address1' => 'Sydney Russell School',
               'address2' => '',
@@ -108,7 +112,11 @@ describe 'Providers API', type: :request do
                 }
               ],
               'institution_code' => 'B123',
-              'institution_name' => 'ACME University',
+              'institution_name' => {
+                'full' => 'ACME University of the North East',
+                'long' => 'ACME University of t',
+                'short' => 'ACME U',
+              },
               'institution_type' => 'O',
               'address1' => 'Bee School',
               'address2' => 'Bee Avenue',
@@ -148,7 +156,11 @@ describe 'Providers API', type: :request do
                                   }
                                 ],
                                 'institution_code' => 'A123',
-                                'institution_name' => 'ACME SCITT',
+                                'institution_name' => {
+                                  'full' => 'ACME SCITT',
+                                  'long' => 'ACME SCITT',
+                                  'short' => 'ACME S',
+                                },
                                 'institution_type' => 'B',
                                 'address1' => 'Shoreditch Park Primary School',
                                 'address2' => '313 Bridport Pl',
@@ -167,7 +179,11 @@ describe 'Providers API', type: :request do
                                   }
                                 ],
                                 'institution_code' => 'B123',
-                                'institution_name' => 'ACME University',
+                                'institution_name' => {
+                                  'full' => 'ACME University of the North East',
+                                  'long' => 'ACME University of t',
+                                  'short' => 'ACME U',
+                                },
                                 'institution_type' => 'O',
                                 'address1' => 'Bee School',
                                 'address2' => 'Bee Avenue',

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ProviderSerializer do
   subject { serialize(provider) }
 
   it { should include(institution_code: provider.provider_code) }
-  it { should include(institution_name: provider.provider_name) }
+  it { should have_key(:institution_name) }
   it { should include(address1: provider.enrichments.last.address1) }
   it { should include(address2: provider.enrichments.last.address2) }
   it { should include(address3: provider.enrichments.last.address3) }


### PR DESCRIPTION
### Context
This is required by downstream consumers.

### Changes proposed in this pull request
Provide multiple provider name versions of various lengths
