### PR TITLE
[1131] API endpoint for updating vacancy status

### DIFF
--- a/app/controllers/api/v2/site_statuses_controller.rb
+++ b/app/controllers/api/v2/site_statuses_controller.rb
@@ -1,7 +1,18 @@
 module API
   module V2
     class SiteStatusesController < API::V2::ApplicationController
-      def update;end
+      deserializable_resource :site_status, only: :update
+
+      def update
+        site_status = authorize SiteStatus.find(params[:id])
+        site_status.update site_status_params
+      end
+
+    private
+
+      def site_status_params
+        params.require(:site_status).permit :vac_status
+      end
     end
   end
 end

--- a/app/controllers/api/v2/site_statuses_controller.rb
+++ b/app/controllers/api/v2/site_statuses_controller.rb
@@ -6,12 +6,19 @@ module API
       def update
         site_status = authorize SiteStatus.find(params[:id])
         site_status.update site_status_params
+
+        render jsonapi: site_status
       end
 
     private
 
       def site_status_params
-        params.require(:site_status).permit :vac_status
+        params.require(:site_status).permit(
+          :applications_accepted_from,
+          :publish,
+          :status,
+          :vac_status
+        )
       end
     end
   end

--- a/app/controllers/api/v2/site_statuses_controller.rb
+++ b/app/controllers/api/v2/site_statuses_controller.rb
@@ -1,0 +1,7 @@
+module API
+  module V2
+    class SiteStatusesController < API::V2::ApplicationController
+      def update;end
+    end
+  end
+end

--- a/app/policies/site_status_policy.rb
+++ b/app/policies/site_status_policy.rb
@@ -7,6 +7,6 @@ class SiteStatusPolicy
   end
 
   def update?
-    site_status&.course&.provider&.in? user.providers
+    CoursePolicy.new(user, site_status&.course).update?
   end
 end

--- a/app/policies/site_status_policy.rb
+++ b/app/policies/site_status_policy.rb
@@ -1,0 +1,12 @@
+class SiteStatusPolicy
+  attr_reader :user, :site_status
+
+  def initialize(user, site_status)
+    @user        = user
+    @site_status = site_status
+  end
+
+  def update?
+    site_status&.course&.provider&.in? user.providers
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,7 @@ Rails.application.routes.draw do
       end
 
       resource :sessions
+      resources :site_statuses, only: :update
     end
   end
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -75,9 +75,5 @@ FactoryBot.define do
     trait :resulting_in_pgde do
       qualification { :pgde }
     end
-
-    trait :without_provider do
-      association :provider, strategy: :null
-    end
   end
 end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -75,5 +75,9 @@ FactoryBot.define do
     trait :resulting_in_pgde do
       qualification { :pgde }
     end
+
+    trait :without_provider do
+      association :provider, strategy: :null
+    end
   end
 end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -41,6 +41,7 @@ FactoryBot.define do
     accrediting_provider { 'N' }
     region_code { ProviderEnrichment.region_codes['London'] }
     opted_in { true }
+    organisations { build_list :organisation, 1 }
 
     transient do
       changed_at           { nil }

--- a/spec/factories/site_statuses.rb
+++ b/spec/factories/site_statuses.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
     association(:site)
     publish { 'N' }
     vac_status { :full_time_vacancies }
+    status { 'running' }
 
     transient do
       any_vancancy { false }

--- a/spec/policies/site_status_policy_spec.rb
+++ b/spec/policies/site_status_policy_spec.rb
@@ -1,34 +1,22 @@
 require 'rails_helper'
 
 describe SiteStatusPolicy do
-  let(:organisation) { create(:organisation, users: [user]) }
-  let!(:provider) {
-    create(:provider,
-            course_count: 0,
-            courses: [course],
-            organisations: [organisation])
-  }
-  let!(:course) do
-    create(
-      :course,
-      site_statuses: build_list(:site_status, 1)
-    )
-  end
-  let(:site_status) { course.site_statuses.first }
+  let(:organisation) { site_status.course.provider.organisations.first }
+  let(:site_status) { create :site_status }
 
   subject { described_class }
 
   permissions :update? do
