### PR TITLE
[850] Implement incremental fetching on CourseController index

### DIFF
--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -20,6 +20,8 @@ module Api
         next_link_header("from_course_id", @courses.last, next_course, changed_since, per_page)
 
         render json: @courses
+      rescue ActiveRecord::StatementInvalid
+        render json: { status: 400, message: 'Invalid changed_since value, the format should be an ISO8601 UTC timestamp, for example: `2019-01-01T12:01:00Z`' }.to_json, status: 400
       end
     end
   end

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -1,9 +1,25 @@
 module Api
   module V1
     class CoursesController < ApplicationController
+      include NextLinkHeader
+      include FirstItemFromNextPage
+
       def index
-        @courses = Course.includes(:sites, :provider, :site_statuses, :subjects)
-        paginate json: @courses
+        per_page = (params[:per_page] || 100).to_i
+        changed_since = params[:changed_since]
+        from_course_id = params[:from_course_id].to_i
+
+        @courses = Course
+          .includes(:sites, :provider, :site_statuses, :subjects)
+          .changed_since(changed_since, from_course_id)
+
+        next_course = first_item_from_next_page(@courses, per_page)
+
+        @courses = @courses.limit(per_page)
+
+        next_link_header("from_course_id", @courses.last, next_course, changed_since, per_page)
+
+        render json: @courses
       end
     end
   end

--- a/app/controllers/api/v1/providers_controller.rb
+++ b/app/controllers/api/v1/providers_controller.rb
@@ -1,23 +1,28 @@
 module Api
   module V1
     class ProvidersController < ApplicationController
+      include NextLinkHeader
+
       # Potential edge case:
       # It is possible for older updated_at values to written to the database after this API has been queried for changes. This would mean that these changes are missed when the client makes a subsequent request using the next-link.
       # Possible causes of older updated_at values:
       # - delay between c# calculating datetime.UtcNow and value being written to postgres
       # - clock drift between servers
       def index
-        page_size = params[:per_page] || 100
+        per_page = params[:per_page] || 100
+        changed_since = params[:changed_since]
+
         ActiveRecord::Base.transaction do
           ActiveRecord::Base.connection.execute('LOCK provider, provider_enrichment, site IN SHARE UPDATE EXCLUSIVE MODE')
-          @providers = Provider.changed_since(params[:changed_since]).limit(page_size)
+          @providers = Provider.changed_since(changed_since).limit(per_page)
         end
+
         last_provider = @providers.last
 
         response.headers['Link'] = if last_provider
-                                     next_link((last_provider.last_published_at + 1.second).utc.iso8601, last_provider.id, page_size)
+                                     next_link((last_provider.last_published_at + 1.second).utc.iso8601, last_provider.id, per_page)
                                    else
-                                     next_link(params[:changed_since], "", page_size)
+                                     next_link(params[:changed_since], "", per_page)
                                    end
 
         render json: @providers

--- a/app/controllers/concerns/first_item_from_next_page.rb
+++ b/app/controllers/concerns/first_item_from_next_page.rb
@@ -1,0 +1,12 @@
+module FirstItemFromNextPage
+  extend ActiveSupport::Concern
+
+private
+
+  def first_item_from_next_page(collection, per_page)
+    has_next_page_available = collection.size > per_page
+    if has_next_page_available
+      collection[per_page]
+    end
+  end
+end

--- a/app/controllers/concerns/next_link_header.rb
+++ b/app/controllers/concerns/next_link_header.rb
@@ -1,0 +1,19 @@
+module NextLinkHeader
+  extend ActiveSupport::Concern
+
+private
+
+  def next_link_header(from_key_string, last_object, next_object, changed_since, per_page)
+    response.headers['Link'] = if last_object
+                                 next_object_timestamp = (next_object ? next_object.updated_at : last_object.updated_at + 1.second).utc.iso8601
+                                 header_content(from_key_string, next_object_timestamp, last_object.id, per_page)
+                               else
+                                 header_content(from_key_string, changed_since, "", per_page)
+                               end
+  end
+
+  def header_content(from_key_string, changed_since, from_object_id, per_page)
+    current_url = request.base_url + request.path
+    "#{current_url}?changed_since=#{changed_since}&#{from_key_string}=#{from_object_id}&per_page=#{per_page}; rel=\"next\""
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -17,6 +17,8 @@
 #  english                 :integer
 #  maths                   :integer
 #  science                 :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #
 
 class Course < ApplicationRecord

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -58,9 +58,9 @@ class Course < ApplicationRecord
   has_many :site_statuses
   has_many :sites, through: :site_statuses
 
