### PR TITLE
[1165] Check for accept_terms_date_utc on every request

### DIFF
--- a/app/controllers/api/v2/application_controller.rb
+++ b/app/controllers/api/v2/application_controller.rb
@@ -3,23 +3,47 @@ module API
     class ApplicationController < ::ApplicationController
       attr_reader :current_user
 
+      before_action :check_terms_accepted
+
       def authenticate
         authenticate_or_request_with_http_token do |token|
-          if Settings.authentication.algorithm == 'plain-text'
-            # This method can be used in development mode to simplify querying
-            # the API with curl. It should allow us to do:
-            #
-            #    curl -H 'Authorization: Bearer user@education.gov.uk' http://localhost:3001/api/v2/providers
-            email = token
-          else
-            (payload, _options) = JWT.decode(token,
-                                                 Settings.authentication.secret,
-                                                 Settings.authentication.algorithm)
-            email = payload['email']
-          end
-          # match email addresses case-insensitively
+          email = email_from_token(token)
+
           @current_user = User.find_by("lower(email) = ?", email.downcase)
+
           @current_user.present?
+        end
+      end
+
+    private
+
+      def check_terms_accepted
+        return if @current_user&.accept_terms_date_utc.present?
+
+        error_body = {
+          errors: [
+            {
+              status: 403,
+              title: 'Forbidden',
+              detail: 'The user has not accepted terms and conditions.'
+            }
+          ]
+        }
+        render json: error_body, status: :forbidden
+      end
+
+      def email_from_token(token)
+        if Settings.authentication.algorithm == 'plain-text'
+          # This method can be used in development mode to simplify querying
+          # the API with curl. It should allow us to do:
+          #
+          #    curl -H 'Authorization: Bearer user@education.gov.uk' http://localhost:3001/api/v2/providers
+          token
+        else
+          (payload, _options) = JWT.decode(token,
+                                               Settings.authentication.secret,
+                                               Settings.authentication.algorithm)
+          payload['email']
         end
       end
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -19,5 +19,6 @@ FactoryBot.define do
     email { Faker::Internet.email }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
+    accept_terms_date_utc { Faker::Date.backward(1) }
   end
 end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -43,6 +43,19 @@ describe 'Courses API v2', type: :request do
       it { should have_http_status(:unauthorized) }
     end
 
+    context 'when user has not accepted terms' do
+      let(:user_without_terms_accepted) { create(:user, accept_terms_date_utc: nil) }
+      let(:organisation) { create(:organisation, users: [user, user_without_terms_accepted]) }
+      let(:payload) { { email: user_without_terms_accepted.email } }
+
+      before do
+        get "/api/v2/providers/#{provider.provider_code}/courses/#{findable_open_course.course_code}",
+            headers: { 'HTTP_AUTHORIZATION' => credentials }
+      end
+
+      it { should have_http_status(:forbidden) }
+    end
+
     context 'when unauthorised' do
       let(:unauthorised_user) { create(:user) }
       let(:payload) { { email: unauthorised_user.email } }


### PR DESCRIPTION
### Context

We need to return a 403 Forbidden if the user hasn't accepted the terms and conditions. The frontend  can then use this to redirect them to manage-courses-ui so that they can choose  to accept.

### Changes proposed in this pull request

Refactors the email retrieval logic and then adds the check for the `accept_terms_date_utc` field.

### Guidance to review

~Not sure if this is where this bit of logic should go; I've thought about creating another `before_action` but then I need to get the token again, which is cumbersome. It's easier to insert the new logic into this existing check.~