### PR TITLE
[953] Set provider.changed_at

### DIFF
--- a/app/models/concerns/changed_at.rb
+++ b/app/models/concerns/changed_at.rb
@@ -1,0 +1,11 @@
+module ChangedAt
+  extend ActiveSupport::Concern
+
+  class_methods do
+  private
+
+    def timestamp_attributes_for_update
+      super + %w[changed_at]
+    end
+  end
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -28,6 +28,7 @@
 
 class Provider < ApplicationRecord
   include RegionCode
+  include ChangedAt
 
   enum provider_type: {
     "SCITT" => "B",

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -237,4 +237,18 @@ RSpec.describe Provider, type: :model do
       end
     end
   end
+
+  describe 'changed_at' do
+    it 'is set on create' do
+      expect(subject.changed_at).to be_present
+      expect(subject.changed_at).to eq subject.updated_at
+    end
+
+    it 'is set on update' do
+      provider = create(:provider, updated_at: 1.hour.ago)
+      provider.touch
+      expect(subject.changed_at).to eq subject.updated_at
+      expect(subject.changed_at).not_to be_within(1.second).of(1.hour.ago)
+    end
+  end
 end


### PR DESCRIPTION
Will be used to return changed records in the UCAS API

### Context

### Changes proposed in this pull request

### Guidance to review