-  scope :changed_since, ->(datetime) do
+  scope :changed_since, ->(datetime, from_course_id = 0) do
     if datetime.present?
-      where("course.updated_at >= ?", datetime)
+      where("course.updated_at >= ? AND course.id > ?", datetime, from_course_id).order(:updated_at, :id)
     end
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -58,6 +58,12 @@ class Course < ApplicationRecord
   has_many :site_statuses
   has_many :sites, through: :site_statuses
 
+  scope :changed_since, ->(datetime) do
+    if datetime.present?
+      where("course.updated_at >= ?", datetime)
+    end
+  end
+
   def recruitment_cycle
     "2019"
   end

--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -6,8 +6,8 @@
 #  provider_code      :text             not null, primary key
 #  json_data          :jsonb
 #  updated_by_user_id :integer
-#  created_at         :datetime         default(Mon, 01 Jan 0001 00:00:00 UTC +00:00), not null
-#  updated_at         :datetime         default(Mon, 01 Jan 0001 00:00:00 UTC +00:00), not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #  created_by_user_id :integer
 #  last_published_at  :datetime
 #  status             :integer          default("draft"), not null

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -17,6 +17,8 @@
 #  english                 :integer
 #  maths                   :integer
 #  science                 :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #
 
 class CourseSerializer < ActiveModel::Serializer

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,20 +49,22 @@ ActiveRecord::Schema.define(version: 0) do
     t.integer "english"
     t.integer "maths"
     t.integer "science"
+    t.datetime "created_at", default: -> { "timezone('utc'::text, now())" }, null: false
+    t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.index ["accrediting_provider_id"], name: "IX_course_accrediting_provider_id"
     t.index ["provider_id", "course_code"], name: "IX_course_provider_id_course_code", unique: true
   end
 
   create_table "course_enrichment", id: :serial, force: :cascade do |t|
     t.integer "created_by_user_id"
-    t.datetime "created_timestamp_utc", null: false
+    t.datetime "created_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.text "provider_code", null: false
     t.jsonb "json_data"
     t.datetime "last_published_timestamp_utc"
     t.integer "status", null: false
     t.text "ucas_course_code", null: false
     t.integer "updated_by_user_id"
-    t.datetime "updated_timestamp_utc", null: false
+    t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.index ["created_by_user_id"], name: "IX_course_enrichment_created_by_user_id"
     t.index ["updated_by_user_id"], name: "IX_course_enrichment_updated_by_user_id"
   end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -17,6 +17,8 @@
 #  english                 :integer
 #  maths                   :integer
 #  science                 :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #
 
 FactoryBot.define do

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -27,5 +27,17 @@ FactoryBot.define do
     name { Faker::ProgrammingLanguage.name }
     qualification { 1 }
     association(:provider)
+
+
+    transient do
+      age { nil }
+    end
+
+    after(:build) do |course, evaluator|
+      if evaluator.age.present?
+        course.created_at = evaluator.age
+        course.updated_at = evaluator.age
+      end
+    end
   end
 end

--- a/spec/factories/provider_enrichments.rb
+++ b/spec/factories/provider_enrichments.rb
@@ -6,8 +6,8 @@
 #  provider_code      :text             not null, primary key
 #  json_data          :jsonb
 #  updated_by_user_id :integer
-#  created_at         :datetime         default(Mon, 01 Jan 0001 00:00:00 UTC +00:00), not null
-#  updated_at         :datetime         default(Mon, 01 Jan 0001 00:00:00 UTC +00:00), not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #  created_by_user_id :integer
 #  last_published_at  :datetime
 #  status             :integer          default("draft"), not null

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -31,4 +31,30 @@ RSpec.describe Course, type: :model do
     it { should belong_to(:accrediting_provider) }
     it { should have_and_belong_to_many(:subjects) }
   end
