### PR TITLE
[1173] add ucas preferences serialiser

### DIFF
--- a/app/models/provider_ucas_preference.rb
+++ b/app/models/provider_ucas_preference.rb
@@ -16,10 +16,10 @@ class ProviderUCASPreference < ApplicationRecord
   belongs_to :provider
 
   enum type_of_gt12: {
-         coming_or_not: 'Coming or Not (GT12B)',
-         coming_enrol: 'Coming / Enrol (GT12E)',
-         not_coming: 'Not coming (GT12N)',
-         no_response: 'No response (GT12)',
+         coming_or_not: 'Coming or Not',
+         coming_enrol: 'Coming / Enrol',
+         not_coming: 'Not coming',
+         no_response: 'No response',
        },
        _prefix: 'type_of_gt12'
 

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -94,17 +94,7 @@ class ProviderSerializer < ActiveModel::Serializer
   end
 
   def type_of_gt12
-    # Temporarily create a value for this field which will be consistent
-    # for this provider. Remove this when we've data for this value to the
-    # db.
-    values = [
-      'Coming / Enrol',
-      'Coming or Not',
-      'No response',
-      'Not coming',
-    ]
-
-    select_value_for_provider(@object.provider_code, values)
+    @object.ucas_preferences.type_of_gt12_before_type_cast
   end
 
   attribute :contacts do

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -80,17 +80,7 @@ class ProviderSerializer < ActiveModel::Serializer
   end
 
   def utt_application_alerts
-    # Temporarily create a value for this field which will be consistent
-    # for this provider. Remove this when we've data for this value to the
-    # db.
-    values = [
-      'No, not required',
-      'Yes, required',
-      'Yes - only my programmes',
-      'Yes - for accredited programmes only',
-    ]
-
-    select_value_for_provider(@object.provider_code, values)
+    @object.ucas_preferences.send_application_alerts_before_type_cast
   end
 
   def type_of_gt12

--- a/spec/factories/provider_ucas_preferences.rb
+++ b/spec/factories/provider_ucas_preferences.rb
@@ -13,7 +13,15 @@
 #
 
 FactoryBot.define do
-  factory :provider_ucas_preference do
+  factory :provider_ucas_preference, aliases: [:ucas_preferences] do
     provider
+    type_of_gt12 do
+      [
+        :coming_or_not,
+        :coming_enrol,
+        :not_coming,
+        :no_response,
+      ].sample
+    end
   end
 end

--- a/spec/factories/provider_ucas_preferences.rb
+++ b/spec/factories/provider_ucas_preferences.rb
@@ -15,12 +15,22 @@
 FactoryBot.define do
   factory :provider_ucas_preference, aliases: [:ucas_preferences] do
     provider
+
     type_of_gt12 do
