### PR TITLE
[1119] emit static contact data

### DIFF
--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -119,7 +119,7 @@ class ProviderSerializer < ActiveModel::Serializer
       {
         "type": type,
        "name": "#{type.humanize.titleize} #{@object.provider_code}",
-       "email": @object.email&.sub(/.*@/, "admin_contact@"),
+       "email": @object.email&.sub(/.*@/, "#{type}@"),
        "telephone": @object.telephone,
       }
     end

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -107,6 +107,24 @@ class ProviderSerializer < ActiveModel::Serializer
     select_value_for_provider(@object.provider_code, values)
   end
 
+  attribute :contacts do
+    %w[
+      admin_contact
+      utt_correspondent
+      web_link_correspondent
+      fraud_contact
+      finance_contact
+      application_alert_recipient
+    ].map do |type|
+      {
+        "type": type,
+       "name": "#{type.humanize.titleize} #{@object.provider_code}",
+       "email": @object.email&.sub(/.*@/, "admin_contact@"),
+       "telephone": @object.telephone,
+      }
+    end
+  end
+
 private
 
   def select_value_for_provider(provider_code, values)

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -109,11 +109,11 @@ class ProviderSerializer < ActiveModel::Serializer
 
   attribute :contacts do
     %w[
-      admin_contact
-      utt_correspondent
-      web_link_correspondent
-      fraud_contact
-      finance_contact
+      admin
+      utt
+      web_link
+      fraud
+      finance
       application_alert_recipient
     ].map do |type|
       {

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -117,10 +117,10 @@ class ProviderSerializer < ActiveModel::Serializer
       application_alert_recipient
     ].map do |type|
       {
-        "type": type,
-       "name": "#{type.humanize.titleize} #{@object.provider_code}",
-       "email": @object.email&.sub(/.*@/, "#{type}@"),
-       "telephone": @object.telephone,
+        type: type,
+        name: "#{type.humanize.titleize} Contact #{@object.provider_code}",
+        email: @object.email&.sub(/.*@/, "#{type}@"),
+        telephone: @object.telephone,
       }
     end
   end

--- a/lib/mcb/commands/apiv1/find.rb
+++ b/lib/mcb/commands/apiv1/find.rb
@@ -7,9 +7,11 @@ description <<~EODESCRIPTION
 EODESCRIPTION
 usage 'find [options] <code>'
 param :code
+option :j, 'json', 'show the returned JSON response'
+
 
 run do |opts, args, _cmd|
-  puts "looking for provider #{args[:code]}"
+  verbose "looking for provider #{args[:code]}"
 
   provider = each_v1_provider(opts).detect do |p|
     p['institution_code'] == args[:code]
@@ -20,9 +22,17 @@ run do |opts, args, _cmd|
     next
   end
 
