### PR TITLE
[1087] Course description

### DIFF
--- a/app/models/concerns/with_qualifications.rb
+++ b/app/models/concerns/with_qualifications.rb
@@ -65,5 +65,9 @@ module WithQualifications
       when "pgde" then [:pgde]
       end
     end
+
+    def qualifications_description
+      qualifications.map(&:upcase).sort.join(" with ")
+    end
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -78,4 +78,8 @@ class Course < ApplicationRecord
   def has_vacancies?
     site_statuses.with_vacancies.any?
   end
+
+  def study_mode_description
+    study_mode.to_s.tr("_", " ")
+  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -82,4 +82,17 @@ class Course < ApplicationRecord
   def study_mode_description
     study_mode.to_s.tr("_", " ")
   end
+
+  def program_type_description
+    if school_direct_salaried_training_programme? then " with salary"
+    elsif pg_teaching_apprenticeship? then " teaching apprenticeship"
+    else ""
+    end
+  end
+
+  def description
+    study_mode_string = (full_time_or_part_time? ? ", " : " ") +
+      study_mode_description
+    qualifications_description + study_mode_string + program_type_description
+  end
 end

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -4,7 +4,7 @@ module API
       type 'courses'
 
       attributes :findable?, :open_for_applications?, :has_vacancies?,
-                 :course_code, :name, :study_mode, :qualifications
+                 :course_code, :name, :study_mode, :qualifications, :description
 
       attribute :start_date do
         @object.start_date&.iso8601

--- a/spec/models/concerns/with_qualifications_spec.rb
+++ b/spec/models/concerns/with_qualifications_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 RSpec.describe WithQualifications, type: :model do
   specs = [
-    qts: [:qts],
-    pgce: [:pgce],
-    pgde: [:pgde],
-    pgce_with_qts: %i[qts pgce],
-    pgde_with_qts: %i[qts pgde],
+    qts: { values: [:qts], description: "QTS" },
+    pgce: { values: [:pgce], description: "PGCE" },
+    pgde: { values: [:pgde], description: "PGDE" },
+    pgce_with_qts: { values: %i[qts pgce], description: "PGCE with QTS" },
+    pgde_with_qts: { values: %i[qts pgde], description: "PGDE with QTS" },
   ].freeze
 
   describe "#qualifications" do
@@ -15,7 +15,8 @@ RSpec.describe WithQualifications, type: :model do
         context "course with qualification=#{qualification}" do
           subject { create(:course, qualification: qualification) }
 
-          its(:qualifications) { should eq(expected) }
+          its(:qualifications) { should eq(expected[:values]) }
+          its(:qualifications_description) { should eq(expected[:description]) }
         end
       end
     end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -196,6 +196,21 @@ RSpec.describe Course, type: :model do
     end
   end
 
+  describe "#study_mode_description" do
+    specs = {
+      full_time: 'full time',
+      part_time: 'part time',
+      full_time_or_part_time: 'full time or part time',
+    }.freeze
+
+    specs.each do |study_mode, expected_description|
+      context study_mode.to_s do
+        subject { create(:course, study_mode: study_mode) }
+        its(:study_mode_description) { should eq(expected_description) }
+      end
+    end
+  end
+
   describe 'qualifications' do
     context "course with qts qualication" do
       let(:subject) { create(:course, :resulting_in_qts) }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -211,6 +211,61 @@ RSpec.describe Course, type: :model do
     end
   end
 
+  describe "#description" do
+    context "for a both full time and part time course" do
+      subject {
+        create(:course,
+               study_mode: :full_time_or_part_time,
+               program_type: :scitt_programme,
+               qualification: :qts)
+      }
+
+      its(:description) { should eq("QTS, full time or part time") }
+    end
+
+    specs = {
+      "QTS, full time or part time" => {
+        study_mode: :full_time_or_part_time,
+        program_type: :scitt_programme,
+        qualification: :qts,
+      },
+      "PGCE with QTS full time with salary" => {
+        study_mode: :full_time,
+        program_type: :school_direct_salaried_training_programme,
+        qualification: :pgce_with_qts,
+      }
+    }.freeze
+
+    specs.each do |expected_description, course_attributes|
+      context "for #{expected_description} course" do
+        subject { create(:course, course_attributes) }
+        its(:description) { should eq(expected_description) }
+      end
+    end
+
+    context "for a salaried course" do
+      subject {
+        create(:course,
+               study_mode: :full_time,
+               program_type: :school_direct_salaried_training_programme,
+               qualification: :pgce_with_qts)
+      }
+
+      its(:description) { should eq("PGCE with QTS full time with salary") }
+    end
+
+    context "for a teaching apprenticeship" do
+      subject {
+        create(:course,
+               study_mode: :part_time,
+               program_type: :pg_teaching_apprenticeship,
+               qualification: :pgde_with_qts)
+      }
+
+      its(:description) { should eq("PGDE with QTS part time teaching apprenticeship") }
+    end
+  end
+
   describe 'qualifications' do
     context "course with qts qualication" do
       let(:subject) { create(:course, :resulting_in_qts) }

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -17,6 +17,7 @@ describe 'Courses API v2', type: :request do
     let(:findable_open_course) {
       create(:course, :resulting_in_pgce_with_qts,
              start_date: Time.now.utc,
+             study_mode: :full_time,
              site_statuses: [create(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_now)])
     }
     let(:provider) {
@@ -71,8 +72,9 @@ describe 'Courses API v2', type: :request do
               "name" => provider.courses[0].name,
               "course_code" => provider.courses[0].course_code,
               "start_date" => provider.courses[0].start_date.iso8601,
-              "study_mode" => provider.courses[0].study_mode,
+              "study_mode" => "full_time",
               "qualifications" => %w[qts pgce],
+              "description" => "PGCE with QTS full time"
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },


### PR DESCRIPTION
### Context
Courses have a consistently worded description (e.g. `PGCE with QTS full time with salary`) which are used in many places in the service. 

### Changes proposed in this pull request
Add a `description` attribute to the `Course` model and expose it in the Courses API V2 for frontend consumption (most immediately in the courses table in Publish).

### Guidance to review
I debated whether the course description is a presentation or a backend concern. My conclusion is that this is a backend concern because:

- it's tightly coupled to the domain
- there is only one representation of this across the entire service
- it needs to be consistent across Publish and Find and hence is part of publishing

