### PR TITLE
[1050] Add mcb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,9 @@ gem 'config'
 # Nicer URL's
 gem 'friendly_id'
 
+# For building cmdline apps (mcb)
+gem 'cri'
+
 group :development, :test do
   # add info about db structure to models and other files
   gem 'annotate'
@@ -99,6 +102,9 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+
+  # Make HTTP requests fun again
+  gem 'httparty'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,12 @@ gem 'friendly_id'
 # For building cmdline apps (mcb)
 gem 'cri'
 
+# Build pretty tables in the terminal
+#   table_print handles ActiveRecord objects and collections really nicely
+gem 'table_print'
+#   terminal-table is a bit more flexible allowing us to use a headers column
+gem 'terminal-table'
+
 group :development, :test do
   # add info about db structure to models and other files
   gem 'annotate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,12 +63,15 @@ GEM
     case_transform (0.2)
       activesupport
     coderay (1.1.2)
+    colored (1.2)
     concurrent-ruby (1.1.4)
     config (1.7.1)
       activesupport (>= 3.0)
       deep_merge (~> 1.2.1)
       dry-validation (>= 0.12.2)
     crass (1.0.4)
+    cri (2.15.3)
+      colored (~> 1.2)
     database_cleaner (1.7.0)
     deep_merge (1.2.1)
     diff-lcs (1.3)
@@ -120,6 +123,9 @@ GEM
       rubocop (~> 0.64)
       rubocop-rspec (~> 1.28)
       scss_lint
+    httparty (0.16.4)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.5.3)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.2)
@@ -165,11 +171,15 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
     mimemagic (0.3.3)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     msgpack (1.2.6)
+    multi_xml (0.6.0)
     multipart-post (2.0.0)
     nio4r (2.3.1)
     nokogiri (1.10.1)
@@ -329,11 +339,13 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   config
+  cri
   database_cleaner
   factory_bot_rails (~> 5.0)
   faker
   friendly_id
   govuk-lint
+  httparty
   jsonapi-rails
   jsonapi-rb
   jsonapi-rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,6 +316,9 @@ GEM
     super_diff (0.1.0)
       diff-lcs
       patience_diff
+    table_print (1.5.6)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     timecop (0.9.1)
@@ -374,6 +377,8 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   super_diff
+  table_print
+  terminal-table
   timecop
   tzinfo-data
 

--- a/README.md
+++ b/README.md
@@ -157,3 +157,23 @@ To track exceptions through Sentry, configure the `SENTRY_DSN` environment varia
 ```
 SENTRY_DSN=https://aaa:bbb@sentry.io/123 rails s
 ```
+
+## mcb Command
+
+This project comes with a script `bin/mcb` which provides certain
+project-specific functionality that is conveniently accessed via the cmdline.
+The goal is to provide access to project data and functionality in a guided
+way that is safer and better sign-posted than using the raw Rails console. This
+can be useful for people who aren't as familiar with the app, or with certain
+complex operations that just aren't already packaged up in the app.
+
+The script's functionality is accessed using sub-commands with built-in
+documentation. This is the best way to discover it's functionality and the
+commands available, and is accessable with the `--help` option:
+
+```
+bin/mcb --help
+```
+
+Commands for mcb are defined in `lib/mcb/commands` and any new commands should
+be organised in an appropriate sub-folder there.

--- a/bin/mcb
+++ b/bin/mcb
@@ -88,7 +88,7 @@ def each_v1_provider(opts)
         }
       )
       providers_list = JSON.parse(response.body)
-      break if providers_list == []
+      break if providers_list.empty?
 
       # Send each provider to the consumer of this enumerator
       providers_list.each { |provider| y << provider }

--- a/bin/mcb
+++ b/bin/mcb
@@ -45,13 +45,13 @@ mcb.add_command(apiv1)
 apiv1.add_command(Cri::Command.load_file("#{lib_dir}/mcb/commands/apiv1/find.rb"))
 
 