-  campuses = provider.delete('campuses')
-  puts Terminal::Table.new rows: provider
-  puts ''
-  puts "Campuses:"
-  tp campuses
+  if opts[:json]
+    puts JSON.pretty_generate(JSON.parse(provider.to_json))
+  else
+    campuses = provider.delete('campuses')
+    contacts = provider.delete('contacts')
+    puts Terminal::Table.new rows: provider
+    puts ''
+    puts "Campuses:"
+    tp campuses
+    puts ''
+    puts "Contacts:"
+    tp contacts
+  end
 end

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -131,38 +131,38 @@ describe 'Providers API', type: :request do
                 'utt_application_alerts' => 'Yes - for accredited programmes only',
                 'contacts' => [
                   {
-                    "type" => "admin_contact",
+                    "type" => "admin",
                     "name" => "Admin Contact A123",
-                    "email" => "admin_contact@acmescitt.education.uk",
+                    "email" => "admin@acmescitt.education.uk",
                     "telephone" => "020 812 345 678"
                   },
                   {
-                    "type" => "utt_correspondent",
-                    "name" => "Utt Correspondent A123",
-                    "email" => "utt_correspondent@acmescitt.education.uk",
+                    "type" => "utt",
+                    "name" => "Utt Contact A123",
+                    "email" => "utt@acmescitt.education.uk",
                     "telephone" => "020 812 345 678"
                   },
                   {
-                    "type" => "web_link_correspondent",
-                    "name" => "Web Link Correspondent A123",
-                    "email" => "web_link_correspondent@acmescitt.education.uk",
+                    "type" => "web_link",
+                    "name" => "Web Link Contact A123",
+                    "email" => "web_link@acmescitt.education.uk",
                     "telephone" => "020 812 345 678"
                   },
                   {
-                    "type" => "fraud_contact",
+                    "type" => "fraud",
                     "name" => "Fraud Contact A123",
-                    "email" => "fraud_contact@acmescitt.education.uk",
+                    "email" => "fraud@acmescitt.education.uk",
                     "telephone" => "020 812 345 678"
                   },
                   {
-                    "type" => "finance_contact",
+                    "type" => "finance",
                     "name" => "Finance Contact A123",
-                    "email" => "finance_contact@acmescitt.education.uk",
+                    "email" => "finance@acmescitt.education.uk",
                     "telephone" => "020 812 345 678"
                   },
                   {
                     "type" => "application_alert_recipient",
-                    "name" => "Application Alert Recipient A123",
+                    "name" => "Application Alert Recipient Contact A123",
                     "email" => "application_alert_recipient@acmescitt.education.uk",
                     "telephone" => "020 812 345 678"
                   }
@@ -195,38 +195,38 @@ describe 'Providers API', type: :request do
                 'utt_application_alerts' => 'Yes - for accredited programmes only',
                 'contacts' => [
                   {
-                    "type" => "admin_contact",
+                    "type" => "admin",
                     "name" => "Admin Contact B123",
-                    "email" => "admin_contact@acmeuniversity.education.uk",
+                    "email" => "admin@acmeuniversity.education.uk",
                     "telephone" => "01273 345 678"
                   },
                   {
-                    "type" => "utt_correspondent",
-                    "name" => "Utt Correspondent B123",
-                    "email" => "utt_correspondent@acmeuniversity.education.uk",
+                    "type" => "utt",
+                    "name" => "Utt Contact B123",
+                    "email" => "utt@acmeuniversity.education.uk",
                     "telephone" => "01273 345 678"
                   },
                   {
-                    "type" => "web_link_correspondent",
-                    "name" => "Web Link Correspondent B123",
-                    "email" => "web_link_correspondent@acmeuniversity.education.uk",
+                    "type" => "web_link",
+                    "name" => "Web Link Contact B123",
+                    "email" => "web_link@acmeuniversity.education.uk",
                     "telephone" => "01273 345 678"
                   },
                   {
-                    "type" => "fraud_contact",
+                    "type" => "fraud",
                     "name" => "Fraud Contact B123",
-                    "email" => "fraud_contact@acmeuniversity.education.uk",
+                    "email" => "fraud@acmeuniversity.education.uk",
                     "telephone" => "01273 345 678"
                   },
                   {
-                    "type" => "finance_contact",
+                    "type" => "finance",
                     "name" => "Finance Contact B123",
-                    "email" => "finance_contact@acmeuniversity.education.uk",
+                    "email" => "finance@acmeuniversity.education.uk",
                     "telephone" => "01273 345 678"
                   },
                   {
                     "type" => "application_alert_recipient",
-                    "name" => "Application Alert Recipient B123",
+                    "name" => "Application Alert Recipient Contact B123",
                     "email" => "application_alert_recipient@acmeuniversity.education.uk",
                     "telephone" => "01273 345 678"
                   }
@@ -280,38 +280,38 @@ describe 'Providers API', type: :request do
                                   'utt_application_alerts' => 'Yes - for accredited programmes only',
                                   'contacts' => [
                                     {
-                                      "type" => "admin_contact",
+                                      "type" => "admin",
                                       "name" => "Admin Contact A123",
-                                      "email" => "admin_contact@acmescitt.education.uk",
+                                      "email" => "admin@acmescitt.education.uk",
                                       "telephone" => "020 812 345 678"
                                     },
                                     {
-                                      "type" => "utt_correspondent",
-                                      "name" => "Utt Correspondent A123",
-                                      "email" => "utt_correspondent@acmescitt.education.uk",
+                                      "type" => "utt",
+                                      "name" => "Utt Contact A123",
+                                      "email" => "utt@acmescitt.education.uk",
                                       "telephone" => "020 812 345 678"
                                     },
                                     {
-                                      "type" => "web_link_correspondent",
-                                      "name" => "Web Link Correspondent A123",
-                                      "email" => "web_link_correspondent@acmescitt.education.uk",
+                                      "type" => "web_link",
+                                      "name" => "Web Link Contact A123",
+                                      "email" => "web_link@acmescitt.education.uk",
                                       "telephone" => "020 812 345 678"
                                     },
                                     {
-                                      "type" => "fraud_contact",
+                                      "type" => "fraud",
                                       "name" => "Fraud Contact A123",
-                                      "email" => "fraud_contact@acmescitt.education.uk",
+                                      "email" => "fraud@acmescitt.education.uk",
                                       "telephone" => "020 812 345 678"
                                     },
                                     {
-                                      "type" => "finance_contact",
+                                      "type" => "finance",
                                       "name" => "Finance Contact A123",
-                                      "email" => "finance_contact@acmescitt.education.uk",
+                                      "email" => "finance@acmescitt.education.uk",
                                       "telephone" => "020 812 345 678"
                                     },
                                     {
                                       "type" => "application_alert_recipient",
-                                      "name" => "Application Alert Recipient A123",
+                                      "name" => "Application Alert Recipient Contact A123",
                                       "email" => "application_alert_recipient@acmescitt.education.uk",
                                       "telephone" => "020 812 345 678"
                                     }
@@ -344,38 +344,38 @@ describe 'Providers API', type: :request do
                                  'utt_application_alerts' => 'Yes - for accredited programmes only',
                                  'contacts' => [
                                    {
-                                     "type" => "admin_contact",
+                                     "type" => "admin",
                                      "name" => "Admin Contact B123",
-                                     "email" => "admin_contact@acmeuniversity.education.uk",
+                                     "email" => "admin@acmeuniversity.education.uk",
                                      "telephone" => "01273 345 678"
                                    },
                                    {
-                                     "type" => "utt_correspondent",
-                                     "name" => "Utt Correspondent B123",
-                                     "email" => "utt_correspondent@acmeuniversity.education.uk",
+                                     "type" => "utt",
+                                     "name" => "Utt Contact B123",
+                                     "email" => "utt@acmeuniversity.education.uk",
                                      "telephone" => "01273 345 678"
                                    },
                                    {
-                                     "type" => "web_link_correspondent",
-                                     "name" => "Web Link Correspondent B123",
-                                     "email" => "web_link_correspondent@acmeuniversity.education.uk",
+                                     "type" => "web_link",
+                                     "name" => "Web Link Contact B123",
+                                     "email" => "web_link@acmeuniversity.education.uk",
                                      "telephone" => "01273 345 678"
                                    },
                                    {
-                                     "type" => "fraud_contact",
+                                     "type" => "fraud",
                                      "name" => "Fraud Contact B123",
-                                     "email" => "fraud_contact@acmeuniversity.education.uk",
+                                     "email" => "fraud@acmeuniversity.education.uk",
                                      "telephone" => "01273 345 678"
                                    },
                                    {
-                                     "type" => "finance_contact",
+                                     "type" => "finance",
                                      "name" => "Finance Contact B123",
-                                     "email" => "finance_contact@acmeuniversity.education.uk",
+                                     "email" => "finance@acmeuniversity.education.uk",
                                      "telephone" => "01273 345 678"
                                    },
                                    {
                                      "type" => "application_alert_recipient",
-                                     "name" => "Application Alert Recipient B123",
+                                     "name" => "Application Alert Recipient Contact B123",
                                      "email" => "application_alert_recipient@acmeuniversity.education.uk",
                                      "telephone" => "01273 345 678"
                                    }

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -129,6 +129,44 @@ describe 'Providers API', type: :request do
                 'recruitment_cycle' => '2019',
                 'type_of_gt12' => 'Not coming',
                 'utt_application_alerts' => 'Yes - for accredited programmes only',
+                'contacts' => [
+                  {
+                    "type" => "admin_contact",
+                    "name" => "Admin Contact A123",
+                    "email" => "admin_contact@acmescitt.education.uk",
+                    "telephone" => "020 812 345 678"
+                  },
+                  {
+                    "type" => "utt_correspondent",
+                    "name" => "Utt Correspondent A123",
+                    "email" => "admin_contact@acmescitt.education.uk",
+                    "telephone" => "020 812 345 678"
+                  },
+                  {
+                    "type" => "web_link_correspondent",
+                    "name" => "Web Link Correspondent A123",
+                    "email" => "admin_contact@acmescitt.education.uk",
+                    "telephone" => "020 812 345 678"
+                  },
+                  {
+                    "type" => "fraud_contact",
+                    "name" => "Fraud Contact A123",
+                    "email" => "admin_contact@acmescitt.education.uk",
+                    "telephone" => "020 812 345 678"
+                  },
+                  {
+                    "type" => "finance_contact",
+                    "name" => "Finance Contact A123",
+                    "email" => "admin_contact@acmescitt.education.uk",
+                    "telephone" => "020 812 345 678"
+                  },
+                  {
+                    "type" => "application_alert_recipient",
+                    "name" => "Application Alert Recipient A123",
+                    "email" => "admin_contact@acmescitt.education.uk",
+                    "telephone" => "020 812 345 678"
+                  }
+                ]
               },
               {
                 'accrediting_provider' => 'N',
@@ -155,6 +193,44 @@ describe 'Providers API', type: :request do
                 'recruitment_cycle' => '2019',
                 'type_of_gt12' => 'Not coming',
                 'utt_application_alerts' => 'Yes - for accredited programmes only',
+                'contacts' => [
+                  {
+                    "type" => "admin_contact",
+                    "name" => "Admin Contact B123",
+                    "email" => "admin_contact@acmeuniversity.education.uk",
+                    "telephone" => "01273 345 678"
+                  },
+                  {
+                    "type" => "utt_correspondent",
+                    "name" => "Utt Correspondent B123",
+                    "email" => "admin_contact@acmeuniversity.education.uk",
+                    "telephone" => "01273 345 678"
+                  },
+                  {
+                    "type" => "web_link_correspondent",
+                    "name" => "Web Link Correspondent B123",
+                    "email" => "admin_contact@acmeuniversity.education.uk",
+                    "telephone" => "01273 345 678"
+                  },
+                  {
+                    "type" => "fraud_contact",
+                    "name" => "Fraud Contact B123",
+                    "email" => "admin_contact@acmeuniversity.education.uk",
+                    "telephone" => "01273 345 678"
+                  },
+                  {
+                    "type" => "finance_contact",
+                    "name" => "Finance Contact B123",
+                    "email" => "admin_contact@acmeuniversity.education.uk",
+                    "telephone" => "01273 345 678"
+                  },
+                  {
+                    "type" => "application_alert_recipient",
+                    "name" => "Application Alert Recipient B123",
+                    "email" => "admin_contact@acmeuniversity.education.uk",
+                    "telephone" => "01273 345 678"
+                  }
+                ]
               }
             ]
           )
@@ -202,6 +278,44 @@ describe 'Providers API', type: :request do
                                   'recruitment_cycle' => '2019',
                                   'type_of_gt12' => 'Not coming',
                                   'utt_application_alerts' => 'Yes - for accredited programmes only',
+                                  'contacts' => [
+                                    {
+                                      "type" => "admin_contact",
+                                      "name" => "Admin Contact A123",
+                                      "email" => "admin_contact@acmescitt.education.uk",
+                                      "telephone" => "020 812 345 678"
+                                    },
+                                    {
+                                      "type" => "utt_correspondent",
+                                      "name" => "Utt Correspondent A123",
+                                      "email" => "admin_contact@acmescitt.education.uk",
+                                      "telephone" => "020 812 345 678"
+                                    },
+                                    {
+                                      "type" => "web_link_correspondent",
+                                      "name" => "Web Link Correspondent A123",
+                                      "email" => "admin_contact@acmescitt.education.uk",
+                                      "telephone" => "020 812 345 678"
+                                    },
+                                    {
+                                      "type" => "fraud_contact",
+                                      "name" => "Fraud Contact A123",
+                                      "email" => "admin_contact@acmescitt.education.uk",
+                                      "telephone" => "020 812 345 678"
+                                    },
+                                    {
+                                      "type" => "finance_contact",
+                                      "name" => "Finance Contact A123",
+                                      "email" => "admin_contact@acmescitt.education.uk",
+                                      "telephone" => "020 812 345 678"
+                                    },
+                                    {
+                                      "type" => "application_alert_recipient",
+                                      "name" => "Application Alert Recipient A123",
+                                      "email" => "admin_contact@acmescitt.education.uk",
+                                      "telephone" => "020 812 345 678"
+                                    }
+                                  ]
                                },
                                {
                                  'accrediting_provider' => 'N',
@@ -228,6 +342,44 @@ describe 'Providers API', type: :request do
                                  'recruitment_cycle' => '2019',
                                  'type_of_gt12' => 'Not coming',
                                  'utt_application_alerts' => 'Yes - for accredited programmes only',
+                                 'contacts' => [
+                                   {
+                                     "type" => "admin_contact",
+                                     "name" => "Admin Contact B123",
+                                     "email" => "admin_contact@acmeuniversity.education.uk",
+                                     "telephone" => "01273 345 678"
+                                   },
+                                   {
+                                     "type" => "utt_correspondent",
+                                     "name" => "Utt Correspondent B123",
+                                     "email" => "admin_contact@acmeuniversity.education.uk",
+                                     "telephone" => "01273 345 678"
+                                   },
+                                   {
+                                     "type" => "web_link_correspondent",
+                                     "name" => "Web Link Correspondent B123",
+                                     "email" => "admin_contact@acmeuniversity.education.uk",
+                                     "telephone" => "01273 345 678"
+                                   },
+                                   {
+                                     "type" => "fraud_contact",
+                                     "name" => "Fraud Contact B123",
+                                     "email" => "admin_contact@acmeuniversity.education.uk",
+                                     "telephone" => "01273 345 678"
+                                   },
+                                   {
+                                     "type" => "finance_contact",
+                                     "name" => "Finance Contact B123",
+                                     "email" => "admin_contact@acmeuniversity.education.uk",
+                                     "telephone" => "01273 345 678"
+                                   },
+                                   {
+                                     "type" => "application_alert_recipient",
+                                     "name" => "Application Alert Recipient B123",
+                                     "email" => "admin_contact@acmeuniversity.education.uk",
+                                     "telephone" => "01273 345 678"
+                                   }
+                                 ]
                                }
                              ])
         end

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -131,40 +131,40 @@ describe 'Providers API', type: :request do
                 'utt_application_alerts' => 'Yes - for accredited programmes only',
                 'contacts' => [
                   {
-                    "type" => "admin",
-                    "name" => "Admin Contact A123",
-                    "email" => "admin@acmescitt.education.uk",
-                    "telephone" => "020 812 345 678"
+                    'type' => 'admin',
+                    'name' => 'Admin Contact A123',
+                    'email' => 'admin@acmescitt.education.uk',
+                    'telephone' => '020 812 345 678'
                   },
                   {
-                    "type" => "utt",
-                    "name" => "Utt Contact A123",
-                    "email" => "utt@acmescitt.education.uk",
-                    "telephone" => "020 812 345 678"
+                    'type' => 'utt',
+                    'name' => 'Utt Contact A123',
+                    'email' => 'utt@acmescitt.education.uk',
+                    'telephone' => '020 812 345 678'
                   },
                   {
-                    "type" => "web_link",
-                    "name" => "Web Link Contact A123",
-                    "email" => "web_link@acmescitt.education.uk",
-                    "telephone" => "020 812 345 678"
+                    'type' => 'web_link',
+                    'name' => 'Web Link Contact A123',
+                    'email' => 'web_link@acmescitt.education.uk',
+                    'telephone' => '020 812 345 678'
                   },
                   {
-                    "type" => "fraud",
-                    "name" => "Fraud Contact A123",
-                    "email" => "fraud@acmescitt.education.uk",
-                    "telephone" => "020 812 345 678"
+                    'type' => 'fraud',
+                    'name' => 'Fraud Contact A123',
+                    'email' => 'fraud@acmescitt.education.uk',
+                    'telephone' => '020 812 345 678'
                   },
                   {
-                    "type" => "finance",
-                    "name" => "Finance Contact A123",
-                    "email" => "finance@acmescitt.education.uk",
-                    "telephone" => "020 812 345 678"
+                    'type' => 'finance',
+                    'name' => 'Finance Contact A123',
+                    'email' => 'finance@acmescitt.education.uk',
+                    'telephone' => '020 812 345 678'
                   },
                   {
-                    "type" => "application_alert_recipient",
-                    "name" => "Application Alert Recipient Contact A123",
-                    "email" => "application_alert_recipient@acmescitt.education.uk",
-                    "telephone" => "020 812 345 678"
+                    'type' => 'application_alert_recipient',
+                    'name' => 'Application Alert Recipient Contact A123',
+                    'email' => 'application_alert_recipient@acmescitt.education.uk',
+                    'telephone' => '020 812 345 678'
                   }
                 ]
               },