-      [
-        :coming_or_not,
-        :coming_enrol,
-        :not_coming,
-        :no_response,
+      %i[
+        coming_or_not
+        coming_enrol
+        not_coming
+        no_response
+      ].sample
+    end
+
+    send_application_alerts do
+      %i[
+        all
+        none
+        my_programmes
+        accredited_programmes
       ].sample
     end
   end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -70,6 +70,10 @@ FactoryBot.define do
       if evaluator.changed_at.present?
         provider.update changed_at: evaluator.changed_at
       end
+
+      if provider.ucas_preferences.nil?
+        provider.ucas_preferences = create(:ucas_preferences, provider: provider)
+      end
     end
   end
 end

--- a/spec/factory_specs/provider_ucas_preferences_spec.rb
+++ b/spec/factory_specs/provider_ucas_preferences_spec.rb
@@ -1,10 +1,27 @@
 require "rails_helper"
 
 describe 'ProviderUCASPreference factory' do
-  let(:provider_ucas_preferences) { create(:provider_ucas_preference) }
+  subject { create(:provider_ucas_preference) }
 
-  it 'creates ProviderUCASPreference object' do
-    expect(provider_ucas_preferences).to be_instance_of(ProviderUCASPreference)
-    expect(provider_ucas_preferences).to be_valid
+  let(:valid_types_of_gt12) do
+    %w[
+      coming_or_not
+      coming_enrol
+      not_coming
+      no_response
+    ]
   end
+  let(:valid_send_application_alerts) do
+    %w[
+      all
+      none
+      my_programmes
+      accredited_programmes
+    ]
+  end
+
+  it { should be_instance_of(ProviderUCASPreference) }
+  it { should be_valid }
+  its(:type_of_gt12) { should be_in valid_types_of_gt12 }
+  its(:send_application_alerts) { should be_in valid_send_application_alerts }
 end

--- a/spec/models/provider_ucas_preference_spec.rb
+++ b/spec/models/provider_ucas_preference_spec.rb
@@ -23,10 +23,10 @@ describe ProviderUCASPreference, type: :model do
         .to define_enum_for(:type_of_gt12)
               .backed_by_column_of_type(:text)
               .with_values(
-                coming_or_not: 'Coming or Not (GT12B)',
-                coming_enrol: 'Coming / Enrol (GT12E)',
-                not_coming: 'Not coming (GT12N)',
-                no_response: 'No response (GT12)',
+                coming_or_not: 'Coming or Not',
+                coming_enrol: 'Coming / Enrol',
+                not_coming: 'Not coming',
+                no_response: 'No response',
               )
               .with_prefix('type_of_gt12')
     end

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -17,6 +17,10 @@ describe 'Providers API', type: :request do
     end
 
     context "without changed_since parameter" do
+      let(:ucas_preferences) do
+        build(:ucas_preferences,
+               type_of_gt12: :not_coming)
+      end
       let!(:provider) do
         create(:provider,
                provider_name: 'ACME SCITT',
@@ -35,7 +39,8 @@ describe 'Providers API', type: :request do
                accrediting_provider: 'Y',
                scheme_member: 'Y',
                last_published_at: DateTime.now.utc,
-               enrichments: [enrichment])
+               enrichments: [enrichment],
+               ucas_preferences: ucas_preferences)
       end
       let!(:site) do
         create(:site,
@@ -55,6 +60,10 @@ describe 'Providers API', type: :request do
               telephone: '020 8123 1234',
               region_code: :scotland)
       end
