### PR TITLE
[953] add Timecop gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,9 @@ group :development, :test do
   gem 'rspec-rails'
 
   gem 'rspec-json_matchers'
+
+  # Allow us to freeze time in tests
+  gem 'timecop'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,6 +300,7 @@ GEM
       sprockets (>= 3.0.0)
     thor (0.20.3)
     thread_safe (0.3.6)
+    timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.4.1)
@@ -349,6 +350,7 @@ DEPENDENCIES
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
+  timecop
   tzinfo-data
 
 RUBY VERSION


### PR DESCRIPTION
### Context

Pulled this out of #131 since that PR was getting rather big. Timecop allows us to freeze time in tests so that we aren't sensitive to timing issues / race conditions.

### Changes proposed in this pull request

Add timecop gem

### Guidance to review

#131 relies on this being merged.