### PR TITLE
1109 re add verify authorized

### DIFF
--- a/app/controllers/api/v2/sessions_controller.rb
+++ b/app/controllers/api/v2/sessions_controller.rb
@@ -6,6 +6,8 @@ module API
       deserializable_resource :session
 
       def create
+        skip_authorization
+
         @current_user.update(
           create_params.merge(
             last_login_date_utc: Time.now.utc

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,5 @@ class ApplicationController < ActionController::API
 
   # child must define authenticate method
   before_action :authenticate
+  after_action :verify_authorized
 end


### PR DESCRIPTION
### Context

Controller actions should be checking that authorisations has been performed to make sure we don't accidentally create controller actions that don't authorize.

### Changes proposed in this pull request

Re-add this authorizaton verification, it was removed accidentally in #124.

### Guidance to review

Now that we-ve re-added authorizaton verification we need to explicitly skip
authorization for `SessionsController#create`.