### PR TITLE
Missing address for provider

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -64,13 +64,9 @@ class Provider < ApplicationRecord
   def address_info
     fields = %w[address1 address2 address3 address4 postcode]
 
+    result = valid_enriched_address_info
 
-    result = enrichments.with_address_info.first.present? && enrichments.with_address_info.first
-      .attributes_before_type_cast
-      .slice(*fields)
-
-
-    if !result.present? || fields.none? { |field| result[field].present? }
+    if !result.present?
       result = self
         .attributes_before_type_cast
         .slice(*fields)
@@ -80,5 +76,15 @@ class Provider < ApplicationRecord
     result['region_code'] = (enrichments.with_address_info.first || self).region_code_before_type_cast
 
     result
+  end
+
+  def valid_enriched_address_info
+    fields = %w[address1 address2 address3 address4 postcode]
+
+    result = enrichments.with_address_info.first.present? && enrichments.with_address_info.first
+    .attributes_before_type_cast
+    .slice(*fields)
+
+    result = !result.present? || fields.any? { |field| result[field].present? } ? result : nil
   end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -75,17 +75,17 @@ class Provider < ApplicationRecord
   end
 
   def valid_enriched_address_info
-    return nil unless enrichments.with_address_info.present?
+    return nil unless enrichments.latest_created_at.with_address_info.first.present?
 
     fields = %w[address1 address2 address3 address4 postcode]
 
-    result = enrichments.with_address_info.first
+    result = enrichments.latest_created_at.with_address_info.first
      .attributes_before_type_cast
      .slice(*fields)
 
     return nil unless (result.select { |_k, v| v.present? }).present?
 
-    result['region_code'] = enrichments.with_address_info.first.region_code_before_type_cast
+    result['region_code'] = enrichments.latest_created_at.with_address_info.first.region_code_before_type_cast
     result
   end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -62,11 +62,11 @@ class Provider < ApplicationRecord
 
   # TODO: filter to published enrichments, maybe rename to published_address_info
   def address_info
-    fields = %w[address1 address2 address3 address4 postcode]
-
     result = valid_enriched_address_info
 
     if !result.present?
+      fields = %w[address1 address2 address3 address4 postcode]
+
       result = self
         .attributes_before_type_cast
         .slice(*fields)

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -62,30 +62,10 @@ class Provider < ApplicationRecord
 
   # TODO: filter to published enrichments, maybe rename to published_address_info
   def address_info
-    result = valid_enriched_address_info
+    fields = %w[address1 address2 address3 address4 postcode region_code]
 
-    unless result.present?
-      fields = %w[address1 address2 address3 address4 postcode region_code]
-      result = self
+    (enrichments.latest_created_at.with_address_info.first || self)
       .attributes_before_type_cast
       .slice(*fields)
-    end
-
-    result
-  end
-
-  def valid_enriched_address_info
-    return nil unless enrichments.latest_created_at.with_address_info.first.present?
-
-    fields = %w[address1 address2 address3 address4 postcode]
-
-    result = enrichments.latest_created_at.with_address_info.first
-     .attributes_before_type_cast
-     .slice(*fields)
-
-    return nil unless (result.select { |_k, v| v.present? }).present?
-
-    result['region_code'] = enrichments.latest_created_at.with_address_info.first.region_code_before_type_cast
-    result
   end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -62,8 +62,23 @@ class Provider < ApplicationRecord
 
   # TODO: filter to published enrichments, maybe rename to published_address_info
   def address_info
-    (enrichments.with_address_info.last || self)
+    fields = %w[address1 address2 address3 address4 postcode]
+
+
+    result = enrichments.with_address_info.first.present? && enrichments.with_address_info.first
       .attributes_before_type_cast
-      .slice('address1', 'address2', 'address3', 'address4', 'postcode', 'region_code')
+      .slice(*fields)
+
+
+    if !result.present? || fields.none? { |field| result[field].present? }
+      result = self
+        .attributes_before_type_cast
+        .slice(*fields)
+    end
+
+    # region_code should be present in enrichment regardless
+    result['region_code'] = (enrichments.with_address_info.first || self).region_code_before_type_cast
+
+    result
   end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -62,10 +62,8 @@ class Provider < ApplicationRecord
 
   # TODO: filter to published enrichments, maybe rename to published_address_info
   def address_info
