### PR TITLE
1179 add provider contact serializer

### DIFF
--- a/app/serializers/contact_serializer.rb
+++ b/app/serializers/contact_serializer.rb
@@ -21,19 +21,5 @@
 class ContactSerializer < ActiveModel::Serializer
   belongs_to :provider
 
-  attribute :type do
-    object.type
-  end
-
-  attribute :name do
-    object.name
-  end
-
-  attribute :email do
-    object.email
-  end
-
-  attribute :telephone do
-    object.telephone
-  end
+  attributes :type, :name, :email, :telephone
 end

--- a/app/serializers/contact_serializer.rb
+++ b/app/serializers/contact_serializer.rb
@@ -1,0 +1,39 @@
+# == Schema Information
+#
+# Table name: contact
+#
+#  id          :bigint(8)        not null, primary key
+#  provider_id :integer          not null
+#  type        :text             not null
+#  name        :text
+#  email       :text
+#  telephone   :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+# application alert recipient has been added as a contact manually in the provider
+# contact serializer (../provider_serializer.rb:38). It has not been added into
+# the enum in the contact model as it's does not share the name and email attribute.
+# It is simply a contact email address and is more suited to sit in the ucas
+# preferences model.
+
+class ContactSerializer < ActiveModel::Serializer
+  belongs_to :provider
+
+  attribute :type do
+    object.type
+  end
+
+  attribute :name do
+    object.name
+  end
+
+  attribute :email do
+    object.email
+  end
+
+  attribute :telephone do
+    object.telephone
+  end
+end

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -33,7 +33,14 @@ class ProviderSerializer < ActiveModel::Serializer
   attributes :institution_code, :institution_name, :institution_type, :accrediting_provider,
              :address1, :address2, :address3, :address4, :postcode, :region_code, :scheme_member,
              :contact_name, :email, :telephone, :recruitment_cycle, :utt_application_alerts,
-             :type_of_gt12
+             :type_of_gt12, :application_alert_recipient
+
+  attribute :contacts do
+    object.contacts.map { |c| c.attributes.slice('type', 'name', 'email', 'telephone') } + [{
+      type: 'application_alert_recipient',
+      email: object.ucas_preferences.application_alert_email,
+      }]
+  end
 
   def institution_code
     object.provider_code
@@ -87,22 +94,8 @@ class ProviderSerializer < ActiveModel::Serializer
     @object.ucas_preferences.type_of_gt12_before_type_cast
   end
 
-  attribute :contacts do
-    %w[
-      admin
-      utt
-      web_link
-      fraud
-      finance
-      application_alert_recipient
-    ].map do |type|
-      {
-        type: type,
-        name: "#{type.humanize.titleize} Contact #{@object.provider_code}",
-        email: @object.email&.sub(/.*@/, "#{type}@"),
-        telephone: @object.telephone,
-      }
-    end
+  def application_alert_recipient
+    @object.ucas_preferences.application_alert_email
   end
 
 private

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -35,14 +35,14 @@ class ProviderSerializer < ActiveModel::Serializer
              :contact_name, :email, :telephone, :recruitment_cycle, :utt_application_alerts,
              :type_of_gt12
 
-             # application alert reciepient has not been added into the enum in the contact model
-             # as it's does not share the name and email attribute. It is simply a contact email
-             # address and is more suited to sit in the ucas  preferences model. However, in the docs
+             # application alert recipient has not been added into the enum in the contact model
+             # as it does not share the name and email attribute. It is simply a contact email
+             # address and is more suited to sit in the ucas preferences model. However, in the docs
              # it is exposed in the contacts so has been added directly into the contacts attribute
-             # see lines 109-120 for logic.
+             # see generate_provider_contacts and return_application_alert_recipient for logic.
 
   attribute :contacts do
-    generate_provider_contacts + add_application_alert_recipient
+    generate_provider_contacts + application_alert_recipient
   end
 
   def institution_code
