### PR TITLE
Add desc to create-dev-user rake task so it shows up with rake -T

### DIFF
--- a/lib/tasks/create_dev_user.rake
+++ b/lib/tasks/create_dev_user.rake
@@ -22,6 +22,7 @@ namespace :db do
     Rake::Task['db:drop_dev_user'].execute
   end
 
+  desc 'Create the dev user role'
   task :create_dev_user do
     run_sql <<~EOSQL.strip
       CREATE USER manage_courses_backend WITH SUPERUSER CREATEDB PASSWORD 'manage_courses_backend';


### PR DESCRIPTION
### Context

When we currently do `rake -T` we don't see the `create_dev_user` task.

### Changes proposed in this pull request

Add it to the `rake -T` by giving it a `desc`.

### Guidance to review
