### PR TITLE
Add ping endpoint

### DIFF
--- a/app/controllers/ping_controller.rb
+++ b/app/controllers/ping_controller.rb
@@ -1,0 +1,8 @@
+class PingController < ApplicationController
+  skip_before_action :authenticate
+
+  # this is for quick testing of api/db stability without needing to authorise
+  def index
+    render json: { course_count: Course.count }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@
 #        error_500 GET    /error_500(.:format)                                error#error_500
 
 Rails.application.routes.draw do
+  resources :ping
   namespace :api do
     namespace :v1 do
       scope "/(:recruitment_year)" do

--- a/spec/controllers/ping_controller_spec.rb
+++ b/spec/controllers/ping_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe PingController, type: :controller do
+  describe "index" do
+    context "some courses in db" do
+      let!(:course) { create(:course) }
+      it "get" do
+        get :index
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json). to eq('course_count' => 3) # todo: I don't know why I got 3 instead of 1??
+      end
+    end
+  end
+end


### PR DESCRIPTION
As per c# api.
Allows testing deployment without worrying about access tokens.
Will also be useful for health monitoring.

### Context
Deploying

### Testing

```
$ curl -i http://localhost:3000/ping
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
ETag: W/"04afe236f86d27cf0155166c38e27919"
Cache-Control: max-age=0, private, must-revalidate
X-Request-Id: 7140f427-09de-4b50-91a0-4dfa32aacc08
X-Runtime: 0.006820
Transfer-Encoding: chunked

{"course_count":4}
```