### PR TITLE
[1145] Remove friendly_id

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,9 +51,6 @@ gem 'jwt'
 # Formalise config settings with support for env vars
 gem 'config'
 
-# Nicer URL's
-gem 'friendly_id'
-
 # For building cmdline apps (mcb)
 gem 'cri'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,8 +115,6 @@ GEM
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
-    friendly_id (5.2.5)
-      activerecord (>= 4.0.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     govuk-lint (3.11.0)
@@ -346,7 +344,6 @@ DEPENDENCIES
   database_cleaner
   factory_bot_rails (~> 5.0)
   faker
-  friendly_id
   govuk-lint
   httparty
   jsonapi-rails

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -2,7 +2,7 @@ module API
   module V2
     class CoursesController < API::V2::ApplicationController
       def index
-        provider = Provider.friendly.find(params[:provider_code])
+        provider = Provider.find_by!(provider_code: params[:provider_code])
         authorize provider, :can_list_courses?
         authorize Course
 

--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -12,7 +12,7 @@ module API
       end
 
       def show
-        provider = Provider.friendly.find(params[:code].upcase)
+        provider = Provider.find_by!(provider_code: params[:code].upcase)
         authorize provider, :show?
 
         render jsonapi: provider

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -31,9 +31,6 @@ class Provider < ApplicationRecord
   include RegionCode
   include ChangedAt
 
-  extend FriendlyId
-  friendly_id :provider_code, use: :slugged, slug_column: :provider_code
-
   enum provider_type: {
     scitt: "B",
     lead_school: "Y",


### PR DESCRIPTION
### Context
Cleaning up find by `provider_code`

### Changes proposed in this pull request
Remove `friendly_id`

### Guidance to review
`/api/v2/providers/A9/courses`
`/api/v2/providers/A9`

Check the mcf still works `/organisations`
