### PR TITLE
Switch to Rubocop for linting Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - docker-compose exec web /bin/sh -c "bundle exec rails db:setup"
 script:
   - docker-compose exec web /bin/sh -c "bundle exec rake spec"
-  - docker-compose exec web /bin/sh -c "bundle exec govuk-lint-ruby app config db lib spec Gemfile --format clang"
+  - docker-compose exec web /bin/sh -c "bundle exec rubocop app config db lib spec Gemfile --format clang"
 deploy:
   provider: script
   script: bash docker-push.sh

--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,9 @@ group :development, :test do
   gem 'rspec-json_matchers'
   gem 'rspec-rails'
 
+  # A Ruby static code analyzer and formatter
+  gem 'rubocop', require: false
+
   # Make diffs of Ruby objects much more readable
   gem 'super_diff'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,6 +381,7 @@ DEPENDENCIES
   rspec-json_matchers
   rspec-rails
   rspec_junit_formatter
+  rubocop
   schema_to_scaffold
   sentry-raven
   shoulda-matchers (~> 4.0)

--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ bundle exec rspec
 It's best to lint just your app directories and not those belonging to the framework:
 
 ```bash
-bundle exec govuk-lint-ruby app config db lib spec --format clang
+bundle exec rubocop app config db lib spec --format clang
 
 or
 
-docker-compose exec web /bin/sh -c "bundle exec govuk-lint-ruby app config db lib spec Gemfile --format clang"
+docker-compose exec web /bin/sh -c "bundle exec rubocop app config db lib spec Gemfile --format clang"
 ```
 
 ## Accessing API

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ steps:
     DOCKER_OVERRIDE: $(dockerOverride)
 
 - script: |
-    $DOCKER_OVERRIDE exec -T web /bin/sh -c "bundle exec govuk-lint-ruby app config db lib spec --format clang"
+    $DOCKER_OVERRIDE exec -T web /bin/sh -c "bundle exec rubocop app config db lib spec --format clang"
   displayName: 'Execute linters'
   env:
     DOCKER_OVERRIDE: $(dockerOverride)

--- a/lib/tasks/govuk_lint.rake
+++ b/lib/tasks/govuk_lint.rake
@@ -2,6 +2,6 @@ desc "Lint ruby code"
 namespace :lint do
   task :ruby do
     puts 'Linting...'
-    system 'bundle exec govuk-lint-ruby app config db lib spec Gemfile --format clang -a'
+    system 'bundle exec rubocop app config db lib spec Gemfile --format clang -a'
   end
 end


### PR DESCRIPTION
GOV.UK Lint is being deperacated, this is the new way of using it.

### Context

GOV.UK Lint is being deprecated, it's recommended to be used in this way instead.

I haven left the SCSS listing in there, they recommend using node based tooling for that instead.

### Changes proposed in this pull request

Switch from govuk-lint-ruby to Rubocop configured to use govuk-lint's rules.

### Guidance to review