### PR TITLE
quiet down jsonapi-rails' logging

### DIFF
--- a/config/initializers/jsonapi.rb
+++ b/config/initializers/jsonapi.rb
@@ -35,4 +35,15 @@ JSONAPI::Rails.configure do |config|
   #
   # # Set a default pagination scheme.
   # config.jsonapi_pagination = ->(_) { nil }
+  #
+  # # Set a logger.
+  # config.logger = Logger.new(STDOUT)
+  #
+  # Uncomment the following to disable logging.
+  # config.logger = Logger.new(STDOUT)
+
+  # This might be the right thing to do. It cleans up logging in the test env,
+  # at the very least, and seems to dump the logs into `log/test.log` as would
+  # be expected.
+  config.logger = Rails.logger
 end


### PR DESCRIPTION
This was introduced with the 0.3.1 -> 0.4.0 bump (++git bisect).

### Context

Since updating `jsonapi-rails` from 0.3.1 -> 0.4.0, logging has been added and enabled for all environments.

```
.I, [2019-03-26T21:47:55.947742 #80214]  INFO -- : Completed JSON API rendering (31.21ms)
.I, [2019-03-26T21:47:55.987199 #80214]  INFO -- : Completed JSON API rendering (3.02ms)
.I, [2019-03-26T21:47:56.035756 #80214]  INFO -- : Completed JSON API rendering (4.55ms)
.I, [2019-03-26T21:47:56.084163 #80214]  INFO -- : Completed JSON API rendering (3.23ms)
.I, [2019-03-26T21:47:56.176322 #80214]  INFO -- : Completed JSON API rendering (5.1ms)
.I, [2019-03-26T21:47:56.211181 #80214]  INFO -- : Completed JSON API rendering (2.33ms)
.I, [2019-03-26T21:47:56.264898 #80214]  INFO -- : Completed JSON API rendering (1.36ms)
```

### Changes proposed in this pull request

Disable logging in test env.

### GUideline 4 revoo

Buy me a donut if you like this change.