@@ -110,7 +110,7 @@ private
     object.contacts.map { |c| c.attributes.slice('type', 'name', 'email', 'telephone') }
   end
 
-  def add_application_alert_recipient
+  def application_alert_recipient
     [{
       type: 'application_alert_recipient',
       name: '',

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -20,4 +20,24 @@ FactoryBot.define do
     email { Faker::Internet.email }
     telephone { Faker::PhoneNumber.phone_number }
   end
+
+  trait :admin_contact do
+    type { :admin }
+  end
+
+  trait :utt_contact do
+    type { :utt }
+  end
+
+  trait :web_link_contact do
+    type { :web_link }
+  end
+
+  trait :finance_contact do
+    type { :finance }
+  end
+
+  trait :fraud_contact do
+    type { :fraud }
+  end
 end

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -15,29 +15,29 @@
 FactoryBot.define do
   factory :contact do
     provider
-    type { 'admin' }
+    admin_type
     name { Faker::Name.name }
     email { Faker::Internet.email }
     telephone { Faker::PhoneNumber.phone_number }
   end
 
-  trait :admin_contact do
+  trait :admin_type do
     type { :admin }
   end
 
-  trait :utt_contact do
+  trait :utt_type do
     type { :utt }
   end
 
-  trait :web_link_contact do
+  trait :web_link_type do
     type { :web_link }
   end
 
-  trait :finance_contact do
+  trait :finance_type do
     type { :finance }
   end
 
-  trait :fraud_contact do
+  trait :fraud_type do
     type { :fraud }
   end
 end

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -16,5 +16,8 @@ FactoryBot.define do
   factory :contact do
     provider
     type { 'admin' }
+    name { Faker::Name.name }
+    email { Faker::Internet.email }
+    telephone { Faker::PhoneNumber.phone_number }
   end
 end

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -20,7 +20,32 @@ describe 'Providers API', type: :request do
       let(:ucas_preferences) do
         build(:ucas_preferences,
               type_of_gt12: :not_coming,
-              send_application_alerts: :all,)
+              send_application_alerts: :all,
+              application_alert_email: 'application_alert_recipient@acmescitt.education.uk')
+      end
+      let(:contacts) do
+        [
+        build(:contact, type: 'admin',
+                        name: 'Admin Contact A123',
+                        email: 'admin@acmescitt.education.uk',
+                        telephone: '020 812 345 678'),
+        build(:contact, type: 'utt',
+                        name: 'Utt Contact A123',
+                        email: 'utt@acmescitt.education.uk',
+                        telephone: '020 812 345 678'),
+        build(:contact, type: 'web_link',
+                        name: 'Web Link Contact A123',
+                        email: 'web_link@acmescitt.education.uk',
+                        telephone: '020 812 345 678'),
+        build(:contact, type: 'fraud',
+                        name: 'Fraud Contact A123',
+                        email: 'fraud@acmescitt.education.uk',
+                        telephone: '020 812 345 678'),
+        build(:contact, type: 'finance',
+                        name: 'Finance Contact A123',
+                        email: 'finance@acmescitt.education.uk',
+                        telephone: '020 812 345 678')
+        ]
       end
       let!(:provider) do
         create(:provider,
@@ -41,7 +66,8 @@ describe 'Providers API', type: :request do
                scheme_member: 'Y',
                last_published_at: DateTime.now.utc,
                enrichments: [enrichment],
-               ucas_preferences: ucas_preferences)
+               ucas_preferences: ucas_preferences,
+               contacts: contacts)
       end
       let!(:site) do
         create(:site,
@@ -64,7 +90,32 @@ describe 'Providers API', type: :request do
       let(:ucas_preferences2) do
         build(:ucas_preferences,
               type_of_gt12: :coming_or_not,
-              send_application_alerts: :none)
+              send_application_alerts: :none,
+              application_alert_email: 'application_alert_recipient@acmeuniversity.education.uk')
+      end
+      let(:contacts2) do
+        [
+        build(:contact, type: 'admin',
+                        name: 'Admin Contact B123',
+                        email: 'admin@acmeuniversity.education.uk',
+                        telephone: '01273 345 678'),
+        build(:contact, type: 'utt',
+                        name: 'Utt Contact B123',
+                        email: 'utt@acmeuniversity.education.uk',
+                        telephone: '01273 345 678'),
+        build(:contact, type: 'web_link',
+                        name: 'Web Link Contact B123',
+                        email: 'web_link@acmeuniversity.education.uk',
+                        telephone: '01273 345 678'),
+        build(:contact, type: 'fraud',
+                        name: 'Fraud Contact B123',
+                        email: 'fraud@acmeuniversity.education.uk',
+                        telephone: '01273 345 678'),
+        build(:contact, type: 'finance',
+                        name: 'Finance Contact B123',
+                        email: 'finance@acmeuniversity.education.uk',
+                        telephone: '01273 345 678')
+        ]
       end
       let(:provider2) do
         create(:provider,
@@ -85,7 +136,8 @@ describe 'Providers API', type: :request do
               last_published_at: DateTime.now.utc,
               enrichments: [],
               site_count: 0,
-              ucas_preferences: ucas_preferences2)
+              ucas_preferences: ucas_preferences2,
+              contacts: contacts2)
       end
       let!(:site2) do
         create(:site,
@@ -141,6 +193,7 @@ describe 'Providers API', type: :request do
                 'recruitment_cycle' => '2019',
                 'type_of_gt12' => 'Not coming',
                 'utt_application_alerts' => 'Yes, required',
+                'application_alert_recipient' => 'application_alert_recipient@acmescitt.education.uk',
                 'contacts' => [
                   {
                     'type' => 'admin',
@@ -174,9 +227,7 @@ describe 'Providers API', type: :request do
                   },
                   {
                     'type' => 'application_alert_recipient',
-                    'name' => 'Application Alert Recipient Contact A123',
-                    'email' => 'application_alert_recipient@acmescitt.education.uk',
-                    'telephone' => '020 812 345 678'
+                    'email' => 'application_alert_recipient@acmescitt.education.uk'
                   }
                 ]
               },
