### PR TITLE
[993] Create new endpoint in for user session

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,13 @@ file
 ```
 
 ```bash
-export SETTINGS__FILE__BASED__SETTINGS_ENV1="machine wins"
+export SETTINGS__FILE__BASED__SETTINGS__ENV1="machine wins"
 ```
 
 ```ruby
 puts Settings.file.based.setting.env1
 
-# machine wins
+machine wins
 ```
 
 Any `Machine based env variables settings` that is not prefixed with `SETTINGS`.* are not considered for general consumption.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,33 @@ Encoding the payload can be done with the [Ruby `jwt` gem](https://github.com/jw
 JWT.encode payload, SECRET, 'HS256'
 ```
 
+## Settings vs config vs Environment variables
+
+Refer to the [the config gem](https://github.com/railsconfig/config#accessing-the-settings-object) to understand the `file based settings` loading order.
+
+To override file based via `Machine based env variables settings`
+```bash
+cat config/settings.yml
+file
+  based
+    settings
+      env1: 'some file based value'
+```
+
+```bash
+export SETTINGS__FILE__BASED__SETTINGS_ENV1="machine wins"
+```
+
+```ruby
+puts Settings.file.based.setting.env1
+
+# machine wins
+```
+
+Any `Machine based env variables settings` that is not prefixed with `SETTINGS`.* are not considered for general consumption.
+
+
+
 ## CI variables
 
 You'll need to define the `AZURE_CR_PASSWORD` in Travis in order to successfully build and publish. This can be done using this command:

--- a/app/controllers/api/v2/sessions_controller.rb
+++ b/app/controllers/api/v2/sessions_controller.rb
@@ -1,0 +1,15 @@
+module API
+  module V2
+    class SessionsController < ApplicationController
+      def create
+        @current_user.update(
+          last_login_date_utc: Time.now.utc,
+          first_name: params[:first_name],
+          last_name: params[:last_name]
+        )
+
+        render jsonapi: @current_user
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,8 @@ Rails.application.routes.draw do
           resources :courses
         end
       end
+
+      resource :session
     end
   end
 

--- a/spec/requests/api/v2/session_spec.rb
+++ b/spec/requests/api/v2/session_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+describe '/api/v2/session', type: :request do
+  let(:user)    { create(:user) }
+  let(:payload) { { email: user.email } }
+  let(:token) do
+    JWT.encode payload.to_json,
+               Settings.authentication.secret,
+               Settings.authentication.algorithm
+  end
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+
+  context 'when unauthenticated' do
+    let(:payload) { { email: 'foo@bar' } }
+
+    before do
+      get "/api/v2/users/#{user.id}",
+          headers: { 'HTTP_AUTHORIZATION' => credentials }
+    end
+
+    subject { response }
+
+    it { should have_http_status(:unauthorized) }
+  end
+
+  describe 'creating a session' do
+    let(:user)    { create(:user, last_login_date_utc: 10.days.ago) }
+    it 'saves the last login time' do
+      Timecop.freeze do
+        post '/api/v2/session',
+             headers: { 'HTTP_AUTHORIZATION' => credentials }
+
+        # OS vs TimeCop vs db, most likely db (nanoseconds are omitted), hence
+        # 'be_within(1.second).of Time.now.utc' vs 'eq Time.now.utc'
+        expect(user.reload.last_login_date_utc).to be_within(1.second).of Time.now.utc
+      end
+    end
+
+    it 'returns the user record' do
+      post '/api/v2/session',
+           headers: { 'HTTP_AUTHORIZATION' => credentials },
+           params: { first_name: user.first_name, last_name: user.last_name }
+
+      json_response = JSON.parse response.body
+      expect(json_response).to eq(
+        "data" => {
+          "id" => user.id.to_s,
+          "type" => "users",
+          "attributes" => {
+            "first_name" => user.first_name,
+            "last_name" => user.last_name,
+            "email" => user.email,
+          }
+        },
+          "jsonapi" => {
+            "version" => "1.0"
+          }
+        )
+    end
+
+    it 'returns the updated user record' do
+      post '/api/v2/session',
+           headers: { 'HTTP_AUTHORIZATION' => credentials },
+           params: { first_name: "updated first_name", last_name: "updated last_name" }
+
+      json_response = JSON.parse response.body
+      expect(json_response).to eq(
+        "data" => {
+          "id" => user.id.to_s,
+          "type" => "users",
+          "attributes" => {
+            "first_name" => "updated first_name",
+            "last_name" => "updated last_name",
+            "email" => user.email,
+          }
+        },
+          "jsonapi" => {
+            "version" => "1.0"
+          }
+        )
+      user.reload
+      expect(user.first_name).to eq "updated first_name"
+      expect(user.last_name).to eq "updated last_name"
+    end
+  end
+end


### PR DESCRIPTION
### Context
The ability to create a session and update the user last login time as will as the first and last name. 


### Changes proposed in this pull request
Endpoint exists and frontend is able to "create" a session for new user login.
The last_login timestamp is incremented after this endpoint is accessed

### Guidance to review
This needs to work with frontend.