### PR TITLE
[1133] Add env vars for course republishing to VSTS

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -113,6 +113,18 @@
         "metadata": {
             "description": "Auth secret for manage back-end."
         }
+    },
+    "settingsManageApiBaseUrl": {
+        "type": "string",
+        "metadata": {
+            "description": "The base URL for manage-courses-api."
+        }
+    },
+    "settingsManageApiSecret": {
+        "type": "string",
+        "metadata": {
+            "description": "The secret shared between manage courses backend and manage courses API to authorize requests."
+        }
     }
   },
   "variables": {
@@ -233,6 +245,14 @@
               {
                   "name": "SETTINGS__AUTHENTICATION__SECRET",
                   "value": "[parameters('settingsAuthenticationSecret')]"
+              },
+              {
+                  "name": "SETTINGS__MANAGE_API__BASE_URL",
+                  "value": "[parameters('settingsManageApiBaseUrl')]"
+              },
+              {
+                  "name": "SETTINGS__MANAGE_API__SECRET",
+                  "value": "[parameters('settingsManageApiSecret')]"
               }
             ]
           },


### PR DESCRIPTION
### Context

This gives manage-courses-backend the information it needs to trigger course republishing on manage-courses-api.

Terraform prior art: https://github.com/DFE-Digital/bat-infrastructure/pull/119

### Guidance to review

I don't understand VSTS very well so don't know if adding this without going and poking the interface to define values for `settingsManageApiBaseUrl` and `settingsManageApiSecret` will cause everything to break.