### PR TITLE
953 add provider changed at & configure docker to run migrations in prod etc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN apk add --update --no-cache --virtual build-dependances \
 
 ADD . $APP_HOME/
 
-CMD bundle exec rails server -b 0.0.0.0
+CMD bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ### Native
 
 1. Run `bundle install` to install the gem dependencies
-2. Run `rails db:setup` to create a development and testing database
+2. Run `bundle exec rails db:setup` to create a development and testing database
 3. Run `bundle exec rails server` to launch the app on http://localhost:3000.
 
 ### Docker

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@
 2. Run `rails db:setup` to create a development and testing database
 3. Run `bundle exec rails server` to launch the app on http://localhost:3000.
 
+#### Updating
+
+1. `git pull`
+2. `rails db:migrate`
+
 ### Docker
 
 Run this in a shell and leave it running:
@@ -43,6 +48,12 @@ docker-compose exec web /bin/sh -c "bundle exec rails db:setup"
 ```
 
 Then open http://localhost:3000 to see the app.
+
+#### Updating
+
+1. `git pull`
+2. `docker-compose up --build --detach` - this will recreate the image if there's any changes
+3. `docker-compose exec web /bin/sh -c "bundle exec rails db:migrate"`
 
 ## Accessing API
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,6 @@
 2. Run `rails db:setup` to create a development and testing database
 3. Run `bundle exec rails server` to launch the app on http://localhost:3000.
 
-#### Updating
-
-1. `git pull`
-2. `rails db:migrate`
-
 ### Docker
 
 Run this in a shell and leave it running:
@@ -48,12 +43,6 @@ docker-compose exec web /bin/sh -c "bundle exec rails db:setup"
 ```
 
 Then open http://localhost:3000 to see the app.
-
-#### Updating
-
-1. `git pull`
-2. `docker-compose up --build --detach` - this will recreate the image if there's any changes
-3. `docker-compose exec web /bin/sh -c "bundle exec rails db:migrate"`
 
 ## Accessing API
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -23,6 +23,7 @@
 #  updated_at           :datetime         not null
 #  accrediting_provider :text
 #  last_published_at    :datetime
+#  changed_at           :datetime         not null
 #
 
 class Provider < ApplicationRecord

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -23,6 +23,7 @@
 #  updated_at           :datetime         not null
 #  accrediting_provider :text
 #  last_published_at    :datetime
+#  changed_at           :datetime         not null
 #
 
 class ProviderSerializer < ActiveModel::Serializer

--- a/db/migrate/20190213160920_add_changed_at_to_provider.rb
+++ b/db/migrate/20190213160920_add_changed_at_to_provider.rb
@@ -1,0 +1,5 @@
+class AddChangedAtToProvider < ActiveRecord::Migration[5.2]
+  def change
+    add_column :provider, :changed_at, :datetime, default: -> { "timezone('utc'::text, now())" }, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2019_02_13_160920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -140,6 +140,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.text "accrediting_provider"
     t.datetime "last_published_at"
+    t.datetime "changed_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.index ["last_published_at"], name: "IX_provider_last_published_at"
     t.index ["provider_code"], name: "IX_provider_provider_code", unique: true
   end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -23,6 +23,7 @@
 #  updated_at           :datetime         not null
 #  accrediting_provider :text
 #  last_published_at    :datetime
+#  changed_at           :datetime         not null
 #
 
 FactoryBot.define do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -23,6 +23,7 @@
 #  updated_at           :datetime         not null
 #  accrediting_provider :text
 #  last_published_at    :datetime
+#  changed_at           :datetime         not null
 #
 
 require 'rails_helper'

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -23,6 +23,7 @@
 #  updated_at           :datetime         not null
 #  accrediting_provider :text
 #  last_published_at    :datetime
+#  changed_at           :datetime         not null
 #
 
 require "rails_helper"


### PR DESCRIPTION
### Context
`provider.changed_at` is going to be used to track any change that would cause a re-export for the ucas apply system. It's an amalgamation of last_published and updated_at along with dependent record changes

Doing this as a separate PR as it's our first ever migration on the rails side to avoid tying it up with the functionality to update it.

### Changes proposed in this pull request

* First migration - adds new column.
* Baseline schema.rb version (done automatically by the rails tools)

### Guidance to review

Test migration from clean setup of db, and with sanitized backup from prod. I've done both and it worked for me.