### PR TITLE
[1126] use fully-qualified ApplicationController class

### DIFF
--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -1,6 +1,6 @@
 module API
   module V1
-    class CoursesController < ApplicationController
+    class CoursesController < API::V1::ApplicationController
       include NextLinkHeader
       include FirstItemFromNextPage
 

--- a/app/controllers/api/v1/providers_controller.rb
+++ b/app/controllers/api/v1/providers_controller.rb
@@ -1,6 +1,6 @@
 module API
   module V1
-    class ProvidersController < ApplicationController
+    class ProvidersController < API::V1::ApplicationController
       include NextLinkHeader
 
       # Potential edge case:

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -1,6 +1,6 @@
 module API
   module V1
-    class SubjectsController < ApplicationController
+    class SubjectsController < API::V1::ApplicationController
       def index
         @subjects = Subject.all
         paginate json: @subjects

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -1,6 +1,6 @@
 module API
   module V2
-    class CoursesController < ApplicationController
+    class CoursesController < API::V2::ApplicationController
       def index
         provider = Provider.friendly.find(params[:provider_code])
         authorize provider, :can_list_courses?

--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -1,6 +1,6 @@
 module API
   module V2
-    class ProvidersController < ApplicationController
+    class ProvidersController < API::V2::ApplicationController
       before_action :get_user, if: -> { params[:user_id].present? }
 
       def index

--- a/app/controllers/api/v2/sessions_controller.rb
+++ b/app/controllers/api/v2/sessions_controller.rb
@@ -1,6 +1,6 @@
 module API
   module V2
-    class SessionsController < ApplicationController
+    class SessionsController < API::V2::ApplicationController
       include ValidateJsonapiType
 
       deserializable_resource :session

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -1,6 +1,6 @@
 module API
   module V2
-    class UsersController < ApplicationController
+    class UsersController < API::V2::ApplicationController
       def show
         user = User.find(params[:id])
         authorize user


### PR DESCRIPTION
Trello ticket: https://trello.com/c/AiWztw9a/1126-tests-failing-when-run-in-a-certain-order

We have more than one `ApplicationController` class:

- ::ApplicationController
- ::API::V1::ApplicationController
- ::API::V2::ApplicationController

Because of this, Rails can get confused when trying to autoload constants. For
example:

  module API
    module V1
      class ProvidersController < ApplicationController

could pull in the wrong ApplicationController. At least, this has been the case
with RSpec tests where running the V2 specs before running the V1 specs were
causing most V1 specs to fail. This change fully quaifies ApplicationController
when used as a base class like this.
