### PR TITLE
Add recruitment cycle

### DIFF
--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -2,7 +2,16 @@ module Api
   module V1
     class CoursesController < ApplicationController
       def index
-        @courses = Course.all.includes(:sites, :provider, :site_statuses)
+        recruitment_cycle_year = params[:recruitment_cycle_year]
+        if recruitment_cycle_year.present?
+          if recruitment_cycle_year == "2019"
+            @courses = Course.all.includes(:sites, :provider, :site_statuses)
+          else
+            return render plain: "courses for year '#{recruitment_cycle_year}' not found", status: :not_found
+          end
+        else
+          @courses = Course.all.includes(:sites, :provider, :site_statuses)
+        end
         paginate json: @courses
       end
     end

--- a/app/controllers/api/v1/providers_controller.rb
+++ b/app/controllers/api/v1/providers_controller.rb
@@ -2,7 +2,16 @@ module Api
   module V1
     class ProvidersController < ApplicationController
       def index
-        @providers = Provider.all
+        recruitment_cycle_year = params[:recruitment_cycle_year]
+        if recruitment_cycle_year.present?
+          if recruitment_cycle_year == "2019"
+            @providers = Provider.all
+          else
+            return render plain: "providers for year '#{recruitment_cycle_year}' not found", status: :not_found
+          end
+        else
+          @providers = Provider.all
+        end
         paginate json: @providers
       end
     end

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -2,7 +2,16 @@ module Api
   module V1
     class SubjectsController < ApplicationController
       def index
-        @subjects = Subject.all
+        recruitment_cycle_year = params[:recruitment_cycle_year]
+        if recruitment_cycle_year.present?
+          if recruitment_cycle_year == "2019"
+            @subjects = Subject.all
+          else
+            return render plain: "subjects for year '#{recruitment_cycle_year}' not found", status: :not_found
+          end
+        else
+          @subjects = Subject.all
+        end
         paginate json: @subjects
       end
     end

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -26,7 +26,7 @@ class CourseSerializer < ActiveModel::Serializer
   has_one :accrediting_provider
 
   attributes :course_code, :start_month, :name, :study_mode, :copy_form_required, :profpost_flag,
-             :program_type, :modular, :english, :maths, :science, :qualification, :recruitment_cycle,
+             :program_type, :modular, :english, :maths, :science, :qualification,
              :start_month_string, :age_range
 
   def profpost_flag
@@ -55,10 +55,5 @@ class CourseSerializer < ActiveModel::Serializer
 
   def copy_form_required
     "Y" # we want to always create PDFs for applications coming in
-  end
-
-  # TODO: make recruitment cycle dynamic
-  def recruitment_cycle
-    "2019"
   end
 end

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -14,7 +14,7 @@
 #
 
 class SiteSerializer < ActiveModel::Serializer
-  attributes :campus_code, :name, :region_code, :recruitment_cycle
+  attributes :campus_code, :name, :region_code
 
   def campus_code
     object.code
@@ -26,10 +26,5 @@ class SiteSerializer < ActiveModel::Serializer
 
   def region_code
     '%02d' % object.region_code_before_type_cast if object.region_code.present?
-  end
-
-  # TODO: make recruitment cycle dynamic
-  def recruitment_cycle
-    "2019"
   end
 end

--- a/app/serializers/site_status_serializer.rb
+++ b/app/serializers/site_status_serializer.rb
@@ -12,7 +12,7 @@
 #
 
 class SiteStatusSerializer < ActiveModel::Serializer
-  attributes :campus_code, :name, :vac_status, :publish, :status, :course_open_date, :recruitment_cycle
+  attributes :campus_code, :name, :vac_status, :publish, :status, :course_open_date
 
   def campus_code
     object.site.code
@@ -32,10 +32,5 @@ class SiteStatusSerializer < ActiveModel::Serializer
 
   def name
     object.site.location_name
