### PR TITLE
[1025] Don't return 2020 data through the V1 API yet

### DIFF
--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -5,6 +5,12 @@ module API
       include FirstItemFromNextPage
 
       def index
+        # only return 2019 courses until rollover is supported
+        if params[:recruitment_year].present? && params[:recruitment_year] != '2019'
+          render json: [], status: 404
+          return
+        end
+
         per_page = (params[:per_page] || 100).to_i
         changed_since = params[:changed_since]
 

--- a/app/controllers/api/v1/providers_controller.rb
+++ b/app/controllers/api/v1/providers_controller.rb
@@ -15,6 +15,12 @@ module API
       #   to postgres
       # - clock drift between servers
       def index
+        # only return 2019 courses until rollover is supported
+        if params[:recruitment_year].present? && params[:recruitment_year] != '2019'
+          render json: [], status: 404
+          return
+        end
+
         per_page = params[:per_page] || 100
         changed_since = params[:changed_since]
         ActiveRecord::Base.transaction do

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -111,5 +111,22 @@ describe API::V1::CoursesController, type: :controller do
         its(%w[changed_since]) { should eq format_timestamp(changed_since) }
       end
     end
+
+    context "for next recruitment year" do
+      let!(:course) { create(:course) }
+      let(:params) {
+        { recruitment_year: '2020' }
+      }
+
+      before do
+        controller.index
+      end
+
+      describe 'returned courses in JSON' do
+        subject { response.body }
+
+        it { should_not have_courses }
+      end
+    end
   end
 end

--- a/spec/controllers/api/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/v1/providers_controller_spec.rb
@@ -111,5 +111,22 @@ describe API::V1::ProvidersController, type: :controller do
         its(%w[changed_since]) { should eq format_timestamp(changed_since) }
       end
     end
+
+    context "for next recruitment year" do
+      let!(:course) { create(:provider) }
+      let(:params) {
+        { recruitment_year: '2020' }
+      }
+
+      before do
+        controller.index
+      end
+
+      describe 'returned courses in JSON' do
+        subject { response.body }
+
+        it { should_not have_providers }
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context
UCAS are expecting to see no data returned for future recruitment years. This is a reasonable expectation until the API can handle courses from multiple cycles.

https://trello.com/c/D9OBiECj/1025-ensure-recruitmentcycle-2020-endpoints-are-returning-empty-data-sets

### Changes proposed in this pull request
Return a hardcoded empty list when the recruitment year isn't 2019.

### Guidance to review
This is a temporary state of affairs until rollover and multi-year courses are supported.
