### PR TITLE
[1173] Make the provider serialiser more resilient

### DIFF
--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -90,11 +90,11 @@ class ProviderSerializer < ActiveModel::Serializer
   end
 
   def utt_application_alerts
-    @object.ucas_preferences.send_application_alerts_before_type_cast
+    @object.ucas_preferences&.send_application_alerts_before_type_cast
   end
 
   def type_of_gt12
-    @object.ucas_preferences.type_of_gt12_before_type_cast
+    @object.ucas_preferences&.type_of_gt12_before_type_cast
   end
 
 private
@@ -114,7 +114,7 @@ private
     [{
       type: 'application_alert_recipient',
       name: '',
-      email: object.ucas_preferences.application_alert_email,
+      email: object.ucas_preferences&.application_alert_email,
       telephone: ''
       }]
   end

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -85,6 +85,19 @@ describe ProviderSerializer do
     it { should eq provider.ucas_preferences.send_application_alerts_before_type_cast }
   end
 
+  context "when UCAS preferences are missing" do
+    before do
+      provider.ucas_preferences.destroy
+      provider.reload
+    end
+
+    it "handles the missing data gracefully" do
+      expect(subject['utt_application_alerts']).to be_nil
+      expect(subject['type_of_gt12']).to be_nil
+      expect(subject['contacts'].detect { |c| c['type'] == 'application_alert_recipient' }['email']).to be_nil
+    end
+  end
+
   describe 'contacts' do
     describe 'generate provider object returns the providers contacts' do
       let(:provider) do


### PR DESCRIPTION
### Context
The serialiser shouldn't fall over if the UCAS preferences aren't set for
some reason (they should be, theoretically, but it's impossible to guarantee this
given the state of the existing data).

### Changes proposed in this pull request
Guard against missing UCAS preferences.
