### PR TITLE
Include recruitment_year into routes

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -57,4 +57,8 @@ class Course < ApplicationRecord
   has_and_belongs_to_many :subjects
   has_many :site_statuses
   has_many :sites, through: :site_statuses
+
+  def recruitment_cycle
+    "2019"
+  end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -22,4 +22,8 @@ class Site < ApplicationRecord
   include RegionCode
 
   belongs_to :provider
+
+  def recruitment_cycle
+    "2019"
+  end
 end

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -30,4 +30,8 @@ class SiteStatus < ApplicationRecord
 
   belongs_to :site
   belongs_to :course
+
+  def recruitment_cycle
+    "2019"
+  end
 end

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -57,8 +57,7 @@ class CourseSerializer < ActiveModel::Serializer
     "Y" # we want to always create PDFs for applications coming in
   end
 
-  # TODO: make recruitment cycle dynamic
   def recruitment_cycle
-    "2019"
+    object.recruitment_cycle
   end
 end

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -31,8 +31,7 @@ class SiteSerializer < ActiveModel::Serializer
     '%02d' % object.region_code_before_type_cast if object.region_code.present?
   end
 
-  # TODO: make recruitment cycle dynamic
   def recruitment_cycle
-    "2019"
+    object.recruitment_cycle
   end
 end

--- a/app/serializers/site_status_serializer.rb
+++ b/app/serializers/site_status_serializer.rb
@@ -34,8 +34,7 @@ class SiteStatusSerializer < ActiveModel::Serializer
     object.site.location_name
   end
 
-  # TODO: make recruitment cycle dynamic
   def recruitment_cycle
-    "2019"
+    object.recruitment_cycle
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,31 +1,33 @@
 # == Route Map
 #
-#           Prefix Verb   URI Pattern                     Controller#Action
-# api_v1_providers GET    /api/v1/providers(.:format)     api/v1/providers#index
-#                  POST   /api/v1/providers(.:format)     api/v1/providers#create
-#  api_v1_provider GET    /api/v1/providers/:id(.:format) api/v1/providers#show
-#                  PATCH  /api/v1/providers/:id(.:format) api/v1/providers#update
-#                  PUT    /api/v1/providers/:id(.:format) api/v1/providers#update
-#                  DELETE /api/v1/providers/:id(.:format) api/v1/providers#destroy
-#  api_v1_subjects GET    /api/v1/subjects(.:format)      api/v1/subjects#index
-#                  POST   /api/v1/subjects(.:format)      api/v1/subjects#create
-#   api_v1_subject GET    /api/v1/subjects/:id(.:format)  api/v1/subjects#show
-#                  PATCH  /api/v1/subjects/:id(.:format)  api/v1/subjects#update
-#                  PUT    /api/v1/subjects/:id(.:format)  api/v1/subjects#update
-#                  DELETE /api/v1/subjects/:id(.:format)  api/v1/subjects#destroy
-#   api_v1_courses GET    /api/v1/courses(.:format)       api/v1/courses#index
-#                  POST   /api/v1/courses(.:format)       api/v1/courses#create
-#    api_v1_course GET    /api/v1/courses/:id(.:format)   api/v1/courses#show
-#                  PATCH  /api/v1/courses/:id(.:format)   api/v1/courses#update
-#                  PUT    /api/v1/courses/:id(.:format)   api/v1/courses#update
-#                  DELETE /api/v1/courses/:id(.:format)   api/v1/courses#destroy
+#           Prefix Verb   URI Pattern                                         Controller#Action
+# api_v1_providers GET    /api/v1(/:recruitment_year)/providers(.:format)     api/v1/providers#index
+#                  POST   /api/v1(/:recruitment_year)/providers(.:format)     api/v1/providers#create
+#  api_v1_provider GET    /api/v1(/:recruitment_year)/providers/:id(.:format) api/v1/providers#show
+#                  PATCH  /api/v1(/:recruitment_year)/providers/:id(.:format) api/v1/providers#update
+#                  PUT    /api/v1(/:recruitment_year)/providers/:id(.:format) api/v1/providers#update
+#                  DELETE /api/v1(/:recruitment_year)/providers/:id(.:format) api/v1/providers#destroy
+#  api_v1_subjects GET    /api/v1(/:recruitment_year)/subjects(.:format)      api/v1/subjects#index
+#                  POST   /api/v1(/:recruitment_year)/subjects(.:format)      api/v1/subjects#create
+#   api_v1_subject GET    /api/v1(/:recruitment_year)/subjects/:id(.:format)  api/v1/subjects#show
+#                  PATCH  /api/v1(/:recruitment_year)/subjects/:id(.:format)  api/v1/subjects#update
+#                  PUT    /api/v1(/:recruitment_year)/subjects/:id(.:format)  api/v1/subjects#update
+#                  DELETE /api/v1(/:recruitment_year)/subjects/:id(.:format)  api/v1/subjects#destroy
+#   api_v1_courses GET    /api/v1(/:recruitment_year)/courses(.:format)       api/v1/courses#index
+#                  POST   /api/v1(/:recruitment_year)/courses(.:format)       api/v1/courses#create
+#    api_v1_course GET    /api/v1(/:recruitment_year)/courses/:id(.:format)   api/v1/courses#show
+#                  PATCH  /api/v1(/:recruitment_year)/courses/:id(.:format)   api/v1/courses#update
+#                  PUT    /api/v1(/:recruitment_year)/courses/:id(.:format)   api/v1/courses#update
+#                  DELETE /api/v1(/:recruitment_year)/courses/:id(.:format)   api/v1/courses#destroy
 
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      resources :providers
-      resources :subjects
-      resources :courses
+      scope "/(:recruitment_year)" do
+        resources :providers
+        resources :subjects
+        resources :courses
+      end
     end
   end
 end

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -47,17 +47,17 @@ RSpec.describe "Courses API", type: :request do
     end
 
     it "returns http success" do