-  end
-
-  # TODO: make recruitment cycle dynamic
-  def recruitment_cycle
-    "2019"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,24 +1,28 @@
 # == Route Map
 #
-#           Prefix Verb   URI Pattern                     Controller#Action
-# api_v1_providers GET    /api/v1/providers(.:format)     api/v1/providers#index
-#                  POST   /api/v1/providers(.:format)     api/v1/providers#create
-#  api_v1_provider GET    /api/v1/providers/:id(.:format) api/v1/providers#show
-#                  PATCH  /api/v1/providers/:id(.:format) api/v1/providers#update
-#                  PUT    /api/v1/providers/:id(.:format) api/v1/providers#update
-#                  DELETE /api/v1/providers/:id(.:format) api/v1/providers#destroy
-#  api_v1_subjects GET    /api/v1/subjects(.:format)      api/v1/subjects#index
-#                  POST   /api/v1/subjects(.:format)      api/v1/subjects#create
-#   api_v1_subject GET    /api/v1/subjects/:id(.:format)  api/v1/subjects#show
-#                  PATCH  /api/v1/subjects/:id(.:format)  api/v1/subjects#update
-#                  PUT    /api/v1/subjects/:id(.:format)  api/v1/subjects#update
-#                  DELETE /api/v1/subjects/:id(.:format)  api/v1/subjects#destroy
-#   api_v1_courses GET    /api/v1/courses(.:format)       api/v1/courses#index
-#                  POST   /api/v1/courses(.:format)       api/v1/courses#create
-#    api_v1_course GET    /api/v1/courses/:id(.:format)   api/v1/courses#show
-#                  PATCH  /api/v1/courses/:id(.:format)   api/v1/courses#update
-#                  PUT    /api/v1/courses/:id(.:format)   api/v1/courses#update
-#                  DELETE /api/v1/courses/:id(.:format)   api/v1/courses#destroy
+#           Prefix Verb   URI Pattern                       Controller#Action
+# api_v1_providers GET    /api/v1/providers(.:format)       api/v1/providers#index
+#                  POST   /api/v1/providers(.:format)       api/v1/providers#create
+#  api_v1_provider GET    /api/v1/providers/:id(.:format)   api/v1/providers#show
+#                  PATCH  /api/v1/providers/:id(.:format)   api/v1/providers#update
+#                  PUT    /api/v1/providers/:id(.:format)   api/v1/providers#update
+#                  DELETE /api/v1/providers/:id(.:format)   api/v1/providers#destroy
+#  api_v1_subjects GET    /api/v1/subjects(.:format)        api/v1/subjects#index
+#                  POST   /api/v1/subjects(.:format)        api/v1/subjects#create
+#   api_v1_subject GET    /api/v1/subjects/:id(.:format)    api/v1/subjects#show
+#                  PATCH  /api/v1/subjects/:id(.:format)    api/v1/subjects#update
+#                  PUT    /api/v1/subjects/:id(.:format)    api/v1/subjects#update
+#                  DELETE /api/v1/subjects/:id(.:format)    api/v1/subjects#destroy
+#   api_v1_courses GET    /api/v1/courses(.:format)         api/v1/courses#index
+#                  POST   /api/v1/courses(.:format)         api/v1/courses#create
+#    api_v1_course GET    /api/v1/courses/:id(.:format)     api/v1/courses#show
+#                  PATCH  /api/v1/courses/:id(.:format)     api/v1/courses#update
+#                  PUT    /api/v1/courses/:id(.:format)     api/v1/courses#update
+#                  DELETE /api/v1/courses/:id(.:format)     api/v1/courses#destroy
+#           api_v1 GET    /api/v1/:year/courses(.:format)   api/v1/courses#show {:year=>/(2019|2020)/}
+#                  GET    /api/v1/:year/subjects(.:format)  api/v1/subjects#show {:year=>/(2019|2020)/}
+#                  GET    /api/v1/:year/providers(.:format) api/v1/providers#show {:year=>/(2019|2020)/}
+
 
 Rails.application.routes.draw do
   namespace :api do
