### PR TITLE
[1014] The Course's Qualifications

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -57,6 +57,10 @@ class Course < ApplicationRecord
   has_and_belongs_to_many :subjects
   has_many :site_statuses
   has_many :sites, through: :site_statuses
+  scope :pgde, -> {
+    joins(:provider).
+    joins("INNER JOIN pgde_course ON pgde_course.course_code = course.course_code AND pgde_course.provider_code = provider.provider_code")
+  }
 
   scope :changed_since, ->(datetime, from_course_id = 0) do
     if datetime.present?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -62,16 +62,6 @@ class Course < ApplicationRecord
     joins("INNER JOIN pgde_course ON pgde_course.course_code = course.course_code AND pgde_course.provider_code = provider.provider_code")
   }
 
-  # select * from course
-  # inner join  course_subject
-  #   on course.id = course_subject.course_id
-  # inner join subject
-  #   on  subject.id = course_subject.subject_id
-  #   and  subject.subject_name = 'Further Education'
-  # scope :further_education, -> {
-
-  # }
-
   scope :changed_since, ->(datetime, from_course_id = 0) do
     if datetime.present?
       where("course.updated_at >= ? AND course.id > ?", datetime, from_course_id).order(:updated_at, :id)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -85,8 +85,6 @@ class Course < ApplicationRecord
   end
 
   def qualifications
-    is_fe = subjects.further_education.any?
-
     Qualifications.new(
       profpost_flag: profpost_flag,
       is_pgde: self.in?(Course.pgde),

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -83,4 +83,12 @@ class Course < ApplicationRecord
   def has_vacancies?
     site_statuses.with_vacancies.any?
   end
+
+  def qualifications
+    Qualifications.new(
+      profpost_flag: profpost_flag,
+      is_pgde: self.in?(Course.pgde),
+      is_fe: false, # TODO: implement this properly!
+    ).to_a
+  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -95,11 +95,12 @@ class Course < ApplicationRecord
   end
 
   def qualifications
+    is_fe = subjects.further_education.any?
+
     Qualifications.new(
       profpost_flag: profpost_flag,
       is_pgde: self.in?(Course.pgde),
-      is_fe: false, # TODO: implement this properly!
-
+      is_fe: subjects.further_education.any?,
     ).to_a
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -62,6 +62,16 @@ class Course < ApplicationRecord
     joins("INNER JOIN pgde_course ON pgde_course.course_code = course.course_code AND pgde_course.provider_code = provider.provider_code")
   }
 
+  # select * from course
+  # inner join  course_subject
+  #   on course.id = course_subject.course_id
+  # inner join subject
+  #   on  subject.id = course_subject.subject_id
+  #   and  subject.subject_name = 'Further Education'
+  # scope :further_education, -> {
+
+  # }
+
   scope :changed_since, ->(datetime, from_course_id = 0) do
     if datetime.present?
       where("course.updated_at >= ? AND course.id > ?", datetime, from_course_id).order(:updated_at, :id)
@@ -89,6 +99,7 @@ class Course < ApplicationRecord
       profpost_flag: profpost_flag,
       is_pgde: self.in?(Course.pgde),
       is_fe: false, # TODO: implement this properly!
+
     ).to_a
   end
 end

--- a/app/models/pgde_course.rb
+++ b/app/models/pgde_course.rb
@@ -1,0 +1,11 @@
+# == Schema Information
+#
+# Table name: pgde_course
+#
+#  id            :integer          not null, primary key
+#  course_code   :text             not null
+#  provider_code :text             not null
+#
+
+class PgdeCourse < ApplicationRecord
+end

--- a/app/models/qualifications.rb
+++ b/app/models/qualifications.rb
@@ -1,0 +1,20 @@
+class Qualifications
+  def initialize(profpost_flag:, is_pgde:, is_fe:)
+    @profpost_flag = profpost_flag
+    @is_pgde = is_pgde
+    @is_fe = is_fe
+  end
+
+  def to_a
+    case
+    when @is_pgde
+      @is_fe ? [:qtls, :pgde] : [:qts, :pgde]
+    when @is_fe
+      [:qtls, :pgce]
+    when @profpost_flag == "recommendation_for_qts"
+      [:qts]
+    else
+      [:qts, :pgce]
+    end
+  end
+end

--- a/app/models/qualifications.rb
+++ b/app/models/qualifications.rb
@@ -7,8 +7,10 @@ class Qualifications
 
   def to_a
     case
-    when @is_pgde
-      @is_fe ? [:qtls, :pgde] : [:qts, :pgde]
+    when @is_pgde && @is_fe
+      [:qtls, :pgde]
+    when @is_pgde && !@is_fe
+      [:qts, :pgde]
     when @is_fe
       [:qtls, :pgce]
     when @profpost_flag == "recommendation_for_qts"

--- a/app/models/qualifications.rb
+++ b/app/models/qualifications.rb
@@ -6,16 +6,15 @@ class Qualifications
   end
 
   def to_a
-    if @is_pgde && @is_fe
-      [:pgde] # 'PGDE'
-    elsif @is_pgde && !@is_fe
-      %i[qts pgde] # 'PGDE with QTS'
-    elsif @is_fe
-      [:pgce] # 'PGCE'
-    elsif @profpost_flag == "recommendation_for_qts"
-      [:qts] # 'QTS'
-    else
-      %i[qts pgce] # 'PGCE with QTS'
-    end
+    result = []
+    result << :qts unless @is_fe
+    result += if @is_pgde
+                [:pgde] # 'PGDE'
+              elsif @profpost_flag == "recommendation_for_qts"
+                []
+              else
+                [:pgce]
+              end
+    result
   end
 end

--- a/app/models/qualifications.rb
+++ b/app/models/qualifications.rb
@@ -6,15 +6,22 @@ class Qualifications
   end
 
   def to_a
-    result = []
-    result << :qts unless @is_fe
-    result += if @is_pgde
-                [:pgde] # 'PGDE'
-              elsif @profpost_flag == "recommendation_for_qts"
-                []
-              else
-                [:pgce]
-              end
-    result
+    qts_or_not + uni_qualification_or_not
+  end
+
+private
+
+  def qts_or_not
+    @is_fe ? [] : [:qts]
+  end
+
+  def uni_qualification_or_not
+    if @is_pgde
+      [:pgde]
+    elsif @profpost_flag == "recommendation_for_qts"
+      []
+    else
+      [:pgce]
+    end
   end
 end

--- a/app/models/qualifications.rb
+++ b/app/models/qualifications.rb
@@ -8,11 +8,11 @@ class Qualifications
   def to_a
     case
     when @is_pgde && @is_fe