-    fields = %w[address1 address2 address3 address4 postcode region_code]
-
     (enrichments.latest_created_at.with_address_info.first || self)
       .attributes_before_type_cast
-      .slice(*fields)
+      .slice('address1', 'address2', 'address3', 'address4', 'postcode', 'region_code')
   end
 end

--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -16,6 +16,7 @@
 class ProviderEnrichment < ApplicationRecord
   self.table_name = "provider_enrichment"
   self.primary_key = "provider_code"
+  default_scope { order(created_at: :desc) }
 
   include RegionCode
 

--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -16,7 +16,6 @@
 class ProviderEnrichment < ApplicationRecord
   self.table_name = "provider_enrichment"
   self.primary_key = "provider_code"
-  scope :latest_created_at, -> { order(created_at: :desc) }
 
   include RegionCode
 
@@ -29,6 +28,8 @@ class ProviderEnrichment < ApplicationRecord
           where("json_data ?| array['Address1', 'Address2', 'Address3', 'Address4', 'Postcode']")
             .json_data_where_not(address1: nil, address2: nil, address3: nil, address4: nil, postcode: nil)
         end
+
+  scope :latest_created_at, -> { order(created_at: :desc) }
 
   jsonb_accessor :json_data,
                  email: [:string, store_key: 'Email'],

--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -26,7 +26,7 @@ class ProviderEnrichment < ApplicationRecord
 
   scope :with_address_info,
         -> do
-          where("json_data ?| array['Address1', 'Address2', 'Address3', 'Address4', 'Postcode', 'RegionCode']")
+          where("json_data ?| array['Address1', 'Address2', 'Address3', 'Address4', 'Postcode']")
             .json_data_where_not(address1: nil, address2: nil, address3: nil, address4: nil, postcode: nil)
         end
 

--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -16,7 +16,7 @@
 class ProviderEnrichment < ApplicationRecord
   self.table_name = "provider_enrichment"
   self.primary_key = "provider_code"
-  default_scope { order(created_at: :desc) }
+  scope :latest_created_at, -> { order(created_at: :desc) }
 
   include RegionCode
 
@@ -25,7 +25,10 @@ class ProviderEnrichment < ApplicationRecord
   belongs_to :provider, foreign_key: :provider_code, primary_key: :provider_code
 
   scope :with_address_info,
-        -> { where("json_data ?| array['Address1', 'Address2', 'Address3', 'Address4', 'Postcode', 'RegionCode']") }
+        -> do
+          where("json_data ?| array['Address1', 'Address2', 'Address3', 'Address4', 'Postcode', 'RegionCode']")
+            .json_data_where_not(address1: nil, address2: nil, address3: nil, address4: nil, postcode: nil, region_code: nil)
+        end
 
   jsonb_accessor :json_data,
                  email: [:string, store_key: 'Email'],

--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -27,7 +27,7 @@ class ProviderEnrichment < ApplicationRecord
   scope :with_address_info,
         -> do
           where("json_data ?| array['Address1', 'Address2', 'Address3', 'Address4', 'Postcode', 'RegionCode']")
-            .json_data_where_not(address1: nil, address2: nil, address3: nil, address4: nil, postcode: nil, region_code: nil)
+            .json_data_where_not(address1: nil, address2: nil, address3: nil, address4: nil, postcode: nil)
         end
 
   jsonb_accessor :json_data,

--- a/spec/factories/provider_enrichments.rb
+++ b/spec/factories/provider_enrichments.rb
@@ -20,18 +20,16 @@ FactoryBot.define do
     end
 
     sequence(:provider_code) { |n| "A#{n}" }
