### PR TITLE
[1160] publish course

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -2,6 +2,7 @@ module API
   module V2
     class CoursesController < API::V2::ApplicationController
       before_action :build_provider
+      before_action :build_course, except: :index
 
       def index
         authorize @provider, :can_list_courses?
@@ -11,14 +12,18 @@ module API
       end
 
       def show
-        course = authorize Course.where(provider: @provider).find_by!(course_code: params[:code].upcase)
-        render jsonapi: course, include: [site_statuses: [:site]]
+        render jsonapi: @course, include: [site_statuses: [:site]]
       end
 
     private
 
       def build_provider
         @provider = Provider.find_by!(provider_code: params[:provider_code].upcase)
+      end
+
+      def build_course
+        @course = Course.where(provider: @provider).find_by!(course_code: params[:code].upcase)
+        authorize @course
       end
     end
   end

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -15,6 +15,15 @@ module API
         render jsonapi: @course, include: [site_statuses: [:site]]
       end
 
+      def publish
+        response = ManageCoursesAPI::Request.publish_course(
+          @current_user.email,
+          @provider.provider_code,
+          @course.course_code
+        )
+        render jsonapi: {}
+      end
+
     private
 
       def build_provider

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -15,13 +15,14 @@ module API
         render jsonapi: @course, include: [site_statuses: [:site]]
       end
 