@@ -26,6 +30,11 @@ Rails.application.routes.draw do
       resources :providers
       resources :subjects
       resources :courses
+      scope "/(:recruitment_cycle_year)", constraints: { recruitment_cycle_year: /(2018|2019|2020)/ } do
+        get '/courses', to: 'courses#index'
+        get '/subjects', to: 'subjects#index'
+        get '/providers', to: 'providers#index'
+      end
     end
   end
 end

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -45,73 +45,102 @@ RSpec.describe "Courses API", type: :request do
       )
     end
 
-    it "returns http success" do
-      get "/api/v1/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
-      expect(response).to have_http_status(:success)
-    end
-
-    it "returns http unauthorised" do
-      get "/api/v1/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("foo") }
-      expect(response).to have_http_status(:unauthorized)
-    end
-
-    it "JSON body response contains expected course attributes" do
-      get "/api/v1/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
-
-      json = JSON.parse(response.body)
-      expect(json). to eq([
-        {
-          "course_code" => "2HPF",
-          "start_month" => "2019-09-01T00:00:00Z",
-          "start_month_string" => "September",
-          "name" => "Religious Education",
-          "study_mode" => "F",
-          "copy_form_required" => "Y",
-          "profpost_flag" => "PG",
-          "program_type" => "SD",
-          "age_range" => "P",
-          "modular" => "",
-          "english" => 3,
-          "maths" => 9,
-          "science" => nil,
-          "qualification" => 1,
-          "recruitment_cycle" => "2019",
-          "campus_statuses" => [
-            {
-              "campus_code" => "-",
-              "name" => "Main Site",
-              "vac_status" => "F",
-              "publish" => "Y",
-              "status" => "R",
-              "course_open_date" => "2018-10-09",
-              "recruitment_cycle" => "2019"
-            }
-          ],
-          "subjects" => [
-            {
-              "subject_code" => "1",
-              "subject_name" => "Secondary"
-            },
-            {
-              "subject_code" => "2",
-              "subject_name" => "Mathematics"
-            }
-          ],
-          "provider" => {
-            "institution_code" => "2LD",
-            "institution_name" => "ACME SCITT",
-            "institution_type" => "B",
-            "accrediting_provider" => 'N',
-            "address1" => "Sydney Russell School",
-            "address2" => "Parsloes Avenue",
-            "address3" => "Dagenham",
-            "address4" => "Essex",
-            "postcode" => "RM9 5QT",
-            "region_code" => "07",
+    expected_json = [
+      {
+        "course_code" => "2HPF",
+        "start_month" => "2019-09-01T00:00:00Z",
+        "start_month_string" => "September",
+        "name" => "Religious Education",
+        "study_mode" => "F",
+        "copy_form_required" => "Y",
+        "profpost_flag" => "PG",
+        "program_type" => "SD",
+        "age_range" => "P",
+        "modular" => "",
+        "english" => 3,
+        "maths" => 9,
+        "science" => nil,
+        "qualification" => 1,
+        "campus_statuses" => [
+          {
+            "campus_code" => "-",
+            "name" => "Main Site",
+            "vac_status" => "F",
+            "publish" => "Y",
+            "status" => "R",
+            "course_open_date" => "2018-10-09"
+          }
+        ],
+        "subjects" => [
+          {
+            "subject_code" => "1",
+            "subject_name" => "Secondary"
           },
-          "accrediting_provider" => nil
-        }
-      ])
+          {
+            "subject_code" => "2",
+            "subject_name" => "Mathematics"
+          }
+        ],
+        "provider" => {
+          "institution_code" => "2LD",
+          "institution_name" => "ACME SCITT",
+          "institution_type" => "B",
+          "accrediting_provider" => 'N',
+          "address1" => "Sydney Russell School",
+          "address2" => "Parsloes Avenue",
+          "address3" => "Dagenham",
+          "address4" => "Essex",
+          "postcode" => "RM9 5QT",
+          "region_code" => "07",
+        },
+        "accrediting_provider" => nil
+      }
+    ]
+
+    describe 'index' do
+      it "returns http success" do
+        get "/api/v1/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
+        expect(response).to have_http_status(:success)
+      end
+
+      it "returns http unauthorised" do
+        get "/api/v1/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("foo") }
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "JSON body response contains expected course attributes" do
+        get "/api/v1/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
+        json = JSON.parse(response.body)
+        expect(json). to eq expected_json
+      end
+
+      it "returns http success" do
+        get "/api/v1/2019/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
+        expect(response).to have_http_status(:success)
+      end
+
+      it "returns http unauthorised" do
+        get "/api/v1/2019/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("foo") }
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "JSON body response contains expected course attributes" do
+        get "/api/v1/2019/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
+        json = JSON.parse(response.body)
+        expect(json). to eq expected_json
+      end
+    end
+
+    describe 'not found' do
+      it "returns http not found" do
+        get "/api/v1/2018/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns http not found" do
+        get "/api/v1/2020/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
+        expect(response).to have_http_status(:not_found)
+      end
     end
   end
 end

--- a/spec/requests/api/v1/subject_spec.rb
+++ b/spec/requests/api/v1/subject_spec.rb
@@ -11,30 +11,64 @@ RSpec.describe "Subjecs API", type: :request do
         subject_code: "M4")
     end
 
