### PR TITLE
[1131] Update course changed_at when updating site status

### DIFF
--- a/app/models/concerns/touch_course.rb
+++ b/app/models/concerns/touch_course.rb
@@ -1,0 +1,13 @@
+module TouchCourse
+  extend ActiveSupport::Concern
+
+  included do
+    after_save :touch_course
+  end
+
+private
+
+  def touch_course
+    course.update_changed_at
+  end
+end

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -12,6 +12,8 @@
 #
 
 class SiteStatus < ApplicationRecord
+  include TouchCourse
+
   self.table_name = "course_site"
 
   validate :vac_status_must_be_consistent_with_course_study_mode,

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -14,6 +14,8 @@ require 'rails_helper'
 
 
 RSpec.describe SiteStatus, type: :model do
+  it_behaves_like 'Touch course'
+
   RSpec::Matchers.define :be_findable do
     match do |actual|
       SiteStatus.findable.include?(actual)

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -14,7 +14,7 @@ require 'rails_helper'
 
 
 RSpec.describe SiteStatus, type: :model do
-  it_behaves_like 'Touch course'
+  it_behaves_like 'Touch course', :site_status
 
   RSpec::Matchers.define :be_findable do
     match do |actual|

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -55,6 +55,8 @@ describe "Courses API", type: :request do
           applications_accepted_from: "2018-10-09 00:00:00",
           course: course,
           site: site)
+
+        course.update_attributes changed_at: 2.hours.ago
       end
 
       it "returns http success" do

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -56,7 +56,7 @@ describe "Courses API", type: :request do
           course: course,
           site: site)
 
-        course.update_attributes changed_at: 2.hours.ago
+        course.update changed_at: 2.hours.ago
       end
 
       it "returns http success" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -114,4 +114,7 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 =end
   config.include JSONAPI::RSpec
+
+  # Load shared examples
+  Dir['./spec/support/shared_examples/**/*.rb'].each { |f| require f }
 end

--- a/spec/support/shared_examples/touch_course_spec.rb
+++ b/spec/support/shared_examples/touch_course_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+shared_examples 'Touch course' do
+  describe '#touch_course' do
+    let!(:model) { create(described_class.model_name.singular.to_sym) }
+
+    it 'sets changed_at on the parent course to the current time' do
+      Timecop.freeze do
+        model.save
+        expect(model.course.changed_at).to eq Time.now.utc
+      end
+    end
+
+    it 'leaves updated_at on the parent course unchanged' do
+      timestamp = 1.hour.ago
+      model.course.update updated_at: timestamp
+      model.save
+      expect(model.course.updated_at).to eq timestamp
+    end
+  end
+end

--- a/spec/support/shared_examples/touch_course_spec.rb
+++ b/spec/support/shared_examples/touch_course_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-shared_examples 'Touch course' do
+shared_examples 'Touch course' do |model_factory|
   describe '#touch_course' do
-    let!(:model) { create(described_class.model_name.singular.to_sym) }
+    let!(:model) { create(model_factory) }
 
     it 'sets changed_at on the parent course to the current time' do
       Timecop.freeze do


### PR DESCRIPTION
### Context
Course changed_at is updated when updating site status

### Changes proposed in this pull request
Added ability to update change at for course when site statuses changes.
This is done via a reusable concern, through a call back.