-MCB_ROOT_DIR = File.dirname($0)
 def init_rails
   unless defined?(Rails)
-    exec(File.join(MCB_ROOT_DIR, 'bin', 'rails'), 'runner', $0, *ARGV)
+    app_root = File.expand_path(File.join(File.dirname($0), '..'))
+    exec_path = File.join(app_root, 'bin', 'rails')
+    exec(exec_path, 'runner', $0, *ARGV)
   end
 end
-
 
 def verbose(msg)
   if $verbosity == :verbose
@@ -64,6 +64,9 @@ def error(msg)
 end
 
 def each_v1_provider(opts)
+  # We only need httparty for API V1 calls
+  require 'httparty'
+
   url = opts[:url]
   page_count = 0
   max_pages = 30

--- a/lib/mcb/commands/apiv1.rb
+++ b/lib/mcb/commands/apiv1.rb
@@ -1,0 +1,9 @@
+name 'apiv1'
+summary 'Commands that target the V1 providers endpoint'
+
+option :u, 'url', 'set the url to connect to',
+       argument: :required,
+       default: 'http://localhost:3001/api/v1/2019/providers'
+option :t, 'token', 'set the authorization token',
+       argument: :required,
+       default: 'bats'

--- a/lib/mcb/commands/apiv1/find.rb
+++ b/lib/mcb/commands/apiv1/find.rb
@@ -1,0 +1,25 @@
+name 'find'
+summary 'Find a particular provider entry'
+usage 'find [options] <code>'
+param :code
+
+run do |opts, args, _cmd|
+  # We only need httparty for API V1 calls
+  require 'httparty'
+
+  puts "looking for provider #{args[:code]}"
+
+  provider = each_v1_provider(opts).detect do |p|
+    p['institution_code'] == args[:code]
+  end
+
+  if provider.nil?
+    error "Provider with code '#{code}' not found"
+  else
+    campuses = provider.delete('campuses')
+    puts Terminal::Table.new rows: provider
+    puts ''
+    puts "Campuses:"
+    tp campuses
+  end
+end

--- a/lib/mcb/commands/apiv1/find.rb
+++ b/lib/mcb/commands/apiv1/find.rb
@@ -14,7 +14,7 @@ run do |opts, args, _cmd|
   end
 
   if provider.nil?
-    error "Provider with code '#{code}' not found"
+    error "Provider with code '#{args[:code]}' not found"
   else
     campuses = provider.delete('campuses')
     puts Terminal::Table.new rows: provider

--- a/lib/mcb/commands/apiv1/find.rb
+++ b/lib/mcb/commands/apiv1/find.rb
@@ -4,9 +4,6 @@ usage 'find [options] <code>'
 param :code
 
 run do |opts, args, _cmd|
-  # We only need httparty for API V1 calls
-  require 'httparty'
-
   puts "looking for provider #{args[:code]}"
 
   provider = each_v1_provider(opts).detect do |p|

--- a/lib/mcb/commands/apiv1/find.rb
+++ b/lib/mcb/commands/apiv1/find.rb
@@ -15,11 +15,12 @@ run do |opts, args, _cmd|
 
   if provider.nil?
     error "Provider with code '#{args[:code]}' not found"
-  else
-    campuses = provider.delete('campuses')
-    puts Terminal::Table.new rows: provider
-    puts ''
-    puts "Campuses:"
-    tp campuses
+    next
   end
+
+  campuses = provider.delete('campuses')
+  puts Terminal::Table.new rows: provider
+  puts ''
+  puts "Campuses:"
+  tp campuses
 end

--- a/lib/mcb/commands/apiv1/find.rb
+++ b/lib/mcb/commands/apiv1/find.rb
@@ -1,5 +1,10 @@
 name 'find'
 summary 'Find a particular provider entry'
