### PR TITLE
Remove recruitment_cycle from site and site_status

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -20,8 +20,4 @@ class Site < ApplicationRecord
   include RegionCode
 
   belongs_to :provider
-
-  def recruitment_cycle
-    "2019"
-  end
 end

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -43,8 +43,4 @@ class SiteStatus < ApplicationRecord
   }
   scope :with_vacancies, -> { where.not(vac_status: :no_vacancies) }
   scope :open_for_applications, -> { findable.applications_being_accepted_now.with_vacancies }
-
-  def recruitment_cycle
-    "2019"
-  end
 end

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -17,7 +17,7 @@
 #
 
 class SiteSerializer < ActiveModel::Serializer
-  attributes :campus_code, :name, :region_code, :recruitment_cycle
+  attributes :campus_code, :name, :region_code
 
   def campus_code
     object.code
@@ -29,9 +29,5 @@ class SiteSerializer < ActiveModel::Serializer
 
   def region_code
     '%02d' % object.region_code_before_type_cast if object.region_code.present?
-  end
-
-  def recruitment_cycle
-    object.recruitment_cycle
   end
 end

--- a/app/serializers/site_status_serializer.rb
+++ b/app/serializers/site_status_serializer.rb
@@ -12,7 +12,7 @@
 #
 
 class SiteStatusSerializer < ActiveModel::Serializer
-  attributes :campus_code, :name, :vac_status, :publish, :status, :course_open_date, :recruitment_cycle
+  attributes :campus_code, :name, :vac_status, :publish, :status, :course_open_date
 
   def campus_code
     object.site.code
@@ -36,9 +36,5 @@ class SiteStatusSerializer < ActiveModel::Serializer
 
   def name
     object.site.location_name
-  end
-
-  def recruitment_cycle
-    object.recruitment_cycle
   end
 end

--- a/docs/api.md
+++ b/docs/api.md
@@ -225,7 +225,6 @@ endpoint) if any of these are true:
         "publish": "Y",
         "status": "R",
         "course_open_date": "2018-10-09",
-        "recruitment_cycle": "2019"
       }
     ],
     "subjects": [
@@ -266,7 +265,6 @@ endpoint) if any of these are true:
 | campus_code       | Text      | A-Z, 0-9, "-" or "" | 1-character campus codes |
 | name              | Text      |                     |
 | region_code       | Text      | 01 to 11            | 2-character string       |
-| recruitment_cycle | Text      |                     | 4-character year         |
 
 :warning: - _A single provider can have at most 37 campuses._
 
@@ -282,7 +280,6 @@ endpoint) if any of these are true:
 | publish           | Text                 |                   |
 | status            | Text                 |                   |
 | course_open_date  | ISO 8601 date string |                   |
-| recruitment_cycle | Text                 |                   | 4-character year         |
 
 ## Subjects
 
@@ -397,7 +394,6 @@ endpoint) if any of these are true:
       {
         "campus_code": "",
         "name": "Main Site",
-        "recruitment_cycle": "2019",
         "region_code": "01"
       }
     ]

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -95,7 +95,6 @@ RSpec.describe "Courses API", type: :request do
                 "publish" => "Y",
                 "status" => "R",
                 "course_open_date" => "2018-10-09",
-                "recruitment_cycle" => "2019"
               }
             ],
             "subjects" => [

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -106,7 +106,6 @@ describe 'Providers API', type: :request do
                     'campus_code' => '-',
                     'name' => 'Main site',
                     'region_code' => '01',
-                    'recruitment_cycle' => '2019'
                   }
                 ],
                 'institution_code' => 'A123',
@@ -130,7 +129,6 @@ describe 'Providers API', type: :request do
                     'campus_code' => '-',
                     'name' => 'Main site',
                     'region_code' => '11',
-                    'recruitment_cycle' => '2019'
                   }
                 ],
                 'institution_code' => 'B123',
@@ -175,7 +173,6 @@ describe 'Providers API', type: :request do
                                       'campus_code' => '-',
                                       'name' => 'Main site',
                                       'region_code' => '01',
-                                      'recruitment_cycle' => '2019'
                                     }
                                   ],
                                   'institution_code' => 'A123',
@@ -199,7 +196,6 @@ describe 'Providers API', type: :request do
                                       'campus_code' => '-',
                                       'name' => 'Main site',
                                       'region_code' => '11',
-                                      'recruitment_cycle' => '2019'
                                     }
                                   ],
                                   'institution_code' => 'B123',


### PR DESCRIPTION
### Context
`recruitment_cycle` only applies to `course`
 
### Changes proposed in this pull request
- Remove `recruitment_cycle` from `site`
- Remove `recruitment_cycle` from `site_status`

### Guidance to review
`/api/v1/courses`
