### PR TITLE
Add courses count to v2 providers endpoint

### DIFF
--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -10,6 +10,10 @@ module API
       attribute :institution_name do
         @object.provider_name
       end
+
+      attribute :course_count do
+        @object.courses.count
+      end
     end
   end
 end

--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -11,8 +11,10 @@ module API
         @object.provider_name
       end
 
-      attribute :course_count do
-        @object.courses.count
+      has_many :courses do
+        meta do
+          { count: @object.courses.count }
+        end
       end
     end
   end

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -43,8 +43,14 @@ describe 'Providers API v2', type: :request do
             "type" => "providers",
             "attributes" => {
               "institution_code" => provider.provider_code,
-              "institution_name" => provider.provider_name,
-              "course_count" => provider.courses.count
+              "institution_name" => provider.provider_name
+            },
+            "relationships" => {
+              "courses" => {
+                "meta" => {
+                  "count" => provider.courses.count
+                }
+              }
             }
           }],
           "jsonapi" => {
@@ -67,8 +73,14 @@ describe 'Providers API v2', type: :request do
             "type" => "providers",
             "attributes" => {
               "institution_code" => provider.provider_code,
-              "institution_name" => provider.provider_name,
-              "course_count" => provider.courses.count
+              "institution_name" => provider.provider_name
+            },
+            "relationships" => {
+              "courses" => {
+                "meta" => {
+                  "count" => provider.courses.count
+                }
+              }
             }
           }],
           "jsonapi" => {

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -43,7 +43,8 @@ describe 'Providers API v2', type: :request do
             "type" => "providers",
             "attributes" => {
               "institution_code" => provider.provider_code,
-              "institution_name" => provider.provider_name
+              "institution_name" => provider.provider_name,
+              "course_count" => provider.courses.count
             }
           }],
           "jsonapi" => {
@@ -66,7 +67,8 @@ describe 'Providers API v2', type: :request do
             "type" => "providers",
             "attributes" => {
               "institution_code" => provider.provider_code,
-              "institution_name" => provider.provider_name
+              "institution_name" => provider.provider_name,
+              "course_count" => provider.courses.count
             }
           }],
           "jsonapi" => {


### PR DESCRIPTION
### Context
On the frontend we display the number of courses for each provider

### Changes proposed in this pull request
Add `course_count` to v2 providers endpoint

### Guidance to review
`/api/v2/providers`
