### PR TITLE
1052 add changed at migration to course

### DIFF
--- a/app/controllers/concerns/next_link_header.rb
+++ b/app/controllers/concerns/next_link_header.rb
@@ -7,7 +7,7 @@ private
                                                               params = {})
     if last_object.present?
       params[:changed_since] =
-        incremental_load_timestamp_format last_object.updated_at
+        incremental_load_timestamp_format last_object.changed_at
     end
 
     response.headers['Link'] = "#{url_for(params: params)}; rel=\"next\""

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -19,6 +19,7 @@
 #  science                 :integer
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  changed_at              :datetime         not null
 #
 
 class Course < ApplicationRecord

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -57,10 +57,10 @@ class Course < ApplicationRecord
 
   scope :changed_since, ->(timestamp) do
     if timestamp.present?
-      where("course.updated_at > ?", timestamp)
+      where("course.changed_at > ?", timestamp)
     else
-      where.not(updated_at: nil)
-    end.order(:updated_at, :id)
+      where.not(changed_at: nil)
+    end.order(:changed_at, :id)
   end
 
   scope :providers_have_opted_in, -> { joins(:provider).merge(Provider.opted_in) }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -24,6 +24,7 @@
 
 class Course < ApplicationRecord
   include WithQualifications
+  include ChangedAt
 
   enum program_type: {
     higher_education_programme: "HE",
@@ -78,5 +79,12 @@ class Course < ApplicationRecord
 
   def has_vacancies?
     site_statuses.with_vacancies.any?
+  end
+
+  def update_changed_at(timestamp: Time.now.utc)
+    # Changed_at represents changes to related records as well as course
+    # itself, so we don't want to alter the semantics of updated_at which
+    # represents changes to just the course record.
+    update_columns changed_at: timestamp
   end
 end

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -19,6 +19,7 @@
 #  science                 :integer
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  changed_at              :datetime         not null
 #
 
 class CourseSerializer < ActiveModel::Serializer

--- a/db/migrate/20190301114503_add_changed_at_to_course.rb
+++ b/db/migrate/20190301114503_add_changed_at_to_course.rb
@@ -1,0 +1,5 @@
+class AddChangedAtToCourse < ActiveRecord::Migration[5.2]
+  def change
+    add_column :course, :changed_at, :datetime, default: -> { "timezone('utc'::text, now())" }, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_27_124613) do
+ActiveRecord::Schema.define(version: 2019_03_01_114503) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2019_02_27_124613) do
     t.integer "science"
     t.datetime "created_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
+    t.datetime "changed_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.index ["accrediting_provider_id"], name: "IX_course_accrediting_provider_id"
     t.index ["provider_id", "course_code"], name: "IX_course_provider_id_course_code", unique: true
   end

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -65,8 +65,8 @@ describe API::V1::CoursesController, type: :controller do
     end
 
     context 'with two courses changed at different times' do
-      let(:old_course)  { create(:course, updated_at: 5.minute.ago.utc) }
-      let(:last_course) { create(:course, updated_at: 1.minute.ago.utc) }
+      let(:old_course)  { create(:course, changed_at: 5.minute.ago.utc) }
+      let(:last_course) { create(:course, changed_at: 1.minute.ago.utc) }
 
       # We need to define the before block after any let! statements since they
       # are run in order of definition: we need to call the controller action
@@ -98,7 +98,7 @@ describe API::V1::CoursesController, type: :controller do
 
           its(%w[per_page]) { should eq '100' }
           its(%w[changed_since]) do
-            should eq format_timestamp(last_course.updated_at)
+            should eq format_timestamp(last_course.changed_at)
           end
         end
       end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -19,6 +19,7 @@
 #  science                 :integer
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  changed_at              :datetime         not null
 #
 
 FactoryBot.define do

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -38,6 +38,7 @@ FactoryBot.define do
       if evaluator.age.present?
         course.created_at = evaluator.age
         course.updated_at = evaluator.age
+        course.changed_at = evaluator.age
       end
     end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -19,6 +19,7 @@
 #  science                 :integer
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  changed_at              :datetime         not null
 #
 
 require 'rails_helper'

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -35,6 +35,23 @@ RSpec.describe Course, type: :model do
     it { should have_many(:sites) }
   end
 
+  describe 'changed_at' do
+    it 'is set on create' do
+      course = create(:course)
+      expect(course.changed_at).to be_present
+      expect(course.changed_at).to eq course.updated_at
+    end
+
+    it 'is set on update' do
+      Timecop.freeze do
+        course = create(:course, changed_at: 1.hour.ago)
+        course.touch
+        expect(course.changed_at).to eq course.updated_at
+        expect(course.changed_at).to eq Time.now.utc
+      end
+    end
+  end
+
   describe 'no site statuses' do
     its(:site_statuses) { should be_empty }
     its(:findable?) { should be false }
@@ -180,7 +197,7 @@ RSpec.describe Course, type: :model do
 
     context 'with a course that has been changed less than a second after the given timestamp' do
       let(:timestamp) { 5.minutes.ago }
-      let(:course) { create(:course, updated_at: timestamp + 0.001.seconds) }
+      let(:course) { create(:course, changed_at: timestamp + 0.001.seconds) }
 
       subject { Course.changed_since(timestamp) }
 
@@ -189,7 +206,7 @@ RSpec.describe Course, type: :model do
 
     context 'with a course that has been changed exactly at the given timestamp' do
       let(:timestamp) { 10.minutes.ago }
-      let(:course) { create(:course, updated_at: timestamp) }
+      let(:course) { create(:course, changed_at: timestamp) }
 
       subject { Course.changed_since(timestamp) }
 

--- a/spec/serializers/course_serializer_spec.rb
+++ b/spec/serializers/course_serializer_spec.rb
@@ -19,6 +19,7 @@
 #  science                 :integer
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  changed_at              :datetime         not null
 #
 
 require "rails_helper"


### PR DESCRIPTION
### Context

Incremental fetch is live on prod for provider. This pr refactors course to be in line with provider. 

### Changes proposed in this pull request

- Migration to add changed_at to the course model.
- Added monkey patch to Activerecord to ensure changed_at is updated when a course is created or updated
- Refactored scope to use changed_at rather than updated_at
- Refactored course model, controller and tests to use changed_at

