### PR TITLE
1083 remove provider enrichment hook

### DIFF
--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -17,7 +17,6 @@ class ProviderEnrichment < ApplicationRecord
   self.primary_key = "provider_code"
 
   include RegionCode
-  include TouchProvider
 
   enum status: { draft: 0, published: 1 }
 

--- a/spec/models/provider_enrichment_spec.rb
+++ b/spec/models/provider_enrichment_spec.rb
@@ -16,21 +16,4 @@
 require 'rails_helper'
 
 describe ProviderEnrichment, type: :model do
-  describe '#touch_provider' do
-    let(:provider) { create(:provider) }
-
-    it 'sets changed_at to the current time' do
-      Timecop.freeze do
-        provider.enrichments.update(email: "test@email")
-        expect(provider.changed_at).to eq Time.now.utc
-      end
-    end
-
-    it 'leaves updated_at unchanged' do
-      timestamp = 1.hour.ago
-      provider.update updated_at: timestamp
-      provider.enrichments.update(email: "test@email")
-      expect(provider.updated_at).to eq timestamp
-    end
-  end
 end

--- a/spec/models/provider_enrichment_spec.rb
+++ b/spec/models/provider_enrichment_spec.rb
@@ -16,4 +16,7 @@
 require 'rails_helper'
 
 describe ProviderEnrichment, type: :model do
+  describe 'associations' do
+    it { should belong_to(:provider) }
+  end
 end


### PR DESCRIPTION
### Context

Touch provider logic needs to be ported to V2 for provider enrichment

### Changes proposed in this pull request

- Remove hook from the provider enrichment model
- Remove tests for hook
- Add an association test


