### PR TITLE
Improve default rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,28 @@ docker-compose exec web /bin/sh -c "bundle exec rails db:setup"
 
 Then open http://localhost:3000 to see the app.
 
+## Running specs, linter(without auto correct) and annotate models and serializers
+```
+bundle exec rake
+```
+
+## Running specs
+```
+bundle exec rspec
+```
+
+## Linting
+
+It's best to lint just your app directories and not those belonging to the framework:
+
+```bash
+bundle exec govuk-lint-ruby app config db lib spec --format clang
+
+or
+
+docker-compose exec web /bin/sh -c "bundle exec govuk-lint-ruby app config db lib spec Gemfile --format clang"
+```
+
 ## Accessing API
 
 ### V1
@@ -91,18 +113,6 @@ Encoding the payload can be done with the [Ruby `jwt` gem](https://github.com/jw
 
 ```
 JWT.encode payload, SECRET, 'HS256'
-```
-
-## Linting
-
-It's best to lint just your app directories and not those belonging to the framework:
-
-```bash
-bundle exec govuk-lint-ruby app config db lib spec --format clang
-
-or
-
-docker-compose exec web /bin/sh -c "bundle exec govuk-lint-ruby app config db lib spec Gemfile --format clang"
 ```
 
 ## CI variables

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,7 @@
 require_relative 'config/application'
 
 Rails.application.load_tasks
+
+task lint: ['lint:ruby']
+task annotate: ['db:annotate']
+task default: %i[spec annotate lint]

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -24,6 +24,7 @@
 #  accrediting_provider :text
 #  last_published_at    :datetime
 #  changed_at           :datetime         not null
+#  opted_in             :boolean          default(FALSE)
 #
 
 class Provider < ApplicationRecord

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -24,6 +24,7 @@
 #  accrediting_provider :text
 #  last_published_at    :datetime
 #  changed_at           :datetime         not null
+#  opted_in             :boolean          default(FALSE)
 #
 
 class ProviderSerializer < ActiveModel::Serializer

--- a/lib/tasks/govuk_lint.rake
+++ b/lib/tasks/govuk_lint.rake
@@ -1,0 +1,7 @@
+desc "Lint ruby code"
+namespace :lint do
+  task :ruby do
+    puts 'Linting...'
+    system 'bundle exec govuk-lint-ruby app config db lib spec Gemfile --format clang -a'
+  end
+end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -24,6 +24,7 @@
 #  accrediting_provider :text
 #  last_published_at    :datetime
 #  changed_at           :datetime         not null
+#  opted_in             :boolean          default(FALSE)
 #
 
 FactoryBot.define do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -24,6 +24,7 @@
 #  accrediting_provider :text
 #  last_published_at    :datetime
 #  changed_at           :datetime         not null
+#  opted_in             :boolean          default(FALSE)
 #
 
 require 'rails_helper'

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -24,6 +24,7 @@
 #  accrediting_provider :text
 #  last_published_at    :datetime
 #  changed_at           :datetime         not null
+#  opted_in             :boolean          default(FALSE)
 #
 
 require "rails_helper"


### PR DESCRIPTION
### Context
Running several commands to keep our code clean and happy is a hassle

### Changes proposed in this pull request
- Override `rake` to run the specs, linter and annotate

### Guidance to review
```
bundle exec rake
```