### PR TITLE
capitalise Api module to API

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -1,4 +1,4 @@
-module Api
+module API
   module V1
     class ApplicationController < ::ApplicationController
       def authenticate

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -1,4 +1,4 @@
-module Api
+module API
   module V1
     class CoursesController < ApplicationController
       include NextLinkHeader

--- a/app/controllers/api/v1/providers_controller.rb
+++ b/app/controllers/api/v1/providers_controller.rb
@@ -1,4 +1,4 @@
-module Api
+module API
   module V1
     class ProvidersController < ApplicationController
       include NextLinkHeader

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -1,4 +1,4 @@
-module Api
+module API
   module V1
     class SubjectsController < ApplicationController
       def index

--- a/app/controllers/api/v2/application_controller.rb
+++ b/app/controllers/api/v2/application_controller.rb
@@ -1,4 +1,4 @@
-module Api
+module API
   module V2
     class ApplicationController < ::ApplicationController
       def authenticate

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,7 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.acronym 'API'
+end

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Api::V1::CoursesController, type: :controller do
+RSpec.describe API::V1::CoursesController, type: :controller do
   describe "index" do
     it "render service unavailable" do
       allow(controller).to receive(:index).and_raise(PG::ConnectionBad)

--- a/spec/controllers/api/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/v1/providers_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Api::V1::ProvidersController, type: :controller do
+RSpec.describe API::V1::ProvidersController, type: :controller do
   describe "index" do
     it "render service unavailable" do
       allow(controller).to receive(:index).and_raise(PG::ConnectionBad)

--- a/spec/controllers/api/v1/subjects_controller_spec.rb
+++ b/spec/controllers/api/v1/subjects_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Api::V1::SubjectsController, type: :controller do
+RSpec.describe API::V1::SubjectsController, type: :controller do
   describe "index" do
     it "render service unavailable" do
       allow(controller).to receive(:index).and_raise(PG::ConnectionBad)

--- a/spec/controllers/api/v2/application_controller_spec.rb
+++ b/spec/controllers/api/v2/application_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Api::V2::ApplicationController, type: :controller do
+describe API::V2::ApplicationController, type: :controller do
   describe '#authenticate' do
     let(:user) { create(:user) }
     let(:payload) { { email: user.email } }


### PR DESCRIPTION
Purely for esthetics.

### Context

`Api` just looks weird.

### Changes proposed in this pull request

Rename `Api` to `API`. Requires an addition to the inflector.

### Guidance to review