-      [:qtls, :pgde] # 'PGDE'
+      [:pgde] # 'PGDE'
     when @is_pgde && !@is_fe
       [:qts, :pgde] # 'PGDE with QTS'
     when @is_fe
-      [:qtls, :pgce] # 'PGCE'
+      [:pgce] # 'PGCE'
     when @profpost_flag == "recommendation_for_qts"
       [:qts] # 'QTS'
     else

--- a/app/models/qualifications.rb
+++ b/app/models/qualifications.rb
@@ -6,17 +6,16 @@ class Qualifications
   end
 
   def to_a
-    case
-    when @is_pgde && @is_fe
+    if @is_pgde && @is_fe
       [:pgde] # 'PGDE'
-    when @is_pgde && !@is_fe
-      [:qts, :pgde] # 'PGDE with QTS'
-    when @is_fe
+    elsif @is_pgde && !@is_fe
+      %i[qts pgde] # 'PGDE with QTS'
+    elsif @is_fe
       [:pgce] # 'PGCE'
-    when @profpost_flag == "recommendation_for_qts"
+    elsif @profpost_flag == "recommendation_for_qts"
       [:qts] # 'QTS'
     else
-      [:qts, :pgce] # 'PGCE with QTS'
+      %i[qts pgce] # 'PGCE with QTS'
     end
   end
 end

--- a/app/models/qualifications.rb
+++ b/app/models/qualifications.rb
@@ -8,15 +8,15 @@ class Qualifications
   def to_a
     case
     when @is_pgde && @is_fe
-      [:qtls, :pgde]
+      [:qtls, :pgde] # 'PGDE'
     when @is_pgde && !@is_fe
-      [:qts, :pgde]
+      [:qts, :pgde] # 'PGDE with QTS'
     when @is_fe
-      [:qtls, :pgce]
+      [:qtls, :pgce] # 'PGCE'
     when @profpost_flag == "recommendation_for_qts"
-      [:qts]
+      [:qts] # 'QTS'
     else
-      [:qts, :pgce]
+      [:qts, :pgce] # 'PGCE with QTS'
     end
   end
 end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -8,4 +8,5 @@
 #
 
 class Subject < ApplicationRecord
+  scope :further_education, -> { where(subject_name: 'Further Education') }
 end

--- a/app/serializers/api/v2/course_serializable.rb
+++ b/app/serializers/api/v2/course_serializable.rb
@@ -4,7 +4,7 @@ module API
       type 'courses'
 
       attributes :findable?, :open_for_applications?, :has_vacancies?,
-                 :course_code, :name, :study_mode, :profpost_flag
+                 :course_code, :name, :study_mode, :profpost_flag, :qualifications
 
       attribute :start_date do
         @object.start_date&.iso8601

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -79,6 +79,11 @@ course2 = Course.create!(
   ],
 )
 
