### PR TITLE
[953] remove references to provider_id/course_id for incremental fetch from documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -73,10 +73,8 @@ incremental update should only be performed using the next-page urls provided
 in the response headers. With that in mind, these are the parameters you
 should expect to see:
 
-- `changed_since` - is an ISO 8601 timestamp stating the oldest change to include
-- `from_entity_id` where "entity" is "provider" or "course" - is an internal id
-  used in paging to ensure no ambiguity where record updates within the same
-  second have been split across pages
+- `changed_since` - is an ISO 8601 timestamp stating the oldest change to include.
+
 
 The header format is from [link header
 pagination](https://apievangelist.com/2016/05/02/http-header-awareness-using-the-link-header-for-pagination/).
@@ -140,8 +138,7 @@ This endpoint retrieves a paginated list of courses.
   records](#retrieving-records)
 - It provides the capability outlined above for [retrieving changed
   records](#retrieving-changed-records).
-- Results are sorted by `updated_at` with the oldest update first, then by
-  `course_id` ascending.
+- Results are sorted by `updated_at` with the oldest update first.
 
 ### Example HTTP Requests
 
@@ -329,9 +326,7 @@ This endpoint retrieves all institutions.
   records](#retrieving-records)
 - It provides the capability outlined above for [retrieving changed
   records](#retrieving-changed-records).
-- Results are sorted by `updated_at` with the oldest update first, then by
-  `provider_id` ascending.
-
+- Results are sorted by `updated_at` with the oldest update first.
 ### Example HTTP Request
 
 ```shell


### PR DESCRIPTION
### Context

Incremental fetch has been refactored to use a sub-second changed_since solution instead of using provider_id/course_id.
### Changes proposed in this pull request

References to using provider_id/course_id have been removed from the incremental fetch section of the documentation. 