-    json_data {
-      { 'email' => Faker::Internet.email,
-        'website' => Faker::Internet.url,
-        'address1' => Faker::Address.street_address,
-        'address2' => Faker::Address.community,
-        'address3' => Faker::Address.city,
-        'address4' => Faker::Address.state,
-        'postcode' => Faker::Address.postcode,
-        'region_code' => ProviderEnrichment.region_codes['Eastern'],
-        'train_with_us' => Faker::Lorem.sentence.to_s,
-        'train_with_disability' => Faker::Lorem.sentence.to_s }
-    }
+    email { Faker::Internet.email }
+    website { Faker::Internet.url }
+    address1 { Faker::Address.street_address }
+    address2 { Faker::Address.community }
+    address3 { Faker::Address.city }
+    address4 { Faker::Address.state }
+    postcode { Faker::Address.postcode }
+    region_code { ProviderEnrichment.region_codes['Eastern'] }
+    train_with_us { Faker::Lorem.sentence.to_s }
+    train_with_disability { Faker::Lorem.sentence.to_s }
     created_at { Faker::Date.between 2.days.ago, 1.days.ago }
 
     after(:build) do |enrichment, evaluator|

--- a/spec/factories/provider_enrichments.rb
+++ b/spec/factories/provider_enrichments.rb
@@ -31,6 +31,7 @@ FactoryBot.define do
         'train_with_us' => Faker::Lorem.sentence.to_s,
         'train_with_disability' => Faker::Lorem.sentence.to_s }
     }
+    created_at { Faker::Date.between 2.days.ago, 1.days.ago }
 
     after(:build) do |enrichment, evaluator|
       if evaluator.age.present?

--- a/spec/factories/provider_enrichments.rb
+++ b/spec/factories/provider_enrichments.rb
@@ -28,6 +28,7 @@ FactoryBot.define do
         'address3' => Faker::Address.city,
         'address4' => Faker::Address.state,
         'postcode' => Faker::Address.postcode,
+        'region_code' => ProviderEnrichment.region_codes['Eastern'],
         'train_with_us' => Faker::Lorem.sentence.to_s,
         'train_with_disability' => Faker::Lorem.sentence.to_s }
     }

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -34,6 +34,7 @@ FactoryBot.define do
     address4 { Faker::Address.state }
     postcode { Faker::Address.postcode }
     accrediting_provider { 'N' }
+    region_code { ProviderEnrichment.region_codes['London'] }
 
     transient do
       age          { nil }

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Provider, type: :model do
           end
         end
         context 'enrichment has partial set for address_info' do
