### PR TITLE
[1058] configure Raven not to ignore RecordNotFound errors

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,0 +1,8 @@
+# coding: utf-8
+
+Raven.configure do |config|
+  # Let’s not exclude ActiveRecord::RecordNotFound from Sentry
+  # https://github.com/getsentry/raven-ruby/wiki/Advanced-Configuration#excluding-exceptions
+  config.excluded_exceptions = Raven::Configuration::IGNORE_DEFAULT -
+    ['ActiveRecord::RecordNotFound']
+end


### PR DESCRIPTION
### Context

Raven is configured to ignore `ActiveRecord::RecordNotFound` errors by default.

### Changes proposed in this pull request

Stop ignoring these for the purposes of reporting to Sentry.

### Guidance to review

We considered testing this but then thought it was a bit too trivial.