@@ -195,40 +195,40 @@ describe 'Providers API', type: :request do
                 'utt_application_alerts' => 'Yes - for accredited programmes only',
                 'contacts' => [
                   {
-                    "type" => "admin",
-                    "name" => "Admin Contact B123",
-                    "email" => "admin@acmeuniversity.education.uk",
-                    "telephone" => "01273 345 678"
+                    'type' => 'admin',
+                    'name' => 'Admin Contact B123',
+                    'email' => 'admin@acmeuniversity.education.uk',
+                    'telephone' => '01273 345 678'
                   },
                   {
-                    "type" => "utt",
-                    "name" => "Utt Contact B123",
-                    "email" => "utt@acmeuniversity.education.uk",
-                    "telephone" => "01273 345 678"
+                    'type' => 'utt',
+                    'name' => 'Utt Contact B123',
+                    'email' => 'utt@acmeuniversity.education.uk',
+                    'telephone' => '01273 345 678'
                   },
                   {
-                    "type" => "web_link",
-                    "name" => "Web Link Contact B123",
-                    "email" => "web_link@acmeuniversity.education.uk",
-                    "telephone" => "01273 345 678"
+                    'type' => 'web_link',
+                    'name' => 'Web Link Contact B123',
+                    'email' => 'web_link@acmeuniversity.education.uk',
+                    'telephone' => '01273 345 678'
                   },
                   {
-                    "type" => "fraud",
-                    "name" => "Fraud Contact B123",
-                    "email" => "fraud@acmeuniversity.education.uk",
-                    "telephone" => "01273 345 678"
+                    'type' => 'fraud',
+                    'name' => 'Fraud Contact B123',
+                    'email' => 'fraud@acmeuniversity.education.uk',
+                    'telephone' => '01273 345 678'
                   },
                   {
-                    "type" => "finance",
-                    "name" => "Finance Contact B123",
-                    "email" => "finance@acmeuniversity.education.uk",
-                    "telephone" => "01273 345 678"
+                    'type' => 'finance',
+                    'name' => 'Finance Contact B123',
+                    'email' => 'finance@acmeuniversity.education.uk',
+                    'telephone' => '01273 345 678'
                   },
                   {
-                    "type" => "application_alert_recipient",
-                    "name" => "Application Alert Recipient Contact B123",
-                    "email" => "application_alert_recipient@acmeuniversity.education.uk",
-                    "telephone" => "01273 345 678"
+                    'type' => 'application_alert_recipient',
+                    'name' => 'Application Alert Recipient Contact B123',
+                    'email' => 'application_alert_recipient@acmeuniversity.education.uk',
+                    'telephone' => '01273 345 678'
                   }
                 ]
               }
