### PR TITLE
[1212] Add mcb command to generate JWT tokens

### DIFF
--- a/lib/mcb/commands/apiv2.rb
+++ b/lib/mcb/commands/apiv2.rb
@@ -1,0 +1,2 @@
+name 'apiv2'
+summary 'Commands that target the V2 endpoint'

--- a/lib/mcb/commands/apiv2/token.rb
+++ b/lib/mcb/commands/apiv2/token.rb
@@ -1,0 +1,2 @@
+name 'token'
+summary 'Commands that operate on the V2 JWT token'

--- a/lib/mcb/commands/apiv2/token/generate.rb
+++ b/lib/mcb/commands/apiv2/token/generate.rb
@@ -1,0 +1,14 @@
+name 'generate'
+summary 'Generate a JWT token using the secret'
+usage 'generate [options] <code>'
+param :email
+option :S, 'secret', 'the JWT secret', argument: :required
+
+
+run do |opts, args, _cmd|
+  require 'jwt'
+  payload = { email: args[:email] }
+  token = JWT.encode(payload, opts[:secret], 'HS256')
+
+  puts "Token: #{token}"
+end


### PR DESCRIPTION
### Context
Generating JWT tokens is a bit of a pain

### Changes proposed in this pull request
Add an `mcb` command which helps generate tokens.
