### PR TITLE
[1213] suppress application alert recipient in provider serialiser if…

### DIFF
--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -41,7 +41,11 @@ class ProviderSerializer < ActiveModel::Serializer
              # see generate_provider_contacts and return_application_alert_recipient for logic.
 
   attribute :contacts do
-    generate_provider_contacts + application_alert_recipient
+    if application_alert_recipient
+      generate_provider_contacts + application_alert_recipient
+    else
+      generate_provider_contacts
+    end
   end
 
   def institution_code
@@ -96,11 +100,13 @@ private
   end
 
   def application_alert_recipient
-    [{
-      type: 'application_alert_recipient',
-      name: '',
-      email: object.ucas_preferences&.application_alert_email,
-      telephone: ''
-      }]
+    if object.ucas_preferences&.application_alert_email
+      [{
+        type: 'application_alert_recipient',
+        name: '',
+        email: object.ucas_preferences&.application_alert_email,
+        telephone: ''
+        }]
+    end
   end
 end

--- a/spec/factories/provider_ucas_preferences.rb
+++ b/spec/factories/provider_ucas_preferences.rb
@@ -16,6 +16,8 @@ FactoryBot.define do
   factory :provider_ucas_preference, aliases: [:ucas_preferences] do
     provider
 
+    application_alert_email { Faker::Internet.email }
+
     type_of_gt12 do
       %i[
         coming_or_not

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -80,7 +80,7 @@ describe 'Providers API', type: :request do
         build(:ucas_preferences,
               type_of_gt12: :coming_or_not,
               send_application_alerts: :none,
-              application_alert_email: 'application_alert_recipient@acmeuniversity.education.uk')
+              application_alert_email: nil)
       end
       let(:contacts2) do
         [
@@ -269,12 +269,6 @@ describe 'Providers API', type: :request do
                   'name' => 'Finance Contact B123',
                   'email' => 'finance@acmeuniversity.education.uk',
                   'telephone' => '01273 345 678'
-                },
-                {
-                  'type' => 'application_alert_recipient',
-                  'name' => '',
-                  'email' => 'application_alert_recipient@acmeuniversity.education.uk',
-                  'telephone' => ''
                 }
               ]
             }


### PR DESCRIPTION
### Context
Previously, the provider serialiser added the application alert recipient if nil. This PR fixes that.

### Changes proposed in this pull request
- Added a conditional which only adds the application alert recipient if the email is not nil

### Guidance to review
- I'm feeling really unsure about the change i made to Jake's previous test. If i left the test for "handles the missing data gracefully"  as:
`expect(subject['contacts'].detect { |c| c['type'] == 'application_alert_recipient' }['email']).to be_nil`
rather than: 
`expect(subject['contacts'].detect { |c| c['type'] == 'application_alert_recipient' }).to be_nil`

it fails, as it returns an empty array.

Would also appreciate some input on possibly renaming the generate_provider_contacts, generate_contacts and application_alert recipient method names.