@@ -205,6 +256,7 @@ describe 'Providers API', type: :request do
                 'recruitment_cycle' => '2019',
                 'type_of_gt12' => 'Coming or Not',
                 'utt_application_alerts' => 'No, not required',
+                'application_alert_recipient' => 'application_alert_recipient@acmeuniversity.education.uk',
                 'contacts' => [
                   {
                     'type' => 'admin',
@@ -238,9 +290,7 @@ describe 'Providers API', type: :request do
                   },
                   {
                     'type' => 'application_alert_recipient',
-                    'name' => 'Application Alert Recipient Contact B123',
-                    'email' => 'application_alert_recipient@acmeuniversity.education.uk',
-                    'telephone' => '01273 345 678'
+                    'email' => 'application_alert_recipient@acmeuniversity.education.uk'
                   }
                 ]
               }
@@ -290,6 +340,7 @@ describe 'Providers API', type: :request do
                                   'recruitment_cycle' => '2019',
                                   'type_of_gt12' => 'Not coming',
                                   'utt_application_alerts' => 'Yes, required',
+                                  'application_alert_recipient' => 'application_alert_recipient@acmescitt.education.uk',
                                   'contacts' => [
                                     {
                                       'type' => 'admin',
@@ -323,9 +374,7 @@ describe 'Providers API', type: :request do
                                     },
                                     {
                                       'type' => 'application_alert_recipient',
-                                      'name' => 'Application Alert Recipient Contact A123',
                                       'email' => 'application_alert_recipient@acmescitt.education.uk',
-                                      'telephone' => '020 812 345 678'
                                     }
                                   ]
                                },
@@ -354,6 +403,7 @@ describe 'Providers API', type: :request do
                                  'recruitment_cycle' => '2019',
                                  'type_of_gt12' => 'Coming or Not',
                                  'utt_application_alerts' => 'No, not required',
