### PR TITLE
[1180] Don't use enrichments to generate provider admin contacts

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -63,9 +63,8 @@ class Provider < ApplicationRecord
 
   scope :in_order, -> { order(:provider_name) }
 
-  # TODO: filter to published enrichments, maybe rename to published_address_info
   def contact_info
-    (enrichments.latest_created_at.with_contact_info.first || self)
+    self
       .attributes_before_type_cast
       .slice('address1', 'address2', 'address3', 'address4', 'postcode', 'region_code', 'telephone', 'email')
   end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -63,11 +63,16 @@ class Provider < ApplicationRecord
 
   scope :in_order, -> { order(:provider_name) }
 
-  def contact_info
-    self
-      .attributes_before_type_cast
-      .slice('address1', 'address2', 'address3', 'address4', 'postcode', 'region_code', 'telephone', 'email')
-  end
+  # Currently this isn't used but will likely be needed when
+  # we need to expose the candidate-facing contact info.
+  #
+  # When the time comes:
+  # - rename this method to reflect that it's the candidate-facing contact
+  # def contact_info
+  #   self
+  #     .attributes_before_type_cast
+  #     .slice('address1', 'address2', 'address3', 'address4', 'postcode', 'region_code', 'telephone', 'email')
+  # end
 
   def update_changed_at(timestamp: Time.now.utc)
     # Changed_at represents changes to related records as well as provider

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -63,11 +63,13 @@ class Provider < ApplicationRecord
 
   scope :in_order, -> { order(:provider_name) }
 
-  # Currently this isn't used but will likely be needed when
+  # Currently Provider#contact_info isn't used but will likely be needed when
   # we need to expose the candidate-facing contact info.
   #
   # When the time comes:
   # - rename this method to reflect that it's the candidate-facing contact
+  # - resurrect the tests which were stripped from models/provider_spec.rb
+  #
   # def contact_info
   #   self
   #     .attributes_before_type_cast

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -57,36 +57,8 @@ class ProviderSerializer < ActiveModel::Serializer
     object.provider_type_before_type_cast
   end
 
-  def address1
-    object.contact_info['address1']
-  end
-
-  def address2
-    object.contact_info['address2']
-  end
-
-  def address3
-    object.contact_info['address3']
-  end
-
-  def address4
-    object.contact_info['address4']
-  end
-
-  def postcode
-    object.contact_info['postcode']
-  end
-
-  def email
-    object.contact_info['email']
-  end
-
-  def telephone
-    object.contact_info['telephone']
-  end
-
   def region_code
-    "%02d" % object.contact_info['region_code'] if object.contact_info['region_code'].present?
+    "%02d" % object.region_code_before_type_cast if object.region_code.present?
   end
 
   def utt_application_alerts

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -56,23 +56,6 @@ describe Provider, type: :model do
     end
   end
 
-  describe '#contact_info' do
-    it 'returns address of the provider' do
-      provider = create(:provider, enrichments: [])
-
-      expect(provider.contact_info).to eq(
-        'address1' => provider.address1,
-        'address2' => provider.address2,
-        'address3' => provider.address3,
-        'address4' => provider.address4,
-        'postcode' => provider.postcode,
-        'region_code' => provider.region_code_before_type_cast,
-        'email' => provider.email,
-        'telephone' => provider.telephone
-      )
-    end
-  end
-
   describe '#changed_since' do
     context 'with a provider that has been changed after the given timestamp' do
       let(:provider) { create(:provider, changed_at: 5.minutes.ago) }

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -57,186 +57,19 @@ describe Provider, type: :model do
   end
 
   describe '#contact_info' do
-    context 'empty enrichments' do
-      it 'returns address of the provider' do
-        provider = create(:provider, enrichments: [])
+    it 'returns address of the provider' do
+      provider = create(:provider, enrichments: [])
 