+description <<~EODESCRIPTION
+  Searches for a provider with the given provider code by iterating through all
+  the pages of results provided from the provider endpoint, outputing the found
+  record.
+EODESCRIPTION
 usage 'find [options] <code>'
 param :code
 

--- a/lib/mcb/commands/provider.rb
+++ b/lib/mcb/commands/provider.rb
@@ -1,0 +1,3 @@
+name 'provider'
+summary 'Operate on providers directly in db'
+default_subcommand 'list'

--- a/lib/mcb/commands/provider/list.rb
+++ b/lib/mcb/commands/provider/list.rb
@@ -1,0 +1,18 @@
+name 'list'
+summary 'List providers in db'
+
+run do |_opts, args, _cmd|
+  init_rails
+
+  providers = if args.any?
+                Provider.where(provider_code: args.to_a)
+              else
+                Provider.all
+              end
+
+  tp.set :capitalize_headers, false
+
+  puts "\nProviders:"
+  tp providers, 'id', 'provider_code', 'provider_name', 'provider_type',
+     'postcode'
+end

--- a/lib/mcb/commands/provider/show.rb
+++ b/lib/mcb/commands/provider/show.rb
@@ -1,0 +1,25 @@
+name 'show'
+summary 'Show infomration about provider'
+param :code
+
+run do |_opts, args, _cmd|
+  init_rails
+
+  code = args[:code]
+
+  provider = Provider.find_by(provider_code: code)
+
+  if provider.nil?
+    error "Provider with code '#{code}' not found"
+  else
+    puts 'Provider:'
+    puts Terminal::Table.new rows: provider.attributes
+
+    puts "\nProvider Enrichments:"
+    tp provider.enrichments, 'id', 'status', 'email', 'website', 'address1',
+       'address2', 'address3', 'address4', 'postcode', 'telephone'
+
+    puts "\nProvider Courses:"
+    tp provider.courses
+  end
+end

--- a/mcb
+++ b/mcb
@@ -13,7 +13,11 @@ require 'pry'
 require 'table_print'
 require 'terminal-table'
 
-$mcb = Cri::Command.define do
+tp.set :capitalize_headers, false
+
+lib_dir = 'lib'
+
+mcb = Cri::Command.define do
   name        'mcb'
   usage       'mcb [options]'
   summary     'wrapper for management of manage-curses-backend app'
@@ -28,6 +32,19 @@ $mcb = Cri::Command.define do
   end
 end
 
+# It'd almost be nice to be able to load these automatically, but since we have
+# to express the command structure by loading sub-commands with the correct
+# parent command, I don't think there's a trivial way to do this.
+provider = Cri::Command.load_file("#{lib_dir}/mcb/commands/provider.rb")
+mcb.add_command(provider)
+provider.add_command(Cri::Command.load_file("#{lib_dir}/mcb/commands/provider/list.rb"))
+provider.add_command(Cri::Command.load_file("#{lib_dir}/mcb/commands/provider/show.rb"))
+
+apiv1 = Cri::Command.load_file("#{lib_dir}/mcb/commands/apiv1.rb")
+mcb.add_command(apiv1)
+apiv1.add_command(Cri::Command.load_file("#{lib_dir}/mcb/commands/apiv1/find.rb"))
+
+
 MCB_ROOT_DIR = File.dirname($0)
 def init_rails
   unless defined?(Rails)
@@ -35,75 +52,15 @@ def init_rails
   end
 end
 