+
+  describe '#changed_since' do
+    let!(:old_course) { create(:course, age: 1.hour.ago) }
+    let!(:course) { create(:course, age: 1.hour.ago) }
+
+    context 'with no parameters' do
+      subject { Course.changed_since(nil) }
+      it { should include course }
+      it { should include old_course }
+    end
+
+    context 'with a course that was just updated' do
+      before { course.touch }
+
+      subject { Course.changed_since(10.minutes.ago) }
+
+      it { should include course }
+      it { should_not include old_course }
+    end
+
+    context 'when the checked timestamp matches the course updated_at' do
+      subject { Course.changed_since(course.updated_at) }
+
+      it { should include course }
+    end
+  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -17,6 +17,8 @@
 #  english                 :integer
 #  maths                   :integer
 #  science                 :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #
 
 require 'rails_helper'

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -1,5 +1,10 @@
 require "rails_helper"
 
+def get_course_codes_from_body(body)
+  json = JSON.parse(body)
+  json.map { |course| course["course_code"] }
+end
+
 RSpec.describe "Courses API", type: :request do
   describe 'GET index' do
     let(:credentials) do
@@ -11,16 +16,18 @@ RSpec.describe "Courses API", type: :request do
         .encode_credentials('foo')
     end
 
-    before do
-      provider = FactoryBot.create(:provider,
-                                   provider_name: "ACME SCITT",
-                                   provider_code: "2LD",
-                                   provider_type: "SCITT",
-                                   site_count: 0,
-                                   course_count: 0,
-                                   scheme_member: 'Y',
-                                   enrichments: [])
+    let(:provider) do
+      FactoryBot.create(:provider,
+        provider_name: "ACME SCITT",
+        provider_code: "2LD",
+        provider_type: "SCITT",
+        site_count: 0,
+        course_count: 0,
+        scheme_member: 'Y',
+        enrichments: [])
+    end
 
+    before do
       site = FactoryBot.create(:site, code: "-", location_name: "Main Site", provider: provider)
       subject1 = FactoryBot.create(:subject, subject_code: "1", subject_name: "Secondary")
       subject2 = FactoryBot.create(:subject, subject_code: "2", subject_name: "Mathematics")
@@ -39,7 +46,8 @@ RSpec.describe "Courses API", type: :request do
         profpost_flag: "Postgraduate",
         program_type: "School Direct training programme",
         modular: "",
-        provider: provider)
+        provider: provider,
+        age: 2.hours.ago)
 
       course.site_statuses.first.update(
         vac_status: 'Full time vacancies',
@@ -112,6 +120,114 @@ RSpec.describe "Courses API", type: :request do
             "accrediting_provider" => nil
           }
         ])
