### PR TITLE
[1202] add tag for bat environment for mcb

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,5 +4,6 @@ class ApplicationController < ActionController::API
 
   # child must define authenticate method
   before_action :authenticate
+  before_action :bat_environment
   after_action :verify_authorized
 end

--- a/app/controllers/error_controller.rb
+++ b/app/controllers/error_controller.rb
@@ -1,4 +1,6 @@
 class ErrorController < ActionController::API
+  before_action :bat_environment
+
   def error_500
     raise "This is an error that is triggered by the application when a user accesses the /error_500 route. If you are seeing this in logs, you can ignore it."
   end

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -6,3 +6,7 @@ Raven.configure do |config|
   config.excluded_exceptions = Raven::Configuration::IGNORE_DEFAULT -
     ['ActiveRecord::RecordNotFound']
 end
+
+def bat_environment
+  Raven.tags_context(bat_environment: ENV['SENTRY_ENVIRONMENT'])
+end


### PR DESCRIPTION
### Context

When error messages come through on sentry, there is no quick way to determine which env (dev, stag, prod) the error has originated from.

### Changes proposed in this pull request

- Adds a bat_environment tag which shows the SENTRY_ENVIRONMENT variable at the top of the message. This env variable has been set in azure. 