+                                 'application_alert_recipient' => 'application_alert_recipient@acmeuniversity.education.uk',
                                  'contacts' => [
                                    {
                                      'type' => 'admin',
@@ -387,9 +437,7 @@ describe 'Providers API', type: :request do
                                    },
                                    {
                                      'type' => 'application_alert_recipient',
-                                     'name' => 'Application Alert Recipient Contact B123',
                                      'email' => 'application_alert_recipient@acmeuniversity.education.uk',
-                                     'telephone' => '01273 345 678'
                                    }
                                  ]
                                }

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -193,7 +193,6 @@ describe 'Providers API', type: :request do
                 'recruitment_cycle' => '2019',
                 'type_of_gt12' => 'Not coming',
                 'utt_application_alerts' => 'Yes, required',
-                'application_alert_recipient' => 'application_alert_recipient@acmescitt.education.uk',
                 'contacts' => [
                   {
                     'type' => 'admin',
@@ -227,7 +226,9 @@ describe 'Providers API', type: :request do
                   },
                   {
                     'type' => 'application_alert_recipient',
-                    'email' => 'application_alert_recipient@acmescitt.education.uk'
+                    'name' => '',
+                    'email' => 'application_alert_recipient@acmescitt.education.uk',
+                    'telephone' => ''
                   }
                 ]
               },
@@ -256,7 +257,6 @@ describe 'Providers API', type: :request do
                 'recruitment_cycle' => '2019',
                 'type_of_gt12' => 'Coming or Not',
                 'utt_application_alerts' => 'No, not required',
-                'application_alert_recipient' => 'application_alert_recipient@acmeuniversity.education.uk',
                 'contacts' => [
                   {
                     'type' => 'admin',
@@ -290,7 +290,9 @@ describe 'Providers API', type: :request do
                   },
                   {
                     'type' => 'application_alert_recipient',
-                    'email' => 'application_alert_recipient@acmeuniversity.education.uk'
+                    'name' => '',
+                    'email' => 'application_alert_recipient@acmeuniversity.education.uk',
+                    'telephone' => ''
                   }
                 ]
               }
@@ -340,7 +342,6 @@ describe 'Providers API', type: :request do
                                   'recruitment_cycle' => '2019',
                                   'type_of_gt12' => 'Not coming',
                                   'utt_application_alerts' => 'Yes, required',
-                                  'application_alert_recipient' => 'application_alert_recipient@acmescitt.education.uk',
                                   'contacts' => [
                                     {
                                       'type' => 'admin',
@@ -374,7 +375,9 @@ describe 'Providers API', type: :request do
                                     },
                                     {
                                       'type' => 'application_alert_recipient',
+                                      'name' => '',
                                       'email' => 'application_alert_recipient@acmescitt.education.uk',
+                                      'telephone' => ''
                                     }
                                   ]
                                },
@@ -403,7 +406,6 @@ describe 'Providers API', type: :request do
                                  'recruitment_cycle' => '2019',
                                  'type_of_gt12' => 'Coming or Not',
                                  'utt_application_alerts' => 'No, not required',
-                                 'application_alert_recipient' => 'application_alert_recipient@acmeuniversity.education.uk',
                                  'contacts' => [
                                    {
                                      'type' => 'admin',
@@ -437,7 +439,9 @@ describe 'Providers API', type: :request do
                                    },
                                    {
                                      'type' => 'application_alert_recipient',
+                                     'name' => '',
                                      'email' => 'application_alert_recipient@acmeuniversity.education.uk',
+                                     'telephone' => ''
                                    }
                                  ]
                                }

--- a/spec/serializers/contact_serializer_spec.rb
+++ b/spec/serializers/contact_serializer_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe ContactSerializer do
+  let(:contact) { create :contact }
+
+  subject { serialize(contact) }
+
+  its([:type]) { should eq contact.type }
+  its([:name]) { should eq contact.name }
+  its([:email]) { should eq contact.email }
+  its([:telephone]) { should eq contact.telephone }
+end

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -86,76 +86,16 @@ describe ProviderSerializer do
   end
 
   describe 'contacts' do
