### PR TITLE
[953] update provider.changed_at when site changes

### DIFF
--- a/app/controllers/api/v1/providers_controller.rb
+++ b/app/controllers/api/v1/providers_controller.rb
@@ -27,6 +27,12 @@ module API
 
         last_provider = @providers.last
 
+        # When we extract the changed_at from the last provider, format it with
+        # sub-second timing information (micro-seconds) so that our incremental
+        # fetch can handle many records being updated within the same second.
+        #
+        # The strftime format '%FT%T.%6NZ' is similar to the ISO8601 standard,
+        # (equivalent to %FT%TZ) and adds micro-seconds (%6N).
         response.headers['Link'] = if last_provider
                                      next_link(last_provider.changed_at
                                                  .utc

--- a/app/controllers/api/v1/providers_controller.rb
+++ b/app/controllers/api/v1/providers_controller.rb
@@ -4,27 +4,37 @@ module API
       include NextLinkHeader
 
       # Potential edge case:
-      # It is possible for older updated_at values to written to the database after this API has been queried for changes. This would mean that these changes are missed when the client makes a subsequent request using the next-link.
+      #
+      # It is possible for older updated_at values to written to the database
+      # after this API has been queried for changes. This would mean that these
+      # changes are missed when the client makes a subsequent request using the
+      # next-link.
+      #
       # Possible causes of older updated_at values:
-      # - delay between c# calculating datetime.UtcNow and value being written to postgres
+      # - delay between c# calculating datetime.UtcNow and value being written
+      #   to postgres
       # - clock drift between servers
       def index
         per_page = params[:per_page] || 100
         changed_since = params[:changed_since]
-
         ActiveRecord::Base.transaction do
           ActiveRecord::Base.connection.execute('LOCK provider, provider_enrichment, site IN SHARE UPDATE EXCLUSIVE MODE')
-          @providers = Provider.opted_in.changed_since(changed_since).limit(per_page)
+          @providers = Provider
+                         .opted_in
+                         .changed_since(changed_since)
+                         .limit(per_page)
         end
 
         last_provider = @providers.last
 
         response.headers['Link'] = if last_provider
-                                     next_link((last_provider.last_published_at + 1.second).utc.iso8601, last_provider.id, per_page)
+                                     next_link(last_provider.changed_at
+                                                 .utc
+                                                 .strftime('%FT%T.%6NZ'),
+                                               per_page)
                                    else
-                                     next_link(params[:changed_since], "", per_page)
+                                     next_link(changed_since, per_page)
                                    end
-
         render json: @providers
       rescue ActiveRecord::StatementInvalid
         render json: { status: 400, message: 'Invalid changed_since value, the format should be an ISO8601 UTC timestamp, for example: `2019-01-01T12:01:00Z`' }.to_json, status: 400
@@ -32,9 +42,9 @@ module API
 
     private
 
-      def next_link(changed_since, from_provider_id, per_page)
+      def next_link(changed_since, per_page)
         current_url = request.base_url + request.path
-        "#{current_url}?changed_since=#{changed_since}&from_provider_id=#{from_provider_id}&per_page=#{per_page}; rel=\"next\""
+        "#{current_url}?changed_since=#{changed_since}&per_page=#{per_page}; rel=\"next\""
       end
     end
   end

--- a/app/models/concerns/changed_at.rb
+++ b/app/models/concerns/changed_at.rb
@@ -4,6 +4,11 @@ module ChangedAt
   class_methods do
   private
 
+    # Hook into Rails' built-in mechanism to update `updated_at` by adding to
+    # it's list of columns that get updated when an object changes (by default
+    # this is 'updated_at' and 'updated_on'). This is simpler than using a
+    # before/after save hook and should allow our 'changed_at' to behave in
+    # exactly the same way as 'updated_at'.
     def timestamp_attributes_for_update
       super + %w[changed_at]
     end

--- a/app/models/concerns/changed_at.rb
+++ b/app/models/concerns/changed_at.rb
@@ -1,0 +1,11 @@
+module ChangedAt
+  extend ActiveSupport::Concern
+
+  class_methods do
+  private
+
+    def timestamp_attributes_for_update
+      super + %w[changed_at]
+    end
+  end
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -67,8 +67,9 @@ class Provider < ApplicationRecord
   end
 
   def update_changed_at(timestamp: Time.now.utc)
-    # We don't want `updated_at` to change, only `changed_at`. Otherwise what
-    # would be the point of separating the two?
+    # Changed_at represents changes to related records as well as provider
+    # itself, so we don't want to alter the semantics of updated_at which
+    # represents changes to just the provider record.
     update_columns changed_at: timestamp
   end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -51,10 +51,10 @@ class Provider < ApplicationRecord
 
   scope :changed_since, ->(datetime) do
     if datetime.present?
-      where("last_published_at >= ?", datetime)
+      where("changed_at >= ?", datetime)
     else
-      where("last_published_at is not null")
-    end.order(:last_published_at, :id)
+      where("changed_at is not null")
+    end.order(:changed_at, :id)
   end
 
   scope :opted_in, -> { where(opted_in: true) }

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -29,6 +29,7 @@
 
 class Provider < ApplicationRecord
   include RegionCode
+  include ChangedAt
 
   enum provider_type: {
     scitt: "B",

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -49,9 +49,9 @@ class Provider < ApplicationRecord
            class_name: "ProviderEnrichment"
   has_many :courses
 
-  scope :changed_since, ->(datetime) do
-    if datetime.present?
-      where("changed_at >= ?", datetime)
+  scope :changed_since, ->(timestamp) do
+    if timestamp.present?
+      where("provider.changed_at > ?", timestamp)
     else
       where("changed_at is not null")
     end.order(:changed_at, :id)

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -65,4 +65,10 @@ class Provider < ApplicationRecord
       .attributes_before_type_cast
       .slice('address1', 'address2', 'address3', 'address4', 'postcode', 'region_code')
   end
+
+  def update_changed_at(timestamp: Time.now.utc)
+    # We don't want `updated_at` to change, only `changed_at`. Otherwise what
+    # would be the point of separating the two?
+    update_columns changed_at: timestamp
+  end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -20,4 +20,12 @@ class Site < ApplicationRecord
   include RegionCode
 
   belongs_to :provider
+
+  after_save :touch_provider
+
+private
+
+  def touch_provider
+    provider.update_changed_at
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@
 #                       PUT    /api/v2/providers(/:provider_code)/courses/:id(.:format) api/v2/courses#update
 #                       DELETE /api/v2/providers(/:provider_code)/courses/:id(.:format) api/v2/courses#destroy
 #             error_500 GET    /error_500(.:format)                                     error#error_500
+#            error_nodb GET    /error_nodb(.:format)                                    error#error_nodb
 
 Rails.application.routes.draw do
   namespace :api do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,8 +13,6 @@
 ActiveRecord::Schema.define(version: 2019_02_22_063449) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pg_buffercache"
-  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "__EFMigrationsHistory", primary_key: "MigrationId", id: :string, limit: 150, force: :cascade do |t|

--- a/docs/api.md
+++ b/docs/api.md
@@ -73,10 +73,8 @@ incremental update should only be performed using the next-page urls provided
 in the response headers. With that in mind, these are the parameters you
 should expect to see:
 
-- `changed_since` - is an ISO 8601 timestamp stating the oldest change to include
-- `from_entity_id` where "entity" is "provider" or "course" - is an internal id
-  used in paging to ensure no ambiguity where record updates within the same
-  second have been split across pages
+- `changed_since` - is an ISO 8601 timestamp stating the oldest change to include.
+
 
 The header format is from [link header
 pagination](https://apievangelist.com/2016/05/02/http-header-awareness-using-the-link-header-for-pagination/).
@@ -140,8 +138,7 @@ This endpoint retrieves a paginated list of courses.
   records](#retrieving-records)
 - It provides the capability outlined above for [retrieving changed
   records](#retrieving-changed-records).
-- Results are sorted by `updated_at` with the oldest update first, then by
-  `course_id` ascending.
+- Results are sorted by `updated_at` with the oldest update first.
 
 ### Example HTTP Requests
 
@@ -326,9 +323,7 @@ This endpoint retrieves all institutions.
   records](#retrieving-records)
 - It provides the capability outlined above for [retrieving changed
   records](#retrieving-changed-records).
-- Results are sorted by `updated_at` with the oldest update first, then by
-  `provider_id` ascending.
-
+- Results are sorted by `updated_at` with the oldest update first.
 ### Example HTTP Request
 
 ```shell

--- a/spec/controllers/api/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/v1/providers_controller_spec.rb
@@ -38,6 +38,7 @@ describe API::V1::ProvidersController, type: :controller do
         context 'using a changed_since before any providers have changed' do
           let(:changed_since) { 10.minutes.ago.utc }
 
+          its(%w[per_page]) { should eq '100' }
           its(%w[changed_since]) do
             should eq last_provider.changed_at.strftime('%FT%T.%6NZ')
           end
@@ -46,6 +47,7 @@ describe API::V1::ProvidersController, type: :controller do
         context 'using a changed_since after any providers have changed' do
           let(:changed_since) { Time.now.utc }
 
+          its(%w[per_page]) { should eq '100' }
           its(%w[changed_since]) { should eq changed_since.iso8601 }
         end
       end
@@ -57,6 +59,7 @@ describe API::V1::ProvidersController, type: :controller do
           get :index, params: { changed_since: changed_since.iso8601 }
         end
 
+        its(%w[per_page]) { should eq '100' }
         its(%w[changed_since]) { should eq changed_since.iso8601 }
       end
     end

--- a/spec/controllers/api/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/v1/providers_controller_spec.rb
@@ -39,14 +39,14 @@ describe API::V1::ProvidersController, type: :controller do
           let(:changed_since) { 10.minutes.ago.utc }
 
           its(%w[changed_since]) do
-            should eq last_provider.changed_at.strftime('%FT%T.%6NZ') 
+            should eq last_provider.changed_at.strftime('%FT%T.%6NZ')
           end
         end
 
         context 'using a changed_since after any providers have changed' do
           let(:changed_since) { Time.now.utc }
 
-          its(%w[changed_since])    { should eq changed_since.iso8601 }
+          its(%w[changed_since]) { should eq changed_since.iso8601 }
         end
       end
 
@@ -57,7 +57,7 @@ describe API::V1::ProvidersController, type: :controller do
           get :index, params: { changed_since: changed_since.iso8601 }
         end
 
-        its(%w[changed_since])    { should eq changed_since.iso8601 }
+        its(%w[changed_since]) { should eq changed_since.iso8601 }
       end
     end
   end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -41,6 +41,7 @@ FactoryBot.define do
     opted_in { true }
 
     transient do
+      changed_at           { nil }
       skip_associated_data { false }
       site_count           { 1 }
       sites                { build_list :site, site_count, provider: nil }
@@ -58,6 +59,14 @@ FactoryBot.define do
       # have to do that here.
       provider.enrichments << evaluator.enrichments.each do |enrichment|
         enrichment.provider_code ||= provider.provider_code
+      end
+
+      # Strangely, changed_at doesn't get set if we don't do this, even though
+      # updated_at does. Maybe this is because we've added changed_at to
+      # timestamp_attributes_for_update but FactoryBot doesn't actually
+      # recognise it.
+      if evaluator.changed_at.present?
+        provider.update changed_at: evaluator.changed_at
       end
     end
   end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -39,15 +39,19 @@ RSpec.describe Provider, type: :model do
 
   describe 'changed_at' do
     it 'is set on create' do
-      expect(subject.changed_at).to be_present
-      expect(subject.changed_at).to eq subject.updated_at
+      Timecop.freeze do
+       expect(subject.changed_at).to be_present
+       expect(subject.changed_at).to eq subject.updated_at
+     end
     end
 
     it 'is set on update' do
-      provider = create(:provider, updated_at: 1.hour.ago)
-      provider.touch
-      expect(subject.changed_at).to eq subject.updated_at
-      expect(subject.changed_at).not_to be_within(1.second).of(1.hour.ago)
+      Timecop.freeze do
+        provider = create(:provider, updated_at: 1.hour.ago)
+        provider.touch
+        expect(subject.changed_at).to eq subject.updated_at
+        expect(subject.changed_at).not_to be_within(1.second).of(1.hour.ago)
+      end
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -215,7 +215,7 @@ describe Provider, type: :model do
   end
 
   describe '#changed_since' do
-    context 'with a provider that has been published after the given timestamp' do
+    context 'with a provider that has been changed after the given timestamp' do
       let(:provider) { create(:provider, changed_at: 5.minutes.ago) }
 
       subject { Provider.changed_since(10.minutes.ago) }
@@ -223,16 +223,25 @@ describe Provider, type: :model do
       it { should include provider }
     end
 
-    context 'with a provider that has been published exactly at the given timestamp' do
+    context 'with a provider that has been changed less than a second after the given timestamp' do
+      let(:timestamp) { 5.minutes.ago }
+      let(:provider) { create(:provider, changed_at: timestamp + (0.001).seconds) }
+
+      subject { Provider.changed_since(timestamp) }
+
+      it { should include provider }
+    end
+
+    context 'with a provider that has been changed exactly at the given timestamp' do
       let(:publish_time) { 10.minutes.ago }
       let(:provider) { create(:provider, changed_at: publish_time) }
 
       subject { Provider.changed_since(publish_time) }
 
-      it { should include provider }
+      it { should_not include provider }
     end
 
-    context 'with a provider that has been published before the given timestamp' do
+    context 'with a provider that has been changed before the given timestamp' do
       let(:provider) { create(:provider, changed_at: 1.hour.ago) }
 
       subject { Provider.changed_since(10.minutes.ago) }

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -248,4 +248,18 @@ RSpec.describe Provider, type: :model do
       expect(Provider.opted_in).to match_array([opted_in_provider])
     end
   end
+
+  describe 'changed_at' do
+    it 'is set on create' do
+      expect(subject.changed_at).to be_present
+      expect(subject.changed_at).to eq subject.updated_at
+    end
+
+    it 'is set on update' do
+      provider = create(:provider, updated_at: 1.hour.ago)
+      provider.touch
+      expect(subject.changed_at).to eq subject.updated_at
+      expect(subject.changed_at).not_to be_within(1.second).of(1.hour.ago)
+    end
+  end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -225,7 +225,7 @@ describe Provider, type: :model do
 
     context 'with a provider that has been changed less than a second after the given timestamp' do
       let(:timestamp) { 5.minutes.ago }
-      let(:provider) { create(:provider, changed_at: timestamp + (0.001).seconds) }
+      let(:provider) { create(:provider, changed_at: timestamp + 0.001.seconds) }
 
       subject { Provider.changed_since(timestamp) }
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -29,7 +29,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Provider, type: :model do
+describe Provider, type: :model do
   subject { create(:provider) }
 
   describe 'associations' do
@@ -39,19 +39,16 @@ RSpec.describe Provider, type: :model do
 
   describe 'changed_at' do
     it 'is set on create' do
-      Timecop.freeze do
-       expect(subject.changed_at).to be_present
-       expect(subject.changed_at).to eq subject.updated_at
-     end
+      provider = Provider.create
+      expect(provider.changed_at).to be_present
+      expect(provider.changed_at).to eq provider.updated_at
     end
 
     it 'is set on update' do
-      Timecop.freeze do
-        provider = create(:provider, updated_at: 1.hour.ago)
-        provider.touch
-        expect(subject.changed_at).to eq subject.updated_at
-        expect(subject.changed_at).not_to be_within(1.second).of(1.hour.ago)
-      end
+      provider = create(:provider, updated_at: 1.hour.ago)
+      provider.touch
+      expect(provider.changed_at).to eq provider.updated_at
+      expect(provider.changed_at).not_to be_within(1.second).of(1.hour.ago)
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -45,10 +45,12 @@ describe Provider, type: :model do
     end
 
     it 'is set on update' do
-      provider = create(:provider, updated_at: 1.hour.ago)
-      provider.touch
-      expect(provider.changed_at).to eq provider.updated_at
-      expect(provider.changed_at).not_to be_within(1.second).of(1.hour.ago)
+      Timecop.freeze do
+        provider = create(:provider, updated_at: 1.hour.ago)
+        provider.touch
+        expect(provider.changed_at).to eq provider.updated_at
+        expect(provider.changed_at).to eq Time.now.utc
+      end
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -261,7 +261,7 @@ describe Provider, type: :model do
     end
   end
 
-  describe '#updated_changed_at' do
+  describe '#update_changed_at' do
     let(:provider) { create(:provider, changed_at: 1.hour.ago) }
 
     it 'sets changed_at to the current time' do
@@ -272,7 +272,7 @@ describe Provider, type: :model do
     end
 
     it 'sets changed_at to the given time' do
-      timestamp = Time.now.utc
+      timestamp = 1.hour.ago
       provider.update_changed_at timestamp: timestamp
       expect(provider.changed_at).to eq timestamp
     end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -216,7 +216,7 @@ describe Provider, type: :model do
 
   describe '#changed_since' do
     context 'with a provider that has been published after the given timestamp' do
-      let(:provider) { create(:provider, last_published_at: 5.minutes.ago) }
+      let(:provider) { create(:provider, changed_at: 5.minutes.ago) }
 
       subject { Provider.changed_since(10.minutes.ago) }
 
@@ -225,7 +225,7 @@ describe Provider, type: :model do
 
     context 'with a provider that has been published exactly at the given timestamp' do
       let(:publish_time) { 10.minutes.ago }
-      let(:provider) { create(:provider, last_published_at: publish_time) }
+      let(:provider) { create(:provider, changed_at: publish_time) }
 
       subject { Provider.changed_since(publish_time) }
 
@@ -233,25 +233,11 @@ describe Provider, type: :model do
     end
 
     context 'with a provider that has been published before the given timestamp' do
-      let(:provider) { create(:provider, last_published_at: 1.hour.ago) }
+      let(:provider) { create(:provider, changed_at: 1.hour.ago) }
 
       subject { Provider.changed_since(10.minutes.ago) }
 
       it { should_not include provider }
-    end
-
-    context 'with a provider that has never been published' do
-      let(:provider) { create(:provider, last_published_at: nil) }
-
-      describe 'with non-nil changed_since' do
-        subject { Provider.changed_since(10.minutes.ago) }
-        it { should_not include provider }
-      end
-
-      describe 'with changed_since set to nil' do
-        subject { Provider.changed_since(nil) }
-        it { should_not include provider }
-      end
     end
   end
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -24,4 +24,22 @@ RSpec.describe Provider, type: :model do
   describe 'associations' do
     it { should belong_to(:provider) }
   end
+
+  describe '#touch_provider' do
+    let(:site) { create(:site) }
+
+    it 'sets changed_at to the current time' do
+      Timecop.freeze do
+        site.touch
+        expect(site.provider.changed_at).to eq Time.now.utc
+      end
+    end
+
+    it 'leaves updated_at unchanged' do
+      timestamp = 1.hour.ago
+      site.provider.update updated_at: timestamp
+      site.touch
+      expect(site.provider.updated_at).to eq timestamp
+    end
+  end
 end

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -359,6 +359,13 @@ describe 'Providers API', type: :request do
 
           get_next_providers response.headers['Link'].split(';').first
           expect(response.body).to have_provider_codes([])
+
+          random_provider = Provider.all.sample
+          random_provider.touch
+
+          get_next_providers response.headers['Link'].split(';').first
+          expect(response.body)
+            .to have_provider_codes([random_provider.provider_code])
         end
       end
     end

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -335,10 +335,10 @@ describe 'Providers API', type: :request do
 
       context "with many providers updated in the same second" do
         before do
-          t = 1.second.ago,
+          updated_at = 1.second.ago
           25.times do |i|
             create(:provider, provider_code: "PROV#{i + 1}",
-                   updated_at: t,
+                   updated_at: updated_at,
                    sites: [],
                    enrichments: [])
           end


### PR DESCRIPTION
### Context

We need to track this for the incremental API so that it can include all related data that might have changed. I.e. if a site has changed then that provider needs to be included in the relevant `changed_since` range even though the provider record hasn't changed.

### Changes proposed in this pull request

`provider.changed_at` is updated when site is updated, while `provider.updated_at` is unaffected.

We also change the implementation of the incremental load by `from_provider_id` from the `Next` link, and using sub-second values for `changed_since` manages to achieve the desired goal of ordering the set of changed providers with a resolution higher then seconds. This is supported by the `changed_at` column without any modifications, we just need to format the timestamp with the `strftime` format `%FT%T.%6N` instead of using `iso8601`.

The `courses` controller will have to be updated to also use sub-second values for `changed_since`