### PR TITLE
[1043] change course incremental api to use sub-second changed_since

### DIFF
--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -12,7 +12,7 @@ module API
           ActiveRecord::Base.connection.execute('LOCK provider, provider_enrichment, site IN SHARE UPDATE EXCLUSIVE MODE')
           # TODO: This will need to be scoped to opted-in providers.
           @courses = Course
-          .providers_have_opted_in
+                       .providers_have_opted_in
                        .includes(:sites, :provider, :site_statuses, :subjects)
                        .changed_since(changed_since)
                        .limit(per_page)

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -7,17 +7,21 @@ module API
       def index
         per_page = (params[:per_page] || 100).to_i
         changed_since = params[:changed_since]
-        from_course_id = params[:from_course_id].to_i
 
-        @courses = Course
-          .includes(:sites, :provider, :site_statuses, :subjects)
-          .changed_since(changed_since, from_course_id)
+        ActiveRecord::Base.transaction do
+          ActiveRecord::Base.connection.execute('LOCK provider, provider_enrichment, site IN SHARE UPDATE EXCLUSIVE MODE')
+          # TODO: This will need to be scoped to opted-in providers.
+          @courses = Course
+                       .includes(:sites, :provider, :site_statuses, :subjects)
+                       .changed_since(changed_since)
+                       .limit(per_page)
+        end
 
-        next_course = first_item_from_next_page(@courses, per_page)
-
-        @courses = @courses.limit(per_page)
-
-        next_link_header("from_course_id", @courses.last, next_course, changed_since, per_page)
+        set_next_link_header_using_changed_since_or_last_object(
+          @courses.last,
+          changed_since: changed_since,
+          per_page: per_page
+        )
 
         render json: @courses
       rescue ActiveRecord::StatementInvalid

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -57,7 +57,7 @@ class Course < ApplicationRecord
     if timestamp.present?
       where("course.updated_at > ?", timestamp)
     else
-      where("updated_at is not null")
+      where.not(updated_at: nil)
     end.order(:updated_at, :id)
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -53,10 +53,12 @@ class Course < ApplicationRecord
   has_many :site_statuses
   has_many :sites, through: :site_statuses
 
-  scope :changed_since, ->(datetime, from_course_id = 0) do
-    if datetime.present?
-      where("course.updated_at >= ? AND course.id > ?", datetime, from_course_id).order(:updated_at, :id)
-    end
+  scope :changed_since, ->(timestamp) do
+    if timestamp.present?
+      where("course.updated_at > ?", timestamp)
+    else
+      where("updated_at is not null")
+    end.order(:updated_at, :id)
   end
 
   def recruitment_cycle

--- a/docs/api.md
+++ b/docs/api.md
@@ -151,7 +151,7 @@ curl -v "https://api2.publish-teacher-training-courses.service.gov.uk/api/v1/201
 Subsequent pages / incremental fetch, using the "next" url in the "Link" header from the previous request:
 
 ```shell
-curl -v "https://api2.publish-teacher-training-courses.service.gov.uk/api/v1/2019/courses?changed_since=xxx&from_course_id=nnn" -H "Authorization: Bearer your_api_key"
+curl -v "https://api2.publish-teacher-training-courses.service.gov.uk/api/v1/2019/courses?changed_since=xxx" -H "Authorization: Bearer your_api_key"
 ```
 
 ### What constitutes a course change

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -1,0 +1,135 @@
+require 'rails_helper'
+
+describe API::V1::CoursesController, type: :controller do
+  describe '#index' do
+    RSpec::Matchers.define :have_courses do |*courses|
+      def course_codes(body)
+        json = JSON.parse(body)
+        json.map { |course| course["course_code"] }
+      end
+
+      match do |body|
+        course_codes(body) == courses.map(&:course_code)
+      end
+
+      failure_message do |body|
+        <<~STRING
+          expected course codes #{courses.map(&:course_code)}
+            to be found in body #{course_codes(body)}
+        STRING
+      end
+    end
+
+    # Format we use for changed_since param.
+    let(:timestamp_format) { '%FT%T.%6NZ' }
+
+    def format_timestamp(timestamp)
+      timestamp.strftime(timestamp_format)
+    end
+
+    # Default sensible params used by tests.
+    let(:params) do
+      {
+        changed_since: format_timestamp(changed_since)
+      }
+    end
+
+    before do
+      allow(controller).to receive(:authenticate)
+
+      # A bit of boilerplate setup since this isn't an integration or
+      # functional test. There may be a more standard way of doing this
+      # which would be better.
+      assigns(:_params).merge! params
+
+      # Stubbing out the data that Rails' url_for relies on is too tricky,
+      # so just stub the whole method out.
+      allow(controller).to receive(:url_for) do |options = {}|
+        'http://test.local/api/v1/course?' + options[:params].to_query
+      end
+      controller.response = response
+    end
+
+    context 'with two courses changed at different times' do
+      let(:old_course)  { create(:course, updated_at: 5.minute.ago.utc) }
+      let(:last_course) { create(:course, updated_at: 1.minute.ago.utc) }
+
+      # We need to define the before block after any let! statements since they
+      # are run in order of definition: we need to call the controller action
+      # after any let! fixtures are created.
+      before do
+        old_course
+        last_course
+
+        controller.index
+      end
+
+      context 'using a changed_since before any courses have changed' do
+        # Gets placed into params.
+        let(:changed_since) { 10.minutes.ago.utc }
+
+        describe 'returned courses in JSON' do
+          subject { response.body }
+
+          it {
+            should have_courses(old_course, last_course)
+          }
+        end
+
+        describe 'generated next link' do
+          subject do
+            # Parse out the query params for testing.
+            Rack::Utils.parse_query(URI(response.headers['Link']).query)
+          end
+
+          its(%w[per_page]) { should eq '100' }
+          its(%w[changed_since]) do
+            should eq format_timestamp(last_course.updated_at)
+          end
+        end
+      end
+
+      context 'using a changed_since after any courses have changed' do
+        describe 'generated next link' do
+          subject do
+            # Parse out the query params for testing.
+            Rack::Utils.parse_query(URI(response.headers['Link']).query)
+          end
+
+          let(:changed_since) { Time.now.utc }
+
+          its(%w[per_page]) { should eq '100' }
+          its(%w[changed_since]) { should eq params[:changed_since] }
+        end
+      end
+    end
+
+    context 'with no courses at all' do
+      # No courses, so this could be anything really.
+      let(:changed_since) { 10.minutes.ago.utc }
+
+      before do
+        controller.index
+      end
+
+      describe 'returned courses in JSON' do
+        subject { response.body }
+
+        # TODO: This isn't very clear, it should be "should_not have_courses"
+        it { should have_courses }
+      end
+
+      describe 'generated next link' do
+        subject do
+          # Parse out the query params for testing.
+          Rack::Utils.parse_query(URI(response.headers['Link']).query)
+        end
+
+        let(:changed_since) { DateTime.now.utc }
+
+        its(%w[per_page]) { should eq '100' }
+        its(%w[changed_since]) { should eq format_timestamp(changed_since) }
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -20,6 +20,20 @@ describe API::V1::CoursesController, type: :controller do
       end
     end
 
