### PR TITLE
[1160] Fix how Faraday is used

### DIFF
--- a/app/services/manage_courses_api.rb
+++ b/app/services/manage_courses_api.rb
@@ -15,7 +15,7 @@ module ManageCoursesAPI
       def sync_course_with_search_and_compare(email, provider_code, course_code)
         response = api.post(
           "/api/Publish/internal/course/#{provider_code}/#{course_code}",
-          email: email
+          { email: email }.to_json
         )
         if response.success?
           JSON.parse(response.body)["result"]

--- a/spec/services/manage_courses_api_spec.rb
+++ b/spec/services/manage_courses_api_spec.rb
@@ -29,7 +29,7 @@ describe ManageCoursesAPI do
       describe "with a normal response" do
         before do
           stub_request(:post, Settings.manage_api.base_url + "/api/Publish/internal/course/#{provider_code}/#{course_code}")
-            .with { |req| req.body == body }
+            .with { |req| req.body == body.to_json }
             .to_return(
               status: 200,
               body: '{ "result": true }'


### PR DESCRIPTION
### Context
Without this fix, Faraday throws an exception:

```
NoMethodError: undefined method `bytesize' for {:email=>"xxxx"}:Hash
```

### Changes proposed in this pull request
According to https://github.com/lostisland/faraday/issues/726, we should be calling
a `to_json` on the body.