@@ -280,40 +280,40 @@ describe 'Providers API', type: :request do
                                   'utt_application_alerts' => 'Yes - for accredited programmes only',
                                   'contacts' => [
                                     {
-                                      "type" => "admin",
-                                      "name" => "Admin Contact A123",
-                                      "email" => "admin@acmescitt.education.uk",
-                                      "telephone" => "020 812 345 678"
+                                      'type' => 'admin',
+                                      'name' => 'Admin Contact A123',
+                                      'email' => 'admin@acmescitt.education.uk',
+                                      'telephone' => '020 812 345 678'
                                     },
                                     {
-                                      "type" => "utt",
-                                      "name" => "Utt Contact A123",
-                                      "email" => "utt@acmescitt.education.uk",
-                                      "telephone" => "020 812 345 678"
+                                      'type' => 'utt',
+                                      'name' => 'Utt Contact A123',
+                                      'email' => 'utt@acmescitt.education.uk',
+                                      'telephone' => '020 812 345 678'
                                     },
                                     {
-                                      "type" => "web_link",
-                                      "name" => "Web Link Contact A123",
-                                      "email" => "web_link@acmescitt.education.uk",
-                                      "telephone" => "020 812 345 678"
+                                      'type' => 'web_link',
+                                      'name' => 'Web Link Contact A123',
+                                      'email' => 'web_link@acmescitt.education.uk',
+                                      'telephone' => '020 812 345 678'
                                     },
                                     {
-                                      "type" => "fraud",
-                                      "name" => "Fraud Contact A123",
-                                      "email" => "fraud@acmescitt.education.uk",
-                                      "telephone" => "020 812 345 678"
+                                      'type' => 'fraud',
+                                      'name' => 'Fraud Contact A123',
+                                      'email' => 'fraud@acmescitt.education.uk',
+                                      'telephone' => '020 812 345 678'
                                     },
                                     {
-                                      "type" => "finance",
-                                      "name" => "Finance Contact A123",
-                                      "email" => "finance@acmescitt.education.uk",
-                                      "telephone" => "020 812 345 678"
+                                      'type' => 'finance',
+                                      'name' => 'Finance Contact A123',
+                                      'email' => 'finance@acmescitt.education.uk',
+                                      'telephone' => '020 812 345 678'
                                     },
                                     {
-                                      "type" => "application_alert_recipient",
-                                      "name" => "Application Alert Recipient Contact A123",
-                                      "email" => "application_alert_recipient@acmescitt.education.uk",
-                                      "telephone" => "020 812 345 678"
+                                      'type' => 'application_alert_recipient',
+                                      'name' => 'Application Alert Recipient Contact A123',
+                                      'email' => 'application_alert_recipient@acmescitt.education.uk',
+                                      'telephone' => '020 812 345 678'
                                     }
                                   ]
                                },