+      end
+    end
+
+    context "with changed_since parameter" do
+      describe "JSON body response" do
+        it 'contains expected courses' do
+          old_course = create(:course, course_code: "SINCE1", age: 1.hour.ago)
+          updated_course = create(:course, course_code: "SINCE2", age: 5.minutes.ago)
+
+          get '/api/v1/courses',
+              headers: { 'HTTP_AUTHORIZATION' => credentials },
+              params: { changed_since: 10.minutes.ago.utc.iso8601 }
+
+          returned_course_codes = get_course_codes_from_body(response.body)
+
+          expect(returned_course_codes).not_to include old_course.course_code
+          expect(returned_course_codes).to include updated_course.course_code
+        end
+      end
+
+      it 'includes correct next link in response headers' do
+        create(:course, course_code: "LAST1", age: 10.minutes.ago, provider: provider)
+
+        timestamp_of_last_course = 2.minutes.ago
+        last_course_in_results = create(:course, course_code: "LAST2", age: timestamp_of_last_course, provider: provider)
+
+        get '/api/v1/courses',
+          headers: { 'HTTP_AUTHORIZATION' => credentials },
+          params: { changed_since: 30.minutes.ago.utc.iso8601 }
+
+        expect(response.headers).to have_key "Link"
+        expected = /#{request.base_url + request.path}\?changed_since=#{(timestamp_of_last_course + 1.second).utc.iso8601}&from_course_id=#{last_course_in_results.id}&per_page=100; rel="next"$/
+        expect(response.headers["Link"]).to match expected
+      end
+
+      it 'includes correct next link when there is an empty set' do
+        provided_timestamp = 5.seconds.ago.utc.iso8601
+
+        get '/api/v1/courses',
+          headers: { 'HTTP_AUTHORIZATION' => credentials },
+          params: { changed_since: provided_timestamp }
+
+        expected = /#{request.base_url + request.path}\?changed_since=#{provided_timestamp}&from_course_id=&per_page=100; rel="next"$/
+        expect(response.headers["Link"]).to match expected
+      end
+
+      context "with many courses" do
+        before do
+          11.times do |i|
+            create(:course, course_code: "CRSE#{i + 1}", age: (20 - i).minutes.ago, provider: provider)
+          end
+        end
+
+        it 'pages properly' do
+          get '/api/v1/courses',
+            headers: { 'HTTP_AUTHORIZATION' => credentials },
+            params: { changed_since: 21.minutes.ago.utc.iso8601, per_page: 10 }
+
+          returned_course_codes = get_course_codes_from_body(response.body)
+
+          expected_course_codes = (1..10).map { |n| "CRSE#{n}" }
+          expect(returned_course_codes).to match_array expected_course_codes
+
+          next_url = response.headers["Link"]
+
+          get next_url,
+            headers: { 'HTTP_AUTHORIZATION' => credentials }
+
+          returned_course_codes = get_course_codes_from_body(response.body)
+
+          expect(returned_course_codes.size).to eq 1
+          expect(returned_course_codes).to include "CRSE11"
+
+          next_url = response.headers["Link"]
+
+          get next_url,
+            headers: { 'HTTP_AUTHORIZATION' => credentials }
+
+          returned_course_codes = get_course_codes_from_body(response.body)
+
+          expect(returned_course_codes.size).to eq 0
+        end
+      end
+
+      context "with courses with the same timestamp" do
+        before do
+          3.times do |i|
+            create(:course, course_code: "CRSE#{i + 1}", age: 2.minutes.ago, provider: provider)
+          end
+        end
+
+        it 'pages properly' do
+          get '/api/v1/courses',
+            headers: { 'HTTP_AUTHORIZATION' => credentials },
+            params: { changed_since: 3.minutes.ago.utc.iso8601, per_page: 1 }
+
+          returned_course_codes = get_course_codes_from_body(response.body)
+
+          3.times do |i|
+            expect(returned_course_codes).to include "CRSE#{i + 1}"
+
+            get response.headers["Link"], headers: { 'HTTP_AUTHORIZATION' => credentials }
+
+            returned_course_codes = get_course_codes_from_body(response.body)
+          end
+
+          expect(returned_course_codes.size).to eq 0
+        end
       end
     end
   end

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -2,6 +2,15 @@ require "rails_helper"
 
 RSpec.describe "Courses API", type: :request do
   describe 'GET index' do
+    let(:credentials) do
+      ActionController::HttpAuthentication::Token
+        .encode_credentials('bats')
+    end
+    let(:unauthorized_credentials) do
+      ActionController::HttpAuthentication::Token
+        .encode_credentials('foo')
+    end
+
     before do
       provider = FactoryBot.create(:provider,
                                    provider_name: "ACME SCITT",
@@ -40,68 +49,70 @@ RSpec.describe "Courses API", type: :request do
       )
     end
 
-    it "returns http success" do
-      get "/api/v1/2019/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
-      expect(response).to have_http_status(:success)
-    end
+    context "without changed_since parameter" do
+      it "returns http success" do
+        get "/api/v1/2019/courses", headers: { 'HTTP_AUTHORIZATION' => credentials }
+        expect(response).to have_http_status(:success)
+      end
 
-    it "returns http unauthorised" do
-      get "/api/v1/2019/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("foo") }
-      expect(response).to have_http_status(:unauthorized)
-    end
+      it "returns http unauthorised" do
+        get "/api/v1/2019/courses", headers: { 'HTTP_AUTHORIZATION' => unauthorized_credentials }
+        expect(response).to have_http_status(:unauthorized)
+      end
 
