### PR TITLE
1045 make changed at unique

### DIFF
--- a/db/migrate/20190313153617_change_changed_at_to_unique.rb
+++ b/db/migrate/20190313153617_change_changed_at_to_unique.rb
@@ -1,0 +1,6 @@
+class ChangeChangedAtToUnique < ActiveRecord::Migration[5.2]
+  def change
+    add_index :provider, :changed_at, unique: true
+    add_index :course, :changed_at, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_06_122110) do
+ActiveRecord::Schema.define(version: 2019_03_13_153617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -53,6 +53,7 @@ ActiveRecord::Schema.define(version: 2019_03_06_122110) do
     t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.datetime "changed_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.index ["accrediting_provider_id"], name: "IX_course_accrediting_provider_id"
+    t.index ["changed_at"], name: "index_course_on_changed_at", unique: true
     t.index ["provider_id", "course_code"], name: "IX_course_provider_id_course_code", unique: true
   end
 
@@ -143,6 +144,7 @@ ActiveRecord::Schema.define(version: 2019_03_06_122110) do
     t.datetime "last_published_at"
     t.datetime "changed_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.boolean "opted_in", default: false
+    t.index ["changed_at"], name: "index_provider_on_changed_at", unique: true
     t.index ["last_published_at"], name: "IX_provider_last_published_at"
     t.index ["provider_code"], name: "IX_provider_provider_code", unique: true
   end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -27,7 +27,8 @@ FactoryBot.define do
     sequence(:course_code) { |n| "C#{n}D3" }
     name { Faker::ProgrammingLanguage.name }
     qualification { :pgce_with_qts }
-    association(:provider, course_count: 0)
+
+    association(:provider)
     study_mode { :full_time }
     resulting_in_pgce_with_qts
 

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -47,7 +47,7 @@ FactoryBot.define do
       skip_associated_data { false }
       site_count           { 1 }
       sites                { build_list :site, site_count, provider: nil }
-      course_count         { 2 }
+      course_count         { 0 }
       enrichments          { [build(:provider_enrichment)] }
     end
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -18,7 +18,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Provider, type: :model do
+describe Provider, type: :model do
   subject { create(:site) }
 
   describe 'associations' do

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -5,7 +5,7 @@ def get_course_codes_from_body(body)
   json.map { |course| course["course_code"] }
 end
 
-RSpec.describe "Courses API", type: :request do
+describe "Courses API", type: :request do
   describe 'GET index' do
     let(:credentials) do
       ActionController::HttpAuthentication::Token
@@ -22,7 +22,6 @@ RSpec.describe "Courses API", type: :request do
         provider_code: "2LD",
         provider_type: :scitt,
         site_count: 0,
-        course_count: 0,
         scheme_member: 'Y',
         enrichments: [])
     end


### PR DESCRIPTION
### Context

To prevent bulk updates from breaking incremental fetch a unique constraint has been added to changed_at for provider and course.

### Changes proposed in this pull request

Migration created for unique constraint implemented on changed_at column for provider
Migration created for unique constraint implemented on changed_at column for course
Changed provider factory bots default course count from 2 to 0 

