### PR TITLE
[1014] Simplify qualifications logic

### DIFF
--- a/app/models/concerns/with_qualifications.rb
+++ b/app/models/concerns/with_qualifications.rb
@@ -47,27 +47,22 @@ module WithQualifications
       pgde
     ]
 
-    def is_further_education?
-      subjects.further_education.any?
-    end
-
+    # This field may seem like an unnecessary overhead when there is already a
+    # database-backed `qualification` field. However it's misleading, from the
+    # point of view of the teacher training domain, to think of 'PGCE with QTS'
+    # as a single qualification, since the QTS and PGCE aspects are completely
+    # separate and may even be delivered in different places by different providers.
+    # e.g. the QTS might come from a SCITT but the PGCE would come from a university.
+    #
+    # It's more accurate (and hopefully more future-proof) to represent qualifications
+    # as a list and leave the gluing of them to the presentation layer.
     def qualifications
-      qts_if_any + qualification_awarded_by_uni_if_any
-    end
-
-  private
-
-    def qts_if_any
-      is_further_education? ? [] : [:qts]
-    end
-
-    def qualification_awarded_by_uni_if_any
-      if PGDECourse.is_one?(self)
-        [:pgde]
-      elsif recommendation_for_qts?
-        []
-      else
-        [:pgce]
+      case qualification
+      when "qts" then [:qts]
+      when "pgce_with_qts" then %i[qts pgce]
+      when "pgde_with_qts" then %i[qts pgde]
+      when "pgce" then [:pgce]
+      when "pgde" then [:pgde]
       end
     end
   end

--- a/app/models/concerns/with_qualifications.rb
+++ b/app/models/concerns/with_qualifications.rb
@@ -2,10 +2,34 @@ module WithQualifications
   extend ActiveSupport::Concern
 
   included do
+    # The training programme outcome that originated in the UCAS NetUpdate system.
+    #
+    # See [UCAS Teacher Training Set-up Guide](https://www.ucas.com/file/115581/download?token=mv-G6P53),
+    # page 32
     enum profpost_flag: {
+
+      # Recommendation for QTS: the student will not receive an academic teacher
+      # training qualification on successful completion of the
+      # programme.
       recommendation_for_qts: "",
+
+      # Professional: the student will receive a Professional Graduate
+      # Certificate of Education (offered at Level 6) or Professional
+      # Graduate Diploma in Education (PGDE), with no credits or
+      # modules at postgraduate (master’s) Level 7 on successful
+      # completion of the programme.
       professional: "PF",
+
+      # Postgraduate: the student will receive a Postgraduate Certificate
+      # of Education (PGCE) or other qualification which includes at
+      # least one module or some credits at postgraduate
+      # (master’s) Level 7 on successful completion the
+      # programme.
       postgraduate: "PG",
+
+      # Both professional and postgraduate: the student has the option of taking at least one
+      # postgraduate (master’s) Level 7 module or obtaining some
+      # postgraduate-level credits as part of the programme.
       professional_postgraduate: "BO",
     }
 

--- a/app/models/concerns/with_qualifications.rb
+++ b/app/models/concerns/with_qualifications.rb
@@ -33,6 +33,20 @@ module WithQualifications
       professional_postgraduate: "BO",
     }
 
+    # When UCAS basic courses were being imported into Manage Courses DB, this
+    # field wasn't coming from the UCAS data. Instead, the UCAS importer derived
+    # this field from the `profpost_flag`, the `pgde_course` table and from the
+    # subjects this course was tagged to.
+    #
+    # Defined here: https://github.com/DFE-Digital/manage-courses-api/blob/master/src/ManageCourses.Domain/Models/CourseQualification.cs
+    enum qualification: %i[
+      qts
+      pgce_with_qts
+      pgde_with_qts
+      pgce
+      pgde
+    ]
+
     def is_further_education?
       subjects.further_education.any?
     end

--- a/app/models/pgde_course.rb
+++ b/app/models/pgde_course.rb
@@ -7,11 +7,9 @@
 #  provider_code :text             not null
 #
 
