### PR TITLE
Simplify provider changed_since

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -45,18 +45,7 @@ class Provider < ApplicationRecord
 
   scope :changed_since, ->(datetime) do
     if datetime.present?
-      left_joins(:sites, :enrichments)
-        .where(
-          <<~EOSQL,
-            provider.updated_at >= :since
-              OR site.updated_at >= :since
-              OR (provider_enrichment.status = :status
-                  AND provider_enrichment.updated_at >= :since)
-          EOSQL
-          since: datetime,
-          status: ProviderEnrichment.statuses['published']
-        )
-        .order(:updated_at, :id)
+      where("updated_at >= ?", datetime).order(:updated_at, :id)
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -220,52 +220,5 @@ RSpec.describe Provider, type: :model do
         it { should include provider }
       end
     end
-
-    context 'with a provider enrichment that has published changes' do
-      before do
-        provider.enrichments.first.update(
-          status: :published,
-          updated_at: DateTime.now
-        )
-      end
-
-      subject { Provider.changed_since(10.minutes.ago) }
-
-      it { should_not include old_provider }
-      it { should     include provider }
-
-      describe 'when the checked timestamp matches the enrichment updated_at' do
-        subject { Provider.changed_since(provider.enrichments.first.updated_at) }
-
-        it { should include provider }
-      end
-    end
-
-    context 'with an old provider that has a new draft enrichment' do
-      before do
-        provider.enrichments.first.update(
-          status: :draft,
-          updated_at: DateTime.now
-        )
-      end
-
-      subject { Provider.changed_since(10.minutes.ago) }
-
-      it { should_not include provider }
-    end
-
-    context 'with a provider whose site has been updated' do
-      before  { provider.sites.first.touch }
-      subject { Provider.changed_since(10.minutes.ago) }
-
-      it { should_not include old_provider }
-      it { should     include provider }
-
-      describe "when the checked timestamp matches the site updated_at" do
-        subject { Provider.changed_since(provider.sites.first.updated_at) }
-
-        it { should include provider }
-      end
-    end
   end
 end

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -226,12 +226,6 @@ describe 'Providers API', type: :request do
 
           updated_provider = create(:provider, provider_code: "SINCE2", age: 5.minutes.ago)
 
-          provider_with_updated_enrichment = create(:provider, provider_code: "SINCE3", age: 1.hour.ago)
-          provider_with_updated_enrichment.enrichments.first.published!
-
-          provider_with_updated_site = create(:provider, provider_code: "SINCE4", age: 1.hour.ago)
-          provider_with_updated_site.sites.first.touch
-
           get '/api/v1/providers',
               headers: { 'HTTP_AUTHORIZATION' => credentials },
               params: { changed_since: 10.minutes.ago.utc.iso8601 }
@@ -240,8 +234,6 @@ describe 'Providers API', type: :request do
 
           expect(returned_provider_codes).not_to include old_provider.provider_code
           expect(returned_provider_codes).to include updated_provider.provider_code
-          expect(returned_provider_codes).to include provider_with_updated_enrichment.provider_code
-          expect(returned_provider_codes).to include provider_with_updated_site.provider_code
         end
       end
 


### PR DESCRIPTION
### Context
Provider `changed_since`

### Changes proposed in this pull request
The c# api is going to deal with this i.e. update the Provider `updated_at` column everytime a site is updated or an enrichment is created.

### Guidance to review
Example - `http://localhost:3000/api/v1/2019/providers?changed_since=20190206`