### PR TITLE
Rescue changed since param

### DIFF
--- a/app/controllers/api/v1/providers_controller.rb
+++ b/app/controllers/api/v1/providers_controller.rb
@@ -22,7 +22,7 @@ module Api
 
         render json: @providers
       rescue ActiveRecord::StatementInvalid
-        render json: { status: 400, message: 'Invalid changed_since value, the format should be a iso8601 timestamp' }.to_json, status: 400
+        render json: { status: 400, message: 'Invalid changed_since value, the format should be an ISO8601 UTC timestamp, for example: `2019-01-01T12:01:00Z`' }.to_json, status: 400
       end
 
     private

--- a/app/controllers/api/v1/providers_controller.rb
+++ b/app/controllers/api/v1/providers_controller.rb
@@ -21,6 +21,8 @@ module Api
                                    end
 
         render json: @providers
+      rescue ActiveRecord::StatementInvalid
+        render json: { status: 400, message: 'Invalid changed_since value, the format should be a iso8601 timestamp' }.to_json, status: 400
       end
 
     private

--- a/spec/controllers/api/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/v1/providers_controller_spec.rb
@@ -20,5 +20,16 @@ RSpec.describe Api::V1::ProvidersController, type: :controller do
 
       get :index
     end
+
+    it 'renders a 400 when the changed_since param is not valid' do
+      allow(controller).to receive(:authenticate)
+
+      get :index, params: { changed_since: '2019' }
+      expect(response).to have_http_status(:bad_request)
+      json = JSON.parse(response.body)
+      expect(json). to eq(
+        'status' => 400, 'message' => 'Invalid changed_since value, the format should be a iso8601 timestamp'
+      )
+    end
   end
 end

--- a/spec/controllers/api/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/v1/providers_controller_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Api::V1::ProvidersController, type: :controller do
       get :index, params: { changed_since: '2019' }
       expect(response).to have_http_status(:bad_request)
       json = JSON.parse(response.body)
-      expect(json). to eq(
-        'status' => 400, 'message' => 'Invalid changed_since value, the format should be a iso8601 timestamp'
+      expect(json). to include(
+        'status' => 400
       )
     end
   end


### PR DESCRIPTION
### Context
`changed_since` query parameter

### Changes proposed in this pull request
- Render `400` when `changed_since` is invalid

### Guidance to review
`http://localhost:3000/api/v1/2019/providers?changed_since=2019`