-    describe 'admin contact' do
-      let(:provider) do
-        create :provider,
-               contacts: [admin]
-      end
-      let(:admin) { create(:contact, type: 'admin') }
-
-      subject { serialize(provider)['contacts'].find { |c| c[:type] == 'admin' } }
-
-      its([:name]) { should eq admin.name }
-      its([:email]) { should eq admin.email }
-      its([:telephone]) { should eq admin.telephone }
+    let(:provider) do
+      create :provider,
+             contacts: [utt]
     end
+    let(:utt) { create(:contact, type: 'utt') }
 
-    describe 'utt contact' do
-      let(:provider) do
-        create :provider,
-               contacts: [utt]
-      end
-      let(:utt) { create(:contact, type: 'utt') }
+    subject { serialize(provider)['contacts'].find { |c| c[:type] == 'utt' } }
 
-      subject { serialize(provider)['contacts'].find { |c| c[:type] == 'utt' } }
-
-      its([:name]) { should eq utt.name }
-      its([:email]) { should eq utt.email }
-      its([:telephone]) { should eq utt.telephone }
-    end
-
-    describe 'web_link contact' do
-      let(:provider) do
-        create :provider,
-               contacts: [web_link]
-      end
-      let(:web_link) { create(:contact, type: 'web_link') }
-
-      subject { serialize(provider)['contacts'].find { |c| c[:type] == 'web_link' } }
-
-      its([:name]) { should eq web_link.name }
-      its([:email]) { should eq web_link.email }
-      its([:telephone]) { should eq web_link.telephone }
-    end
-
-    describe 'fraud contact' do
-      let(:provider) do
-        create :provider,
-               contacts: [fraud]
-      end
-
-      let(:fraud) { create(:contact, type: 'fraud') }
-
-      subject { serialize(provider)['contacts'].find { |c| c[:type] == 'fraud' } }
-
-      its([:name]) { should eq fraud.name }
-      its([:email]) { should eq fraud.email }
-      its([:telephone]) { should eq fraud.telephone }
-    end
-
-    describe 'finance contact' do
-      let(:provider) do
-        create :provider,
-               contacts: [finance]
-      end
-
-      let(:finance) { create(:contact, type: 'finance') }
-
-      subject { serialize(provider)['contacts'].find { |c| c[:type] == 'finance' } }
-
-      its([:name]) { should eq finance.name }
-      its([:email]) { should eq finance.email }
-      its([:telephone]) { should eq finance.telephone }
-    end
+    its([:name]) { should eq utt.name }
+    its([:email]) { should eq utt.email }
+    its([:telephone]) { should eq utt.telephone }
   end
 end

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -90,7 +90,7 @@ describe ProviderSerializer do
       create :provider,
              contacts: [utt]
     end
-    let(:utt) { create(:contact, type: 'utt') }
+    let(:utt) { create(:contact, :utt_type) }
 
     subject { serialize(provider)['contacts'].find { |c| c[:type] == 'utt' } }
 

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -84,4 +84,78 @@ describe ProviderSerializer do
 
     it { should eq provider.ucas_preferences.send_application_alerts_before_type_cast }
   end
