### PR TITLE
Re-add pg_* extensions to schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,6 +13,8 @@
 ActiveRecord::Schema.define(version: 2019_03_06_122110) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_buffercache"
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "__EFMigrationsHistory", primary_key: "MigrationId", id: :string, limit: 150, force: :cascade do |t|


### PR DESCRIPTION
These extensions are present in a recent pg_dump from production,
so they should be here too.

### Context
They re-appeared on my machine, seems everyone is in a different state. Realised that I'm running from a sanitized restore of prod, which brings the enabled extensions across.