+PgdeCourse.create!(
+  provider_code: course2.provider.provider_code,
+  course_code: course2.course_code,
+)
+
 SiteStatus.create!(
   site: Site.last,
   vac_status: "B",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,6 +16,7 @@ accrediting_provider = Provider.create!(provider_name: 'Acme SCITT', provider_co
   "English" => "Q3",
   "Mathematics" => "G1",
   "Biology" => "C1",
+  "Further Education" => "41",
 }.each do |name, code|
   Subject.create!(
     subject_name: name,
@@ -75,7 +76,8 @@ course2 = Course.create!(
   qualification: 1,
   subjects: [
     Subject.find_by(subject_name: "Secondary"),
-    Subject.find_by(subject_name: "Biology")
+    Subject.find_by(subject_name: "Biology"),
+    Subject.find_by(subject_name: "Further Education"),
   ],
 )
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -31,12 +31,17 @@ FactoryBot.define do
 
     transient do
       age { nil }
+      is_pgde { false }
     end
 
     after(:build) do |course, evaluator|
       if evaluator.age.present?
         course.created_at = evaluator.age
         course.updated_at = evaluator.age
+      end
+
+      if evaluator.is_pgde
+        create(:pgde_course, provider_code: course.provider.provider_code, course_code: course.course_code)
       end
     end
   end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -32,49 +32,47 @@ FactoryBot.define do
       age { nil }
     end
 
-    after(:build) do |course, evaluator|
-      if evaluator.age.present?
-        course.created_at = evaluator.age
-        course.updated_at = evaluator.age
-      end
-    end
-  end
-
-  factory :course_with_qualication, parent: :course do
-    trait :with_further_education_subject do
+    trait :in_further_education do
       after(:build) do |course|
         course.subjects << create(:futher_education_subject)
       end
     end
 
-    trait :with_pgde_course do
+    trait :marked_as_pgde do
       after(:build) do |course|
         create(:pgde_course, provider_code: course.provider.provider_code, course_code: course.course_code)
       end
     end
 
-    factory :course_with_qts_qualication do
+    trait :resulting_in_qts do
       profpost_flag { :recommendation_for_qts }
     end
 
-    factory :course_with_pgce_qts_qualication do
+    trait :resulting_in_pgce_with_qts do
       profpost_flag { %i[professional postgraduate professional_postgraduate].sample }
     end
 
-    factory :course_with_pgde_qts_qualication do
-      with_pgde_course
+    trait :resulting_in_pgde_with_qts do
+      marked_as_pgde
       profpost_flag { %i[recommendation_for_qts professional postgraduate professional_postgraduate].sample }
     end
 
-    factory :course_with_pgce_qualication do
-      with_further_education_subject
+    trait :resulting_in_pgce do
+      in_further_education
       profpost_flag { %i[professional postgraduate professional_postgraduate].sample }
     end
 
-    factory :course_with_pgde_qualication do
-      with_pgde_course
-      with_further_education_subject
+    trait :resulting_in_pgde do
+      marked_as_pgde
+      in_further_education
       profpost_flag { %i[recommendation_for_qts professional postgraduate professional_postgraduate].sample }
+    end
+
+    after(:build) do |course, evaluator|
+      if evaluator.age.present?
+        course.created_at = evaluator.age
+        course.updated_at = evaluator.age
+      end
     end
   end
 end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -41,20 +41,15 @@ FactoryBot.define do
   end
 
   factory :course_with_qualication, parent: :course do
-    transient do
-      have_pgde { false }
-      have_fe_subject { false }
-    end
-
     trait :with_further_education_subject do
-      transient do
-        have_fe_subject { true }
+      after(:build) do |course|
+        course.subjects << create(:futher_education_subject)
       end
     end
 
     trait :with_pgde_course do
-      transient do
-        have_pgde { true }
+      after(:build) do |course|
+        create(:pgde_course, provider_code: course.provider.provider_code, course_code: course.course_code)
       end
     end
 
@@ -80,16 +75,6 @@ FactoryBot.define do
       with_pgde_course
       with_further_education_subject
       profpost_flag { %i[recommendation_for_qts professional postgraduate professional_postgraduate].sample }
-    end
-
-    after(:build) do |course, evaluator|
-      if evaluator.have_pgde
-        create(:pgde_course, provider_code: course.provider.provider_code, course_code: course.course_code)
-      end
-
-      if evaluator.have_fe_subject
-        course.subjects << create(:futher_education_subject)
-      end
     end
   end
 end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -58,13 +58,9 @@ FactoryBot.define do
       end
     end
 
-    # #[:qts] # 'QTS'
-    # ["recommendation_for_qts", :not_pgde, :not_fe]        => %i[qts],
-
     factory :course_with_qts_qualication do
       profpost_flag { :recommendation_for_qts }
     end
-
 
     factory :course_with_pgce_qts_qualication do
       profpost_flag { %i[professional postgraduate professional_postgraduate].sample }

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -28,10 +28,8 @@ FactoryBot.define do
     qualification { 1 }
     association(:provider)
 
-
     transient do
       age { nil }
-      is_pgde { false }
     end
 
     after(:build) do |course, evaluator|
@@ -39,9 +37,62 @@ FactoryBot.define do
         course.created_at = evaluator.age
         course.updated_at = evaluator.age
       end
+    end
+  end
 
-      if evaluator.is_pgde
+  factory :course_with_qualication, parent: :course do
+    transient do
+      have_pgde { false }
+      have_fe_subject { false }
+    end
+
+    trait :with_further_education_subject do
+      transient do
+        have_fe_subject { true }
+      end
+    end
+
+    trait :with_pgde_course do
+      transient do
+        have_pgde { true }
+      end
+    end
+
+    # #[:qts] # 'QTS'
+    # ["recommendation_for_qts", :not_pgde, :not_fe]        => %i[qts],
+
+    factory :course_with_qts_qualication do
+      profpost_flag { :recommendation_for_qts }
+    end
+
+
+    factory :course_with_pgce_qts_qualication do
+      profpost_flag { %i[professional postgraduate professional_postgraduate].sample }
+    end
+
+    factory :course_with_pgde_qts_qualication do
+      with_pgde_course
+      profpost_flag { %i[recommendation_for_qts professional postgraduate professional_postgraduate].sample }
+    end
+
+    factory :course_with_pgce_qualication do
+      with_further_education_subject
+      profpost_flag { %i[professional postgraduate professional_postgraduate].sample }
+    end
+
+    factory :course_with_pgde_qualication do
+      with_pgde_course
+      with_further_education_subject
+      profpost_flag { %i[recommendation_for_qts professional postgraduate professional_postgraduate].sample }
+    end
+
+    after(:build) do |course, evaluator|
+      if evaluator.have_pgde
         create(:pgde_course, provider_code: course.provider.provider_code, course_code: course.course_code)
+      end
+
+      if evaluator.have_fe_subject
+        course.subjects << create(:futher_education_subject)
       end
     end
   end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -27,6 +27,7 @@ FactoryBot.define do
     name { Faker::ProgrammingLanguage.name }
     qualification { 1 }
     association(:provider)
+    profpost_flag { %i[recommendation_for_qts professional postgraduate professional_postgraduate].sample }
 
     transient do
       age { nil }
@@ -54,7 +55,6 @@ FactoryBot.define do
 
     trait :resulting_in_pgde_with_qts do
       marked_as_pgde
-      profpost_flag { %i[recommendation_for_qts professional postgraduate professional_postgraduate].sample }
     end
 
     trait :resulting_in_pgce do
@@ -65,7 +65,6 @@ FactoryBot.define do
     trait :resulting_in_pgde do
       marked_as_pgde
       in_further_education
-      profpost_flag { %i[recommendation_for_qts professional postgraduate professional_postgraduate].sample }
     end
 
     after(:build) do |course, evaluator|

--- a/spec/factories/pgde_course.rb
+++ b/spec/factories/pgde_course.rb
@@ -1,0 +1,13 @@
+# == Schema Information
+#
+# Table name: pgde_course
+#
+#  id            :integer          not null, primary key
+#  course_code   :text             not null
+#  provider_code :text             not null
+#
+
+FactoryBot.define do
+  factory :pgde_course do
+  end
+end

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -11,5 +11,9 @@ FactoryBot.define do
   factory :subject do
     sequence(:subject_code, &:to_s)
     subject_name { Faker::ProgrammingLanguage.name }
+
+    factory :futher_education_subject do
+      subject_name { 'Further Education' }
+    end
   end
 end

--- a/spec/factory_specs/course_spec.rb
+++ b/spec/factory_specs/course_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe "Course Factory" do
+  let(:course) { create(:course, is_pgde: true) }
+
+  it "created a pgde course" do
+    expect(course).to be_instance_of(Course)
+    expect(course).to be_valid
+    expect(course.in?(Course.pgde)).to be true
+  end
+end

--- a/spec/factory_specs/course_spec.rb
+++ b/spec/factory_specs/course_spec.rb
@@ -8,16 +8,16 @@ describe "Course Factory" do
     expect(course).to be_valid
   end
 
-  context "course with_pgde_course" do
-    let(:course) { create(:course_with_qualication, :with_pgde_course) }
+  context "course resulting_in_pgde" do
+    let(:course) { create(:course, :resulting_in_pgde) }
 
     it "created course" do
       expect(course.in?(Course.pgde)).to be true
     end
   end
 
-  context "course with_further_education_subject" do
-    let(:course) { create(:course_with_qualication, :with_further_education_subject) }
+  context "course in_further_education" do
+    let(:course) { create(:course, :in_further_education) }
 
     it "created course" do
       expect(course.subjects.further_education.any?).to be true

--- a/spec/factory_specs/course_spec.rb
+++ b/spec/factory_specs/course_spec.rb
@@ -1,11 +1,26 @@
 require 'rails_helper'
 
 describe "Course Factory" do
-  let(:course) { create(:course, is_pgde: true) }
+  let(:course) { create(:course) }
 
-  it "created a pgde course" do
+  it "created course" do
     expect(course).to be_instance_of(Course)
     expect(course).to be_valid
-    expect(course.in?(Course.pgde)).to be true
+  end
+
+  context "course with_pgde_course" do
+    let(:course) { create(:course_with_qualication, :with_pgde_course) }
+
+    it "created course" do
+      expect(course.in?(Course.pgde)).to be true
+    end
+  end
+
+  context "course with_further_education_subject" do
+    let(:course) { create(:course_with_qualication, :with_further_education_subject) }
+
+    it "created course" do
+      expect(course.subjects.further_education.any?).to be true
+    end
   end
 end

--- a/spec/factory_specs/subject_spec.rb
+++ b/spec/factory_specs/subject_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe "Subject 'Further Education' Factory" do
+  let(:subject) { create(:futher_education_subject) }
+
+  it "created subject" do
+    expect(subject).to be_instance_of(Subject)
+    expect(subject).to be_valid
+    expect(subject.subject_name).to eq 'Further Education'
+    expect(subject.in?(Subject.further_education)).to be true
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -25,6 +25,7 @@ require 'rails_helper'
 
 RSpec.describe Course, type: :model do
   let(:subject) { create(:course) }
+
   describe 'associations' do
     it { should belong_to(:provider) }
     it { should belong_to(:accrediting_provider).optional }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -182,31 +182,31 @@ RSpec.describe Course, type: :model do
 
   describe 'qualifications' do
     context "course with qts qualication" do
-      let(:subject) { create(:course_with_qts_qualication) }
+      let(:subject) { create(:course, :resulting_in_qts) }
 
       its(:qualifications) { should eq %i[qts] }
     end
 
     context "course with pgce qts qualication" do
-      let(:subject) { create(:course_with_pgce_qts_qualication) }
+      let(:subject) { create(:course, :resulting_in_pgce_with_qts) }
 
       its(:qualifications) { should eq %i[qts pgce] }
     end
 
     context "course with pgde qts qualication" do
-      let(:subject) { create(:course_with_pgde_qts_qualication) }
+      let(:subject) { create(:course, :resulting_in_pgde_with_qts) }
 
       its(:qualifications) { should eq %i[qts pgde] }
     end
 
     context "course with pgce qualication" do
-      let(:subject) { create(:course_with_pgce_qualication) }
+      let(:subject) { create(:course, :resulting_in_pgce) }
 
       its(:qualifications) { should eq %i[pgce] }
     end
 
     context "course with pgde qualication" do
-      let(:subject) { create(:course_with_pgde_qualication) }
+      let(:subject) { create(:course, :resulting_in_pgde) }
 
       its(:qualifications) { should eq %i[pgde] }
     end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -179,4 +179,36 @@ RSpec.describe Course, type: :model do
       it { should include course }
     end
   end
+
+  describe 'qualifications' do
+    context "course with qts qualication" do
+      let(:subject) { create(:course_with_qts_qualication) }
+
+      its(:qualifications) { should eq %i[qts] }
+    end
+
+    context "course with pgce qts qualication" do
+      let(:subject) { create(:course_with_pgce_qts_qualication) }
+
+      its(:qualifications) { should eq %i[qts pgce] }
+    end
+
+    context "course with pgde qts qualication" do
+      let(:subject) { create(:course_with_pgde_qts_qualication) }
+
+      its(:qualifications) { should eq %i[qts pgde] }
+    end
+
+    context "course with pgce qualication" do
+      let(:subject) { create(:course_with_pgce_qualication) }
+
+      its(:qualifications) { should eq %i[pgce] }
+    end
+
+    context "course with pgde qualication" do
+      let(:subject) { create(:course_with_pgde_qualication) }
+
+      its(:qualifications) { should eq %i[pgde] }
+    end
+  end
 end

--- a/spec/models/qualifications_spec.rb
+++ b/spec/models/qualifications_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe Qualifications, type: :model do
 
   specs.each do |spec|
     spec.each do |inputs, expected|
-      pp expected
       profpost_flag = inputs[0]
       is_pgde = (inputs[1] == :is_pgde)
       is_fe = (inputs[2] == :is_fe)

--- a/spec/models/qualifications_spec.rb
+++ b/spec/models/qualifications_spec.rb
@@ -1,37 +1,56 @@
 require 'rails_helper'
 
 RSpec.describe Qualifications, type: :model do
-  specs = {
-    ["recommendation_for_qts", :not_pgde, :not_fe] => %i[qts],
+  qtl_specs = [
+    ["recommendation_for_qts", :not_pgde, :not_fe] => %i[qts]
+  ]
+
+  qts_pgce_specs = [
     ["professional", :not_pgde, :not_fe] => %i[qts pgce],
     ["postgraduate", :not_pgde, :not_fe] => %i[qts pgce],
     ["professional_postgraduate", :not_pgde, :not_fe] => %i[qts pgce],
+  ]
 
+  qts_pgde_specs = [
     ["recommendation_for_qts", :is_pgde, :not_fe] => %i[qts pgde],
     ["professional", :is_pgde, :not_fe] => %i[qts pgde],
     ["postgraduate", :is_pgde, :not_fe] => %i[qts pgde],
     ["professional_postgraduate", :is_pgde, :not_fe] => %i[qts pgde],
+  ]
 
-    ["recommendation_for_qts", :not_pgde, :is_fe] => [], # nonsensical scenario
+  pgce_specs = [
     ["professional", :not_pgde, :is_fe] => %i[pgce],
     ["postgraduate", :not_pgde, :is_fe] => %i[pgce],
-    ["professional_postgraduate", :not_pgde, :is_fe] => %i[pgce],
+    ["professional_postgraduate", :not_pgde, :is_fe] => %i[pgce]
+  ]
 
+  pgde_specs = [
     ["recommendation_for_qts", :is_pgde, :is_fe] => %i[pgde],
     ["professional", :is_pgde, :is_fe] => %i[pgde],
     ["postgraduate", :is_pgde, :is_fe] => %i[pgde],
     ["professional_postgraduate", :is_pgde, :is_fe] => %i[pgde],
-  }.freeze
+  ]
 
-  specs.each do |inputs, expected|
-    profpost_flag = inputs[0]
-    is_pgde = (inputs[1] == :is_pgde)
-    is_fe = (inputs[2] == :is_fe)
+  nonsensical_specs = [
+    ["recommendation_for_qts", :not_pgde, :is_fe] => []
+]
 
-    context "is #{profpost_flag} and is pgde #{is_pgde} and further education #{is_fe}" do
-      subject { Qualifications.new(profpost_flag: profpost_flag, is_pgde: is_pgde, is_fe: is_fe) }
+  specs = nonsensical_specs + qtl_specs + qts_pgce_specs + qts_pgde_specs + pgce_specs + pgde_specs
 
-      its(:to_a) { should eq(expected) }
+  specs.freeze
+
+  specs.each do |spec|
+    spec.each do |inputs, expected|
+      pp expected
+      profpost_flag = inputs[0]
+      is_pgde = (inputs[1] == :is_pgde)
+      is_fe = (inputs[2] == :is_fe)
+
+      context "is #{profpost_flag} and is pgde #{is_pgde} and further education #{is_fe}" do
+        subject { Qualifications.new(profpost_flag: profpost_flag, is_pgde: is_pgde, is_fe: is_fe) }
+
+        its(:to_a) { should eq(expected) }
+      end
     end
   end
 end

--- a/spec/models/qualifications_spec.rb
+++ b/spec/models/qualifications_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Qualifications, type: :model do
     context "is recommendation_for_qts and is not pgde and is not further education" do
       subject { Qualifications.new(profpost_flag: "recommendation_for_qts", is_pgde: false, is_fe: false) }
 
-      its(:to_a) { should eq([:qts])}
+      its(:to_a) { should eq([:qts]) }
     end
   end
 
@@ -13,19 +13,19 @@ RSpec.describe Qualifications, type: :model do
     context "is professional and is not pgde and is not further education" do
       subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: false) }
 