-          it 'returns address of the provider' do
+          it 'returns address of the enrichment' do
             enrichment = build(:provider_enrichment, json_data: { 'email' => Faker::Internet.email,
             'website' => Faker::Internet.url,
             'address1' => Faker::Address.street_address,
@@ -136,6 +136,28 @@ RSpec.describe Provider, type: :model do
               'postcode' => enrichment.postcode,
               'region_code' => enrichment.region_code
             )
+          end
+
+          context 'enrichment has only region code set for address_info' do
+            it 'returns address of the provider' do
+              london = ProviderEnrichment.region_codes['London']
+
+              enrichment = build(:provider_enrichment, json_data: { 'email' => Faker::Internet.email,
+              'website' => Faker::Internet.url,
+              'region_code' => 'No region',
+              'train_with_us' => Faker::Lorem.sentence.to_s,
+              'train_with_disability' => Faker::Lorem.sentence.to_s })
+              provider = create(:provider, region_code: london, enrichments: [enrichment])
+
+              expect(provider.address_info).to eq(
+                'address1' => provider.address1,
+                'address2' => provider.address2,
+                'address3' => provider.address3,
+                'address4' => provider.address4,
+                'postcode' => provider.postcode,
+                'region_code' => london
+              )
+            end
           end
         end
       end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -50,45 +50,48 @@ RSpec.describe Provider, type: :model do
 
       context 'provider has enrichments' do
         context 'enrichment has nothing set for address_info' do
-          it 'returns address of the provider' do
-            enrichment = build(:provider_enrichment)
-            provider = create(:provider, enrichments: [enrichment])
+          context 'via absent json_data fields' do
+            it 'returns address of the provider' do
+              enrichment = build(:provider_enrichment)
+              provider = create(:provider, enrichments: [enrichment])
 
-            # forcing all fields to be absent in json_data altogether
-            ProviderEnrichment.connection.update(<<~EOSQL)
-              UPDATE provider_enrichment
-                    SET json_data=json_data-'Address1'-'Address2'-'Address3'-'Address4'-'Postcode'-'RegionCode'
-                    WHERE provider_code='#{enrichment.provider_code}'
-            EOSQL
+              # forcing all fields to be absent in json_data altogether
+              ProviderEnrichment.connection.update(<<~EOSQL)
+                UPDATE provider_enrichment
+                      SET json_data=json_data-'Address1'-'Address2'-'Address3'-'Address4'-'Postcode'-'RegionCode'
+                      WHERE provider_code='#{enrichment.provider_code}'
+              EOSQL
 
-            expect(provider.address_info).to eq(
-              'address1' => provider.address1,
-              'address2' => provider.address2,
-              'address3' => provider.address3,
-              'address4' => provider.address4,
-              'postcode' => provider.postcode,
-              'region_code' => provider.region_code_before_type_cast
-            )
+              expect(provider.address_info).to eq(
+                'address1' => provider.address1,
+                'address2' => provider.address2,
+                'address3' => provider.address3,
+                'address4' => provider.address4,
+                'postcode' => provider.postcode,
+                'region_code' => provider.region_code_before_type_cast
+              )
+            end
           end
+          context 'via nil fields' do
+            it 'returns address of the provider' do
+              enrichment = build(:provider_enrichment,
+                  address1: nil,
+                  address2: nil,
+                  address3: nil,
+                  address4: nil,
+                  postcode: nil,
+                  region_code: nil)
+              provider = create(:provider, enrichments: [enrichment])
 
-          it 'returns address of the provider' do
-            enrichment = build(:provider_enrichment,
-                address1: nil,
-                address2: nil,
-                address3: nil,
-                address4: nil,
-                postcode: nil,
-                region_code: nil)
-            provider = create(:provider, enrichments: [enrichment])
-
-            expect(provider.address_info).to eq(
-              'address1' => provider.address1,
-              'address2' => provider.address2,
-              'address3' => provider.address3,
-              'address4' => provider.address4,
-              'postcode' => provider.postcode,
-              'region_code' => provider.region_code_before_type_cast
-            )
+              expect(provider.address_info).to eq(
+                'address1' => provider.address1,
+                'address2' => provider.address2,
+                'address3' => provider.address3,
+                'address4' => provider.address4,
+                'postcode' => provider.postcode,
+                'region_code' => provider.region_code_before_type_cast
+              )
+            end
           end
         end
 
@@ -144,48 +147,47 @@ RSpec.describe Provider, type: :model do
           context 'enrichment has only region code set for address_info' do
             london = ProviderEnrichment.region_codes['London']
             no_region = ProviderEnrichment.region_codes['No region']
+            context 'via absent json_data fields' do
+              it 'returns address of the provider' do
+                enrichment = build(:provider_enrichment, region_code: no_region,)
+                provider = create(:provider, region_code: london, enrichments: [enrichment])
 
-            it 'returns address of the provider' do
-              enrichment = build(:provider_enrichment, region_code: no_region,
-              address1: nil,
-              address2: nil,
-              address3: nil,
-              address4: nil,
-              postcode: nil)
-              provider = create(:provider, region_code: london, enrichments: [enrichment])
+                # forcing all fields apart region_code to be absent in json_data altogether
+                ProviderEnrichment.connection.update(<<~EOSQL)
+                  UPDATE provider_enrichment
+                        SET json_data=json_data-'Address1'-'Address2'-'Address3'-'Address4'-'Postcode'
+                        WHERE provider_code='#{enrichment.provider_code}'
+                EOSQL
 
-              expect(provider.address_info).to eq(
-                'address1' => provider.address1,
-                'address2' => provider.address2,
-                'address3' => provider.address3,
-                'address4' => provider.address4,
-                'postcode' => provider.postcode,
-                'region_code' => provider.region_code_before_type_cast
-              )
+                expect(provider.address_info).to eq(
+                  'address1' => provider.address1,
+                  'address2' => provider.address2,
+                  'address3' => provider.address3,
+                  'address4' => provider.address4,
+                  'postcode' => provider.postcode,
+                  'region_code' => provider.region_code_before_type_cast
+                )
+              end
             end
+            context 'via nil fields' do
+              it 'returns address of the provider' do
+                enrichment = build(:provider_enrichment, region_code: no_region,
+                address1: nil,
+                address2: nil,
+                address3: nil,
+                address4: nil,
+                postcode: nil)
+                provider = create(:provider, region_code: london, enrichments: [enrichment])
 
-            it 'returns address of the provider' do
-              enrichment = build(:provider_enrichment, region_code: no_region, address2: nil,
-              address3: nil,
-              address4: nil,
-              postcode: nil)
-              provider = create(:provider, region_code: london, enrichments: [enrichment])
-
-              # forcing all fields apart region_code to be absent in json_data altogether
-              ProviderEnrichment.connection.update(<<~EOSQL)
-                UPDATE provider_enrichment
-                      SET json_data=json_data-'Address1'-'Address2'-'Address3'-'Address4'-'Postcode'
-                      WHERE provider_code='#{enrichment.provider_code}'
-              EOSQL
-
-              expect(provider.address_info).to eq(
-                'address1' => provider.address1,
-                'address2' => provider.address2,
-                'address3' => provider.address3,
-                'address4' => provider.address4,
-                'postcode' => provider.postcode,
-                'region_code' => provider.region_code_before_type_cast
-              )
+                expect(provider.address_info).to eq(
+                  'address1' => provider.address1,
+                  'address2' => provider.address2,
+                  'address3' => provider.address3,
+                  'address4' => provider.address4,
+                  'postcode' => provider.postcode,
+                  'region_code' => provider.region_code_before_type_cast
+                )
+              end
             end
           end
         end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe Provider, type: :model do
   end
 
   describe '#address_info' do
-    describe 'returns address of the provider' do
-      it 'even empty enrichments' do
+    context 'empty enrichments' do
+      it 'returns address of the provider' do
         provider = create(:provider, enrichments: [])
 
         expect(provider.address_info).to eq(
@@ -48,100 +48,102 @@ RSpec.describe Provider, type: :model do
         )
       end
 
-      it 'even when enrichment has nothing set for address_info' do
-        enrichment = build(:provider_enrichment, json_data: { 'email' => Faker::Internet.email,
-        'website' => Faker::Internet.url,
-        'train_with_us' => Faker::Lorem.sentence.to_s,
-        'train_with_disability' => Faker::Lorem.sentence.to_s })
-        provider = create(:provider, enrichments: [enrichment])
+      context 'provider has enrichments' do
+        context 'enrichment has nothing set for address_info' do
+          it 'returns address of the provider' do
+            enrichment = build(:provider_enrichment, json_data: { 'email' => Faker::Internet.email,
+            'website' => Faker::Internet.url,
+            'train_with_us' => Faker::Lorem.sentence.to_s,
+            'train_with_disability' => Faker::Lorem.sentence.to_s })
+            provider = create(:provider, enrichments: [enrichment])
+            expect(provider.address_info).to eq(
+              'address1' => provider.address1,
+              'address2' => provider.address2,
+              'address3' => provider.address3,
+              'address4' => provider.address4,
+              'postcode' => provider.postcode,
+              'region_code' => provider.region_code
+            )
+          end
+          it 'returns address of the provider' do
+            enrichment = build(:provider_enrichment, json_data: { 'email' => Faker::Internet.email,
+            'website' => Faker::Internet.url,
+            'train_with_us' => Faker::Lorem.sentence.to_s,
+            'train_with_disability' => Faker::Lorem.sentence.to_s,
+            'address1' => nil,
+            'address2' => nil,
+            'address3' => nil,
+            'address4' => nil,
+            'postcode' => nil })
+            provider = create(:provider, enrichments: [enrichment])
 
-        expect(provider.address_info).to eq(
-          'address1' => provider.address1,
-          'address2' => provider.address2,
-          'address3' => provider.address3,
-          'address4' => provider.address4,
-          'postcode' => provider.postcode,
-          'region_code' => provider.region_code
-        )
-      end
+            expect(provider.address_info).to eq(
+              'address1' => provider.address1,
+              'address2' => provider.address2,
+              'address3' => provider.address3,
+              'address4' => provider.address4,
+              'postcode' => provider.postcode,
+              'region_code' => provider.region_code
+            )
+          end
+        end
 
-      it 'even when enrichment has nil set for address_info' do
-        enrichment = build(:provider_enrichment, json_data: { 'email' => Faker::Internet.email,
-        'website' => Faker::Internet.url,
-        'train_with_us' => Faker::Lorem.sentence.to_s,
-        'train_with_disability' => Faker::Lorem.sentence.to_s,
-        'address1' => nil,
-        'address2' => nil,
-        'address3' => nil,
-        'address4' => nil,
-        'postcode' => nil })
-        provider = create(:provider, enrichments: [enrichment])
+        context 'enrichment is valid' do
+          it 'returns json_data from the first enrichment' do
+            enrichment = build(:provider_enrichment)
+            provider = create(:provider, enrichments: [enrichment])
 
-        expect(provider.address_info).to eq(
-          'address1' => provider.address1,
-          'address2' => provider.address2,
-          'address3' => provider.address3,
-          'address4' => provider.address4,
-          'postcode' => provider.postcode,
-          'region_code' => provider.region_code
-        )
-      end
-    end
+            expect(provider.address_info).to eq(
+              'address1' => enrichment.address1,
+              'address2' => enrichment.address2,
+              'address3' => enrichment.address3,
+              'address4' => enrichment.address4,
+              'postcode' => enrichment.postcode,
+              'region_code' => enrichment.region_code
+            )
+          end
 
-    context 'provider has enrichments' do
-      it 'returns json_data from the first enrichment' do
-        enrichment = build(:provider_enrichment)
-        provider = create(:provider, enrichments: [enrichment])
+          it 'returns json_data from the newest enrichment' do
+            enrichment = build(:provider_enrichment)
+            newest_enrichment = build(:provider_enrichment, created_at: Date.today)
+            provider = create(:provider, enrichments: [enrichment, newest_enrichment])
 
-        expect(provider.address_info).to eq(
-          'address1' => enrichment.address1,
-          'address2' => enrichment.address2,
-          'address3' => enrichment.address3,
-          'address4' => enrichment.address4,
-          'postcode' => enrichment.postcode,
-          'region_code' => enrichment.region_code
-        )
-      end
+            expect(provider.address_info).to eq(
+              'address1' => newest_enrichment.address1,
+              'address2' => newest_enrichment.address2,
+              'address3' => newest_enrichment.address3,
+              'address4' => newest_enrichment.address4,
+              'postcode' => newest_enrichment.postcode,
+              'region_code' => newest_enrichment.region_code
+            )
+          end
+        end
+        context 'enrichment has partial set for address_info' do
+          it 'returns address of the provider' do
+            enrichment = build(:provider_enrichment, json_data: { 'email' => Faker::Internet.email,
+            'website' => Faker::Internet.url,
+            'address1' => Faker::Address.street_address,
+            'postcode' => nil,
+            'train_with_us' => Faker::Lorem.sentence.to_s,
+            'train_with_disability' => Faker::Lorem.sentence.to_s })
+            provider = create(:provider, enrichments: [enrichment])
 
-      it 'returns json_data from the newest enrichment' do
-        enrichment = build(:provider_enrichment)
-        newest_enrichment = build(:provider_enrichment, created_at: Date.today)
-        provider = create(:provider, enrichments: [enrichment, newest_enrichment])
-
-        expect(provider.address_info).to eq(
-          'address1' => newest_enrichment.address1,
-          'address2' => newest_enrichment.address2,
-          'address3' => newest_enrichment.address3,
-          'address4' => newest_enrichment.address4,
-          'postcode' => newest_enrichment.postcode,
-          'region_code' => newest_enrichment.region_code
-        )
-      end
-
-      it 'even when enrichment has partial set for address_info' do
-        enrichment = build(:provider_enrichment, json_data: { 'email' => Faker::Internet.email,
-        'website' => Faker::Internet.url,
-        'address1' => Faker::Address.street_address,
-        'postcode' => nil,
-        'train_with_us' => Faker::Lorem.sentence.to_s,
-        'train_with_disability' => Faker::Lorem.sentence.to_s })
-        provider = create(:provider, enrichments: [enrichment])
-
-        expect(provider.address_info).to eq(
-          'address1' => enrichment.address1,
-          'address2' => enrichment.address2,
-          'address3' => enrichment.address3,
-          'address4' => enrichment.address4,
-          'postcode' => enrichment.postcode,
-          'region_code' => enrichment.region_code
-        )
+            expect(provider.address_info).to eq(
+              'address1' => enrichment.address1,
+              'address2' => enrichment.address2,
+              'address3' => enrichment.address3,
+              'address4' => enrichment.address4,
+              'postcode' => enrichment.postcode,
+              'region_code' => enrichment.region_code
+            )
+          end
+        end
       end
     end
   end
-
   describe '#changed_since' do
     let!(:old_provider) { create(:provider, age: 1.hour.ago) }
-    let!(:provider)     { create(:provider, age: 1.hour.ago) }
+    let!(:provider) { create(:provider, age: 1.hour.ago) }
 
     context 'with a provider with no enrichments or sites' do
       let(:provider) { create(:provider, enrichments: [], sites: []) }

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -34,20 +34,38 @@ RSpec.describe Provider, type: :model do
   end
 
   describe '#address_info' do
-    it 'returns address of the provider' do
-      provider = create(:provider, enrichments: [])
-      expect(provider.address_info).to eq(
-        'address1' => provider.address1,
-        'address2' => provider.address2,
-        'address3' => provider.address3,
-        'address4' => provider.address4,
-        'postcode' => provider.postcode,
-        'region_code' => provider.region_code
-      )
+    describe 'returns address of the provider' do
+      it 'even empty enrichments' do
+        provider = create(:provider, enrichments: [])
+        expect(provider.address_info).to eq(
+          'address1' => provider.address1,
+          'address2' => provider.address2,
+          'address3' => provider.address3,
+          'address4' => provider.address4,
+          'postcode' => provider.postcode,
+          'region_code' => provider.region_code
+        )
+      end
+
+      it 'even when enrichment has nothing set for address_info' do
+        enrichment = build(:provider_enrichment, json_data: { 'email' => Faker::Internet.email,
+        'website' => Faker::Internet.url,
+        'train_with_us' => Faker::Lorem.sentence.to_s,
+        'train_with_disability' => Faker::Lorem.sentence.to_s })
+        provider = create(:provider, enrichments: [enrichment])
+        expect(provider.address_info).to eq(
+          'address1' => provider.address1,
+          'address2' => provider.address2,
+          'address3' => provider.address3,
+          'address4' => provider.address4,
+          'postcode' => provider.postcode,
+          'region_code' => provider.region_code
+        )
+      end
     end
 
     context 'provider has enrichments' do
-      it 'returns json_data from the last enrichment' do
+      it 'returns json_data from the first enrichment' do
         enrichment = build(:provider_enrichment)
         provider = create(:provider, enrichments: [enrichment])
 
@@ -58,6 +76,21 @@ RSpec.describe Provider, type: :model do
           'address4' => enrichment.address4,
           'postcode' => enrichment.postcode,
           'region_code' => enrichment.region_code
+        )
+      end
+
+      it 'returns json_data from the newest enrichment' do
+        enrichment = build(:provider_enrichment)
+        newest_enrichment = build(:provider_enrichment, created_at: Date.today)
+        provider = create(:provider, enrichments: [enrichment, newest_enrichment])
+
+        expect(provider.address_info).to eq(
+          'address1' => newest_enrichment.address1,
+          'address2' => newest_enrichment.address2,
+          'address3' => newest_enrichment.address3,
+          'address4' => newest_enrichment.address4,
+          'postcode' => newest_enrichment.postcode,
+          'region_code' => newest_enrichment.region_code
         )
       end
     end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Provider, type: :model do
     describe 'returns address of the provider' do
       it 'even empty enrichments' do
         provider = create(:provider, enrichments: [])
