### PR TITLE
Add course scope for opted in providers

### DIFF
--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -10,6 +10,7 @@ module API
         from_course_id = params[:from_course_id].to_i
 
         @courses = Course
+          .providers_have_opted_in
           .includes(:sites, :provider, :site_statuses, :subjects)
           .changed_since(changed_since, from_course_id)
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -59,6 +59,8 @@ class Course < ApplicationRecord
     end
   end
 
+  scope :providers_have_opted_in, -> { joins(:provider).merge(Provider.opted_in) }
+
   def recruitment_cycle
     "2019"
   end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -211,4 +211,22 @@ RSpec.describe Course, type: :model do
       its(:qualifications) { should eq %i[pgde] }
     end
   end
+
+  describe '.providers_have_opted_in' do
+    let(:course) { create(:course, provider: provider) }
+
+    subject { Course.providers_have_opted_in }
+
+    context 'provider is opted in' do
+      let(:provider) { create(:provider, opted_in: true) }
+
+      it { should include(course) }
+    end
+
+    context 'provider is opted in' do
+      let(:provider) { create(:provider, opted_in: false) }
+
+      it { should_not include(course) }
+    end
+  end
 end


### PR DESCRIPTION
### Context
The courses endpoint should only return courses where their providers are opted in

### Changes proposed in this pull request
Add scope to courses endpoint

### Guidance to review
`/api/v1/courses`