-class PGDECourse < ApplicationRecord
-  def self.is_one?(course)
-    where(
-      course_code: course.course_code,
-      provider_code: course.provider.provider_code
-    ).exists?
-  end
-end
+# Prior to the UCAS transition, this class is only used in the UCAS importer to
+# calculate the `course#qualification` database column.
+#
+# TODO: delete this class (and entire table) after the UCAS transition is finished
+
+class PGDECourse < ApplicationRecord; end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,7 +46,7 @@ course1 = Course.create!(
   english: 9,
   science: nil,
   modular: "M",
-  qualification: 1,
+  qualification: :pgce_with_qts,
   subjects: [
     Subject.find_by(subject_name: "Secondary"),
     Subject.find_by(subject_name: "Mathematics")
@@ -73,7 +73,7 @@ course2 = Course.create!(
   english: 9,
   science: nil,
   modular: "",
-  qualification: 1,
+  qualification: :pgce_with_qts,
   subjects: [
     Subject.find_by(subject_name: "Secondary"),
     Subject.find_by(subject_name: "Biology"),
@@ -100,7 +100,7 @@ Course.create!(
   course_code: "5W2A",
   provider: Provider.create!(provider_name: "Acme Alliance", provider_code: "A02"),
   accrediting_provider: accrediting_provider,
-  qualification: 1,
+  qualification: :pgce_with_qts,
   subjects: [
     Subject.last
   ]
@@ -110,7 +110,7 @@ Course.create!(
   name: Faker::ProgrammingLanguage.name,
   course_code: "9A5Y",
   provider: Provider.create!(provider_name: 'Big Uni', provider_code: 'B01'),
-  qualification: 1
+  qualification: :pgce_with_qts
 )
 
 10.times do |i|

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -40,38 +40,24 @@ FactoryBot.define do
       end
     end
 
-    trait :in_further_education do
-      after(:build) do |course|
-        course.subjects << create(:futher_education_subject)
-      end
-    end
-
-    trait :marked_as_pgde do
-      after(:build) do |course|
-        create(:pgde_course, provider_code: course.provider.provider_code, course_code: course.course_code)
-      end
-    end
-
     trait :resulting_in_qts do
-      profpost_flag { :recommendation_for_qts }
+      qualification { :qts }
     end
 
     trait :resulting_in_pgce_with_qts do
-      profpost_flag { %i[professional postgraduate professional_postgraduate].sample }
+      qualification { :pgce_with_qts }
     end
 
     trait :resulting_in_pgde_with_qts do
-      marked_as_pgde
+      qualification { :pgde_with_qts }
     end
 
     trait :resulting_in_pgce do
-      in_further_education
-      profpost_flag { %i[professional postgraduate professional_postgraduate].sample }
+      qualification { :pgce }
     end
 
     trait :resulting_in_pgde do
-      marked_as_pgde
-      in_further_education
+      qualification { :pgde }
     end
   end
 end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
   factory :course do
     sequence(:course_code) { |n| "C#{n}D3" }
     name { Faker::ProgrammingLanguage.name }
-    qualification { 1 }
+    qualification { :pgce_with_qts }
     association(:provider)
     resulting_in_pgce_with_qts
 

--- a/spec/factories/pgde_course.rb
+++ b/spec/factories/pgde_course.rb
@@ -7,6 +7,8 @@
 #  provider_code :text             not null
 #
 
+# TODO: delete this class (and `PGDECourse`) after the UCAS transition is finished
+
 FactoryBot.define do
   factory :pgde_course do
   end

--- a/spec/factory_specs/course_spec.rb
+++ b/spec/factory_specs/course_spec.rb
@@ -12,15 +12,7 @@ describe "Course Factory" do
     let(:course) { create(:course, :resulting_in_pgde) }
 
     it "created course" do
-      expect(PGDECourse.is_one?(course)).to be true
-    end
-  end
-
-  context "course in_further_education" do
-    let(:course) { create(:course, :in_further_education) }
-
-    it "created course" do
-      expect(course.subjects.further_education.any?).to be true
+      expect(course.qualification).to eq("pgde")
     end
   end
 end

--- a/spec/models/concerns/with_qualifications_spec.rb
+++ b/spec/models/concerns/with_qualifications_spec.rb
@@ -1,53 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe WithQualifications, type: :model do
-  qts_specs = [
-    ["recommendation_for_qts", :not_pgde, :not_fe] => %i[qts]
-  ]
+  specs = [
+    qts: [:qts],
+    pgce: [:pgce],
+    pgde: [:pgde],
+    pgce_with_qts: %i[qts pgce],
+    pgde_with_qts: %i[qts pgde],
+  ].freeze
 
-  qts_pgce_specs = [
-    ["professional", :not_pgde, :not_fe] => %i[qts pgce],
-    ["postgraduate", :not_pgde, :not_fe] => %i[qts pgce],
-    ["professional_postgraduate", :not_pgde, :not_fe] => %i[qts pgce],
-  ]
+  describe "#qualifications" do
+    specs.each do |spec|
+      spec.each do |qualification, expected|
+        context "course with qualification=#{qualification}" do
+          subject { create(:course, qualification: qualification) }
 
-  qts_pgde_specs = [
-    ["recommendation_for_qts", :is_pgde, :not_fe] => %i[qts pgde],
-    ["professional", :is_pgde, :not_fe] => %i[qts pgde],
-    ["postgraduate", :is_pgde, :not_fe] => %i[qts pgde],
-    ["professional_postgraduate", :is_pgde, :not_fe] => %i[qts pgde],
-  ]
-
-  pgce_specs = [
-    ["professional", :not_pgde, :is_further_education] => %i[pgce],
-    ["postgraduate", :not_pgde, :is_further_education] => %i[pgce],
-    ["professional_postgraduate", :not_pgde, :is_further_education] => %i[pgce]
-  ]
-
-  pgde_specs = [
-    ["recommendation_for_qts", :is_pgde, :is_further_education] => %i[pgde],
-    ["professional", :is_pgde, :is_further_education] => %i[pgde],
-    ["postgraduate", :is_pgde, :is_further_education] => %i[pgde],
-    ["professional_postgraduate", :is_pgde, :is_further_education] => %i[pgde],
-  ]
-
-  nonsensical_specs = [
-    ["recommendation_for_qts", :not_pgde, :is_further_education] => []
-  ]
-
-  specs = (nonsensical_specs + qts_specs + qts_pgce_specs + qts_pgde_specs + pgce_specs + pgde_specs).freeze
-
-  specs.each do |spec|
-    spec.each do |inputs, expected|
-      profpost_flag = inputs[0]
-      factory_settings = []
-      factory_settings << :marked_as_pgde if inputs[1] == :is_pgde
-      factory_settings << :in_further_education if inputs[2] == :is_further_education
-
-      context "course with profpost_flag=#{profpost_flag}, #{factory_settings.join(', ')}" do
-        subject { create(:course, *factory_settings, profpost_flag: profpost_flag) }
-
-        its(:qualifications) { should eq(expected) }
+          its(:qualifications) { should eq(expected) }
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

#135 introduced a lot of logic to derive qualifications, based on UCAS information and the `pgde_course` overlay table. However, what I've since learned is that the UCAS importer already does this and persists an enum into the `course#qualification` column. We can just use this column in a much more direct way for the Course API v2.

Once the UCAS transition happens and the UCAS importer is turned off, we can probably stop using the `profpost_flag` and the `pgde_course` table, and just use `course#qualification` instead.

### Changes proposed in this pull request

* use the `qualification` enum on `course`
* throw away a lot of the complexity
* document qualification-related fields in order for the learnings to not get lost
* leave `TODO`s to simplify (i.e. delete) this logic even further, post-transition

### Guidance to review

![facepalm](https://media.giphy.com/media/3ov9jCGzR1JtD8Hlni/giphy.gif)