-    it "returns http success" do
-      get "/api/v1/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
-      expect(response).to have_http_status(:success)
+    expected_json = [
+      {
+        "subject_name" => "Mathematics",
+        "subject_code" => "B1",
+      },
+      {
+        "subject_name" => "Biology",
+        "subject_code" => "M4",
+      },
+    ]
+
+    describe 'index' do
+      it "returns http success" do
+        get "/api/v1/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
+        expect(response).to have_http_status(:success)
+      end
+
+      it "returns http unauthorized" do
+        get "/api/v1/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("foo") }
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "JSON body response contains expected provider attributes" do
+        get "/api/v1/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
+
+        json = JSON.parse(response.body)
+        expect(json).to eq expected_json
+      end
     end
 
-    it "returns http unauthorized" do
-      get "/api/v1/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("foo") }
-      expect(response).to have_http_status(:unauthorized)
+    describe 'show' do
+      it "returns http success" do
+        get "/api/v1/2019/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
+        expect(response).to have_http_status(:success)
+      end
+
+      it "returns http unauthorized" do
+        get "/api/v1/2019/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("foo") }
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "JSON body response contains expected provider attributes" do
+        get "/api/v1/2019/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
+
+        json = JSON.parse(response.body)
+        expect(json).to eq expected_json
+      end
     end
+    describe 'not found' do
+      it "returns http not found" do
+        get "/api/v1/2018/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
+        expect(response).to have_http_status(:not_found)
+      end
 
-    it "JSON body response contains expected provider attributes" do
-      get "/api/v1/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
-
-      json = JSON.parse(response.body)
-      expect(json).to eq([
-        {
-          "subject_name" => "Mathematics",
-          "subject_code" => "B1",
-        },
-        {
-          "subject_name" => "Biology",
-          "subject_code" => "M4",
-        },
-      ])
+      it "returns http not found" do
+        get "/api/v1/2020/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
+        expect(response).to have_http_status(:not_found)
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
`recruitment cycle` endpoints

`/api/v1/:recruitment_cycle_year/xxx` 
where `recruitment_cycle_year` is either 2019 or 2020
where `xxx` is either courses, or, providers, or subjects.

### Changes proposed in this pull request
Add `/api/v1/:recruitment_cycle_year/xxx` 
For now 2020 endpoint will be returning http status code 404

### Guidance to review
https://github.com/DFE-Digital/manage-courses-backend/blob/master/docs/api.md#preparation-for-the-next-recruitment-cycle-rollover

These will be new endpoints added, existing `/api/v1/xxx`  will stay

