### PR TITLE
[1216] Add content status

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -104,4 +104,15 @@ class Course < ApplicationRecord
       study_mode_description
     qualifications_description + study_mode_string + program_type_description
   end
+
+  def enrichments
+    # This isn't implemented with pure ActiveRecord associations because for historic reasons,
+    # CourseEnrichment uses `course_code` and `provider_code` instead of
+    # `course_id` and `provider_id`. This should be fixed when the UCAS data model
+    # is revisited.
+    CourseEnrichment.where(
+      provider_code: self.provider.provider_code,
+      ucas_course_code: self.course_code
+    )
+  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -115,4 +115,18 @@ class Course < ApplicationRecord
       ucas_course_code: self.course_code
     )
   end
+
+  def content_status
+    newest_enrichment = enrichments.order('created_at desc').first
+
+    if newest_enrichment.nil?
+      :empty
+    elsif newest_enrichment.published?
+      :published
+    elsif newest_enrichment.has_been_published_before?
+      :published_with_unpublished_changes
+    else
+      :draft
+    end
+  end
 end

--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: course_enrichment
+#
+#  id                           :integer          not null, primary key
+#  created_by_user_id           :integer
+#  created_at                   :datetime         not null
+#  provider_code                :text             not null
+#  json_data                    :jsonb
+#  last_published_timestamp_utc :datetime
+#  status                       :integer          not null
+#  ucas_course_code             :text             not null
+#  updated_by_user_id           :integer
+#  updated_at                   :datetime         not null
+#
+
+class CourseEnrichment < ApplicationRecord
+end

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -4,7 +4,8 @@ module API
       type 'courses'
 
       attributes :findable?, :open_for_applications?, :has_vacancies?,
-                 :course_code, :name, :study_mode, :qualifications, :description
+                 :course_code, :name, :study_mode, :qualifications, :description,
+                 :content_status
 
       attribute :start_date do
         @object.start_date&.iso8601

--- a/spec/factories/course_enrichments.rb
+++ b/spec/factories/course_enrichments.rb
@@ -14,6 +14,24 @@
 #  updated_at                   :datetime         not null
 #
 
-class CourseEnrichment < ApplicationRecord
-  enum status: %i[draft published]
+FactoryBot.define do
+  factory :course_enrichment do
+    sequence(:provider_code) { |n| "A#{n}" }
+    sequence(:ucas_course_code) { |n| "C#{n}D3" }
+    status { :draft }
+  end
+
+  trait :initial_draft do
+    last_published_timestamp_utc { nil }
+  end
+
+  trait :published do
+    status { :published }
+    last_published_timestamp_utc { 5.days.ago }
+  end
+
+  trait :subsequent_draft do
+    status { :draft }
+    last_published_timestamp_utc { 5.days.ago }
+  end
 end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -34,6 +34,7 @@ FactoryBot.define do
 
     transient do
       with_site_statuses { [] }
+      with_enrichments { [] }
       age { nil }
     end
 
@@ -53,6 +54,14 @@ FactoryBot.define do
         else
           create(:site_status, *traits, attrs)
         end
+      end
+
+      evaluator.with_enrichments.each do |trait, attributes = {}|
+        defaults = {
+          ucas_course_code: course.course_code,
+          provider_code: course.provider.provider_code,
+        }
+        create(:course_enrichment, trait, attributes.merge(defaults))
       end
     end
 

--- a/spec/factory_specs/course_enrichment_spec.rb
+++ b/spec/factory_specs/course_enrichment_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe 'Course enrichment factory' do
+  context "initial draft enrichment" do
+    subject { create(:course_enrichment, :initial_draft) }
+
+    it { should be_valid }
+    its(:last_published_timestamp_utc) { should be_nil }
+    its(:published?) { should be_falsey }
+  end
+
+  context "published enrichment" do
+    subject { create(:course_enrichment, :published) }
+
+    it { should be_valid }
+    its(:last_published_timestamp_utc) { should_not be_nil }
+    its(:published?) { should be_truthy }
+  end
+
+  context "subsequent draft enrichment" do
+    subject { create(:course_enrichment, :subsequent_draft) }
+
+    it { should be_valid }
+    its(:last_published_timestamp_utc) { should_not be_nil }
+    its(:published?) { should be_falsey }
+  end
+end

--- a/spec/factory_specs/course_spec.rb
+++ b/spec/factory_specs/course_spec.rb
@@ -10,4 +10,22 @@ describe "Course factory" do
     subject { create(:course, :resulting_in_pgde) }
     its(:qualification) { should eq("pgde") }
   end
+
+  context "with_course_enrichments" do
+    subject {
+      create(:course, with_enrichments: [
+        [:published, created_at: 5.days.ago],
+        [:published, created_at: 3.days.ago],
+        [:subsequent_draft, created_at: 1.day.ago],
+      ])
+    }
+
+    it "has enrichments" do
+      expect(subject.enrichments.size).to eq(3)
+
+      expect(CourseEnrichment.where('created_at < ?', Time.now).count).to eq(3)
+      expect(CourseEnrichment.where('created_at < ?', 2.days.ago).count).to eq(2)
+      expect(CourseEnrichment.where('created_at < ?', 4.days.ago).count).to eq(1)
+    end
+  end
 end

