### PR TITLE
[1150] Handle user email matching case-insensitively

### DIFF
--- a/app/controllers/api/v2/application_controller.rb
+++ b/app/controllers/api/v2/application_controller.rb
@@ -17,7 +17,8 @@ module API
                                                  Settings.authentication.algorithm)
             email = payload['email']
           end
-          @current_user = User.find_by(email: email)
+          # match email addresses case-insensitively
+          @current_user = User.find_by("lower(email) = ?", email.downcase)
           @current_user.present?
         end
       end

--- a/spec/controllers/api/v2/application_controller_spec.rb
+++ b/spec/controllers/api/v2/application_controller_spec.rb
@@ -46,6 +46,12 @@ describe API::V2::ApplicationController, type: :controller do
         end
       end
 
+      context 'email case not the same as in the DB' do
+        let(:payload) { { email: user.email.upcase } }
+
+        it { should be true }
+      end
+
       describe 'errors' do
         context 'empty payload' do
           let(:payload) {}


### PR DESCRIPTION
### Context

In line with the API design philosophy of "be permissive in what you accept and strict with what you return".

This change allows the V2 API to authenticate successfully in cases where the email address in the database (which is all lowercase by convention) doesn't match a mixed-case email coming through on the Authorization header from DfE Sign-in.
