### PR TITLE
Re-enable rspec printing dots when running specs locally

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
---format RspecJunitFormatter
 --require spec_helper

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ steps:
   displayName: 'Build image'
 
 - script: |
-    docker run "$(tag)" /bin/sh -c "bundle exec rake spec SPEC_OPTS='--format RspecJunitFormatter' | sed -e 1d >> rspec-results.xml
+    docker run "$(tag)" /bin/sh -c "bundle exec rake spec SPEC_OPTS='--format RspecJunitFormatter'" | sed -e 1d >> rspec-results.xml
   displayName: 'Execute tests'
 
 - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,10 +25,10 @@ steps:
   displayName: 'Build image'
 
 - script: |
-    docker run "$(tag)" /bin/sh -c "bundle exec rake spec" | sed -e 1d >> rspec-results.xml
+    docker run "$(tag)" /bin/sh -c "bundle exec rake spec SPEC_OPTS='--format RspecJunitFormatter' | sed -e 1d >> rspec-results.xml
   displayName: 'Execute tests'
 
-- script: | 
+- script: |
     docker run "$(tag)" /bin/sh -c "bundle exec govuk-lint-ruby app config db lib spec --format clang"
   displayName: 'Execute linters'
 


### PR DESCRIPTION
### Context
#128 changed RSpec to output results as JUnit-formatted XML. However this makes it really hard to see what's going on when running specs during development.

### Changes proposed in this pull request
Re-enable rspec printing dots when running specs locally. This includes changes to the CI build to preserve the JUnit-formatted output.

### Guidance to review
Not sure I've got the escaping correct in `azure-pipelines.yml`?