-provider = $mcb.define_command do
-  name 'provider'
-  summary 'Operate on providers directly in db'
-  default_subcommand 'list'
-end
-
-provider.define_command do
-  name 'list'
-  summary 'List providers in db'
-
-  run do |_opts, args, _cmd|
-    init_rails
-
-    providers = if args.any?
-                  Provider.where(provider_code: args.to_a)
-                else
-                  Provider.all
-                end
-
-    tp.set :capitalize_headers, false
-
-    puts "\nProviders:"
-    tp providers, 'id', 'provider_code', 'provider_name', 'provider_type',
-       'postcode'
-  end
-end
-
-provider.define_command do
-  name 'show'
-  summary 'Show infomration about provider'
-  param :code
-
-  run do |_opts, args, _cmd|
-    init_rails
-
-    code = args[:code]
-
-    provider = Provider.find_by(provider_code: code)
-
-    puts 'Provider:'
-    puts Terminal::Table.new rows: provider.attributes
-
-    tp.set :capitalize_headers, false
-
-    puts "\nProvider Enrichments:"
-    tp provider.enrichments, 'id', 'status', 'email', 'website', 'address1',
-       'address2', 'address3', 'address4', 'postcode', 'telephone'
-
-    puts "\nProvider Courses:"
-    tp provider.courses
-  end
-end
-
-apiv1 = $mcb.define_command do
-  name 'apiv1'
-  summary 'Commands that target the V1 providers endpoint'
-
-  option :u, 'url', 'set the url to connect to',
-         argument: :required,
-         default: 'http://localhost:3001/api/v1/2019/providers'
-  option :t, 'token', 'set the authorization token',
-         argument: :required,
-         default: 'bats'
-end
 
 def verbose(msg)
   if $verbosity == :verbose
     puts msg
   end
+end
+
+def error(msg)
+  puts msg
 end
 
 def each_v1_provider(opts)
@@ -139,24 +96,4 @@ def each_v1_provider(opts)
   end
 end
 
-apiv1.define_command do
-  name 'find'
-  summary 'Find a particular provider entry'
-  usage 'find [options] <code>'
-  param :code
-
-  run do |opts, args, _cmd|
-    # We only need httparty for API V1 calls
-    require 'httparty'
-
-    puts "looking for provider #{args[:code]}"
-
-    provider = each_v1_provider(opts).detect do |p|
-      p['institution_code'] == args[:code]
-    end
-
-    ap provider if provider
-  end
-end
-
-$mcb.run(ARGV.dup) if File.basename(__FILE__) == File.basename($0)
+mcb.run(ARGV.dup) if File.basename(__FILE__) == File.basename($0)

--- a/mcb
+++ b/mcb
@@ -1,0 +1,100 @@
+#!/usr/bin/env ruby
+# -!- mode: ruby -!-
+
+# Wrapper for management functions for manage-courses-backend
+#
+# Run with:
+#
+#  bundle exec mcb
+
+require 'cri'
+require 'pry'
+require 'ap'
+
+$mcb = Cri::Command.define do
+  name        'mcb'
+  usage       'mcb [options]'
+  summary     'wrapper for management of manage-curses-backend app'
+
+  option :v, 'verbose', 'display progess info' do |value|
+    $verbosity = :verbose if value
+  end
+
+  flag :h, :help, 'show help for this command' do |_value, cmd|
+    puts cmd.help
+    exit 0
+  end
+end
+
+apiv1 = $mcb.define_command do
+  name 'apiv1'
+  summary 'Commands that target the V1 providers endpoint'
+
+  option :u, 'url', 'set the url to connect to',
+         argument: :required,
+         default: 'http://localhost:3001/api/v1/2019/providers'
+  option :t, 'token', 'set the authorization token',
+         argument: :required,
+         default: 'bats'
+end
+
+def verbose(msg)
+  if $verbosity == :verbose
+    puts msg
+  end
+end
+
+def each_v1_provider(opts)
+  url = opts[:url]
+  page_count = 0
+  max_pages = 30
+
+  Enumerator.new do |y|
+    loop do
+      if page_count > max_pages
+        raise RuntimeError.new(
+          "too many page requests, stopping at #{page_count}" +
+          " as a safeguard. Increase max page_count if necessary."
+        )
+      end
+
+      verbose "Requesting page #{page_count + 1}: #{url}"
+      response = HTTParty.get(
+        url,
+        headers: {
+          authorization: "Bearer #{opts[:token]}"
+        }
+      )
+      providers_list = JSON.parse(response.body)
+      break if providers_list == []
+
+      # Send each provider to the consumer of this enumerator
+      providers_list.each { |provider| y << provider }
+
+      url = response.headers[:link].sub(/;.*/, '')
+      page_count += 1
+    end
+  end
+end
+
+apiv1.define_command do
+  name 'find'
+  summary 'Find a particular provider entry'
+  usage 'find [options] <code>'
+  param :code
+
+  run do |opts, args, _cmd|
+    # We only need httparty for API V1 calls
+    require 'httparty'
+
+    puts "looking for provider #{args[:code]}"
+
+    provider = each_v1_provider(opts).detect do |p|
+      p['institution_code'] == args[:code]
+    end
+
+    ap provider if provider
+  end
+end
+
+$mcb.run(ARGV) if File.basename(__FILE__) == File.basename($0)