+      let(:ucas_preferences2) do
+        build(:ucas_preferences,
+              type_of_gt12: :coming_or_not)
+      end
       let(:provider2) do
         create(:provider,
               provider_name: 'ACME University',
@@ -73,7 +82,8 @@ describe 'Providers API', type: :request do
               scheme_member: 'N',
               last_published_at: DateTime.now.utc,
               enrichments: [],
-              site_count: 0)
+              site_count: 0,
+              ucas_preferences: ucas_preferences2)
       end
       let!(:site2) do
         create(:site,
@@ -191,7 +201,7 @@ describe 'Providers API', type: :request do
                 'email' => 'info@acmeuniversity.education.uk',
                 'contact_name' => 'James Brown',
                 'recruitment_cycle' => '2019',
-                'type_of_gt12' => 'Not coming',
+                'type_of_gt12' => 'Coming or Not',
                 'utt_application_alerts' => 'Yes - for accredited programmes only',
                 'contacts' => [
                   {
@@ -340,7 +350,7 @@ describe 'Providers API', type: :request do
                                  'email' => 'info@acmeuniversity.education.uk',
                                  'contact_name' => 'James Brown',
                                  'recruitment_cycle' => '2019',
-                                 'type_of_gt12' => 'Not coming',
+                                 'type_of_gt12' => 'Coming or Not',
                                  'utt_application_alerts' => 'Yes - for accredited programmes only',
                                  'contacts' => [
                                    {
@@ -409,7 +419,9 @@ describe 'Providers API', type: :request do
       end
 
       it 'includes correct next link in response headers' do
-        create(:provider, provider_code: "LAST1", changed_at: 10.minutes.ago)
+        create(:provider,
+               provider_code: "LAST1",
+               changed_at: 10.minutes.ago)
 
         timestamp_of_last_provider = 2.minutes.ago
         create(:provider,

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -19,7 +19,8 @@ describe 'Providers API', type: :request do
     context "without changed_since parameter" do
       let(:ucas_preferences) do
         build(:ucas_preferences,
-               type_of_gt12: :not_coming)
+              type_of_gt12: :not_coming,
+              send_application_alerts: :all,)
       end
       let!(:provider) do
         create(:provider,
@@ -62,7 +63,8 @@ describe 'Providers API', type: :request do
       end
       let(:ucas_preferences2) do
         build(:ucas_preferences,
-              type_of_gt12: :coming_or_not)
+              type_of_gt12: :coming_or_not,
+              send_application_alerts: :none)
       end
       let(:provider2) do
         create(:provider,
@@ -138,7 +140,7 @@ describe 'Providers API', type: :request do
                 'contact_name' => 'Amy Smith',
                 'recruitment_cycle' => '2019',
                 'type_of_gt12' => 'Not coming',
-                'utt_application_alerts' => 'Yes - for accredited programmes only',
+                'utt_application_alerts' => 'Yes, required',
                 'contacts' => [
                   {
                     'type' => 'admin',
@@ -202,7 +204,7 @@ describe 'Providers API', type: :request do
                 'contact_name' => 'James Brown',
                 'recruitment_cycle' => '2019',
                 'type_of_gt12' => 'Coming or Not',
-                'utt_application_alerts' => 'Yes - for accredited programmes only',
+                'utt_application_alerts' => 'No, not required',
                 'contacts' => [
                   {
                     'type' => 'admin',
@@ -287,7 +289,7 @@ describe 'Providers API', type: :request do
                                   'contact_name' => 'Amy Smith',
                                   'recruitment_cycle' => '2019',
                                   'type_of_gt12' => 'Not coming',
-                                  'utt_application_alerts' => 'Yes - for accredited programmes only',
+                                  'utt_application_alerts' => 'Yes, required',
                                   'contacts' => [
                                     {
                                       'type' => 'admin',
@@ -351,7 +353,7 @@ describe 'Providers API', type: :request do
                                  'contact_name' => 'James Brown',
                                  'recruitment_cycle' => '2019',
                                  'type_of_gt12' => 'Coming or Not',
-                                 'utt_application_alerts' => 'Yes - for accredited programmes only',
+                                 'utt_application_alerts' => 'No, not required',
                                  'contacts' => [
                                    {
                                      'type' => 'admin',

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -78,4 +78,10 @@ describe ProviderSerializer do
 
     it { should eq provider.ucas_preferences.type_of_gt12_before_type_cast }
   end
+
+  describe 'utt_application_alerts' do
+    subject { serialize(provider)['utt_application_alerts'] }
+
+    it { should eq provider.ucas_preferences.send_application_alerts_before_type_cast }
+  end
 end

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -29,8 +29,9 @@
 
 require "rails_helper"
 
-RSpec.describe ProviderSerializer do
+describe ProviderSerializer do
   let(:provider) { create :provider }
+
   subject { serialize(provider) }
 
   it { should include(institution_code: provider.provider_code) }
@@ -70,5 +71,11 @@ RSpec.describe ProviderSerializer do
       it { is_expected.to eql("%02d" % region_code) }
       it { is_expected.not_to eql("%02d" % 0) }
     end
+  end
+
+  describe 'type_of_gt12' do
+    subject { serialize(provider)['type_of_gt12'] }
+
+    it { should eq provider.ucas_preferences.type_of_gt12_before_type_cast }
   end
 end


### PR DESCRIPTION
https://trello.com/c/kezSZblP/1173-provider-preferences-serialiser

### Context

We need to expose the provider preferences that are in the DB in the V1 API, right now they are being semi-randomly chosen.

### Changes proposed in this pull request

This change pulls these values from the DB in the serialiser, and fixes a bunch of related tests.

