### PR TITLE
953 change changed_since scope to use last_published_at

### DIFF
--- a/app/controllers/api/v1/providers_controller.rb
+++ b/app/controllers/api/v1/providers_controller.rb
@@ -15,7 +15,7 @@ module Api
         last_provider = @providers.last
 
         response.headers['Link'] = if last_provider
-                                     next_link((last_provider.updated_at + 1.second).utc.iso8601, last_provider.id, page_size)
+                                     next_link((last_provider.last_published_at + 1.second).utc.iso8601, last_provider.id, page_size)
                                    else
                                      next_link(params[:changed_since], "", page_size)
                                    end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -45,8 +45,10 @@ class Provider < ApplicationRecord
 
   scope :changed_since, ->(datetime) do
     if datetime.present?
-      where("updated_at >= ?", datetime).order(:updated_at, :id)
-    end
+      where("last_published_at >= ?", datetime)
+    else
+      where("last_published_at is not null")
+    end.order(:last_published_at, :id)
   end
 
   # TODO: filter to published enrichments, maybe rename to published_address_info

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -136,8 +136,10 @@ ActiveRecord::Schema.define(version: 0) do
     t.integer "region_code"
     t.datetime "created_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
+    t.datetime "last_published_at"
     t.text "accrediting_provider"
     t.index ["provider_code"], name: "IX_provider_provider_code", unique: true
+    t.index ["last_published_at"], name: "IX_provider_last_published_at"
   end
 
   create_table "provider_enrichment", id: :integer, force: :cascade do |t|

--- a/spec/controllers/api/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/v1/providers_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Api::V1::ProvidersController, type: :controller do
     end
 
     describe 'generated next link' do
-      let!(:oldy_provider) { create(:provider, last_published_at: 5.minute.ago.utc) }
+      let!(:old_provider) { create(:provider, last_published_at: 5.minute.ago.utc) }
       let!(:last_provider) { create(:provider, last_published_at: 1.minute.ago.utc) }
       let(:last_provider_id) { last_provider.id }
 

--- a/spec/controllers/api/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/v1/providers_controller_spec.rb
@@ -31,5 +31,22 @@ RSpec.describe Api::V1::ProvidersController, type: :controller do
         'status' => 400
       )
     end
+
+    describe 'generated next link' do
+      let!(:oldy_provider) { create(:provider, last_published_at: 5.minute.ago.utc) }
+      let!(:last_provider) { create(:provider, last_published_at: 1.minute.ago.utc) }
+      let(:last_provider_id) { last_provider.id }
+
+      before do
+        allow(controller).to receive(:authenticate)
+
+        get :index, params: { changed_since: 10.minutes.ago.utc }
+      end
+
+      subject { response.headers['Link'] }
+
+      it { is_expected.to match %r{changed_since=#{(last_provider.last_published_at + 1.second).iso8601}} }
+      it { is_expected.to match %r{from_provider_id=#{last_provider_id}} }
+    end
   end
 end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -37,19 +37,11 @@ FactoryBot.define do
     region_code { ProviderEnrichment.region_codes['London'] }
 
     transient do
-      age                  { nil }
       skip_associated_data { false }
       site_count           { 1 }
-      sites                { build_list :site, site_count, provider: nil, age: age }
+      sites                { build_list :site, site_count, provider: nil }
       course_count         { 2 }
-      enrichments          { [build(:provider_enrichment, age: age)] }
-    end
-
-    after(:build) do |provider, evaluator|
-      if evaluator.age.present?
-        provider.created_at = evaluator.age
-        provider.updated_at = evaluator.age
-      end
+      enrichments          { [build(:provider_enrichment)] }
     end
 
     after(:create) do |provider, evaluator|

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -34,6 +34,7 @@ describe 'Providers API', type: :request do
               region_code: 'London',
               accrediting_provider: 'Y',
               scheme_member: 'Y',
+              last_published_at: DateTime.now.utc,
               enrichments: [enrichment])
       end
       let!(:site) do
@@ -68,6 +69,7 @@ describe 'Providers API', type: :request do
               region_code: 'South West',
               accrediting_provider: 'N',
               scheme_member: 'N',
+              last_published_at: DateTime.now.utc,
               enrichments: [],
               site_count: 0)
       end
@@ -222,9 +224,13 @@ describe 'Providers API', type: :request do
     context "with changed_since parameter" do
       describe "JSON body response" do
         it 'contains expected providers' do
-          old_provider = create(:provider, provider_code: "SINCE1", age: 1.hour.ago)
+          old_provider = create(:provider,
+                                provider_code: "SINCE1",
+                                last_published_at: 1.hour.ago)
 
-          updated_provider = create(:provider, provider_code: "SINCE2", age: 5.minutes.ago)
+          updated_provider = create(:provider,
+                                    provider_code: "SINCE2",
+                                    last_published_at: 5.minutes.ago)
 
           get '/api/v1/providers',
               headers: { 'HTTP_AUTHORIZATION' => credentials },
@@ -238,10 +244,12 @@ describe 'Providers API', type: :request do
       end
 
       it 'includes correct next link in response headers' do
-        create(:provider, provider_code: "LAST1", age: 10.minutes.ago)
+        create(:provider, provider_code: "LAST1", last_published_at: 10.minutes.ago)
 
         timestamp_of_last_provider = 2.minutes.ago
-        last_provider_in_results = create(:provider, provider_code: "LAST2", age: timestamp_of_last_provider)
+        last_provider_in_results = create(:provider,
+                                          provider_code: "LAST2",
+                                          last_published_at: timestamp_of_last_provider)
 
         get '/api/v1/providers',
           headers: { 'HTTP_AUTHORIZATION' => credentials },
@@ -266,7 +274,10 @@ describe 'Providers API', type: :request do
       context "with many providers" do
         before do
           11.times do |i|
-            create(:provider, provider_code: "PROV#{i + 1}", age: (20 - i).minutes.ago, sites: [], enrichments: [])
+            create(:provider, provider_code: "PROV#{i + 1}",
+                   last_published_at: (20 - i).minutes.ago,
+                   sites: [],
+                   enrichments: [])
           end
         end
 


### PR DESCRIPTION
### Context

#### Why are we doing this?

To ensure providers are exported whenever they, or any entities that indicate the the provider info has changed.

#### Background

To support the incremental results in the API providers endpoint we want to update the last_published_at column on the provider when a related entity, site or provider enrichments for example. This will be needed in the future once the Rails backend takes on the work of updating the providers and their related entities.

The C# has already been updated to populate this data. https://github.com/DFE-Digital/manage-courses-api/pull/267

### Changes proposed in this pull request

* Switch to `provider.last_published_at` instead of `updated_at`
* Schema has been manually modified to match changes from .NET app.

# ~~do not merge~~

~~Until the c# schema change has shipped to prod https://github.com/DFE-Digital/manage-courses-api/pull/267~~