+
+  describe 'contacts' do
+    describe 'admin contact' do
+      let(:provider) do
+        create :provider,
+               contacts: [admin]
+      end
+      let(:admin) { create(:contact, type: 'admin') }
+
+      subject { serialize(provider)['contacts'].find { |c| c[:type] == 'admin' } }
+
+      its([:name]) { should eq admin.name }
+      its([:email]) { should eq admin.email }
+      its([:telephone]) { should eq admin.telephone }
+    end
+
+    describe 'utt contact' do
+      let(:provider) do
+        create :provider,
+               contacts: [utt]
+      end
+      let(:utt) { create(:contact, type: 'utt') }
+
+      subject { serialize(provider)['contacts'].find { |c| c[:type] == 'utt' } }
+
+      its([:name]) { should eq utt.name }
+      its([:email]) { should eq utt.email }
+      its([:telephone]) { should eq utt.telephone }
+    end
+
+    describe 'web_link contact' do
+      let(:provider) do
+        create :provider,
+               contacts: [web_link]
+      end
+      let(:web_link) { create(:contact, type: 'web_link') }
+
+      subject { serialize(provider)['contacts'].find { |c| c[:type] == 'web_link' } }
+
+      its([:name]) { should eq web_link.name }
+      its([:email]) { should eq web_link.email }
+      its([:telephone]) { should eq web_link.telephone }
+    end
+
+    describe 'fraud contact' do
+      let(:provider) do
+        create :provider,
+               contacts: [fraud]
+      end
+
+      let(:fraud) { create(:contact, type: 'fraud') }
+
+      subject { serialize(provider)['contacts'].find { |c| c[:type] == 'fraud' } }
+
+      its([:name]) { should eq fraud.name }
+      its([:email]) { should eq fraud.email }
+      its([:telephone]) { should eq fraud.telephone }
+    end
+
+    describe 'finance contact' do
+      let(:provider) do
+        create :provider,
+               contacts: [finance]
+      end
+
+      let(:finance) { create(:contact, type: 'finance') }
+
+      subject { serialize(provider)['contacts'].find { |c| c[:type] == 'finance' } }
+
+      its([:name]) { should eq finance.name }
+      its([:email]) { should eq finance.email }
+      its([:telephone]) { should eq finance.telephone }
+    end
+  end
 end

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -86,16 +86,26 @@ describe ProviderSerializer do
   end
 
   describe 'contacts' do
-    let(:provider) do
-      create :provider,
-             contacts: [utt]
+    describe 'generate provider object returns the providers contacts' do
+      let(:provider) do
+        create :provider,
+               contacts: [contact]
+      end
+      let(:contact) { create(:contact) }
+
+      subject { serialize(provider)['contacts'].find { |c| c[:type] == contact.type } }
+
+      its([:name]) { should eq contact.name }
+      its([:email]) { should eq contact.email }
+      its([:telephone]) { should eq contact.telephone }
     end
-    let(:utt) { create(:contact, :utt_type) }
 
-    subject { serialize(provider)['contacts'].find { |c| c[:type] == 'utt' } }
+    describe 'the application alert recipient has been serialized upon instantiation of the contact object' do
+      subject { serialize(provider)['contacts'].find { |c| c[:type] == 'application_alert_recipient' } }
 
-    its([:name]) { should eq utt.name }
-    its([:email]) { should eq utt.email }
-    its([:telephone]) { should eq utt.telephone }
+      its([:name]) { should eq '' }
+      its([:email]) { should eq provider.ucas_preferences.application_alert_email }
+      its([:telephone]) { should eq '' }
+    end
   end
 end


### PR DESCRIPTION
### Context

We need to expose the provider contacts/application alert recipient  in the V1 API.

### Changes proposed in this pull request

- Attributes added to the contact factory bot
- Creates a contact serialiser 
- Removes dummy data logic from the provider serializer
- Adds application alert recipient as an attribute to the provider serialiser
- Adds contacts as an attribute to the alert serialiser

### Guidance to review

Application alert recipient is an anomalous contact as it is simply an email address that is contacted on application receipt. Due to this it has been added a column by UCAS preferences model and is exposed in the api via adding it manually to the Provider Serialiser contacts attribute.

Lines 38-43 of provider serialiser (see bold)

attribute :contacts do
    object.contacts.map { |c| c.attributes.slice('type', 'name', 'email', 'telephone') } + **[{
      type: 'application_alert_recipient',
      email: object.ucas_preferences.application_alert_email,
      }]**
  end