### PR TITLE
Use auth token from environment if available in dev

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,5 +44,5 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.authentication_token = "bats"
+  config.authentication_token = ENV.fetch("AUTHENTICATION_TOKEN", "bats")
 end


### PR DESCRIPTION
UCAS env is now in dev mode, so it had reverted to the default token
which is not what we want.

This patch means that local development still gets the default token,
and we can run development mode in azure with a custom token (for
pre-production environments).

This will go away when we switch to the settings gem for the v1 api.