@@ -344,40 +344,40 @@ describe 'Providers API', type: :request do
                                  'utt_application_alerts' => 'Yes - for accredited programmes only',
                                  'contacts' => [
                                    {
-                                     "type" => "admin",
-                                     "name" => "Admin Contact B123",
-                                     "email" => "admin@acmeuniversity.education.uk",
-                                     "telephone" => "01273 345 678"
+                                     'type' => 'admin',
+                                     'name' => 'Admin Contact B123',
+                                     'email' => 'admin@acmeuniversity.education.uk',
+                                     'telephone' => '01273 345 678'
                                    },
                                    {
-                                     "type" => "utt",
-                                     "name" => "Utt Contact B123",
-                                     "email" => "utt@acmeuniversity.education.uk",
-                                     "telephone" => "01273 345 678"
+                                     'type' => 'utt',
+                                     'name' => 'Utt Contact B123',
+                                     'email' => 'utt@acmeuniversity.education.uk',
+                                     'telephone' => '01273 345 678'
                                    },
                                    {
-                                     "type" => "web_link",
-                                     "name" => "Web Link Contact B123",
-                                     "email" => "web_link@acmeuniversity.education.uk",
-                                     "telephone" => "01273 345 678"
+                                     'type' => 'web_link',
+                                     'name' => 'Web Link Contact B123',
+                                     'email' => 'web_link@acmeuniversity.education.uk',
+                                     'telephone' => '01273 345 678'
                                    },
                                    {
-                                     "type" => "fraud",
-                                     "name" => "Fraud Contact B123",
-                                     "email" => "fraud@acmeuniversity.education.uk",
-                                     "telephone" => "01273 345 678"
+                                     'type' => 'fraud',
+                                     'name' => 'Fraud Contact B123',
+                                     'email' => 'fraud@acmeuniversity.education.uk',
+                                     'telephone' => '01273 345 678'
                                    },
                                    {
-                                     "type" => "finance",
-                                     "name" => "Finance Contact B123",
-                                     "email" => "finance@acmeuniversity.education.uk",
-                                     "telephone" => "01273 345 678"
+                                     'type' => 'finance',
+                                     'name' => 'Finance Contact B123',
+                                     'email' => 'finance@acmeuniversity.education.uk',
+                                     'telephone' => '01273 345 678'
                                    },
                                    {
-                                     "type" => "application_alert_recipient",
-                                     "name" => "Application Alert Recipient Contact B123",
-                                     "email" => "application_alert_recipient@acmeuniversity.education.uk",
-                                     "telephone" => "01273 345 678"
+                                     'type' => 'application_alert_recipient',
+                                     'name' => 'Application Alert Recipient Contact B123',
+                                     'email' => 'application_alert_recipient@acmeuniversity.education.uk',
+                                     'telephone' => '01273 345 678'
                                    }
                                  ]
                                }

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -139,31 +139,31 @@ describe 'Providers API', type: :request do
                   {
                     "type" => "utt_correspondent",
                     "name" => "Utt Correspondent A123",
-                    "email" => "admin_contact@acmescitt.education.uk",
+                    "email" => "utt_correspondent@acmescitt.education.uk",
                     "telephone" => "020 812 345 678"
                   },
                   {
                     "type" => "web_link_correspondent",
                     "name" => "Web Link Correspondent A123",
-                    "email" => "admin_contact@acmescitt.education.uk",
+                    "email" => "web_link_correspondent@acmescitt.education.uk",
                     "telephone" => "020 812 345 678"
                   },
                   {
                     "type" => "fraud_contact",
                     "name" => "Fraud Contact A123",
-                    "email" => "admin_contact@acmescitt.education.uk",
+                    "email" => "fraud_contact@acmescitt.education.uk",
                     "telephone" => "020 812 345 678"
                   },
                   {
                     "type" => "finance_contact",
                     "name" => "Finance Contact A123",
-                    "email" => "admin_contact@acmescitt.education.uk",
+                    "email" => "finance_contact@acmescitt.education.uk",
                     "telephone" => "020 812 345 678"
                   },
                   {
                     "type" => "application_alert_recipient",
                     "name" => "Application Alert Recipient A123",
-                    "email" => "admin_contact@acmescitt.education.uk",
+                    "email" => "application_alert_recipient@acmescitt.education.uk",
                     "telephone" => "020 812 345 678"
                   }
                 ]