-      its(:to_a) { should match_array([:qts, :pgce])}
+      its(:to_a) { should match_array(%i[qts pgce]) }
     end
 
     context "is postgraduate and is not pgde and is not further education" do
       subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: false) }
 
-      its(:to_a) { should match_array([:qts, :pgce])}
+      its(:to_a) { should match_array(%i[qts pgce]) }
     end
 
     context "is professional_postgraduate and is not pgde and is not further education" do
       subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: false) }
 
-      its(:to_a) { should match_array([:qts, :pgce])}
+      its(:to_a) { should match_array(%i[qts pgce]) }
     end
   end
 
@@ -33,51 +33,50 @@ RSpec.describe Qualifications, type: :model do
     context "is recommendation_for_qts and is pgde and is not further education" do
       subject { Qualifications.new(profpost_flag: "recommendation_for_qts", is_pgde: true, is_fe: false) }
 
-      its(:to_a) { should match_array([:qts, :pgde])}
+      its(:to_a) { should match_array(%i[qts pgde]) }
     end
     context "is professional and is pgde and is not further education" do
       subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: false) }
 
-      its(:to_a) { should match_array([:qts, :pgde])}
+      its(:to_a) { should match_array(%i[qts pgde]) }
     end
 
     context "is postgraduate and is pgde and is not further education" do
       subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: false) }
 