-    let(:user) { create :user }
+    let(:user) { create(:user).tap { |u| organisation.users << u } }
 
     context 'with an user inside the organisation' do
       it { should permit(user, site_status) }
     end
 
     context 'with a user outside the organisation' do
-      let(:user_outside_provider) { build(:user) }
+      let(:user) { build(:user) }
 
-      it { should_not permit(user_outside_provider, site_status) }
+      it { should_not permit(user, site_status) }
     end
   end
 end

--- a/spec/policies/site_status_policy_spec.rb
+++ b/spec/policies/site_status_policy_spec.rb
@@ -1,32 +1,34 @@
 require 'rails_helper'
 
 describe SiteStatusPolicy do
-  let(:organisation) { build :organisation, users: [user] }
-  let(:provider)     { build :provider }
-  let(:user)         { build :user }
-  let(:site_status)  { course.site_statuses.first }
-  let(:course) do
-    build(
+  let(:organisation) { create(:organisation, users: [user]) }
+  let!(:provider) {
+    create(:provider,
+            course_count: 0,
+            courses: [course],
+            organisations: [organisation])
+  }
+  let!(:course) do
+    create(
       :course,
-      site_statuses: build_list(:site_status, 1),
-      provider:      provider
+      site_statuses: build_list(:site_status, 1)
     )
   end
+  let(:site_status) { course.site_statuses.first }
 
   subject { described_class }
 
   permissions :update? do
+    let(:user) { create :user }
+
     context 'with an user inside the organisation' do
-      before do
-        allow(user).to receive(:providers).and_return [provider]
-      end
       it { should permit(user, site_status) }
     end
 
     context 'with a user outside the organisation' do
-      let(:user) { build(:user) }
+      let(:user_outside_provider) { build(:user) }
 
-      it { should_not permit(user, site_status) }
+      it { should_not permit(user_outside_provider, site_status) }
     end
   end
 end

--- a/spec/policies/site_status_policy_spec.rb
+++ b/spec/policies/site_status_policy_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe SiteStatusPolicy do
+  let(:organisation) { build :organisation, users: [user] }
+  let(:provider)     { build :provider }
+  let(:user)         { build :user }
+  let(:site_status)  { course.site_statuses.first }
+  let(:course) do
+    build(
+      :course,
+      site_statuses: build_list(:site_status, 1),
+      provider:      provider
+    )
+  end
+
+  subject { described_class }
+
+  permissions :update? do
+    context 'with an user inside the organisation' do
+      before do
+        allow(user).to receive(:providers).and_return [provider]
+      end
+      it { should permit(user, site_status) }
+    end
+
+    context 'with a user outside the organisation' do
+      let(:user) { build(:user) }
+
+      it { should_not permit(user, site_status) }
+    end
+  end
+end

--- a/spec/requests/api/v2/site_statuses_spec.rb
+++ b/spec/requests/api/v2/site_statuses_spec.rb
@@ -14,15 +14,16 @@ describe 'Site Helpers API V2' do
   end
   let(:site_status) { create :site_status }
   let(:params)      { {} }
-  let(:perform_request) do
+
+  subject { response }
+
+  def perform_request
     patch(
       api_v2_site_status_path(site_status),
       headers: { 'HTTP_AUTHORIZATION' => credentials },
       params: params
     )
   end
-
-  subject { response }
 
   describe 'PATCH update' do
     context 'when unauthenticated' do

--- a/spec/requests/api/v2/site_statuses_spec.rb
+++ b/spec/requests/api/v2/site_statuses_spec.rb
@@ -20,7 +20,11 @@ describe 'Site Helpers API V2' do
         create(
           :course,
           provider: provider,
-          with_site_statuses: %i[with_no_vacancies]
+          with_site_statuses: [%i[
+           with_no_vacancies
+           running
+           published
+          ]]
         )
       end
       let(:site_status) { course.site_statuses.first }
@@ -35,9 +39,17 @@ describe 'Site Helpers API V2' do
           )
         }
       end