@@ -203,31 +203,31 @@ describe 'Providers API', type: :request do
                   {
                     "type" => "utt_correspondent",
                     "name" => "Utt Correspondent B123",
-                    "email" => "admin_contact@acmeuniversity.education.uk",
+                    "email" => "utt_correspondent@acmeuniversity.education.uk",
                     "telephone" => "01273 345 678"
                   },
                   {
                     "type" => "web_link_correspondent",
                     "name" => "Web Link Correspondent B123",
-                    "email" => "admin_contact@acmeuniversity.education.uk",
+                    "email" => "web_link_correspondent@acmeuniversity.education.uk",
                     "telephone" => "01273 345 678"
                   },
                   {
                     "type" => "fraud_contact",
                     "name" => "Fraud Contact B123",
-                    "email" => "admin_contact@acmeuniversity.education.uk",
+                    "email" => "fraud_contact@acmeuniversity.education.uk",
                     "telephone" => "01273 345 678"
                   },
                   {
                     "type" => "finance_contact",
                     "name" => "Finance Contact B123",
-                    "email" => "admin_contact@acmeuniversity.education.uk",
+                    "email" => "finance_contact@acmeuniversity.education.uk",
                     "telephone" => "01273 345 678"
                   },
                   {
                     "type" => "application_alert_recipient",
                     "name" => "Application Alert Recipient B123",
-                    "email" => "admin_contact@acmeuniversity.education.uk",
+                    "email" => "application_alert_recipient@acmeuniversity.education.uk",
                     "telephone" => "01273 345 678"
                   }
                 ]
