### PR TITLE
[1162] nest course routes with provider

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,10 +62,8 @@ Rails.application.routes.draw do
       end
 
       resources :providers, param: :code do
-        resources :courses, only: %i[index create]
+        resources :courses, param: :code, only: %i[index create show]
       end
-
-      resources :courses, param: :code, only: :show
 
       resource :sessions
     end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -36,7 +36,7 @@ describe 'Courses API v2', type: :request do
       let(:payload) { { email: 'foo@bar' } }
 
       before do
-        get "/api/v2/courses/#{findable_open_course.course_code}",
+        get "/api/v2/providers/#{provider.provider_code}/courses/#{findable_open_course.course_code}",
             headers: { 'HTTP_AUTHORIZATION' => credentials }
       end
 
@@ -49,7 +49,7 @@ describe 'Courses API v2', type: :request do
 
       it "raises an error" do
         expect {
-          get "/api/v2/courses/#{findable_open_course.course_code}",
+          get "/api/v2/providers/#{provider.provider_code}/courses/#{findable_open_course.course_code}",
             headers: { 'HTTP_AUTHORIZATION' => credentials }
         }.to raise_error Pundit::NotAuthorizedError
       end
@@ -57,7 +57,7 @@ describe 'Courses API v2', type: :request do
 
     describe 'JSON generated for courses' do
       before do
-        get "/api/v2/courses/#{findable_open_course.course_code}",
+        get "/api/v2/providers/#{provider.provider_code}/courses/#{findable_open_course.course_code}",
             headers: { 'HTTP_AUTHORIZATION' => credentials },
             params: { includes: "site_statuses" }
       end


### PR DESCRIPTION
### Context
Courses are unique to a provider

### Changes proposed in this pull request
Nest courses within provider

### Guidance to review
Example endpoint to test `/api/v2/providers/T92/courses/X130`