+      let(:site_status_params)         { params[:_jsonapi][:data][:attributes] }
+      let(:applications_accepted_from) { '2019-01-01 00:00:00' }
+      let(:publish)                    { 'unpublished' }
+      let(:status)                     { 'discontinued' }
+      let(:vac_status)                 { 'full_time_vacancies' }
 
       before do
-        params[:_jsonapi][:data][:attributes][:vac_status] = 'full_time_vacancies'
+        site_status_params[:applications_accepted_from] = applications_accepted_from
+        site_status_params[:publish]                    = publish
+        site_status_params[:status]                     = status
+        site_status_params[:vac_status]                 = vac_status
       end
 
       subject do
@@ -48,7 +60,24 @@ describe 'Site Helpers API V2' do
         )
       end
 
-      it 'updates vacancy status of site statuses for a course' do
+      it 'updates applications_accepted_from on the site status' do
+        expect { subject }.to(
+          change { site_status.reload.applications_accepted_from }
+          .to(Date.parse('2019-01-01 00:00:00'))
+        )
+      end
+
+      it 'updates publish on the site status' do
+        expect { subject }.to(change { site_status.reload.publish }
+          .from('published').to('unpublished'))
+      end
+
+      it 'updates status on the site status' do
+        expect { subject }.to(change { site_status.reload.status }
+          .from('running').to('discontinued'))
+      end
+
+      it 'updates vac_status on the site status' do
         expect { subject }.to(change { site_status.reload.vac_status }
           .from('no_vacancies').to('full_time_vacancies'))
       end

--- a/spec/requests/api/v2/site_statuses_spec.rb
+++ b/spec/requests/api/v2/site_statuses_spec.rb
@@ -64,10 +64,12 @@ describe 'Site Helpers API V2' do
       let(:json_data)                  { JSON.parse(response.body)['data'] }
 
       before do
-        site_status_params[:applications_accepted_from] = applications_accepted_from
-        site_status_params[:publish]                    = publish
-        site_status_params[:status]                     = status
-        site_status_params[:vac_status]                 = vac_status
+        site_status_params.merge!(
+          applications_accepted_from: applications_accepted_from,
+          publish:                    publish,
+          status:                     status,
+          vac_status:                 vac_status,
+        )
       end
 
       subject { perform_request }

--- a/spec/requests/api/v2/site_statuses_spec.rb
+++ b/spec/requests/api/v2/site_statuses_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+describe 'Site Helpers API V2' do
+  let(:user) { create(:user) }
+  let(:organisation) { create(:organisation, users: [user]) }
+  let(:payload) { { email: user.email } }
+  let(:token) do
+    JWT.encode payload,
+                Settings.authentication.secret,
+                Settings.authentication.algorithm
+  end
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+  let!(:provider) { create(:provider, organisations: [organisation]) }
+
+  describe 'PATCH update' do
+    context 'when authenticated' do
+      let(:course) do
+        create(
+          :course,
+          provider: provider,
+          with_site_statuses: %i[with_no_vacancies]
+        )
+      end
+      let(:site_status) { course.site_statuses.first }
+      let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+      let(:params) do
+        {
+          _jsonapi: jsonapi_renderer.render(
+            site_status,
+            class: {
+              SiteStatus: API::V2::SerializableSiteStatus
+            }
+          )
+        }
+      end
+
+      before do
+        params[:_jsonapi][:data][:attributes][:vac_status] = 'full_time_vacancies'
+      end
+
+      subject do
+        patch(
+          api_v2_site_status_path(site_status),
+          headers: { 'HTTP_AUTHORIZATION' => credentials },
+          params: params
+        )
+      end
+
+      it 'updates vacancy status of site statuses for a course' do
+        expect { subject }.to(change { site_status.reload.vac_status }
+          .from('no_vacancies').to('full_time_vacancies'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

The API needs to have an endpoint for the frontend to update vacancy statuses. This is done via the site status, which now has an endpoint to update any of its attributes.

### Changes proposed in this pull request

An update endpoint on `SiteStatus` that takes an HTTP PATCH request with any attributes to update.

### Guidance to review

Please take a look at the specs, there is a lot of setup required there for creating organisations, providers, and users. It might be a good idea to clean that up by making the setup reusable, as a precursor to this PR?