### PR TITLE
[1024] Remove 'Course#qualification' from V1 API

### DIFF
--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -28,7 +28,7 @@ class CourseSerializer < ActiveModel::Serializer
   has_one :accrediting_provider, serializer: CourseProviderSerializer
 
   attributes :course_code, :start_month, :name, :study_mode, :copy_form_required, :profpost_flag,
-             :program_type, :modular, :english, :maths, :science, :qualification, :recruitment_cycle,
+             :program_type, :modular, :english, :maths, :science, :recruitment_cycle,
              :start_month_string, :age_range
 
   def profpost_flag

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe "Courses API", type: :request do
         course_code: "2HPF",
         start_date: Date.new(2019, 9, 1),
         name: "Religious Education",
-        qualification: 1,
         sites: [site],
         subjects: [subject1, subject2],
         study_mode: :full_time,
@@ -87,7 +86,6 @@ RSpec.describe "Courses API", type: :request do
             "english" => 3,
             "maths" => 9,
             "science" => nil,
-            "qualification" => 1,
             "recruitment_cycle" => "2019",
             "campus_statuses" => [
               {

--- a/spec/serializers/course_serializer_spec.rb
+++ b/spec/serializers/course_serializer_spec.rb
@@ -29,5 +29,4 @@ RSpec.describe CourseSerializer do
 
   it { should include(course_code: course.course_code) }
   it { should include(name: course.name) }
-  it { should include(qualification: course.qualification) }
 end


### PR DESCRIPTION
### Context

This field is not documented, nor used by the downstream consumer.

### Changes proposed in this pull request

Remove it from the serialiser.