+
         expect(provider.address_info).to eq(
           'address1' => provider.address1,
           'address2' => provider.address2,
@@ -53,6 +54,29 @@ RSpec.describe Provider, type: :model do
         'train_with_us' => Faker::Lorem.sentence.to_s,
         'train_with_disability' => Faker::Lorem.sentence.to_s })
         provider = create(:provider, enrichments: [enrichment])
+
+        expect(provider.address_info).to eq(
+          'address1' => provider.address1,
+          'address2' => provider.address2,
+          'address3' => provider.address3,
+          'address4' => provider.address4,
+          'postcode' => provider.postcode,
+          'region_code' => provider.region_code
+        )
+      end
+
+      it 'even when enrichment has nil set for address_info' do
+        enrichment = build(:provider_enrichment, json_data: { 'email' => Faker::Internet.email,
+        'website' => Faker::Internet.url,
+        'train_with_us' => Faker::Lorem.sentence.to_s,
+        'train_with_disability' => Faker::Lorem.sentence.to_s,
+        'address1' => nil,
+        'address2' => nil,
+        'address3' => nil,
+        'address4' => nil,
+        'postcode' => nil })
+        provider = create(:provider, enrichments: [enrichment])
+
         expect(provider.address_info).to eq(
           'address1' => provider.address1,
           'address2' => provider.address2,
@@ -91,6 +115,25 @@ RSpec.describe Provider, type: :model do
           'address4' => newest_enrichment.address4,
           'postcode' => newest_enrichment.postcode,
           'region_code' => newest_enrichment.region_code
+        )
+      end
+
+      it 'even when enrichment has partial set for address_info' do
+        enrichment = build(:provider_enrichment, json_data: { 'email' => Faker::Internet.email,
+        'website' => Faker::Internet.url,
+        'address1' => Faker::Address.street_address,
+        'postcode' => nil,
+        'train_with_us' => Faker::Lorem.sentence.to_s,
+        'train_with_disability' => Faker::Lorem.sentence.to_s })
+        provider = create(:provider, enrichments: [enrichment])
+
+        expect(provider.address_info).to eq(
+          'address1' => enrichment.address1,
+          'address2' => enrichment.address2,
+          'address3' => enrichment.address3,
+          'address4' => enrichment.address4,
+          'postcode' => enrichment.postcode,
+          'region_code' => enrichment.region_code
         )
       end
     end

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -84,7 +84,7 @@ describe 'Providers API', type: :request do
               headers: { 'HTTP_AUTHORIZATION' => credentials }
 
           json = JSON.parse(response.body)