-      its(:to_a) { should match_array([:qts, :pgde])}
+      its(:to_a) { should match_array(%i[qts pgde]) }
     end
 
     context "is professional_postgraduate and is pgde and is not further education" do
       subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: false) }
 
-      its(:to_a) { should match_array([:qts, :pgde])}
+      its(:to_a) { should match_array(%i[qts pgde]) }
     end
-
   end
 
   describe 'PGCE' do
     context "is recommendation_for_qts and is not pgde and is further education" do
       subject { Qualifications.new(profpost_flag: "recommendation_for_qts", is_pgde: false, is_fe: true) }
 
-      its(:to_a) { should match_array([:pgce])}
+      its(:to_a) { should match_array([:pgce]) }
     end
 
     context "is professional and is not pdge and is further education" do
       subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: true) }
 
-      its(:to_a) { should match_array([:pgce])}
+      its(:to_a) { should match_array([:pgce]) }
     end
 
     context "is postgraduate and is not pdge and is further education" do
       subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: true) }
 
-      its(:to_a) { should match_array([:pgce])}
+      its(:to_a) { should match_array([:pgce]) }
     end
 
     context "is professional_postgraduate and is not pdge and is further education" do
       subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: true) }
 
-      its(:to_a) { should match_array([:pgce])}
+      its(:to_a) { should match_array([:pgce]) }
     end
   end
 
@@ -85,25 +84,25 @@ RSpec.describe Qualifications, type: :model do
     context "is recommendation_for_qts and is pgde and is further education" do
       subject { Qualifications.new(profpost_flag: "recommendation_for_qts", is_pgde: true, is_fe: true) }
 
-      its(:to_a) { should match_array([:pgde])}
+      its(:to_a) { should match_array([:pgde]) }
     end
 
     context "is professional and is pgde and is further education" do
       subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: true) }
 
-      its(:to_a) { should match_array([:pgde])}
+      its(:to_a) { should match_array([:pgde]) }
     end
 
     context "is postgraduate and is pgde and is further education" do
       subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: true) }
 
-      its(:to_a) { should match_array([:pgde])}
+      its(:to_a) { should match_array([:pgde]) }
     end
 
     context "is professional_postgraduate and is pgde and is further education" do
       subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: true) }
 
-      its(:to_a) { should match_array([:pgde])}
+      its(:to_a) { should match_array([:pgde]) }
     end
   end
 end

--- a/spec/models/qualifications_spec.rb
+++ b/spec/models/qualifications_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Qualifications, type: :model do
+  describe 'QTS only' do
+    subject { Qualifications.new(profpost_flag: "recommendation_for_qts", is_pgde: false, is_fe: false) }
+
+    its(:to_a) { should eq([:qts])}
+  end
+end

--- a/spec/models/qualifications_spec.rb
+++ b/spec/models/qualifications_spec.rb
@@ -55,10 +55,10 @@ RSpec.describe Qualifications, type: :model do
   end
 
   describe 'PGCE' do
-    context "is recommendation_for_qts and is not pgde and is further education" do
+    context "(nonsensical scenario) is recommendation_for_qts and is not pgde and is further education" do
       subject { Qualifications.new(profpost_flag: "recommendation_for_qts", is_pgde: false, is_fe: true) }
 
-      its(:to_a) { should match_array([:pgce]) }
+      its(:to_a) { should be_empty }
     end
 
     context "is professional and is not pdge and is further education" do

--- a/spec/models/qualifications_spec.rb
+++ b/spec/models/qualifications_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Qualifications, type: :model do
-  qtl_specs = [
+  qts_specs = [
     ["recommendation_for_qts", :not_pgde, :not_fe] => %i[qts]
   ]
 
@@ -35,7 +35,7 @@ RSpec.describe Qualifications, type: :model do
     ["recommendation_for_qts", :not_pgde, :is_fe] => []
   ]
 