-      def publish
-        response = ManageCoursesAPI::Request.publish_course(
+      def sync_with_search_and_compare
+        response = ManageCoursesAPI::Request.sync_course_with_search_and_compare(
           @current_user.email,
           @provider.provider_code,
           @course.course_code
         )
-        render jsonapi: {}
+
+        head response ? :ok : :internal_server_error
       end
 
     private
@@ -31,7 +32,7 @@ module API
       end
 
       def build_course
-        @course = Course.where(provider: @provider).find_by!(course_code: params[:code].upcase)
+        @course = @provider.courses.find_by!(course_code: params[:code].upcase)
         authorize @course
       end
     end

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -15,4 +15,5 @@ class CoursePolicy
   end
 
   alias_method :update?, :show?
+  alias_method :publish?, :update?
 end

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -15,5 +15,5 @@ class CoursePolicy
   end
 
   alias_method :update?, :show?
-  alias_method :publish?, :update?
+  alias_method :sync_with_search_and_compare?, :update?
 end

--- a/app/services/manage_courses_api.rb
+++ b/app/services/manage_courses_api.rb
@@ -1,23 +1,23 @@
 module ManageCoursesAPI
   class Connection
-    BASE_URL = Settings.manage_api.base_url
-    TOKEN = Settings.manage_api.secret
-
     def self.api
-      Faraday.new(url: BASE_URL) do |faraday|
+      Faraday.new(url: Settings.manage_api.base_url) do |faraday|
         faraday.response :logger unless Rails.env.test?
         faraday.adapter Faraday.default_adapter
         faraday.headers['Content-Type'] = 'application/json'
-        faraday.headers['Authorization'] = "Bearer #{TOKEN}"
+        faraday.headers['Authorization'] = "Bearer #{Settings.manage_api.secret}"
       end
     end
   end
 
   class Request
     class << self
-      def publish_course(email, provider_code, course_code)
-        response = api.post("/api/Publish/internal/course/#{provider_code}/#{course_code}", email: email)
-        if response.status == 200
+      def sync_course_with_search_and_compare(email, provider_code, course_code)
+        response = api.post(
+          "/api/Publish/internal/course/#{provider_code}/#{course_code}",
+          email: email
+        )
+        if response.success?
           JSON.parse(response.body)["result"]
         else
           false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,9 +63,7 @@ Rails.application.routes.draw do
 
       resources :providers, param: :code do
         resources :courses, param: :code, only: %i[index create show] do
-          member do
-            post :sync_with_search_and_compare
-          end
+          post :sync_with_search_and_compare, on: :member
         end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,7 +64,7 @@ Rails.application.routes.draw do
       resources :providers, param: :code do
         resources :courses, param: :code, only: %i[index create show] do
           member do
-            post :publish
+            post :sync_with_search_and_compare
           end
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,11 @@ Rails.application.routes.draw do
       end
 
       resources :providers, param: :code do
-        resources :courses, param: :code, only: %i[index create show]
+        resources :courses, param: :code, only: %i[index create show] do
+          member do
+            post :publish
+          end
+        end
       end
 
       resource :sessions

--- a/spec/factories/apiv2_token.rb
+++ b/spec/factories/apiv2_token.rb
@@ -1,0 +1,23 @@
+require 'ostruct'
+
+# We only need this strategy here for the moment.
+class JWTStrategy
+  def association; end
+
+  def result(evaluation)
+    JWT.encode evaluation.object.payload,
+               evaluation.object.secret,
+               evaluation.object.algorithm
+  end
+end
+
+FactoryBot.register_strategy(:build_jwt, JWTStrategy)
+
+FactoryBot.define do
+  factory :apiv2, class: OpenStruct do
+    secret    { Settings.authentication.secret }
+    algorithm { Settings.authentication.algorithm }
+    email     { 'foobar@localhost' }
+    payload   { { email: email } }
+  end
+end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -4,11 +4,7 @@ describe 'Courses API v2', type: :request do
   let(:user) { create(:user) }
   let(:organisation) { create(:organisation, users: [user]) }
   let(:payload) { { email: user.email } }
-  let(:token) do
-    JWT.encode payload,
-                Settings.authentication.secret,
-                Settings.authentication.algorithm
-  end
+  let(:token) { build_jwt :apiv2, payload: payload }
   let(:credentials) do
     ActionController::HttpAuthentication::Token.encode_credentials(token)
   end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -134,80 +134,72 @@ describe 'Courses API v2', type: :request do
     end
   end
 
-  describe 'POST publish' do
+  describe 'POST sync_with_search_and_compare' do
+    let(:api_status)   { 200 }
+    let(:api_response) { '{ "result": true }' }
     let!(:stubbed_manage_courses_api_request) do
       stub_request(:post, %r{#{Settings.manage_api.base_url}/api/Publish/internal/course/})
-      .to_return(
-        status: 200,
-        body: '{ "result": true }'
-      )
+        .to_return(
+          status: api_status,
+          body: api_response
+        )
+    end
+    let(:sync_path) do
+      "/api/v2/providers/#{provider.provider_code}" +
+        "/courses/#{course.course_code}/sync_with_search_and_compare"
+    end
+    let(:course) { findable_open_course }
+
+    subject do
+      post sync_path, headers: { 'HTTP_AUTHORIZATION' => credentials }
+      response
     end
 
     context 'when unauthenticated' do
       let(:payload) { { email: 'foo@bar' } }
 
-      before do
-        post "/api/v2/providers/#{provider.provider_code}/courses/#{findable_open_course.course_code}/publish",
-            headers: { 'HTTP_AUTHORIZATION' => credentials }
-      end
-
       it { should have_http_status(:unauthorized) }
     end
 
     context 'when user has not accepted terms' do
-      let(:user_without_terms_accepted) { create(:user, accept_terms_date_utc: nil) }
-      let(:organisation) { create(:organisation, users: [user, user_without_terms_accepted]) }
-      let(:payload) { { email: user_without_terms_accepted.email } }
-
-      before do
-        post "/api/v2/providers/#{provider.provider_code}/courses/#{findable_open_course.course_code}/publish",
-            headers: { 'HTTP_AUTHORIZATION' => credentials }
-      end
+      let(:user)         { create(:user, accept_terms_date_utc: nil) }
+      let(:organisation) { create(:organisation, users: [user]) }
 
       it { should have_http_status(:forbidden) }
     end
 
     context 'when unauthorised' do
       let(:unauthorised_user) { create(:user) }
-      let(:payload) { { email: unauthorised_user.email } }
+      let(:payload)           { { email: unauthorised_user.email } }
 
       it "raises an error" do
-        expect {
-          post "/api/v2/providers/#{provider.provider_code}/courses/#{findable_open_course.course_code}/publish",
-              headers: { 'HTTP_AUTHORIZATION' => credentials }
-        }.to raise_error Pundit::NotAuthorizedError
+        expect { subject }.to raise_error Pundit::NotAuthorizedError
       end
     end
 
     context 'when course and provider is not related' do
       let(:course) { create(:course) }
-      it "raises an error" do
-        expect {
-          post "/api/v2/providers/#{provider.provider_code}/courses/#{course.course_code}/publish",
-              headers: { 'HTTP_AUTHORIZATION' => credentials }
-        }.to raise_error ActiveRecord::RecordNotFound
+
+      it 'raises an error' do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
       end
     end
 
-    describe 'publishing a course' do
-      before do
-        post "/api/v2/providers/#{provider.provider_code}/courses/#{findable_open_course.course_code}/publish",
-            headers: { 'HTTP_AUTHORIZATION' => credentials }
-      end
-
+    context 'when the api responds with a success' do
       it { should have_http_status(:success) }
+    end
 
-      it 'has a data section with the correct attributes' do
-        json_response = JSON.parse response.body
-        expect(json_response).to eq(
-          "data" => nil,
-          "jsonapi" => { "version" => "1.0" },
-        )
-      end
+    context 'when the api responds with result: false' do
+      let(:api_response) { '{ "result": false }' }
 
-      it 'calls Manage Courses API' do
-        expect(stubbed_manage_courses_api_request).to have_been_made
-      end
+      it { should have_http_status(:internal_server_error) }
+    end
+
+    context 'when the api sets http status to 500' do
+      let(:api_status)   { 500 }
+      let(:api_response) { '{ "result": true }' }
+
+      it { should have_http_status(:internal_server_error) }
     end
   end
 

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -144,6 +144,83 @@ describe 'Courses API v2', type: :request do
     end
   end
 
+  describe 'POST publish' do
+    let!(:stubbed_manage_courses_api_request) do
+      stub_request(:post, %r{#{Settings.manage_api.base_url}/api/Publish/internal/course/})
+      .to_return(
+        status: 200,
+        body: '{ "result": true }'
+      )
+    end
+
+    context 'when unauthenticated' do
+      let(:payload) { { email: 'foo@bar' } }
+
+      before do
+        post "/api/v2/providers/#{provider.provider_code}/courses/#{findable_open_course.course_code}/publish",
+            headers: { 'HTTP_AUTHORIZATION' => credentials }
+      end
+
+      it { should have_http_status(:unauthorized) }
+    end
+
+    context 'when user has not accepted terms' do
+      let(:user_without_terms_accepted) { create(:user, accept_terms_date_utc: nil) }
+      let(:organisation) { create(:organisation, users: [user, user_without_terms_accepted]) }
+      let(:payload) { { email: user_without_terms_accepted.email } }
+
+      before do
+        post "/api/v2/providers/#{provider.provider_code}/courses/#{findable_open_course.course_code}/publish",
+            headers: { 'HTTP_AUTHORIZATION' => credentials }
+      end
+
+      it { should have_http_status(:forbidden) }
+    end
+
+    context 'when unauthorised' do
+      let(:unauthorised_user) { create(:user) }
+      let(:payload) { { email: unauthorised_user.email } }
+
+      it "raises an error" do
+        expect {
+          post "/api/v2/providers/#{provider.provider_code}/courses/#{findable_open_course.course_code}/publish",
+              headers: { 'HTTP_AUTHORIZATION' => credentials }
+        }.to raise_error Pundit::NotAuthorizedError
+      end
+    end
+
+    context 'when course and provider is not related' do
+      let(:course) { create(:course) }
+      it "raises an error" do
+        expect {
+          post "/api/v2/providers/#{provider.provider_code}/courses/#{course.course_code}/publish",
+              headers: { 'HTTP_AUTHORIZATION' => credentials }
+        }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+
+    describe 'publishing a course' do
+      before do
+        post "/api/v2/providers/#{provider.provider_code}/courses/#{findable_open_course.course_code}/publish",
+            headers: { 'HTTP_AUTHORIZATION' => credentials }
+      end
+
+      it { should have_http_status(:success) }
+
+      it 'has a data section with the correct attributes' do
+        json_response = JSON.parse response.body
+        expect(json_response).to eq(
+          "data" => nil,
+          "jsonapi" => { "version" => "1.0" },
+        )
+      end
+
+      it 'calls Manage Courses API' do
+        expect(stubbed_manage_courses_api_request).to have_been_made
+      end
+    end
+  end
+
   describe 'GET index' do
     context 'when unauthenticated' do
       let(:payload) { { email: 'foo@bar' } }

--- a/spec/services/manage_courses_api_spec.rb
+++ b/spec/services/manage_courses_api_spec.rb
@@ -20,7 +20,7 @@ describe ManageCoursesAPI do
   describe "Request" do
     subject { ManageCoursesAPI::Request }
 
-    describe "publish_course" do
+    describe 'sync_course_with_search_and_compare' do
       let(:provider_code) { 'X12' }
       let(:course_code) { 'X123' }
       let(:email) { 'foo@bar' }
@@ -37,7 +37,9 @@ describe ManageCoursesAPI do
         end
 
         it "returns true" do
-          result = subject.publish_course(email, provider_code, course_code)
+          result = subject.sync_course_with_search_and_compare(
+            email, provider_code, course_code
+          )
           expect(result).to eq(true)
         end
       end


### PR DESCRIPTION
### Context

When a course is updated, e.g. vacancy statuses are changed, it needs to be pushed out to the `search_and_compare` system.

### Changes proposed in this pull request

Implement an API endpoint that can be used to trigger the syncing of a course to `search_and_compare`.

