### PR TITLE
Implement changed_since-based pagination for providers

### DIFF
--- a/app/controllers/api/v1/providers_controller.rb
+++ b/app/controllers/api/v1/providers_controller.rb
@@ -1,9 +1,33 @@
 module Api
   module V1
     class ProvidersController < ApplicationController
+      # Potential edge case:
+      # It is possible for older updated_at values to written to the database after this API has been queried for changes. This would mean that these changes are missed when the client makes a subsequent request using the next-link.
+      # Possible causes of older updated_at values:
+      # - delay between c# calculating datetime.UtcNow and value being written to postgres
+      # - clock drift between servers
       def index
-        @providers = Provider.changed_since(params[:changed_since])
-        paginate json: @providers
+        page_size = params[:per_page] || 100
+        ActiveRecord::Base.transaction do
+          ActiveRecord::Base.connection.execute('LOCK provider, provider_enrichment, site IN SHARE UPDATE EXCLUSIVE MODE')
+          @providers = Provider.changed_since(params[:changed_since]).limit(page_size)
+        end
+        last_provider = @providers.last
+
+        response.headers['Link'] = if last_provider
+                                     next_link((last_provider.updated_at + 1.second).utc.iso8601, last_provider.id, page_size)
+                                   else
+                                     next_link(params[:changed_since], "", page_size)
+                                   end
+
+        render json: @providers
+      end
+
+    private
+
+      def next_link(changed_since, from_provider_id, per_page)
+        current_url = request.base_url + request.path
+        "#{current_url}?changed_since=#{changed_since}&from_provider_id=#{from_provider_id}&per_page=#{per_page}; rel=\"next\""
       end
     end
   end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -45,16 +45,18 @@ class Provider < ApplicationRecord
 
   scope :changed_since, ->(datetime) do
     if datetime.present?
-      left_joins(:sites, :enrichments).where(
-        <<~EOSQL,
-          provider.updated_at >= :since
-            OR site.updated_at >= :since
-            OR (provider_enrichment.status = :status
-                AND provider_enrichment.updated_at >= :since)
-        EOSQL
-        since: datetime,
-        status: ProviderEnrichment.statuses['published']
-      )
+      left_joins(:sites, :enrichments)
+        .where(
+          <<~EOSQL,
+            provider.updated_at >= :since
+              OR site.updated_at >= :since
+              OR (provider_enrichment.status = :status
+                  AND provider_enrichment.updated_at >= :since)
+          EOSQL
+          since: datetime,
+          status: ProviderEnrichment.statuses['published']
+        )
+        .order(:updated_at, :id)
     end
   end
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,6 +24,8 @@ since the last request. This is intended to reduce the data transfer volumes
 and processing needed to synchronise the UCAS apply system with DfE's course
 data on a schedule.
 
+You can control page size using the `?per_page=100` query parameter.
+
 :rocket: _This feature is a work in progress and the API may not yet provide the stated
 capabilities and interface_ - [trello
 card](https://trello.com/c/HMAlga4l/852-implement-incremental-fetch-for-providers)

--- a/spec/controllers/api/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/v1/providers_controller_spec.rb
@@ -13,5 +13,12 @@ RSpec.describe Api::V1::ProvidersController, type: :controller do
         'code' => 503, 'status' => 'Service Unavailable'
       )
     end
+
+    it "calls limit on the model with default value of 100" do
+      allow(controller).to receive(:authenticate)
+      expect(Provider).to receive_message_chain(:changed_since, :limit).with(100).and_return([])
+
+      get :index
+    end
   end
 end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -37,11 +37,12 @@ FactoryBot.define do
     region_code { ProviderEnrichment.region_codes['London'] }
 
     transient do
-      age          { nil }
-      site_count   { 1 }
-      sites        { build_list :site, site_count, provider: nil, age: age }
-      course_count { 2 }
-      enrichments  { [build(:provider_enrichment, age: age)] }
+      age                  { nil }
+      skip_associated_data { false }
+      site_count           { 1 }
+      sites                { build_list :site, site_count, provider: nil, age: age }
+      course_count         { 2 }
+      enrichments          { [build(:provider_enrichment, age: age)] }
     end
 
     after(:build) do |provider, evaluator|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,6 +53,9 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin


### PR DESCRIPTION
This brings the API in line with our documentation, by querying the database with the necessary ordering, limiting, and then adding a custom response header with the correctly formed URL.

Also enables focusing by using `fit`, `fdescribe`, `fcontext` in rspec; see the first commit.

Paired with @timabell.