### PR TITLE
[1234] optionally include sites with provider show endpoint

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -15,7 +15,7 @@ module API
         provider = Provider.find_by!(provider_code: params[:code].upcase)
         authorize provider, :show?
 
-        render jsonapi: provider
+        render jsonapi: provider, include: params[:include]
       end
 
     private

--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -11,6 +11,8 @@ module API
         @object.provider_name
       end
 
+      has_many :sites
+
       has_many :courses do
         meta do
           { count: @object.courses.size }


### PR DESCRIPTION
### Context
Training locations.

We need to expose `sites` on the provider#show endpoint in order to allow users access to update the `sites` aka training locations

### Changes proposed in this pull request
- Optionally include `sites` on provider#show endpoint

### Guidance to review
Example url to test `localhost:3001/api/v2/providers/A9?include=sites`