--- a/mcb
+++ b/mcb
@@ -7,9 +7,11 @@
 #
 #  bundle exec mcb
 
+require 'ap'
 require 'cri'
 require 'pry'
-require 'ap'
+require 'table_print'
+require 'terminal-table'
 
 $mcb = Cri::Command.define do
   name        'mcb'
@@ -23,6 +25,66 @@ $mcb = Cri::Command.define do
   flag :h, :help, 'show help for this command' do |_value, cmd|
     puts cmd.help
     exit 0
+  end
+end
+
+MCB_ROOT_DIR = File.dirname($0)
+def init_rails
+  unless defined?(Rails)
+    exec(File.join(MCB_ROOT_DIR, 'bin', 'rails'), 'runner', $0, *ARGV)
+  end
+end
+
+provider = $mcb.define_command do
+  name 'provider'
+  summary 'Operate on providers directly in db'
+  default_subcommand 'list'
+end
+
+provider.define_command do
+  name 'list'
+  summary 'List providers in db'
+
+  run do |_opts, args, _cmd|
+    init_rails
+
+    providers = if args.any?
+                  Provider.where(provider_code: args.to_a)
+                else
+                  Provider.all
+                end
+
+    tp.set :capitalize_headers, false
+
+    puts "\nProviders:"
+    tp providers, 'id', 'provider_code', 'provider_name', 'provider_type',
+       'postcode'
+  end
+end
+
+provider.define_command do
+  name 'show'
+  summary 'Show infomration about provider'
+  param :code
+
+  run do |_opts, args, _cmd|
+    init_rails
+
+    code = args[:code]
+
+    provider = Provider.find_by(provider_code: code)
+
+    puts 'Provider:'
+    puts Terminal::Table.new rows: provider.attributes
+
+    tp.set :capitalize_headers, false
+
+    puts "\nProvider Enrichments:"
+    tp provider.enrichments, 'id', 'status', 'email', 'website', 'address1',
+       'address2', 'address3', 'address4', 'postcode', 'telephone'
+
+    puts "\nProvider Courses:"
+    tp provider.courses
   end
 end
 
@@ -97,4 +159,4 @@ apiv1.define_command do
   end
 end
 
-$mcb.run(ARGV) if File.basename(__FILE__) == File.basename($0)
+$mcb.run(ARGV.dup) if File.basename(__FILE__) == File.basename($0)


### PR DESCRIPTION
### Context

cmdline util to help use the app db and apis

### Changes proposed in this pull request

Add a cmdline helper script to perform common functions on the API. For example:

* display the data presented by the v1 api for a given provider (pages through all the data to find the provider code given)
* display data help for a provider in the db including attributes, enrichments, courses, etc

The goal is to provide access to the data and functionality in a guided way that is safer and better sign-posted than using the raw Rails console. This can be useful for people who aren't as familiar with the data, or with certain complex operations that just aren't already packaged up in the app.

### Guidance to review

This was done as a quick stab to see if it's viable and useful. We should move commands out into separate modules in `lib` or similar.