-  specs = (nonsensical_specs + qtl_specs + qts_pgce_specs + qts_pgde_specs + pgce_specs + pgde_specs).freeze
+  specs = (nonsensical_specs + qts_specs + qts_pgce_specs + qts_pgde_specs + pgce_specs + pgde_specs).freeze
 
   specs.each do |spec|
     spec.each do |inputs, expected|

--- a/spec/models/qualifications_spec.rb
+++ b/spec/models/qualifications_spec.rb
@@ -35,9 +35,7 @@ RSpec.describe Qualifications, type: :model do
     ["recommendation_for_qts", :not_pgde, :is_fe] => []
   ]
 
-  specs = nonsensical_specs + qtl_specs + qts_pgce_specs + qts_pgde_specs + pgce_specs + pgde_specs
-
-  specs.freeze
+  specs = (nonsensical_specs + qtl_specs + qts_pgce_specs + qts_pgde_specs + pgce_specs + pgde_specs).freeze
 
   specs.each do |spec|
     spec.each do |inputs, expected|

--- a/spec/models/qualifications_spec.rb
+++ b/spec/models/qualifications_spec.rb
@@ -59,25 +59,25 @@ RSpec.describe Qualifications, type: :model do
     context "is recommendation_for_qts and is not pgde and is further education" do
       subject { Qualifications.new(profpost_flag: "recommendation_for_qts", is_pgde: false, is_fe: true) }
 
-      its(:to_a) { should match_array([:qtls, :pgce])}
+      its(:to_a) { should match_array([:pgce])}
     end
 
     context "is professional and is not pdge and is further education" do
       subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: true) }
 
-      its(:to_a) { should match_array([:qtls, :pgce])}
+      its(:to_a) { should match_array([:pgce])}
     end
 
     context "is postgraduate and is not pdge and is further education" do
       subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: true) }
 
-      its(:to_a) { should match_array([:qtls, :pgce])}
+      its(:to_a) { should match_array([:pgce])}
     end
 
     context "is professional_postgraduate and is not pdge and is further education" do
       subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: true) }
 
-      its(:to_a) { should match_array([:qtls, :pgce])}
+      its(:to_a) { should match_array([:pgce])}
     end
   end
 
@@ -85,25 +85,25 @@ RSpec.describe Qualifications, type: :model do
     context "is recommendation_for_qts and is pgde and is further education" do
       subject { Qualifications.new(profpost_flag: "recommendation_for_qts", is_pgde: true, is_fe: true) }
 
-      its(:to_a) { should match_array([:qtls, :pgde])}
+      its(:to_a) { should match_array([:pgde])}
     end
 
     context "is professional and is pgde and is further education" do
       subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: true) }
 
-      its(:to_a) { should match_array([:qtls, :pgde])}
+      its(:to_a) { should match_array([:pgde])}
     end
 
     context "is postgraduate and is pgde and is further education" do
       subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: true) }
 
-      its(:to_a) { should match_array([:qtls, :pgde])}
+      its(:to_a) { should match_array([:pgde])}
     end
 
     context "is professional_postgraduate and is pgde and is further education" do
       subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: true) }
 
-      its(:to_a) { should match_array([:qtls, :pgde])}
+      its(:to_a) { should match_array([:pgde])}
     end
   end
 end

--- a/spec/models/qualifications_spec.rb
+++ b/spec/models/qualifications_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Qualifications, type: :model do
 
   nonsensical_specs = [
     ["recommendation_for_qts", :not_pgde, :is_fe] => []
-]
+  ]
 
   specs = nonsensical_specs + qtl_specs + qts_pgce_specs + qts_pgde_specs + pgce_specs + pgde_specs
 

--- a/spec/models/qualifications_spec.rb
+++ b/spec/models/qualifications_spec.rb
@@ -1,9 +1,107 @@
 require 'rails_helper'
 
 RSpec.describe Qualifications, type: :model do
-  describe 'QTS only' do
-    subject { Qualifications.new(profpost_flag: "recommendation_for_qts", is_pgde: false, is_fe: false) }
+  describe 'QTS' do
+    context "is recommendation_for_qts and is not pgde and is not further education" do
+      subject { Qualifications.new(profpost_flag: "recommendation_for_qts", is_pgde: false, is_fe: false) }
 
-    its(:to_a) { should eq([:qts])}
+      its(:to_a) { should eq([:qts])}
+    end
+  end
+
+  describe 'PGCE with QTS' do
+    context "is professional and is not pgde and is not further education" do
+      subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: false) }
+
+      its(:to_a) { should match_array([:qts, :pgce])}
+    end
+
+    context "is postgraduate and is not pgde and is not further education" do
+      subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: false) }
+
+      its(:to_a) { should match_array([:qts, :pgce])}
+    end
+
+    context "is professional_postgraduate and is not pgde and is not further education" do
+      subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: false) }
+
+      its(:to_a) { should match_array([:qts, :pgce])}
+    end
+  end
+
+  describe 'PGDE with QTS' do
+    # when @is_pgde && !@is_fe
+    # [:qts, :pgde]
+    context "is recommendation_for_qts and is pgde and is not further education" do
+      subject { Qualifications.new(profpost_flag: "recommendation_for_qts", is_pgde: true, is_fe: false) }
+
+      its(:to_a) { should match_array([:qts, :pgde])}
+    end
+    context "is professional and is pgde and is not further education" do
+      subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: false) }
+
+      its(:to_a) { should match_array([:qts, :pgde])}
+    end
+
+    context "is postgraduate and is pgde and is not further education" do
+      subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: false) }
+
+      its(:to_a) { should match_array([:qts, :pgde])}
+    end
+
+    context "is professional_postgraduate and is pgde and is not further education" do
+      subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: false) }
+
+      its(:to_a) { should match_array([:qts, :pgde])}
+    end
+
+  end
+
+
+  describe 'PGCE' do
+    context "is professional and is not pdge and is further education" do
+      subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: true) }
+
+      its(:to_a) { should match_array([:qtls, :pgce])}
+    end
+
+    context "is postgraduate and is not pdge and is further education" do
+      subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: true) }
+
+      its(:to_a) { should match_array([:qtls, :pgce])}
+    end
+
+    context "is professional_postgraduate and is not pdge and is further education" do
+      subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: true) }
+
+      its(:to_a) { should match_array([:qtls, :pgce])}
+    end
+  end
+
+  describe 'PGDE' do
+    context "is recommendation_for_qts and is pgde and is further education" do
+      subject { Qualifications.new(profpost_flag: "recommendation_for_qts", is_pgde: true, is_fe: true) }
+
+      its(:to_a) { should match_array([:qtls, :pgde])}
+    end
+    context "is professional and is pgde and is further education" do
+      subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: true) }
+
+      its(:to_a) { should match_array([:qtls, :pgde])}
+    end
+
+    context "is postgraduate and is pgde and is further education" do
+      subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: true) }
+
+      its(:to_a) { should match_array([:qtls, :pgde])}
+    end
+
+    context "is professional_postgraduate and is pgde and is further education" do
+      subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: true) }
+
+      its(:to_a) { should match_array([:qtls, :pgde])}
+    end
   end
 end