+    RSpec::Matchers.define :have_empty_response do
+      match do |body|
+        json = JSON.parse(body)
+        json == []
+      end
+
+      failure_message do |body|
+        <<~STRING
+          Expected empty array '[]' response, got:
+          #{body}
+        STRING
+      end
+    end
+
     # Format we use for changed_since param.
     let(:timestamp_format) { '%FT%T.%6NZ' }
 
@@ -105,7 +119,6 @@ describe API::V1::CoursesController, type: :controller do
     end
 
     context 'with no courses at all' do
-      # No courses, so this could be anything really.
       let(:changed_since) { 10.minutes.ago.utc }
 
       before do
@@ -115,8 +128,7 @@ describe API::V1::CoursesController, type: :controller do
       describe 'returned courses in JSON' do
         subject { response.body }
 
-        # TODO: This isn't very clear, it should be "should_not have_courses"
-        it { should have_courses }
+        it { should have_empty_response }
       end
 
       describe 'generated next link' do

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
     sequence(:course_code) { |n| "C#{n}D3" }
     name { Faker::ProgrammingLanguage.name }
     qualification { :pgce_with_qts }
-    association(:provider)
+    association(:provider, course_count: 0)
     resulting_in_pgce_with_qts
 
     transient do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -155,16 +155,20 @@ RSpec.describe Course, type: :model do
   end
 
   describe '#changed_since' do
-    let!(:old_course) { create(:course, age: 1.hour.ago) }
-    let!(:course) { create(:course, age: 1.hour.ago) }
-
     context 'with no parameters' do
+      let!(:old_course) { create(:course, age: 1.hour.ago) }
+      let!(:course) { create(:course, age: 1.hour.ago) }
+
       subject { Course.changed_since(nil) }
+
       it { should include course }
       it { should include old_course }
     end
 
     context 'with a course that was just updated' do
+      let(:course) { create(:course, age: 1.hour.ago) }
+      let!(:old_course) { create(:course, age: 1.hour.ago) }
+
       before { course.touch }
 
       subject { Course.changed_since(10.minutes.ago) }
@@ -173,10 +177,22 @@ RSpec.describe Course, type: :model do
       it { should_not include old_course }
     end
 
-    context 'when the checked timestamp matches the course updated_at' do
-      subject { Course.changed_since(course.updated_at) }
+    context 'with a course that has been changed less than a second after the given timestamp' do
+      let(:timestamp) { 5.minutes.ago }
+      let(:course) { create(:course, updated_at: timestamp + 0.001.seconds) }
+
+      subject { Course.changed_since(timestamp) }
 
       it { should include course }
+    end
+
+    context 'with a course that has been changed exactly at the given timestamp' do
+      let(:timestamp) { 10.minutes.ago }
+      let(:course) { create(:course, updated_at: timestamp) }
+
+      subject { Course.changed_since(timestamp) }
+
+      it { should_not include course }
     end
   end
 


### PR DESCRIPTION
This brings it inline with the implementation of the provider incremental api
endpoint. Changes include:

- remove from_course_id param from next link header and Course scope
- format changed_since param in next link header to include micro-seconds

### Guidance to review

We want to add some more thorough tests that exercise larger page sizes and counts, it seems the existing tests didn't catch certain failures, but the implementation seems solid and can be reviewed independently of those tests.

We plan to make another PR to use `changed_at` instead of `updated_at`, which is required to record updates done to course enrichments.