### PR TITLE
[1181] use admin contact in provider record if not in contacts table

### DIFF
--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -107,7 +107,21 @@ private
   end
 
   def generate_provider_contacts
-    object.contacts.map { |c| c.attributes.slice('type', 'name', 'email', 'telephone') }
+    provider_contacts = object.contacts.map do |c|
+      c.attributes.slice('type', 'name', 'email', 'telephone')
+    end
+
+    has_admin_contact = provider_contacts.any? { |c| c['type'] == 'admin' }
+    unless has_admin_contact
+      provider_contacts.prepend(
+        type: 'admin',
+        name: object.contact_name,
+        email: object.email,
+        telephone: object.telephone
+      )
+    end
+
+    provider_contacts
   end
 
   def application_alert_recipient

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -36,6 +36,7 @@ FactoryBot.define do
     address3 { Faker::Address.city }
     address4 { Faker::Address.state }
     postcode { Faker::Address.postcode }
+    contact_name { Faker::Name.name }
     email { Faker::Internet.email }
     telephone { Faker::PhoneNumber.phone_number }
     accrediting_provider { 'N' }

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -87,13 +87,10 @@ describe ProviderSerializer do
 
   describe 'contacts' do
     describe 'generate provider object returns the providers contacts' do
-      let(:provider) do
-        create :provider,
-               contacts: [contact]
-      end
-      let(:contact) { create(:contact) }
+      let(:contact)  { create :contact }
+      let(:provider) { create :provider, contacts: [contact] }
 
-      subject { serialize(provider)['contacts'].find { |c| c[:type] == contact.type } }
+      subject { serialize(provider)['contacts'].first }
 
       its([:name]) { should eq contact.name }
       its([:email]) { should eq contact.email }
@@ -106,6 +103,29 @@ describe ProviderSerializer do
       its([:name]) { should eq '' }
       its([:email]) { should eq provider.ucas_preferences.application_alert_email }
       its([:telephone]) { should eq '' }
+    end
+
+    describe 'admin contact' do
+      context 'exists on provider record and not in contacts table' do
+        let(:provider) { create :provider }
+
+        subject { serialize(provider)['contacts'].find { |c| c[:type] == 'admin' } }
+
+        its([:name]) { should eq provider.contact_name }
+        its([:email]) { should eq provider.email }
+        its([:telephone]) { should eq provider.telephone }
+      end
+
+      context 'exists in contacts table' do
+        let(:contact)  { create :contact, type: 'admin' }
+        let(:provider) { create :provider, contacts: [contact] }
+
+        subject { serialize(provider)['contacts'].find { |c| c[:type] == 'admin' } }
+
+        its([:name]) { should eq contact.name }
+        its([:email]) { should eq contact.email }
+        its([:telephone]) { should eq contact.telephone }
+      end
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/WRv7HyW0/1181-provider-contacts-use-table-for-admin-contact-with-fallback

### Context

To facilitate the gradual transition of providers to the separation of front-office contacts (for candidates) and back-office admin contact (for UCAS), we want to support either retrieving the admin contact from the provider record (our old model) or retrieving the admin contact from the contacts table (the new model).

### Changes proposed in this pull request

When serialising the provider use the admin contact from the provider record if present.