+
+

--- a/spec/models/qualifications_spec.rb
+++ b/spec/models/qualifications_spec.rb
@@ -1,108 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe Qualifications, type: :model do
-  describe 'QTS' do
-    context "is recommendation_for_qts and is not pgde and is not further education" do
-      subject { Qualifications.new(profpost_flag: "recommendation_for_qts", is_pgde: false, is_fe: false) }
+  specs = {
+    ["recommendation_for_qts", :not_pgde, :not_fe] => %i[qts],
+    ["professional", :not_pgde, :not_fe] => %i[qts pgce],
+    ["postgraduate", :not_pgde, :not_fe] => %i[qts pgce],
+    ["professional_postgraduate", :not_pgde, :not_fe] => %i[qts pgce],
 
-      its(:to_a) { should eq([:qts]) }
-    end
-  end
+    ["recommendation_for_qts", :is_pgde, :not_fe] => %i[qts pgde],
+    ["professional", :is_pgde, :not_fe] => %i[qts pgde],
+    ["postgraduate", :is_pgde, :not_fe] => %i[qts pgde],
+    ["professional_postgraduate", :is_pgde, :not_fe] => %i[qts pgde],
 
-  describe 'PGCE with QTS' do
-    context "is professional and is not pgde and is not further education" do
-      subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: false) }
+    ["recommendation_for_qts", :not_pgde, :is_fe] => [], # nonsensical scenario
+    ["professional", :not_pgde, :is_fe] => %i[pgce],
+    ["postgraduate", :not_pgde, :is_fe] => %i[pgce],
+    ["professional_postgraduate", :not_pgde, :is_fe] => %i[pgce],
 
-      its(:to_a) { should match_array(%i[qts pgce]) }
-    end
+    ["recommendation_for_qts", :is_pgde, :is_fe] => %i[pgde],
+    ["professional", :is_pgde, :is_fe] => %i[pgde],
+    ["postgraduate", :is_pgde, :is_fe] => %i[pgde],
+    ["professional_postgraduate", :is_pgde, :is_fe] => %i[pgde],
+  }.freeze
 
-    context "is postgraduate and is not pgde and is not further education" do
-      subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: false) }
+  specs.each do |inputs, expected|
+    profpost_flag = inputs[0]
+    is_pgde = (inputs[1] == :is_pgde)
+    is_fe = (inputs[2] == :is_fe)
 
-      its(:to_a) { should match_array(%i[qts pgce]) }
-    end
+    context "is #{profpost_flag} and is pgde #{is_pgde} and further education #{is_fe}" do
+      subject { Qualifications.new(profpost_flag: profpost_flag, is_pgde: is_pgde, is_fe: is_fe) }
 
-    context "is professional_postgraduate and is not pgde and is not further education" do
-      subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: false) }
-
-      its(:to_a) { should match_array(%i[qts pgce]) }
-    end
-  end
-
-  describe 'PGDE with QTS' do
-    context "is recommendation_for_qts and is pgde and is not further education" do
-      subject { Qualifications.new(profpost_flag: "recommendation_for_qts", is_pgde: true, is_fe: false) }
-
-      its(:to_a) { should match_array(%i[qts pgde]) }
-    end
-    context "is professional and is pgde and is not further education" do
-      subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: false) }
-
-      its(:to_a) { should match_array(%i[qts pgde]) }
-    end
-
-    context "is postgraduate and is pgde and is not further education" do
-      subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: false) }
-
-      its(:to_a) { should match_array(%i[qts pgde]) }
-    end
-
-    context "is professional_postgraduate and is pgde and is not further education" do
-      subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: false) }
-
-      its(:to_a) { should match_array(%i[qts pgde]) }
-    end
-  end
-
-  describe 'PGCE' do
-    context "(nonsensical scenario) is recommendation_for_qts and is not pgde and is further education" do
-      subject { Qualifications.new(profpost_flag: "recommendation_for_qts", is_pgde: false, is_fe: true) }
-
-      its(:to_a) { should be_empty }
-    end
-
-    context "is professional and is not pdge and is further education" do
-      subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: true) }
-
-      its(:to_a) { should match_array([:pgce]) }
-    end
-
-    context "is postgraduate and is not pdge and is further education" do
-      subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: true) }
-
-      its(:to_a) { should match_array([:pgce]) }
-    end
-
-    context "is professional_postgraduate and is not pdge and is further education" do
-      subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: true) }
-
-      its(:to_a) { should match_array([:pgce]) }
-    end
-  end
-
-  describe 'PGDE' do
-    context "is recommendation_for_qts and is pgde and is further education" do
-      subject { Qualifications.new(profpost_flag: "recommendation_for_qts", is_pgde: true, is_fe: true) }
-
-      its(:to_a) { should match_array([:pgde]) }
-    end
-
-    context "is professional and is pgde and is further education" do
-      subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: true) }
-
-      its(:to_a) { should match_array([:pgde]) }
-    end
-
-    context "is postgraduate and is pgde and is further education" do
-      subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: true) }
-
-      its(:to_a) { should match_array([:pgde]) }
-    end
-
-    context "is professional_postgraduate and is pgde and is further education" do
-      subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: true) }
-
-      its(:to_a) { should match_array([:pgde]) }
+      its(:to_a) { should eq(expected) }
     end
   end
 end

--- a/spec/models/qualifications_spec.rb
+++ b/spec/models/qualifications_spec.rb
@@ -30,8 +30,6 @@ RSpec.describe Qualifications, type: :model do
   end
 
   describe 'PGDE with QTS' do
-    # when @is_pgde && !@is_fe
-    # [:qts, :pgde]
     context "is recommendation_for_qts and is pgde and is not further education" do
       subject { Qualifications.new(profpost_flag: "recommendation_for_qts", is_pgde: true, is_fe: false) }
 
@@ -57,8 +55,13 @@ RSpec.describe Qualifications, type: :model do
 
   end
 