@@ -288,31 +288,31 @@ describe 'Providers API', type: :request do
                                     {
                                       "type" => "utt_correspondent",
                                       "name" => "Utt Correspondent A123",
-                                      "email" => "admin_contact@acmescitt.education.uk",
+                                      "email" => "utt_correspondent@acmescitt.education.uk",
                                       "telephone" => "020 812 345 678"
                                     },
                                     {
                                       "type" => "web_link_correspondent",
                                       "name" => "Web Link Correspondent A123",
-                                      "email" => "admin_contact@acmescitt.education.uk",
+                                      "email" => "web_link_correspondent@acmescitt.education.uk",
                                       "telephone" => "020 812 345 678"
                                     },
                                     {
                                       "type" => "fraud_contact",
                                       "name" => "Fraud Contact A123",
-                                      "email" => "admin_contact@acmescitt.education.uk",
+                                      "email" => "fraud_contact@acmescitt.education.uk",
                                       "telephone" => "020 812 345 678"
                                     },
                                     {
                                       "type" => "finance_contact",
                                       "name" => "Finance Contact A123",
-                                      "email" => "admin_contact@acmescitt.education.uk",
+                                      "email" => "finance_contact@acmescitt.education.uk",
                                       "telephone" => "020 812 345 678"
                                     },
                                     {
                                       "type" => "application_alert_recipient",
                                       "name" => "Application Alert Recipient A123",
-                                      "email" => "admin_contact@acmescitt.education.uk",
+                                      "email" => "application_alert_recipient@acmescitt.education.uk",
                                       "telephone" => "020 812 345 678"
                                     }
                                   ]
