### PR TITLE
[1015] Add opted_in for providers

### DIFF
--- a/app/controllers/api/v1/providers_controller.rb
+++ b/app/controllers/api/v1/providers_controller.rb
@@ -14,7 +14,7 @@ module API
 
         ActiveRecord::Base.transaction do
           ActiveRecord::Base.connection.execute('LOCK provider, provider_enrichment, site IN SHARE UPDATE EXCLUSIVE MODE')
-          @providers = Provider.changed_since(changed_since).limit(per_page)
+          @providers = Provider.opted_in.changed_since(changed_since).limit(per_page)
         end
 
         last_provider = @providers.last

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -55,6 +55,8 @@ class Provider < ApplicationRecord
     end.order(:last_published_at, :id)
   end
 
+  scope :opted_in, -> { where(opted_in: true) }
+
   # TODO: filter to published enrichments, maybe rename to published_address_info
   def address_info
     (enrichments.latest_created_at.with_address_info.first || self)

--- a/db/migrate/20190222063449_add_opted_in_to_provider.rb
+++ b/db/migrate/20190222063449_add_opted_in_to_provider.rb
@@ -1,0 +1,5 @@
+class AddOptedInToProvider < ActiveRecord::Migration[5.2]
+  def change
+    add_column :provider, :opted_in, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_13_160920) do
+ActiveRecord::Schema.define(version: 2019_02_22_063449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -141,6 +141,7 @@ ActiveRecord::Schema.define(version: 2019_02_13_160920) do
     t.text "accrediting_provider"
     t.datetime "last_published_at"
     t.datetime "changed_at", default: -> { "timezone('utc'::text, now())" }, null: false
+    t.boolean "opted_in", default: false
     t.index ["last_published_at"], name: "IX_provider_last_published_at"
     t.index ["provider_code"], name: "IX_provider_provider_code", unique: true
   end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -37,6 +37,7 @@ FactoryBot.define do
     postcode { Faker::Address.postcode }
     accrediting_provider { 'N' }
     region_code { ProviderEnrichment.region_codes['London'] }
+    opted_in { true }
 
     transient do
       skip_associated_data { false }

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -238,4 +238,13 @@ RSpec.describe Provider, type: :model do
       end
     end
   end
+
+  describe '.opted_in' do
+    let!(:opted_in_provider) { create(:provider, opted_in: true) }
+    let!(:opted_out_provder) { create(:provider, opted_in: false) }
+
+    it 'returns only the opted_in provider' do
+      expect(Provider.opted_in).to match_array([opted_in_provider])
+    end
+  end
 end


### PR DESCRIPTION
### Context
UCAS Transition

### Changes proposed in this pull request
Add `opted_in` to providers and scope v1/providers to only return when `true`