-
   describe 'PGCE' do
+    context "is recommendation_for_qts and is not pgde and is further education" do
+      subject { Qualifications.new(profpost_flag: "recommendation_for_qts", is_pgde: false, is_fe: true) }
+
+      its(:to_a) { should match_array([:qtls, :pgce])}
+    end
+
     context "is professional and is not pdge and is further education" do
       subject { Qualifications.new(profpost_flag: "professional", is_pgde: false, is_fe: true) }
 
@@ -84,6 +87,7 @@ RSpec.describe Qualifications, type: :model do
 
       its(:to_a) { should match_array([:qtls, :pgde])}
     end
+
     context "is professional and is pgde and is further education" do
       subject { Qualifications.new(profpost_flag: "professional", is_pgde: true, is_fe: true) }
 
@@ -103,5 +107,3 @@ RSpec.describe Qualifications, type: :model do
     end
   end
 end
-
-

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -73,6 +73,7 @@ describe 'Courses API v2', type: :request do
               "profpost_flag" => provider.courses[0].profpost_flag,
               "start_date" => provider.courses[0].start_date.iso8601,
               "study_mode" => provider.courses[0].study_mode,
+              "qualifications" => %w[qts pgce],
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },


### PR DESCRIPTION
### Context
The course's qualifications

The possible qualification can only be one of the following
`QTS`
`PGCE with QTS`
`PGDE with QTS`
`PGCE`
`PGDE` 
based on the `profpost_flag` and `pdge_course` and is the course's subject is a `Further Education` in some combination

### Changes proposed in this pull request
Added the course's qualifications

### Guidance to review
#### Basic
![image](https://user-images.githubusercontent.com/470137/53172047-45b3cf80-35dc-11e9-9680-8685449973b7.png)


#### Real Life
From the csharp side, the understanding of `qualification` is duplicated and disconnected and overloaded with usage.

duplicated as its spread across 3 projects 
disconnected due to mismatch compiled version of 
`GovUk.Education.SearchAndCompare.Domain.Models.Enums.IncludesPgce`
overloaded due to search and compare ui and api

From manage-courses-api
https://github.com/DFE-Digital/manage-courses-api/blob/89c801a71495fd06211e5e52e62598a042fb9fe8/src/ManageCourses.Api/Mapping/CourseMapper.cs#L206

https://github.com/DFE-Digital/manage-courses-api/blob/807e85297db2a73486cce824938e31aec159ffa8/src/ManageCourses.Domain/Models/CourseQualification.cs

based on the above as
```csharp
            {CourseQualification.Qts, IncludesPgce.No},
            {CourseQualification.QtsWithPgce, IncludesPgce.Yes},
            {CourseQualification.QtsWithPgde, IncludesPgce.QtsWithPgde},
            {CourseQualification.QtlsWithPgce, IncludesPgce.QtlsWithPgce},
            {CourseQualification.QtlsWithPgde, IncludesPgce.QtlsWithPgde}
```

disconnected
```csharp
            {CourseQualification.Qts, IncludesPgce.No},
            {CourseQualification.QtsWithPgce, IncludesPgce.Yes},
```

From search-and-compare-ui
https://github.com/DFE-Digital/search-and-compare-ui/blob/0f9513dfd1d622bcee33e72904555ebe093b4e15/shared/Views/Shared/Components/CourseDetails/_Qualification.cshtml

extracted from the above as (and is along with https://github.com/DFE-Digital/manage-courses-api/blob/89c801a71495fd06211e5e52e62598a042fb9fe8/src/ManageCourses.Api/Mapping/CourseMapper.cs#L46 and https://github.com/DFE-Digital/manage-courses-api/blob/master/src/ManageCourses.UcasCourseImporter/importer/Mapping/QualificationMapper.cs as the final knowledge for the port to `ruby`)
```csharp
@if(Model.Course.IncludesPgce.Equals(IncludesPgce.QtsOnly))
{
      return "QTS";
}
else if (Model.Course.IncludesPgce.Equals(IncludesPgce.QtsWithPgce))
{
      return "PGCE with QTS";
}
else if (Model.Course.IncludesPgce.Equals(IncludesPgce.QtsWithPgde))
{
      return "PGDE with QTS";
}
else if (Model.Course.IncludesPgce.Equals(IncludesPgce.QtlsWithPgce))
{
      return "PGCE";
}
else if (Model.Course.IncludesPgce.Equals(IncludesPgce.QtlsWithPgde))
{
      return "PGDE";
}

```

From search-and-compare-api
https://github.com/DFE-Digital/search-and-compare-api/blob/40182def7f6e59802fd7af955b0913b888000668/src/domain/Models/Enums/IncludesPgce.cs


``` csharp
namespace GovUk.Education.SearchAndCompare.Domain.Models.Enums
{
    public enum IncludesPgce
    {
        /* QTS only search category */
        QtsOnly = 0,


        /* QTS + PGCE search category */
        QtsWithPgce = 1,
        QtsWithOptionalPgce = 2, 
        QtsWithPgde = 3,
        

        /* "Other" search category */
        QtlsOnly = 4, 
        QtlsWithPgce = 5,
        QtlsWithPgde = 6,
    }
}
```
and this https://github.com/DFE-Digital/search-and-compare-api/blob/61fb5c0b758f81229e1fb6eee5853667e8063639/src/domain/Models/Enums/IncludesPgce.cs

```csharp
namespace GovUk.Education.SearchAndCompare.Domain.Models.Enums
{
    public enum IncludesPgce
    {
        /* QTS only search category */
        No = 0, // QtsOnly


        /* QTS + PGCE search category */
        Yes = 1, // QtsWithPgce
        QtsWithOptionalPgce = 2,
        QtsWithPgde = 3,
        

        /* "Other" search category */
        QtlsOnly = 4,
        QtlsWithPgce = 5,
        QtlsWithPgde = 6,
    }
}
``` 
disconnected
```csharp
        No = 0, // QtsOnly
        Yes = 1, // QtsWithPgce
```

overloaded
```csharp
        QtsWithOptionalPgce = 2, // concluded as used as search term...?
        QtlsOnly = 4, // concluded as used as search term...?
```
overloaded reasoning
see https://github.com/DFE-Digital/search-and-compare-api/blob/40182def7f6e59802fd7af955b0913b888000668/src/api/Controllers/CoursesController.cs#L333

and this https://github.com/DFE-Digital/search-and-compare-api/blob/61fb5c0b758f81229e1fb6eee5853667e8063639/src/domain/Filters/Enums/QualificationOption.cs