-        expect(provider.contact_info).to eq(
-          'address1' => provider.address1,
-          'address2' => provider.address2,
-          'address3' => provider.address3,
-          'address4' => provider.address4,
-          'postcode' => provider.postcode,
-          'region_code' => provider.region_code_before_type_cast,
-          'email' => provider.email,
-          'telephone' => provider.telephone
-        )
-      end
-
-      context 'provider has enrichments' do
-        context 'enrichment has nothing set for contact_info' do
-          context 'via absent json_data fields' do
-            it 'returns address of the provider' do
-              enrichment = build(:provider_enrichment)
-              provider = create(:provider, enrichments: [enrichment])
-
-              # forcing all fields to be absent in json_data altogether
-              ProviderEnrichment.connection.update(<<~EOSQL)
-                UPDATE provider_enrichment
-                      SET json_data=json_data-'Address1'-'Address2'-'Address3'-'Address4'-'Postcode'-'RegionCode'-'Email'-'Telephone'
-                      WHERE provider_code='#{enrichment.provider_code}'
-              EOSQL
-
-              expect(provider.contact_info).to eq(
-                'address1' => provider.address1,
-                'address2' => provider.address2,
-                'address3' => provider.address3,
-                'address4' => provider.address4,
-                'postcode' => provider.postcode,
-                'region_code' => provider.region_code_before_type_cast,
-                'email' => provider.email,
-                'telephone' => provider.telephone
-              )
-            end
-          end
-          context 'via nil fields' do
-            it 'returns address of the provider' do
-              enrichment = build(:provider_enrichment,
-                  address1: nil,
-                  address2: nil,
-                  address3: nil,
-                  address4: nil,
-                  postcode: nil,
-                  region_code: nil,
-                  email: nil,
-                  telephone: nil)
-              provider = create(:provider, enrichments: [enrichment])
-
-              expect(provider.contact_info).to eq(
-                'address1' => provider.address1,
-                'address2' => provider.address2,
-                'address3' => provider.address3,
-                'address4' => provider.address4,
-                'postcode' => provider.postcode,
-                'region_code' => provider.region_code_before_type_cast,
-                'email' => provider.email,
-                'telephone' => provider.telephone
-              )
-            end
-          end
-        end
-
-        context 'enrichment is valid' do
-          it 'returns json_data from the first enrichment' do
-            enrichment = build(:provider_enrichment)
-            provider = create(:provider, enrichments: [enrichment])
-
-            expect(provider.contact_info).to eq(
-              'address1' => enrichment.address1,
-              'address2' => enrichment.address2,
-              'address3' => enrichment.address3,
-              'address4' => enrichment.address4,
-              'postcode' => enrichment.postcode,
-              'region_code' => enrichment.region_code_before_type_cast,
-              'email' => enrichment.email,
-              'telephone' => enrichment.telephone
-            )
-          end
-
-          it 'returns json_data from the newest enrichment' do
-            enrichment = build(:provider_enrichment)
-            newest_enrichment = build(:provider_enrichment, created_at: Date.today)
-            provider = create(:provider, enrichments: [enrichment, newest_enrichment])
-
-            expect(provider.contact_info).to eq(
-              'address1' => newest_enrichment.address1,
-              'address2' => newest_enrichment.address2,
-              'address3' => newest_enrichment.address3,
-              'address4' => newest_enrichment.address4,
-              'postcode' => newest_enrichment.postcode,
-              'region_code' => newest_enrichment.region_code_before_type_cast,
-              'email' => newest_enrichment.email,
-              'telephone' => newest_enrichment.telephone
-            )
-          end
-        end
-        context 'enrichment has partial set for contact_info' do
-          it 'returns address of the enrichment' do
-            enrichment = build(:provider_enrichment,
-              address2: nil,
-              address3: nil,
-              address4: nil,
-              postcode: nil,
-              email: nil,
-              telephone: nil)
-            provider = create(:provider, enrichments: [enrichment])
-
-            expect(provider.contact_info).to eq(
-              'address1' => enrichment.address1,
-              'address2' => enrichment.address2,
-              'address3' => enrichment.address3,
-              'address4' => enrichment.address4,
-              'postcode' => enrichment.postcode,
-              'region_code' => enrichment.region_code_before_type_cast,
-              'email' => enrichment.email,
-              'telephone' => enrichment.telephone
-            )
-          end
-
-          context 'enrichment has only region code set for contact_info' do
-            london = ProviderEnrichment.region_codes['London']
-            no_region = ProviderEnrichment.region_codes['No region']
-            context 'via absent json_data fields' do
-              it 'returns address of the provider' do
-                enrichment = build(:provider_enrichment, region_code: no_region,)
-                provider = create(:provider, region_code: london, enrichments: [enrichment])
-
-                # forcing all fields apart region_code to be absent in json_data altogether
-                ProviderEnrichment.connection.update(<<~EOSQL)
-                  UPDATE provider_enrichment
-                        SET json_data=json_data-'Address1'-'Address2'-'Address3'-'Address4'-'Postcode'-'RegionCode'-'Email'-'Telephone'
-                        WHERE provider_code='#{enrichment.provider_code}'
-                EOSQL
-
-                expect(provider.contact_info).to eq(
-                  'address1' => provider.address1,
-                  'address2' => provider.address2,
-                  'address3' => provider.address3,
-                  'address4' => provider.address4,
-                  'postcode' => provider.postcode,
-                  'region_code' => provider.region_code_before_type_cast,
-                  'email' => provider.email,
-                  'telephone' => provider.telephone
-                )
-              end
-            end
-            context 'via nil fields' do
-              it 'returns address of the provider' do
-                enrichment = build(:provider_enrichment, region_code: no_region,
-                address1: nil,
-                address2: nil,
-                address3: nil,
-                address4: nil,
-                postcode: nil,
-                email: nil,
-                telephone: nil)
-                provider = create(:provider, region_code: london, enrichments: [enrichment])
-
-                expect(provider.contact_info).to eq(
-                  'address1' => provider.address1,
-                  'address2' => provider.address2,
-                  'address3' => provider.address3,
-                  'address4' => provider.address4,
-                  'postcode' => provider.postcode,
-                  'region_code' => provider.region_code_before_type_cast,
-                  'email' => provider.email,
-                  'telephone' => provider.telephone
-                )
-              end
-            end
-          end
-        end
-      end
+      expect(provider.contact_info).to eq(
+        'address1' => provider.address1,
+        'address2' => provider.address2,
+        'address3' => provider.address3,
+        'address4' => provider.address4,
+        'postcode' => provider.postcode,
+        'region_code' => provider.region_code_before_type_cast,
+        'email' => provider.email,
+        'telephone' => provider.telephone
+      )
     end
   end
 

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -65,7 +65,7 @@ describe 'Providers API', type: :request do
                accrediting_provider: 'Y',
                scheme_member: 'Y',
                last_published_at: DateTime.now.utc,