--- a/spec/factory_specs/course_spec.rb
+++ b/spec/factory_specs/course_spec.rb
@@ -1,18 +1,13 @@
 require 'rails_helper'
 
-describe "Course Factory" do
-  let(:course) { create(:course) }
+describe "Course factory" do
+  subject { create(:course) }
 
-  it "created course" do
-    expect(course).to be_instance_of(Course)
-    expect(course).to be_valid
-  end
+  it { should be_instance_of(Course) }
+  it { should be_valid }
 
   context "course resulting_in_pgde" do
-    let(:course) { create(:course, :resulting_in_pgde) }
-
-    it "created course" do
-      expect(course.qualification).to eq("pgde")
-    end
+    subject { create(:course, :resulting_in_pgde) }
+    its(:qualification) { should eq("pgde") }
   end
 end

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -14,10 +14,21 @@
 #  updated_at                   :datetime         not null
 #
 
-class CourseEnrichment < ApplicationRecord
-  enum status: %i[draft published]
+require 'rails_helper'
 
-  def has_been_published_before?
-    last_published_timestamp_utc.present?
+describe CourseEnrichment, type: :model do
+  context 'when the enrichment is an initial draft' do
+    subject { create(:course_enrichment, :initial_draft) }
+    it { should_not have_been_published_before }
+  end
+
+  context 'when the enrichment is published' do
+    subject { create(:course_enrichment, :published) }
+    it { should have_been_published_before }
+  end
+
+  context 'when the enrichment is a subsequent draft' do
+    subject { create(:course_enrichment, :subsequent_draft) }
+    it { should have_been_published_before }
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -333,4 +333,31 @@ RSpec.describe Course, type: :model do
       it { should_not include(course) }
     end
   end
+
+  describe "#content_status" do
+    context "for a course without any enrichments" do
+      subject { create(:course, with_enrichments: []) }
+      its(:content_status) { should eq(:empty) }
+    end
+
+    context "for a course an initial draft enrichments" do
+      subject { create(:course, with_enrichments: [[:initial_draft]]) }
+      its(:content_status) { should eq(:draft) }
+    end
+
+    context "for a course with a single published enrichment" do
+      subject { create(:course, with_enrichments: [[:published]]) }
+      its(:content_status) { should eq(:published) }
+    end
+
+    context "for a course with multiple published enrichments" do
+      subject { create(:course, with_enrichments: [[:published], [:published]]) }
+      its(:content_status) { should eq(:published) }
+    end
+
+    context "for a course with published enrichments and a draft one" do
+      subject { create(:course, with_enrichments: [[:published], [:subsequent_draft]]) }
+      its(:content_status) { should eq(:published_with_unpublished_changes) }
+    end
+  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -334,6 +334,28 @@ RSpec.describe Course, type: :model do
     end
   end
 
+  describe "#enrichments" do
+    subject {
+      create(:course, with_enrichments: [
+        [:published, created_at: 5.days.ago],
+        [:published, created_at: 3.days.ago],
+        [:subsequent_draft, created_at: 1.day.ago],
+      ]).enrichments
+    }
+
+    let(:another_course) {
+      create(:course, with_enrichments: [
+        [:published, created_at: 5.days.ago],
+      ])
+    }
+
+    its(:size) { should eq(3) }
+
+    it "doesn't overlap with enrichments from another course" do
+      expect(subject & another_course.enrichments).to be_empty
+    end
+  end
+
   describe "#content_status" do
     context "for a course without any enrichments" do
       subject { create(:course, with_enrichments: []) }

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -93,7 +93,8 @@ describe 'Courses API v2', type: :request do
               "start_date" => provider.courses[0].start_date.iso8601,
               "study_mode" => "full_time",
               "qualifications" => %w[qts pgce],
-              "description" => "PGCE with QTS full time"
+              "description" => "PGCE with QTS full time",
+              "content_status" => "empty",
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },
@@ -250,7 +251,8 @@ describe 'Courses API v2', type: :request do
               "start_date" => provider.courses[0].start_date.iso8601,
               "study_mode" => "full_time",
               "qualifications" => %w[qts pgce],
-              "description" => "PGCE with QTS full time"
+              "description" => "PGCE with QTS full time",
+              "content_status" => "empty",
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -12,4 +12,5 @@ describe API::V2::SerializableCourse do
 
   it { should be_json.with_content(type: 'courses') }
   it { should be_json.with_content(course.start_date.iso8601).at_path("attributes.start_date") }
+  it { should be_json.with_content(course.content_status.to_s).at_path("attributes.content_status") }
 end


### PR DESCRIPTION
### Context
The course enrichment status is shown to publishers in the course table

### Changes proposed in this pull request
Add `content_status` to Course API V2.

### Guidance to review
This does a query per-course, which means N+1 queries on the courses table. We may need to consider performance going forward.