### PR TITLE
[1011] Update changed_at when provider enrichment is updated

### DIFF
--- a/app/models/concerns/touch_provider.rb
+++ b/app/models/concerns/touch_provider.rb
@@ -1,6 +1,10 @@
 module TouchProvider
   extend ActiveSupport::Concern
 
+  included do
+    after_save :touch_provider
+  end
+
 private
 
   def touch_provider

--- a/app/models/concerns/touch_provider.rb
+++ b/app/models/concerns/touch_provider.rb
@@ -1,0 +1,9 @@
+module TouchProvider
+  extend ActiveSupport::Concern
+
+private
+
+  def touch_provider
+    provider.update_changed_at
+  end
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -30,7 +30,6 @@
 class Provider < ApplicationRecord
   include RegionCode
   include ChangedAt
-  include TouchProvider
 
   enum provider_type: {
     scitt: "B",

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -30,6 +30,7 @@
 class Provider < ApplicationRecord
   include RegionCode
   include ChangedAt
+  include TouchProvider
 
   enum provider_type: {
     scitt: "B",

--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -18,7 +18,7 @@ class ProviderEnrichment < ApplicationRecord
 
   include RegionCode
   include TouchProvider
-  
+
   enum status: { draft: 0, published: 1 }
 
   belongs_to :provider, foreign_key: :provider_code, primary_key: :provider_code

--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -17,10 +17,13 @@ class ProviderEnrichment < ApplicationRecord
   self.primary_key = "provider_code"
 
   include RegionCode
-
+  include TouchProvider
+  
   enum status: { draft: 0, published: 1 }
 
   belongs_to :provider, foreign_key: :provider_code, primary_key: :provider_code
+
+  after_save :touch_provider
 
   scope :with_address_info,
         -> do

--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -23,8 +23,6 @@ class ProviderEnrichment < ApplicationRecord
 
   belongs_to :provider, foreign_key: :provider_code, primary_key: :provider_code
 
-  after_save :touch_provider
-
   scope :with_address_info,
         -> do
           where("json_data ?| array['Address1', 'Address2', 'Address3', 'Address4', 'Postcode']")

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -18,14 +18,9 @@
 
 class Site < ApplicationRecord
   include RegionCode
+  include TouchProvider
 
   belongs_to :provider
 
   after_save :touch_provider
-
-private
-
-  def touch_provider
-    provider.update_changed_at
-  end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -21,6 +21,4 @@ class Site < ApplicationRecord
   include TouchProvider
 
   belongs_to :provider
-
-  after_save :touch_provider
 end

--- a/spec/models/provider_enrichment_spec.rb
+++ b/spec/models/provider_enrichment_spec.rb
@@ -1,0 +1,36 @@
+# == Schema Information
+#
+# Table name: provider_enrichment
+#
+#  id                 :integer          not null
+#  provider_code      :text             not null, primary key
+#  json_data          :jsonb
+#  updated_by_user_id :integer
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  created_by_user_id :integer
+#  last_published_at  :datetime
+#  status             :integer          default("draft"), not null
+#
+
+require 'rails_helper'
+
+describe ProviderEnrichment, type: :model do
+  describe '#touch_provider' do
+    let(:provider) { create(:provider) }
+
+    it 'sets changed_at to the current time' do
+      Timecop.freeze do
+        provider.enrichments.update(email: "test@email")
+        expect(provider.changed_at).to eq Time.now.utc
+      end
+    end
+
+    it 'leaves updated_at unchanged' do
+      timestamp = 1.hour.ago
+      provider.update updated_at: timestamp
+      provider.enrichments.update(email: "test@email")
+      expect(provider.updated_at).to eq timestamp
+    end
+  end
+end


### PR DESCRIPTION
### Context

Linked to the [953] changed_at pull request. 

https://github.com/DFE-Digital/manage-courses-backend/pull/131

Changes to the provider enrichment model now update changed_at.

### Changes proposed in this pull request

- touch_provider implemented in the provider enrichment model
- touch_provider refactored into a concern
- Tests to check that changed_at is updated when provider enrichment is touched, while leaving updated_at unaffected.