-               enrichments: [enrichment],
+               enrichments: [],
                ucas_preferences: ucas_preferences,
                contacts: contacts)
       end
@@ -75,17 +75,6 @@ describe 'Providers API', type: :request do
               code: '-',
               region_code: :london,
               provider: provider)
-      end
-      let(:enrichment) do
-        build(:provider_enrichment,
-              address1: 'Sydney Russell School',
-              address2: '',
-              address3: 'Dagenham',
-              address4: 'Essex',
-              postcode: 'RM9 5QT',
-              email: 'sydney-russell-school@education.gov.uk',
-              telephone: '020 8123 1234',
-              region_code: :scotland)
       end
       let(:ucas_preferences2) do
         build(:ucas_preferences,
@@ -160,293 +149,143 @@ describe 'Providers API', type: :request do
 
       it 'includes correct next link in response headers'
 
-      context 'with enrichment contact data' do
-        it 'JSON body response contains expected provider attributes' do
-          get '/api/v1/2019/providers',
-              headers: { 'HTTP_AUTHORIZATION' => credentials }
+      it 'JSON body response contains expected provider attributes' do
+        get '/api/v1/2019/providers',
+            headers: { 'HTTP_AUTHORIZATION' => credentials }
 
-          json = JSON.parse(response.body)
-          expect(json).to eq(
-            [
-              {
-                'accrediting_provider' => 'Y',
-                'campuses' => [
-                  {
-                    'campus_code' => '-',
-                    'name' => 'Main site',
-                    'region_code' => '01',
-                  }
-                ],
-                'institution_code' => 'A123',
-                'institution_name' => 'ACME SCITT',
-                'institution_type' => 'B',
-                'address1' => 'Sydney Russell School',
-                'address2' => '',
-                'address3' => 'Dagenham',
-                'address4' => 'Essex',
-                'postcode' => 'RM9 5QT',
-                'region_code' => '11',
-                'scheme_member' => 'Y',
-                'telephone' => '020 8123 1234',
-                'email' => 'sydney-russell-school@education.gov.uk',
-                'contact_name' => 'Amy Smith',
-                'recruitment_cycle' => '2019',
-                'type_of_gt12' => 'Not coming',
-                'utt_application_alerts' => 'Yes, required',
-                'contacts' => [
-                  {
-                    'type' => 'admin',
-                    'name' => 'Admin Contact A123',
-                    'email' => 'admin@acmescitt.education.uk',
-                    'telephone' => '020 812 345 678'
-                  },
-                  {
-                    'type' => 'utt',
-                    'name' => 'Utt Contact A123',
-                    'email' => 'utt@acmescitt.education.uk',
-                    'telephone' => '020 812 345 678'
-                  },
-                  {
-                    'type' => 'web_link',
-                    'name' => 'Web Link Contact A123',
-                    'email' => 'web_link@acmescitt.education.uk',
-                    'telephone' => '020 812 345 678'
-                  },
-                  {
-                    'type' => 'fraud',
-                    'name' => 'Fraud Contact A123',
-                    'email' => 'fraud@acmescitt.education.uk',
-                    'telephone' => '020 812 345 678'
-                  },
-                  {
-                    'type' => 'finance',
-                    'name' => 'Finance Contact A123',
-                    'email' => 'finance@acmescitt.education.uk',
-                    'telephone' => '020 812 345 678'
-                  },
-                  {
-                    'type' => 'application_alert_recipient',
-                    'name' => '',
-                    'email' => 'application_alert_recipient@acmescitt.education.uk',
-                    'telephone' => ''
-                  }
-                ]
-              },
-              {
-                'accrediting_provider' => 'N',
-                'campuses' => [
-                  {
-                    'campus_code' => '-',
-                    'name' => 'Main site',
-                    'region_code' => '11',
-                  }
-                ],
-                'institution_code' => 'B123',
-                'institution_name' => 'ACME University',
-                'institution_type' => 'O',
-                'address1' => 'Bee School',
-                'address2' => 'Bee Avenue',
-                'address3' => 'Bee City',
-                'address4' => 'Bee Hive',
-                'postcode' => 'B3 3BB',
-                'region_code' => '03',
-                'scheme_member' => 'N',
-                'telephone' => '01273 345 678',
-                'email' => 'info@acmeuniversity.education.uk',
-                'contact_name' => 'James Brown',
-                'recruitment_cycle' => '2019',
-                'type_of_gt12' => 'Coming or Not',
-                'utt_application_alerts' => 'No, not required',
-                'contacts' => [
-                  {
-                    'type' => 'admin',
-                    'name' => 'Admin Contact B123',
-                    'email' => 'admin@acmeuniversity.education.uk',
-                    'telephone' => '01273 345 678'
-                  },
-                  {
-                    'type' => 'utt',
-                    'name' => 'Utt Contact B123',
-                    'email' => 'utt@acmeuniversity.education.uk',
-                    'telephone' => '01273 345 678'
-                  },
-                  {
-                    'type' => 'web_link',
-                    'name' => 'Web Link Contact B123',
-                    'email' => 'web_link@acmeuniversity.education.uk',
-                    'telephone' => '01273 345 678'
-                  },
-                  {
-                    'type' => 'fraud',
-                    'name' => 'Fraud Contact B123',
-                    'email' => 'fraud@acmeuniversity.education.uk',
-                    'telephone' => '01273 345 678'
-                  },
-                  {
-                    'type' => 'finance',
-                    'name' => 'Finance Contact B123',
-                    'email' => 'finance@acmeuniversity.education.uk',
-                    'telephone' => '01273 345 678'
-                  },
-                  {
-                    'type' => 'application_alert_recipient',
-                    'name' => '',
-                    'email' => 'application_alert_recipient@acmeuniversity.education.uk',
-                    'telephone' => ''
-                  }
-                ]
-              }
-            ]
-          )
-        end
-      end
-
-      context 'without enrichment contact data' do
-        it 'JSON body response contains expected provider attributes' do
-          # Simulate a provider enrichment that has no contact data. It's not just
-          # a matter of the attributes being nil, the data is actually missing
-          # from json_data
-          ProviderEnrichment.connection.update(<<~EOSQL)
-            UPDATE provider_enrichment
-                  SET json_data=json_data-'Address1'-'Address2'-'Address3'-'Address4'-'Postcode'-'RegionCode'-'Email'-'Telephone'
-                  WHERE provider_code='#{enrichment.provider_code}'
-          EOSQL
-
-          get '/api/v1/providers',
-              headers: { 'HTTP_AUTHORIZATION' => credentials }
-
-          json = JSON.parse(response.body)
-          expect(json).to eq([
-                               {
-                                  'accrediting_provider' => 'Y',
-                                  'campuses' => [
-                                    {
-                                      'campus_code' => '-',
-                                      'name' => 'Main site',
-                                      'region_code' => '01',
-                                    }
-                                  ],
-                                  'institution_code' => 'A123',
-                                  'institution_name' => 'ACME SCITT',
-                                  'institution_type' => 'B',
-                                  'address1' => 'Shoreditch Park Primary School',
-                                  'address2' => '313 Bridport Pl',
-                                  'address3' => nil,
-                                  'address4' => 'London',
-                                  'postcode' => 'N1 5JN',
-                                  'region_code' => '01',
-                                  'scheme_member' => 'Y',
-                                  'telephone' => '020 812 345 678',
-                                  'email' => 'info@acmescitt.education.uk',
-                                  'contact_name' => 'Amy Smith',
-                                  'recruitment_cycle' => '2019',
-                                  'type_of_gt12' => 'Not coming',
-                                  'utt_application_alerts' => 'Yes, required',
-                                  'contacts' => [
-                                    {
-                                      'type' => 'admin',
-                                      'name' => 'Admin Contact A123',
-                                      'email' => 'admin@acmescitt.education.uk',
-                                      'telephone' => '020 812 345 678'
-                                    },
-                                    {
-                                      'type' => 'utt',
-                                      'name' => 'Utt Contact A123',
-                                      'email' => 'utt@acmescitt.education.uk',
-                                      'telephone' => '020 812 345 678'
-                                    },
-                                    {
-                                      'type' => 'web_link',
-                                      'name' => 'Web Link Contact A123',
-                                      'email' => 'web_link@acmescitt.education.uk',
-                                      'telephone' => '020 812 345 678'
-                                    },
-                                    {
-                                      'type' => 'fraud',
-                                      'name' => 'Fraud Contact A123',
-                                      'email' => 'fraud@acmescitt.education.uk',
-                                      'telephone' => '020 812 345 678'
-                                    },
-                                    {
-                                      'type' => 'finance',
-                                      'name' => 'Finance Contact A123',
-                                      'email' => 'finance@acmescitt.education.uk',
-                                      'telephone' => '020 812 345 678'
-                                    },
-                                    {
-                                      'type' => 'application_alert_recipient',
-                                      'name' => '',
-                                      'email' => 'application_alert_recipient@acmescitt.education.uk',
-                                      'telephone' => ''
-                                    }
-                                  ]
-                               },
-                               {
-                                 'accrediting_provider' => 'N',
-                                 'campuses' => [
-                                   {
-                                     'campus_code' => '-',
-                                     'name' => 'Main site',
-                                     'region_code' => '11',
-                                   }
-                                 ],
-                                 'institution_code' => 'B123',
-                                 'institution_name' => 'ACME University',
-                                 'institution_type' => 'O',
-                                 'address1' => 'Bee School',
-                                 'address2' => 'Bee Avenue',
-                                 'address3' => 'Bee City',
-                                 'address4' => 'Bee Hive',
-                                 'postcode' => 'B3 3BB',
-                                 'region_code' => '03',
-                                 'scheme_member' => 'N',
-                                 'telephone' => '01273 345 678',
-                                 'email' => 'info@acmeuniversity.education.uk',
-                                 'contact_name' => 'James Brown',
-                                 'recruitment_cycle' => '2019',
-                                 'type_of_gt12' => 'Coming or Not',
-                                 'utt_application_alerts' => 'No, not required',
-                                 'contacts' => [
-                                   {
-                                     'type' => 'admin',
-                                     'name' => 'Admin Contact B123',
-                                     'email' => 'admin@acmeuniversity.education.uk',
-                                     'telephone' => '01273 345 678'
-                                   },
-                                   {
-                                     'type' => 'utt',
-                                     'name' => 'Utt Contact B123',
-                                     'email' => 'utt@acmeuniversity.education.uk',
-                                     'telephone' => '01273 345 678'
-                                   },
-                                   {
-                                     'type' => 'web_link',
-                                     'name' => 'Web Link Contact B123',
-                                     'email' => 'web_link@acmeuniversity.education.uk',
-                                     'telephone' => '01273 345 678'
-                                   },
-                                   {
-                                     'type' => 'fraud',
-                                     'name' => 'Fraud Contact B123',
-                                     'email' => 'fraud@acmeuniversity.education.uk',
-                                     'telephone' => '01273 345 678'
-                                   },
-                                   {
-                                     'type' => 'finance',
-                                     'name' => 'Finance Contact B123',
-                                     'email' => 'finance@acmeuniversity.education.uk',
-                                     'telephone' => '01273 345 678'
-                                   },
-                                   {
-                                     'type' => 'application_alert_recipient',
-                                     'name' => '',
-                                     'email' => 'application_alert_recipient@acmeuniversity.education.uk',
-                                     'telephone' => ''
-                                   }
-                                 ]
-                               }
-                             ])
-        end
+        json = JSON.parse(response.body)
+        expect(json).to eq(
+          [
+            {
+              'accrediting_provider' => 'Y',
+              'campuses' => [
+                {
+                  'campus_code' => '-',
+                  'name' => 'Main site',
+                  'region_code' => '01',
+                }
+              ],
+              'institution_code' => 'A123',
+              'institution_name' => 'ACME SCITT',
+              'institution_type' => 'B',
+              'address1' => 'Shoreditch Park Primary School',
+              'address2' => '313 Bridport Pl',
+              'address3' => nil,
+              'address4' => 'London',
+              'postcode' => 'N1 5JN',
+              'region_code' => '01',
+              'scheme_member' => 'Y',
+              'telephone' => '020 812 345 678',
+              'email' => 'info@acmescitt.education.uk',
+              'contact_name' => 'Amy Smith',
+              'recruitment_cycle' => '2019',
+              'type_of_gt12' => 'Not coming',
+              'utt_application_alerts' => 'Yes, required',
+              'contacts' => [
+                {
+                  'type' => 'admin',
+                  'name' => 'Admin Contact A123',
+                  'email' => 'admin@acmescitt.education.uk',
+                  'telephone' => '020 812 345 678'
+                },
+                {
+                  'type' => 'utt',
+                  'name' => 'Utt Contact A123',
+                  'email' => 'utt@acmescitt.education.uk',
+                  'telephone' => '020 812 345 678'
+                },
+                {
+                  'type' => 'web_link',
+                  'name' => 'Web Link Contact A123',
+                  'email' => 'web_link@acmescitt.education.uk',
+                  'telephone' => '020 812 345 678'
+                },
+                {
+                  'type' => 'fraud',
+                  'name' => 'Fraud Contact A123',
+                  'email' => 'fraud@acmescitt.education.uk',
+                  'telephone' => '020 812 345 678'
+                },
+                {
+                  'type' => 'finance',
+                  'name' => 'Finance Contact A123',
+                  'email' => 'finance@acmescitt.education.uk',
+                  'telephone' => '020 812 345 678'
+                },
+                {
+                  'type' => 'application_alert_recipient',
+                  'name' => '',
+                  'email' => 'application_alert_recipient@acmescitt.education.uk',
+                  'telephone' => ''
+                }
+              ]
+            },
+            {
+              'accrediting_provider' => 'N',
+              'campuses' => [
+                {
+                  'campus_code' => '-',
+                  'name' => 'Main site',
+                  'region_code' => '11',
+                }
+              ],
+              'institution_code' => 'B123',
+              'institution_name' => 'ACME University',
+              'institution_type' => 'O',
+              'address1' => 'Bee School',
+              'address2' => 'Bee Avenue',
+              'address3' => 'Bee City',
+              'address4' => 'Bee Hive',
+              'postcode' => 'B3 3BB',
+              'region_code' => '03',
+              'scheme_member' => 'N',
+              'telephone' => '01273 345 678',
+              'email' => 'info@acmeuniversity.education.uk',
+              'contact_name' => 'James Brown',
+              'recruitment_cycle' => '2019',
+              'type_of_gt12' => 'Coming or Not',
+              'utt_application_alerts' => 'No, not required',
+              'contacts' => [
+                {
+                  'type' => 'admin',
+                  'name' => 'Admin Contact B123',
+                  'email' => 'admin@acmeuniversity.education.uk',
+                  'telephone' => '01273 345 678'
+                },
+                {
+                  'type' => 'utt',
+                  'name' => 'Utt Contact B123',
+                  'email' => 'utt@acmeuniversity.education.uk',
+                  'telephone' => '01273 345 678'
+                },
+                {
+                  'type' => 'web_link',
+                  'name' => 'Web Link Contact B123',
+                  'email' => 'web_link@acmeuniversity.education.uk',
+                  'telephone' => '01273 345 678'
+                },
+                {
+                  'type' => 'fraud',
+                  'name' => 'Fraud Contact B123',
+                  'email' => 'fraud@acmeuniversity.education.uk',
+                  'telephone' => '01273 345 678'
+                },
+                {
+                  'type' => 'finance',
+                  'name' => 'Finance Contact B123',
+                  'email' => 'finance@acmeuniversity.education.uk',
+                  'telephone' => '01273 345 678'
+                },
+                {
+                  'type' => 'application_alert_recipient',
+                  'name' => '',
+                  'email' => 'application_alert_recipient@acmeuniversity.education.uk',
+                  'telephone' => ''
+                }
+              ]
+            }
+          ]
+        )
       end
     end
 

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -36,42 +36,17 @@ describe ProviderSerializer do
 
   it { should include(institution_code: provider.provider_code) }
   it { should include(institution_name: provider.provider_name) }
-  it { should include(address1: provider.enrichments.last.address1) }
-  it { should include(address2: provider.enrichments.last.address2) }
-  it { should include(address3: provider.enrichments.last.address3) }
-  it { should include(address4: provider.enrichments.last.address4) }
-  it { should include(postcode: provider.enrichments.last.postcode) }
+  it { should include(address1: provider.address1) }
+  it { should include(address2: provider.address2) }
+  it { should include(address3: provider.address3) }
+  it { should include(address4: provider.address4) }
+  it { should include(postcode: provider.postcode) }
+  it { should include(region_code: provider.region_code) }
   it { should include(institution_type: provider.provider_type) }
   it { should include(accrediting_provider: provider.accrediting_provider) }
   it { should include(contact_name: provider.contact_name) }
-  it { should include(email: provider.enrichments.last.email) }
-  it { should include(telephone: provider.enrichments.last.telephone) }
-
-  describe 'ProviderSerializer#region_code' do
-    subject do
-      serialize(provider)["region_code"]
-    end
-
-    describe "provider region code 'London' can be overriden by enrichment region code 'Scotland'" do
-      let(:enrichment) do
-        build(:provider_enrichment, region_code: :scotland)
-      end
-
-      let(:provider) { create :provider, region_code: :london, enrichments: [enrichment] }
-      it { is_expected.not_to eql("%02d" % 1) }
-      it { is_expected.to eql("%02d" % 11) }
-    end
-
-    describe "provider region code 00 is overriden with enrichment region code" do
-      let(:enrichment) do
-        build(:provider_enrichment, region_code: region_code)
-      end
-      let(:region_code) { 1 }
-      let(:provider) { create :provider, region_code: 0, enrichments: [enrichment] }
-      it { is_expected.to eql("%02d" % region_code) }
-      it { is_expected.not_to eql("%02d" % 0) }
-    end
-  end
+  it { should include(email: provider.email) }
+  it { should include(telephone: provider.telephone) }
 
   describe 'type_of_gt12' do
     subject { serialize(provider)['type_of_gt12'] }


### PR DESCRIPTION
### Context
We have been conflating the external, candidate-facing contact (that's the
data on the enrichment) with the admin/back-office contact that DfE/UCAS use
to get in touch with the provider.

### Changes proposed in this pull request
This change separates the two pieces of data; from now on, the Provider API V1
will use the provider contact details that are on the Provider record.

### Guidance to review
So much red.