@@ -352,31 +352,31 @@ describe 'Providers API', type: :request do
                                    {
                                      "type" => "utt_correspondent",
                                      "name" => "Utt Correspondent B123",
-                                     "email" => "admin_contact@acmeuniversity.education.uk",
+                                     "email" => "utt_correspondent@acmeuniversity.education.uk",
                                      "telephone" => "01273 345 678"
                                    },
                                    {
                                      "type" => "web_link_correspondent",
                                      "name" => "Web Link Correspondent B123",
-                                     "email" => "admin_contact@acmeuniversity.education.uk",
+                                     "email" => "web_link_correspondent@acmeuniversity.education.uk",
                                      "telephone" => "01273 345 678"
                                    },
                                    {
                                      "type" => "fraud_contact",
                                      "name" => "Fraud Contact B123",
-                                     "email" => "admin_contact@acmeuniversity.education.uk",
+                                     "email" => "fraud_contact@acmeuniversity.education.uk",
                                      "telephone" => "01273 345 678"
                                    },
                                    {
                                      "type" => "finance_contact",
                                      "name" => "Finance Contact B123",
-                                     "email" => "admin_contact@acmeuniversity.education.uk",
+                                     "email" => "finance_contact@acmeuniversity.education.uk",
                                      "telephone" => "01273 345 678"
                                    },
                                    {
                                      "type" => "application_alert_recipient",
                                      "name" => "Application Alert Recipient B123",
-                                     "email" => "admin_contact@acmeuniversity.education.uk",
+                                     "email" => "application_alert_recipient@acmeuniversity.education.uk",
                                      "telephone" => "01273 345 678"
                                    }
                                  ]


### PR DESCRIPTION
https://trello.com/c/0HJdbyrA/1119-emit-static-contacts-data-for-ucas-api-testing

### Context

UCAS would like to have some data to illustrate how the contacts will show up in the API endpoint the will use. This adds generated contacts data that doesn't rely on us implementing the whole contacts thing.

### Changes proposed in this pull request

Change the providers serialiser to generate contacts data.

### Guidance to review

Also added some extra support for contacts and to the `apiv1 find` subcommand to `mcb`. And also raw-json support.