### PR TITLE
[1105] Return providers in alphabetical order

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -8,7 +8,7 @@ module API
         providers = policy_scope(Provider)
         providers = providers.where(id: @user.providers) if @user.present?
 
-        render jsonapi: providers
+        render jsonapi: providers.in_order
       end
 
     private

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -59,6 +59,8 @@ class Provider < ApplicationRecord
 
   scope :opted_in, -> { where(opted_in: true) }
 
+  scope :in_order, -> { order(:provider_name) }
+
   # TODO: filter to published enrichments, maybe rename to published_address_info
   def address_info
     (enrichments.latest_created_at.with_address_info.first || self)

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -254,10 +254,19 @@ describe Provider, type: :model do
 
   describe '.opted_in' do
     let!(:opted_in_provider) { create(:provider, opted_in: true) }
-    let!(:opted_out_provder) { create(:provider, opted_in: false) }
+    let!(:opted_out_provider) { create(:provider, opted_in: false) }
 
     it 'returns only the opted_in provider' do
       expect(Provider.opted_in).to match_array([opted_in_provider])
+    end
+  end
+
+  describe '.in_order' do
+    let!(:second_alphabetical_provider) { create(:provider, provider_name: "Zork") }
+    let!(:first_alphabetical_provider) { create(:provider, provider_name: "Acme") }
+
+    it 'returns sorted providers' do
+      expect(Provider.in_order).to match_array([first_alphabetical_provider, second_alphabetical_provider])
     end
   end
 

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -106,5 +106,22 @@ describe 'Providers API v2', type: :request do
         )
       end
     end
+
+    context 'with unalphabetical ordering in the database' do
+      let!(:second_alphabetical_provider) { create(:provider, provider_name: 'Zork', organisations: [organisation]) }
+
+      before do
+        provider.update(provider_name: 'Acme') # This moves it last in the order that it gets fetched by default.
+        get "/api/v2/users/#{user.id}/providers", headers: { 'HTTP_AUTHORIZATION' => credentials }
+      end
+
+      let(:provider_names_in_response) {
+        JSON.parse(response.body)["data"].map { |provider| provider["attributes"]["institution_name"] }
+      }
+
+      it 'returns them in alphabetical order' do
+        expect(provider_names_in_response).to eq(%w(Acme Zork))
+      end
+    end
   end
 end


### PR DESCRIPTION
This is the ordering that the frontend needs to display them correctly.