-    it "JSON body response contains expected course attributes" do
-      get "/api/v1/2019/courses", headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
+      it "JSON body response contains expected course attributes" do
+        get "/api/v1/2019/courses", headers: { 'HTTP_AUTHORIZATION' => credentials }
 
-      json = JSON.parse(response.body)
-      expect(json). to eq([
-        {
-          "course_code" => "2HPF",
-          "start_month" => "2019-09-01T00:00:00Z",
-          "start_month_string" => "September",
-          "name" => "Religious Education",
-          "study_mode" => "F",
-          "copy_form_required" => "Y",
-          "profpost_flag" => "PG",
-          "program_type" => "SD",
-          "age_range" => "P",
-          "modular" => "",
-          "english" => 3,
-          "maths" => 9,
-          "science" => nil,
-          "qualification" => 1,
-          "recruitment_cycle" => "2019",
-          "campus_statuses" => [
-            {
-              "campus_code" => "-",
-              "name" => "Main Site",
-              "vac_status" => "F",
-              "publish" => "Y",
-              "status" => "R",
-              "course_open_date" => "2018-10-09",
-              "recruitment_cycle" => "2019"
-            }
-          ],
-          "subjects" => [
-            {
-              "subject_code" => "1",
-              "subject_name" => "Secondary"
+        json = JSON.parse(response.body)
+        expect(json). to eq([
+          {
+            "course_code" => "2HPF",
+            "start_month" => "2019-09-01T00:00:00Z",
+            "start_month_string" => "September",
+            "name" => "Religious Education",
+            "study_mode" => "F",
+            "copy_form_required" => "Y",
+            "profpost_flag" => "PG",
+            "program_type" => "SD",
+            "age_range" => "P",
+            "modular" => "",
+            "english" => 3,
+            "maths" => 9,
+            "science" => nil,
+            "qualification" => 1,
+            "recruitment_cycle" => "2019",
+            "campus_statuses" => [
+              {
+                "campus_code" => "-",
+                "name" => "Main Site",
+                "vac_status" => "F",
+                "publish" => "Y",
+                "status" => "R",
+                "course_open_date" => "2018-10-09",
+                "recruitment_cycle" => "2019"
+              }
+            ],
+            "subjects" => [
+              {
+                "subject_code" => "1",
+                "subject_name" => "Secondary"
+              },
+              {
+                "subject_code" => "2",
+                "subject_name" => "Mathematics"
+              }
+            ],
+            "provider" => {
+              "institution_code" => "2LD",
+              "institution_name" => "ACME SCITT",
+              "institution_type" => "B",
+              "accrediting_provider" => 'N',
+              "scheme_member" => "Y"
             },
-            {
-              "subject_code" => "2",
-              "subject_name" => "Mathematics"
-            }
-          ],
-          "provider" => {
-            "institution_code" => "2LD",
-            "institution_name" => "ACME SCITT",
-            "institution_type" => "B",
-            "accrediting_provider" => 'N',
-            "scheme_member" => "Y"
-          },
-          "accrediting_provider" => nil
-        }
-      ])
+            "accrediting_provider" => nil
+          }
+        ])
+      end
     end
   end
 end

--- a/spec/serializers/course_serializer_spec.rb
+++ b/spec/serializers/course_serializer_spec.rb
@@ -17,6 +17,8 @@
 #  english                 :integer
 #  maths                   :integer
 #  science                 :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #
 
 require "rails_helper"


### PR DESCRIPTION
### Context

This allows users to only fetch a specific set of courses from a passed in changed_since time.

### Changes proposed in this pull request

- Pull in database changes based on the C# API changes
- Implement changed_since scope on the course model
- Implement changed_since param and Link header on course controller similarly to the one in the provider controller; Link header logic is abstracted into a concern

### Guidance to review

The tests are almost a complete carbon copy of the tests from the provider controller. This isn't DRY, but can be made if so requested, it just feels like the correct abstraction for this didn't naturally appear while writing them. Suggestions welcome.

The `rescue` call in the controller is ported from a previous PR by Dan, and is also not DRY. Suggestions welcome once more.

No docs changes were needed for this.

This entire PR will be rebased and squashed / reorganised after the PR stage. The commits should be considered WIP.

This was paired on with @timabell and @davidgisbey.