-          expect(json). to eq(
+          expect(json). to match_array(
             [
               {
                 'accrediting_provider' => 'Y',
@@ -148,7 +148,7 @@ describe 'Providers API', type: :request do
               headers: { 'HTTP_AUTHORIZATION' => credentials }
 
           json = JSON.parse(response.body)
-          expect(json). to eq([
+          expect(json). to match_array([
                                 {
                                   'accrediting_provider' => 'Y',
                                   'campuses' => [

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -141,7 +141,7 @@ describe 'Providers API', type: :request do
           ProviderEnrichment.connection.update(<<~EOSQL)
             UPDATE provider_enrichment
                   SET json_data=json_data-'Address1'-'Address2'-'Address3'-'Address4'-'Postcode'-'RegionCode'
-                  WHERE provider_code='#{enrichment.id}'
+                  WHERE provider_code='#{enrichment.provider_code}'
           EOSQL
 
           get '/api/v1/providers',


### PR DESCRIPTION
### Context
Lack of ordering of provider enrichment where by older version of enrichment details are used instead of new version.

The address section of the enrichment can be empty/blank, ie only enriched the section concerning their accrediting provider, the blanked values are used.

### Changes proposed in this pull request
Added ordering of provider enrichment based on created_at date as default
Fixed the address to hydrate based on using provider details if enrichment is not available

