### PR TITLE
Add missing region_code enum for zero value

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -4,6 +4,7 @@ class Site < ApplicationRecord
   # These correspond to the first-level NUTS regions for the UK (minus Northern Ireland)
   # https://en.wikipedia.org/wiki/First-level_NUTS_of_the_European_Union#United_Kingdom
   enum region_code: {
+    'No region' => 0,
     'London' => 1,
     'South East' => 2,
     'South West' => 3,


### PR DESCRIPTION
This was overlooked in the prior PR which added the enum (#35).