-      get "/api/v1/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
+      get "/api/v1/2019/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
       expect(response).to have_http_status(:success)
     end
 
     it "returns http unauthorised" do
-      get "/api/v1/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("foo") }
+      get "/api/v1/2019/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("foo") }
       expect(response).to have_http_status(:unauthorized)
     end
 
     it "JSON body response contains expected course attributes" do
-      get "/api/v1/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
+      get "/api/v1/2019/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
 
       json = JSON.parse(response.body)
       expect(json). to eq([

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -68,19 +68,19 @@ describe 'Providers API', type: :request do
               provider: provider2)
       end
       it 'returns http success' do
-        get '/api/v1/providers', headers: { 'HTTP_AUTHORIZATION' => credentials }
+        get '/api/v1/2019/providers', headers: { 'HTTP_AUTHORIZATION' => credentials }
         expect(response).to have_http_status(:success)
       end
 
       it 'returns http unauthorised' do
-        get '/api/v1/providers',
+        get '/api/v1/2019/providers',
             headers: { 'HTTP_AUTHORIZATION' => unauthorized_credentials }
         expect(response).to have_http_status(:unauthorized)
       end
 
       context 'with enrichment address data' do
         it 'JSON body response contains expected provider attributes' do
-          get '/api/v1/providers',
+          get '/api/v1/2019/providers',
               headers: { 'HTTP_AUTHORIZATION' => credentials }
 
           json = JSON.parse(response.body)

--- a/spec/requests/api/v1/subject_spec.rb
+++ b/spec/requests/api/v1/subject_spec.rb
@@ -12,17 +12,17 @@ RSpec.describe "Subjecs API", type: :request do
     end
 
     it "returns http success" do
-      get "/api/v1/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
+      get "/api/v1/2019/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
       expect(response).to have_http_status(:success)
     end
 
     it "returns http unauthorized" do
-      get "/api/v1/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("foo") }
+      get "/api/v1/2019/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("foo") }
       expect(response).to have_http_status(:unauthorized)
     end
 
     it "JSON body response contains expected provider attributes" do
-      get "/api/v1/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
+      get "/api/v1/2019/subjects", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
 
       json = JSON.parse(response.body)
       expect(json).to eq([


### PR DESCRIPTION
### Context
`recruitment_cycle`

### Changes proposed in this pull request
Add `recruitment_cycle` into route

### Guidance to review
`http://localhost:3000/api/v1/2019/courses`
`http://localhost:3000/api/v1/2019/providers`
`http://localhost:3000/api/v1/2019/subjects`