### PR TITLE
1131 site status validation

### DIFF
--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -14,6 +14,22 @@
 class SiteStatus < ApplicationRecord
   self.table_name = "course_site"
 
+  ALLOWED_VAC_STATUSES = {
+    nil                      => %w[no_vacancies],
+    'full_time'              => %w[no_vacancies full_time_vacancies],
+    'part_time'              => %w[no_vacancies part_time_vacancies],
+    'full_time_or_part_time' => %w[no_vacancies part_time_vacancies full_time_vacancies both_full_time_and_part_time_vacancies],
+  }.freeze
+
+  validate :validate_vac_status, if: :vac_status_changed?
+
+  def validate_vac_status
+    unless ALLOWED_VAC_STATUSES[self.course.study_mode].include? vac_status
+      errors.add(:vac_status,
+        "can only be #{ALLOWED_VAC_STATUSES[self.course.study_mode].map { |s| "'#{s}'" }.join(', ')} as the course study mode is '#{self.course.study_mode}'")
+    end
+  end
+
   enum vac_status: {
     both_full_time_and_part_time_vacancies: "B",
     part_time_vacancies: "P",

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -31,6 +31,10 @@ FactoryBot.define do
     study_mode { :full_time }
     resulting_in_pgce_with_qts
 
+    trait :skips_validate do
+      to_create { |instance| instance.save(validate: false) }
+    end
+
     transient do
       age { nil }
     end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -30,7 +30,8 @@ FactoryBot.define do
     association(:provider, course_count: 0)
     study_mode { :full_time }
     resulting_in_pgce_with_qts
-    study_mode { :full_time_or_part_time }
+
+    with_study_mode_as_full_time
 
     trait :skips_validate do
       to_create { |instance| instance.save(validate: false) }
@@ -66,6 +67,40 @@ FactoryBot.define do
 
     trait :resulting_in_pgde do
       qualification { :pgde }
+    end
+
+    trait :with_study_mode_as_full_time do
+      study_mode { :full_time }
+    end
+
+    trait :with_study_mode_as_part_time do
+      study_mode { :part_time }
+    end
+
+    trait :with_study_mode_as_full_time_or_part_time do
+      study_mode { :full_time_or_part_time }
+    end
+
+    factory :course_with_site_statuses do
+      with_study_mode_as_full_time_or_part_time
+
+      transient do
+        site_statuses_traits {
+          [
+            [:findable],
+            [:with_any_vacancy],
+            [],
+            [:applications_being_accepted_now],
+            [:applications_being_accepted_in_future]
+          ]
+        }
+      end
+
+      after(:create) do |course, evaluator|
+        evaluator.site_statuses_traits.each do |traits|
+          create(:site_status, *traits, course: course)
+        end
+      end
     end
   end
 end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -30,6 +30,7 @@ FactoryBot.define do
     association(:provider, course_count: 0)
     study_mode { :full_time }
     resulting_in_pgce_with_qts
+    study_mode { :full_time_or_part_time }
 
     trait :skips_validate do
       to_create { |instance| instance.save(validate: false) }

--- a/spec/factories/site_statuses.rb
+++ b/spec/factories/site_statuses.rb
@@ -13,10 +13,11 @@
 
 FactoryBot.define do
   factory :site_status do
-    association(:course)
-    association(:site)
+    course
+    site
+
     publish { 'N' }
-    vac_status { :full_time_vacancies }
+    full_time_vacancies
 
     trait :skips_validate do
       to_create { |instance| instance.save(validate: false) }
@@ -89,15 +90,15 @@ FactoryBot.define do
     end
 
     trait :with_course_study_mode_as_full_time do
-      association(:course, study_mode: :full_time)
+      association(:course, :with_study_mode_as_full_time)
     end
 
     trait :with_course_study_mode_as_part_time do
-      association(:course, study_mode: :part_time)
+      association(:course, :with_study_mode_as_part_time)
     end
 
     trait :with_course_study_mode_as_full_time_or_part_time do
-      association(:course, study_mode: :full_time_or_part_time)
+      association(:course, :with_study_mode_as_full_time_or_part_time)
     end
   end
 end

--- a/spec/factories/site_statuses.rb
+++ b/spec/factories/site_statuses.rb
@@ -19,8 +19,8 @@ FactoryBot.define do
     publish { 'N' }
     full_time_vacancies
 
-    trait :skips_validate do
-      to_create { |instance| instance.save(validate: false) }
+    trait :allow_invalid do
+      to_create(&:save)
     end
 
     trait :published do

--- a/spec/factories/site_statuses.rb
+++ b/spec/factories/site_statuses.rb
@@ -89,15 +89,15 @@ FactoryBot.define do
     end
 
     trait :with_course_study_mode_as_full_time do
-      association(:course, study_mode: "F")
+      association(:course, study_mode: :full_time)
     end
 
     trait :with_course_study_mode_as_part_time do
-      association(:course, study_mode: "P")
+      association(:course, study_mode: :part_time)
     end
 
     trait :with_course_study_mode_as_full_time_or_part_time do
-      association(:course, study_mode: "B")
+      association(:course, study_mode: :full_time_or_part_time)
     end
   end
 end

--- a/spec/factories/site_statuses.rb
+++ b/spec/factories/site_statuses.rb
@@ -18,6 +18,10 @@ FactoryBot.define do
     publish { 'N' }
     vac_status { :full_time_vacancies }
 
+    trait :skips_validate do
+      to_create { |instance| instance.save(validate: false) }
+    end
+
     trait :published do
       publish { :published }
     end
@@ -39,7 +43,7 @@ FactoryBot.define do
     end
 
     trait :with_any_vacancy do
-      vac_status { %i[full_time_vacancies full_time_vacancies part_time_vacancies].sample }
+      vac_status { %i[both_full_time_and_part_time_vacancies full_time_vacancies part_time_vacancies].sample }
     end
 
     trait :with_no_vacancies do
@@ -73,6 +77,27 @@ FactoryBot.define do
     trait :findable do
       running
       published
+    end
+
+    trait :findable_and_with_any_vacancy do
+      findable
+      with_any_vacancy
+    end
+
+    trait :with_course_study_mode_as_nil do
+      association(:course, study_mode: nil)
+    end
+
+    trait :with_course_study_mode_as_full_time do
+      association(:course, study_mode: "F")
+    end
+
+    trait :with_course_study_mode_as_part_time do
+      association(:course, study_mode: "P")
+    end
+
+    trait :with_course_study_mode_as_full_time_or_part_time do
+      association(:course, study_mode: "B")
     end
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -63,25 +63,18 @@ RSpec.describe Course, type: :model do
     describe 'findable?' do
       context 'with at least one site status as findable' do
         context 'single site status as findable' do
-          let(:subject) { create(:course, site_statuses: course_site_statuses) }
+          let(:subject) { create(:course_with_site_statuses, site_statuses_traits: course_site_statuses) }
 
-          let(:course_site_statuses) { [create(:site_status, :findable)] }
+          let(:course_site_statuses) {
+            [[:findable]]
+          }
 
           its(:site_statuses) { should_not be_empty }
           its(:findable?) { should be true }
         end
 
         context 'single site status as findable and mix site status as non findable' do
-          let(:subject) { create(:course, site_statuses: course_site_statuses) }
-
-          let(:course_site_statuses) {
-            [create(:site_status, :findable),
-             create(:site_status, :with_any_vacancy),
-             create(:site_status),
-             create(:site_status, :applications_being_accepted_now),
-             create(:site_status, :applications_being_accepted_in_future)]
-          }
-
+          let(:subject) { create(:course_with_site_statuses) }
           its(:site_statuses) { should_not be_empty }
           its(:findable?) { should be true }
         end
@@ -91,25 +84,18 @@ RSpec.describe Course, type: :model do
     describe 'has_vacancies' do
       context 'with at least one site status has vacancies' do
         context 'single site status has vacancies' do
-          let(:subject) { create(:course, site_statuses: course_site_statuses) }
+          let(:subject) { create(:course_with_site_statuses, site_statuses_traits: course_site_statuses) }
 
-          let(:course_site_statuses) { [create(:site_status, :with_any_vacancy)] }
+          let(:course_site_statuses) {
+            [[:with_any_vacancy]]
+          }
 
           its(:site_statuses) { should_not be_empty }
           its(:has_vacancies?) { should be true }
         end
 
         context 'single site status has vacancies and mix site status with no vacancies' do
-          let(:subject) { create(:course, site_statuses: course_site_statuses) }
-
-          let(:course_site_statuses) {
-            [create(:site_status, :findable),
-             create(:site_status, :with_any_vacancy),
-             create(:site_status),
-             create(:site_status, :applications_being_accepted_now),
-             create(:site_status, :applications_being_accepted_in_future)]
-          }
-
+          let(:subject) { create(:course_with_site_statuses) }
           its(:site_statuses) { should_not be_empty }
           its(:has_vacancies?) { should be true }
         end
@@ -118,47 +104,38 @@ RSpec.describe Course, type: :model do
     describe 'open_for_applications?' do
       context 'with at least one site status applications_being_accepted_now' do
         context 'single site status applications_being_accepted_now as it open now' do
-          let(:subject) { create(:course, site_statuses: course_site_statuses) }
+          let(:subject) { create(:course_with_site_statuses, site_statuses_traits: course_site_statuses) }
 
           let(:course_site_statuses) {
-            [create(:site_status, :findable, :applications_being_accepted_now, :with_any_vacancy)]
+            [%i[findable applications_being_accepted_now with_any_vacancy]]
           }
 
           its(:site_statuses) { should_not be_empty }
           its(:open_for_applications?) { should be true }
         end
         context 'single site status applications_being_accepted_now as it open future' do
-          let(:subject) { create(:course, site_statuses: course_site_statuses) }
+          let(:subject) { create(:course_with_site_statuses, site_statuses_traits: course_site_statuses) }
 
           let(:course_site_statuses) {
-            [create(:site_status, :applications_being_accepted_in_future)]
+            [[:applications_being_accepted_in_future]]
           }
 
           its(:site_statuses) { should_not be_empty }
           its(:open_for_applications?) { should be false }
         end
         context 'site statuses applications_being_accepted_now as it open now & future' do
-          let(:subject) { create(:course, site_statuses: course_site_statuses) }
+          let(:subject) { create(:course_with_site_statuses, site_statuses_traits: course_site_statuses) }
 
           let(:course_site_statuses) {
-            [create(:site_status, :findable, :applications_being_accepted_now, :with_any_vacancy),
-             create(:site_status, :findable, :applications_being_accepted_in_future, :with_any_vacancy)]
+            [%i[findable applications_being_accepted_now with_any_vacancy],
+             %i[findable applications_being_accepted_in_future with_any_vacancy]]
           }
 
           its(:site_statuses) { should_not be_empty }
           its(:open_for_applications?) { should be true }
         end
         context 'site statuses applications_being_accepted_now as it open now & future and mix site status as non findable' do
-          let(:subject) { create(:course, site_statuses: course_site_statuses) }
-
-          let(:course_site_statuses) {
-            [create(:site_status, :findable),
-             create(:site_status, :with_any_vacancy),
-             create(:site_status),
-             create(:site_status, :applications_being_accepted_now),
-             create(:site_status, :applications_being_accepted_in_future)]
-          }
-
+          let(:subject) { create(:course_with_site_statuses) }
           its(:site_statuses) { should_not be_empty }
           its(:findable?) { should be true }
           its(:open_for_applications?) { should be false }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -72,14 +72,14 @@ RSpec.describe Course, type: :model do
         end
 
         context 'single site status as findable and mix site status as non findable' do
-          let(:subject) { create(:course, :skips_validate, site_statuses: course_site_statuses) }
+          let(:subject) { create(:course, site_statuses: course_site_statuses) }
 
           let(:course_site_statuses) {
-            [create(:site_status, :skips_validate, :findable),
-             create(:site_status, :skips_validate, :with_any_vacancy),
-             create(:site_status, :skips_validate),
-             create(:site_status, :skips_validate, :applications_being_accepted_now),
-             create(:site_status, :skips_validate, :applications_being_accepted_in_future)]
+            [create(:site_status, :findable),
+             create(:site_status, :with_any_vacancy),
+             create(:site_status),
+             create(:site_status, :applications_being_accepted_now),
+             create(:site_status, :applications_being_accepted_in_future)]
           }
 
           its(:site_statuses) { should_not be_empty }
@@ -91,23 +91,23 @@ RSpec.describe Course, type: :model do
     describe 'has_vacancies' do
       context 'with at least one site status has vacancies' do
         context 'single site status has vacancies' do
-          let(:subject) { create(:course, :skips_validate, site_statuses: course_site_statuses) }
+          let(:subject) { create(:course, site_statuses: course_site_statuses) }
 
-          let(:course_site_statuses) { [create(:site_status, :skips_validate, :with_any_vacancy)] }
+          let(:course_site_statuses) { [create(:site_status, :with_any_vacancy)] }
 
           its(:site_statuses) { should_not be_empty }
           its(:has_vacancies?) { should be true }
         end
 
         context 'single site status has vacancies and mix site status with no vacancies' do
-          let(:subject) { create(:course, :skips_validate, site_statuses: course_site_statuses) }
+          let(:subject) { create(:course, site_statuses: course_site_statuses) }
 
           let(:course_site_statuses) {
-            [create(:site_status, :skips_validate, :findable),
-             create(:site_status, :skips_validate, :with_any_vacancy),
-             create(:site_status, :skips_validate),
-             create(:site_status, :skips_validate, :applications_being_accepted_now),
-             create(:site_status, :skips_validate, :applications_being_accepted_in_future)]
+            [create(:site_status, :findable),
+             create(:site_status, :with_any_vacancy),
+             create(:site_status),
+             create(:site_status, :applications_being_accepted_now),
+             create(:site_status, :applications_being_accepted_in_future)]
           }
 
           its(:site_statuses) { should_not be_empty }
@@ -118,10 +118,10 @@ RSpec.describe Course, type: :model do
     describe 'open_for_applications?' do
       context 'with at least one site status applications_being_accepted_now' do
         context 'single site status applications_being_accepted_now as it open now' do
-          let(:subject) { create(:course, :skips_validate, site_statuses: course_site_statuses) }
+          let(:subject) { create(:course, site_statuses: course_site_statuses) }
 
           let(:course_site_statuses) {
-            [create(:site_status, :skips_validate, :findable, :applications_being_accepted_now, :with_any_vacancy)]
+            [create(:site_status, :findable, :applications_being_accepted_now, :with_any_vacancy)]
           }
 
           its(:site_statuses) { should_not be_empty }
@@ -138,25 +138,25 @@ RSpec.describe Course, type: :model do
           its(:open_for_applications?) { should be false }
         end
         context 'site statuses applications_being_accepted_now as it open now & future' do
-          let(:subject) { create(:course, :skips_validate, site_statuses: course_site_statuses) }
+          let(:subject) { create(:course, site_statuses: course_site_statuses) }
 
           let(:course_site_statuses) {
-            [create(:site_status, :skips_validate, :findable, :applications_being_accepted_now, :with_any_vacancy),
-             create(:site_status, :skips_validate, :findable, :applications_being_accepted_in_future, :with_any_vacancy)]
+            [create(:site_status, :findable, :applications_being_accepted_now, :with_any_vacancy),
+             create(:site_status, :findable, :applications_being_accepted_in_future, :with_any_vacancy)]
           }
 
           its(:site_statuses) { should_not be_empty }
           its(:open_for_applications?) { should be true }
         end
         context 'site statuses applications_being_accepted_now as it open now & future and mix site status as non findable' do
-          let(:subject) { create(:course, :skips_validate, site_statuses: course_site_statuses) }
+          let(:subject) { create(:course, site_statuses: course_site_statuses) }
 
           let(:course_site_statuses) {
-            [create(:site_status, :skips_validate, :findable),
-             create(:site_status, :skips_validate, :with_any_vacancy),
-             create(:site_status, :skips_validate),
-             create(:site_status, :skips_validate, :applications_being_accepted_now),
-             create(:site_status, :skips_validate, :applications_being_accepted_in_future)]
+            [create(:site_status, :findable),
+             create(:site_status, :with_any_vacancy),
+             create(:site_status),
+             create(:site_status, :applications_being_accepted_now),
+             create(:site_status, :applications_being_accepted_in_future)]
           }
 
           its(:site_statuses) { should_not be_empty }
@@ -174,7 +174,7 @@ RSpec.describe Course, type: :model do
 
   describe '#changed_since' do
     context 'with no parameters' do
-      let!(:old_course) { create(:course, :skips_validate, age: 1.hour.ago) }
+      let!(:old_course) { create(:course, age: 1.hour.ago) }
       let!(:course) { create(:course, age: 1.hour.ago) }
 
       subject { Course.changed_since(nil) }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -72,14 +72,14 @@ RSpec.describe Course, type: :model do
         end
 
         context 'single site status as findable and mix site status as non findable' do
-          let(:subject) { create(:course, site_statuses: course_site_statuses) }
+          let(:subject) { create(:course, :skips_validate, site_statuses: course_site_statuses) }
 
           let(:course_site_statuses) {
-            [create(:site_status, :findable),
-             create(:site_status, :with_any_vacancy),
-             create(:site_status),
-             create(:site_status, :applications_being_accepted_now),
-             create(:site_status, :applications_being_accepted_in_future)]
+            [create(:site_status, :skips_validate, :findable),
+             create(:site_status, :skips_validate, :with_any_vacancy),
+             create(:site_status, :skips_validate),
+             create(:site_status, :skips_validate, :applications_being_accepted_now),
+             create(:site_status, :skips_validate, :applications_being_accepted_in_future)]
           }
 
           its(:site_statuses) { should_not be_empty }
@@ -91,23 +91,23 @@ RSpec.describe Course, type: :model do
     describe 'has_vacancies' do
       context 'with at least one site status has vacancies' do
         context 'single site status has vacancies' do
-          let(:subject) { create(:course, site_statuses: course_site_statuses) }
+          let(:subject) { create(:course, :skips_validate, site_statuses: course_site_statuses) }
 
-          let(:course_site_statuses) { [create(:site_status, :with_any_vacancy)] }
+          let(:course_site_statuses) { [create(:site_status, :skips_validate, :with_any_vacancy)] }
 
           its(:site_statuses) { should_not be_empty }
           its(:has_vacancies?) { should be true }
         end
 
         context 'single site status has vacancies and mix site status with no vacancies' do
-          let(:subject) { create(:course, site_statuses: course_site_statuses) }
+          let(:subject) { create(:course, :skips_validate, site_statuses: course_site_statuses) }
 
           let(:course_site_statuses) {
-            [create(:site_status, :findable),
-             create(:site_status, :with_any_vacancy),
-             create(:site_status),
-             create(:site_status, :applications_being_accepted_now),
-             create(:site_status, :applications_being_accepted_in_future)]
+            [create(:site_status, :skips_validate, :findable),
+             create(:site_status, :skips_validate, :with_any_vacancy),
+             create(:site_status, :skips_validate),
+             create(:site_status, :skips_validate, :applications_being_accepted_now),
+             create(:site_status, :skips_validate, :applications_being_accepted_in_future)]
           }
 
           its(:site_statuses) { should_not be_empty }
@@ -118,10 +118,10 @@ RSpec.describe Course, type: :model do
     describe 'open_for_applications?' do
       context 'with at least one site status applications_being_accepted_now' do
         context 'single site status applications_being_accepted_now as it open now' do
-          let(:subject) { create(:course, site_statuses: course_site_statuses) }
+          let(:subject) { create(:course, :skips_validate, site_statuses: course_site_statuses) }
 
           let(:course_site_statuses) {
-            [create(:site_status, :findable, :applications_being_accepted_now, :with_any_vacancy)]
+            [create(:site_status, :skips_validate, :findable, :applications_being_accepted_now, :with_any_vacancy)]
           }
 
           its(:site_statuses) { should_not be_empty }
@@ -138,25 +138,25 @@ RSpec.describe Course, type: :model do
           its(:open_for_applications?) { should be false }
         end
         context 'site statuses applications_being_accepted_now as it open now & future' do
-          let(:subject) { create(:course, site_statuses: course_site_statuses) }
+          let(:subject) { create(:course, :skips_validate, site_statuses: course_site_statuses) }
 
           let(:course_site_statuses) {
-            [create(:site_status, :findable, :applications_being_accepted_now, :with_any_vacancy),
-             create(:site_status, :findable, :applications_being_accepted_in_future, :with_any_vacancy)]
+            [create(:site_status, :skips_validate, :findable, :applications_being_accepted_now, :with_any_vacancy),
+             create(:site_status, :skips_validate, :findable, :applications_being_accepted_in_future, :with_any_vacancy)]
           }
 
           its(:site_statuses) { should_not be_empty }
           its(:open_for_applications?) { should be true }
         end
         context 'site statuses applications_being_accepted_now as it open now & future and mix site status as non findable' do
-          let(:subject) { create(:course, site_statuses: course_site_statuses) }
+          let(:subject) { create(:course, :skips_validate, site_statuses: course_site_statuses) }
 
           let(:course_site_statuses) {
-            [create(:site_status, :findable),
-             create(:site_status, :with_any_vacancy),
-             create(:site_status),
-             create(:site_status, :applications_being_accepted_now),
-             create(:site_status, :applications_being_accepted_in_future)]
+            [create(:site_status, :skips_validate, :findable),
+             create(:site_status, :skips_validate, :with_any_vacancy),
+             create(:site_status, :skips_validate),
+             create(:site_status, :skips_validate, :applications_being_accepted_now),
+             create(:site_status, :skips_validate, :applications_being_accepted_in_future)]
           }
 
           its(:site_statuses) { should_not be_empty }
@@ -174,7 +174,7 @@ RSpec.describe Course, type: :model do
 
   describe '#changed_since' do
     context 'with no parameters' do
-      let!(:old_course) { create(:course, age: 1.hour.ago) }
+      let!(:old_course) { create(:course, :skips_validate, age: 1.hour.ago) }
       let!(:course) { create(:course, age: 1.hour.ago) }
 
       subject { Course.changed_since(nil) }

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -71,12 +71,12 @@ RSpec.describe SiteStatus, type: :model do
     end
 
     describe 'if on find, application date open and has part-time vacancies' do
-      subject { create(:site_status, :findable, :applications_being_accepted_now, :part_time_vacancies) }
+      subject { create(:site_status, :with_course_study_mode_as_part_time, :findable, :applications_being_accepted_now, :part_time_vacancies) }
       it { should be_open_for_applications }
     end
 
     describe 'if on find, application date open and has both full-time and part-time vacancies' do
-      subject { create(:site_status, :findable, :applications_being_accepted_now, :both_full_time_and_part_time_vacancies) }
+      subject { create(:site_status, :with_course_study_mode_as_full_time_or_part_time, :findable, :applications_being_accepted_now, :both_full_time_and_part_time_vacancies) }
       it { should be_open_for_applications }
     end
 
@@ -98,7 +98,7 @@ RSpec.describe SiteStatus, type: :model do
 
   describe "has vacancies?" do
     describe 'if has part-time vacancies' do
-      subject { create(:site_status, :part_time_vacancies) }
+      subject { create(:site_status, :with_course_study_mode_as_part_time, :part_time_vacancies) }
       it { should have_vacancies }
     end
 
@@ -108,7 +108,7 @@ RSpec.describe SiteStatus, type: :model do
     end
 
     describe 'if has both full-time and part-time vacancies' do
-      subject { create(:site_status, :both_full_time_and_part_time_vacancies) }
+      subject { create(:site_status, :with_course_study_mode_as_full_time_or_part_time, :both_full_time_and_part_time_vacancies) }
       it { should have_vacancies }
     end
 
@@ -141,7 +141,7 @@ RSpec.describe SiteStatus, type: :model do
 
     specs.each do |spec|
       context "site status #{spec[:study_mode].to_s.humanize(capitalize: false)}" do
-        subject { create(:site_status, spec[:study_mode]) }
+        subject { create(:site_status, spec[:study_mode], :with_no_vacancies) }
 
         spec[:valid_states].each do |state|
           context "set a valid vac_status to #{state}" do

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -39,82 +39,138 @@ RSpec.describe SiteStatus, type: :model do
 
   describe 'is it on find?' do
     describe 'if discontinued on UCAS' do
-      subject { create(:site_status, :discontinued) }
+      subject { create(:site_status, :skips_validate, :discontinued) }
       it { should_not be_findable }
     end
 
     describe 'if suspended on UCAS' do
-      subject { create(:site_status, :suspended) }
+      subject { create(:site_status, :skips_validate, :suspended) }
       it { should_not be_findable }
     end
 
     describe 'if new on UCAS' do
-      subject { create(:site_status, :new) }
+      subject { create(:site_status, :skips_validate, :new) }
       it { should_not be_findable }
     end
 
     describe 'if running but not published on UCAS' do
-      subject { create(:site_status, :running, :unpublished) }
+      subject { create(:site_status, :skips_validate, :running, :unpublished) }
       it { should_not be_findable }
     end
 
     describe 'if running and published on UCAS' do
-      subject { create(:site_status, :running, :published) }
+      subject { create(:site_status, :skips_validate, :running, :published) }
       it { should be_findable }
     end
   end
 
   describe 'applications open?' do
     describe 'if on find, application date open and has full-time vacancies' do
-      subject { create(:site_status, :findable, :applications_being_accepted_now, :full_time_vacancies) }
+      subject { create(:site_status, :skips_validate, :findable, :applications_being_accepted_now, :full_time_vacancies) }
       it { should be_open_for_applications }
     end
 
     describe 'if on find, application date open and has part-time vacancies' do
-      subject { create(:site_status, :findable, :applications_being_accepted_now, :part_time_vacancies) }
+      subject { create(:site_status, :skips_validate, :findable, :applications_being_accepted_now, :part_time_vacancies) }
       it { should be_open_for_applications }
     end
 
     describe 'if on find, application date open and has both full-time and part-time vacancies' do
-      subject { create(:site_status, :findable, :applications_being_accepted_now, :both_full_time_and_part_time_vacancies) }
+      subject { create(:site_status, :skips_validate, :findable, :applications_being_accepted_now, :both_full_time_and_part_time_vacancies) }
       it { should be_open_for_applications }
     end
 
     describe 'if not on find' do
-      subject { create(:site_status, :suspended) }
+      subject { create(:site_status, :skips_validate, :suspended) }
       it { should_not be_open_for_applications }
     end
 
     describe 'if on find but applications accepted in the future' do
-      subject { create(:site_status, :findable, :applications_being_accepted_in_future) }
+      subject { create(:site_status, :skips_validate, :findable, :applications_being_accepted_in_future) }
       it { should_not be_open_for_applications }
     end
 
     describe 'if on find, applications accepted now but no vacancies' do
-      subject { create(:site_status, :findable, :applications_being_accepted_now, :with_no_vacancies) }
+      subject { create(:site_status, :skips_validate, :findable, :applications_being_accepted_now, :with_no_vacancies) }
       it { should_not be_open_for_applications }
     end
   end
 
   describe "has vacancies?" do
     describe 'if has part-time vacancies' do
-      subject { create(:site_status, :part_time_vacancies) }
+      subject { create(:site_status, :skips_validate, :part_time_vacancies) }
       it { should have_vacancies }
     end
 
     describe 'if has full-time vacancies' do
-      subject { create(:site_status, :full_time_vacancies) }
+      subject { create(:site_status, :skips_validate, :full_time_vacancies) }
       it { should have_vacancies }
     end
 
     describe 'if has both full-time and part-time vacancies' do
-      subject { create(:site_status, :both_full_time_and_part_time_vacancies) }
+      subject { create(:site_status, :skips_validate, :both_full_time_and_part_time_vacancies) }
       it { should have_vacancies }
     end
 
     describe 'if has no vacancies' do
-      subject { create(:site_status, :with_no_vacancies) }
+      subject { create(:site_status, :skips_validate, :with_no_vacancies) }
       it { should_not have_vacancies }
+    end
+  end
+
+  describe "#update" do
+    all_vac_statuses = %w[no_vacancies part_time_vacancies full_time_vacancies both_full_time_and_part_time_vacancies]
+    specs = [
+      {
+        study_mode: :with_course_study_mode_as_nil,
+        valid_states: %w[no_vacancies]
+      },
+      {
+        study_mode: :with_course_study_mode_as_full_time,
+        valid_states: %w[no_vacancies full_time_vacancies]
+      },
+      {
+        study_mode: :with_course_study_mode_as_part_time,
+        valid_states: %w[no_vacancies part_time_vacancies]
+      },
+      {
+        study_mode: :with_course_study_mode_as_full_time_or_part_time,
+        valid_states: all_vac_statuses
+      },
+    ].freeze
+
+    specs.each do |spec|
+      context "site status #{spec[:study_mode].to_s.humanize(capitalize: false)}" do
+        subject { create(:site_status, spec[:study_mode]) }
+
+        spec[:valid_states].each do |state|
+          context "set a valid vac_status to #{state}" do
+            let!(:has_saved) {
+              subject.update(vac_status: state)
+            }
+
+            it "updated successfully" do
+              expect(subject.vac_status).to eq state.to_s
+              expect(has_saved).to eq true
+            end
+          end
+        end
+
+        invalid_states = (spec[:valid_states] + all_vac_statuses) - (spec[:valid_states] & all_vac_statuses)
+
+        invalid_states.each do |state|
+          context "set an invalid the vac_status to #{state}" do
+            let!(:has_saved) {
+              subject.update(vac_status: state)
+            }
+
+            it "updated unsuccessfully" do
+              expect(subject.vac_status).to eq state.to_s
+              expect(has_saved).to eq false
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -39,81 +39,81 @@ RSpec.describe SiteStatus, type: :model do
 
   describe 'is it on find?' do
     describe 'if discontinued on UCAS' do
-      subject { create(:site_status, :skips_validate, :discontinued) }
+      subject { create(:site_status, :discontinued) }
       it { should_not be_findable }
     end
 
     describe 'if suspended on UCAS' do
-      subject { create(:site_status, :skips_validate, :suspended) }
+      subject { create(:site_status, :suspended) }
       it { should_not be_findable }
     end
 
     describe 'if new on UCAS' do
-      subject { create(:site_status, :skips_validate, :new) }
+      subject { create(:site_status, :new) }
       it { should_not be_findable }
     end
 
     describe 'if running but not published on UCAS' do
-      subject { create(:site_status, :skips_validate, :running, :unpublished) }
+      subject { create(:site_status, :running, :unpublished) }
       it { should_not be_findable }
     end
 
     describe 'if running and published on UCAS' do
-      subject { create(:site_status, :skips_validate, :running, :published) }
+      subject { create(:site_status, :running, :published) }
       it { should be_findable }
     end
   end
 
   describe 'applications open?' do
     describe 'if on find, application date open and has full-time vacancies' do
-      subject { create(:site_status, :skips_validate, :findable, :applications_being_accepted_now, :full_time_vacancies) }
+      subject { create(:site_status, :findable, :applications_being_accepted_now, :full_time_vacancies) }
       it { should be_open_for_applications }
     end
 
     describe 'if on find, application date open and has part-time vacancies' do
-      subject { create(:site_status, :skips_validate, :findable, :applications_being_accepted_now, :part_time_vacancies) }
+      subject { create(:site_status, :findable, :applications_being_accepted_now, :part_time_vacancies) }
       it { should be_open_for_applications }
     end
 
     describe 'if on find, application date open and has both full-time and part-time vacancies' do
-      subject { create(:site_status, :skips_validate, :findable, :applications_being_accepted_now, :both_full_time_and_part_time_vacancies) }
+      subject { create(:site_status, :findable, :applications_being_accepted_now, :both_full_time_and_part_time_vacancies) }
       it { should be_open_for_applications }
     end
 
     describe 'if not on find' do
-      subject { create(:site_status, :skips_validate, :suspended) }
+      subject { create(:site_status, :suspended) }
       it { should_not be_open_for_applications }
     end
 
     describe 'if on find but applications accepted in the future' do
-      subject { create(:site_status, :skips_validate, :findable, :applications_being_accepted_in_future) }
+      subject { create(:site_status, :findable, :applications_being_accepted_in_future) }
       it { should_not be_open_for_applications }
     end
 
     describe 'if on find, applications accepted now but no vacancies' do
-      subject { create(:site_status, :skips_validate, :findable, :applications_being_accepted_now, :with_no_vacancies) }
+      subject { create(:site_status, :findable, :applications_being_accepted_now, :with_no_vacancies) }
       it { should_not be_open_for_applications }
     end
   end
 
   describe "has vacancies?" do
     describe 'if has part-time vacancies' do
-      subject { create(:site_status, :skips_validate, :part_time_vacancies) }
+      subject { create(:site_status, :part_time_vacancies) }
       it { should have_vacancies }
     end
 
     describe 'if has full-time vacancies' do
-      subject { create(:site_status, :skips_validate, :full_time_vacancies) }
+      subject { create(:site_status, :full_time_vacancies) }
       it { should have_vacancies }
     end
 
     describe 'if has both full-time and part-time vacancies' do
-      subject { create(:site_status, :skips_validate, :both_full_time_and_part_time_vacancies) }
+      subject { create(:site_status, :both_full_time_and_part_time_vacancies) }
       it { should have_vacancies }
     end
 
     describe 'if has no vacancies' do
-      subject { create(:site_status, :skips_validate, :with_no_vacancies) }
+      subject { create(:site_status, :with_no_vacancies) }
       it { should_not have_vacancies }
     end
   end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -14,10 +14,10 @@ describe 'Courses API v2', type: :request do
   end
 
   let(:findable_open_course) {
-    create(:course, :skips_validate, :resulting_in_pgce_with_qts,
+    create(:course, :resulting_in_pgce_with_qts,
            start_date: Time.now.utc,
            study_mode: :full_time,
-           site_statuses: [create(:site_status, :skips_validate, :findable, :with_any_vacancy, :applications_being_accepted_now)])
+           site_statuses: [create(:site_status, :findable, :full_time_vacancies, :applications_being_accepted_now)])
   }
   let!(:provider) {
     create(:provider,

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -14,10 +14,10 @@ describe 'Courses API v2', type: :request do
   end
 
   let(:findable_open_course) {
-    create(:course, :resulting_in_pgce_with_qts,
+    create(:course, :skips_validate, :resulting_in_pgce_with_qts,
            start_date: Time.now.utc,
            study_mode: :full_time,
-           site_statuses: [create(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_now)])
+           site_statuses: [create(:site_status, :skips_validate, :findable, :with_any_vacancy, :applications_being_accepted_now)])
   }
   let!(:provider) {
     create(:provider,


### PR DESCRIPTION
### Context
Validation for site status when updating. 

### Changes proposed in this pull request
Added validation for site status.
Added skip validation traits for `course` & `site_status`
Seeding of database is more correct now

### Guidance to review
Ignore more or less everything... that's with `:skip_validate`

Just look at
- app/models/site_status.rb
- spec/factories/courses.rb
- spec/factories/site_statuses.rb
- spec/models/site_status_spec.rb
- db/seeds.rd
 

`:skip_validate` 

1. added to the existing tests as a stop gap as previous tests setup has no consideration of correctiveness of data context
2. nice to have in cases where we want to mock out true values stat is in database

The only redeeming thing about ruby/rails is really factorybot...