### PR TITLE
[1205] request confirmation when running against Azure app

### DIFF
--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -1,7 +1,7 @@
 require 'logger'
 
 module MCB
-  LOGGER = Logger.new(STDOUT)
+  LOGGER = Logger.new(STDERR)
 
   LOGGER.formatter = proc do |severity, _datetime, _progname, msg|
     if severity == Logger::INFO

--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -19,9 +19,15 @@ module MCB
     unless defined?(Rails)
       app_root = File.expand_path(File.join(File.dirname($0), '..'))
       exec_path = File.join(app_root, 'bin', 'rails')
-      ENV["DISABLE_SPRING"] = "true" # prevent caching of environment variables by spring
+
+      # prevent caching of environment variables by spring
+      ENV["DISABLE_SPRING"] = "true"
+
       verbose("Running #{exec_path}")
-      exec(exec_path, 'runner', $0, *ARGV)
+
+      # --webapp only needs to be processed on the first time through
+      new_argv = remove_option_with_arg(ARGV, '--webapp')
+      exec(exec_path, 'runner', $0, *new_argv)
     end
   end
 
@@ -59,4 +65,20 @@ module MCB
     verbose("Running: #{cmd}")
     `#{cmd}`
   end
+
+  def self.remove_option_with_arg(argv, *options)
+    argv.dup.tap do |new_argv|
+      options.each do |option|
+        if (index = new_argv.find_index { |o| o == option })
+          new_argv.delete_at index
+          # delete the argument as well as the option
+          new_argv.delete_at index
+        else
+          new_argv.delete_if { |o| o.match %r{#{option}=} }
+        end
+      end
+    end
+  end
+
+  private_class_method :remove_option_with_arg
 end

--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -15,7 +15,9 @@ module MCB
   #
   # Not all mcb commands require the rails env, e.g. the API ones don't. Use
   # this method in those commands that do.
-  def self.init_rails
+  def self.init_rails(**opts)
+    MCB::Azure.configure_for_webapp(opts) if opts.key? :webapp
+
     unless defined?(Rails)
       app_root = File.expand_path(File.join(File.dirname($0), '..'))
       exec_path = File.join(app_root, 'bin', 'rails')

--- a/lib/mcb/azure.rb
+++ b/lib/mcb/azure.rb
@@ -36,6 +36,27 @@ module MCB
       ENV['DB_DATABASE'] = app_config["PG_DATABASE"]
       ENV['DB_USERNAME'] = app_config["PG_USERNAME"]
       ENV['DB_PASSWORD'] = app_config["PG_PASSWORD"]
+
+    # Pull in the app config from Azure and prompt the user for the
+    # RAILS_ENV to make sure they are running against the environment they
+    # expect.
+    #
+    # We use keyword params here to accept the opts that are passed into
+    # the commands.
+    def self.configure_for_webapp(webapp:, rgroup: nil, **_opts)
+      rgroup ||= rgroup_for_app(webapp)
+      app_config = MCB::Azure.get_config(webapp, rgroup: rgroup)
+
+      # TODO: only require confirmation on commands that write to the db
+      print "As a safety measure, please enter the expected RAILS_ENV for #{webapp}: "
+      expected_environment = $stdin.readline.chomp
+
+      if app_config['RAILS_ENV'] != expected_environment
+        raise "RAILS_ENV for #{webapp} does not match: " \
+              "#{app_config['RAILS_ENV']} != #{expected_environment}"
+      end
+
+      MCB::Azure.configure_database(webapp, app_config: app_config)
     end
   end
 end

--- a/lib/mcb/azure.rb
+++ b/lib/mcb/azure.rb
@@ -10,7 +10,16 @@ module MCB
       JSON.parse(raw_json)
     end
 
-    def self.get_config(app, rgroup)
+    def self.rgroup_for_app(app)
+      MCB::Azure
+        .get_apps
+        .select { |s| s["name"] == app }
+        .first
+        .fetch('resourceGroup')
+    end
+
+    def self.get_config(app, rgroup: nil)
+      rgroup ||= rgroup_for_app(app)
       raw_json = MCB::run_command(
         "az webapp config appsettings list -g #{rgroup} -n #{app}"
       )
@@ -18,13 +27,8 @@ module MCB
       config.map { |c| [c["name"], c["value"]] }.to_h
     end
 
-    def self.configure_database(app)
-      rgroup = MCB::Azure
-                 .get_apps
-                 .select { |s| s["name"] == app }
-                 .first
-                 .fetch('resourceGroup')
-      app_config = MCB::Azure.get_config(app, rgroup)
+    def self.configure_database(app, app_config: nil)
+      app_config ||= MCB::Azure.get_config(app)
       ENV['DB_HOSTNAME'] = app_config["MANAGE_COURSES_POSTGRESQL_SERVICE_HOST"]
       ENV['DB_DATABASE'] = app_config["PG_DATABASE"]
       ENV['DB_USERNAME'] = app_config["PG_USERNAME"]

--- a/lib/mcb/azure.rb
+++ b/lib/mcb/azure.rb
@@ -16,6 +16,9 @@ module MCB
         .select { |s| s["name"] == app }
         .first
         .fetch('resourceGroup')
+    rescue # rubocop: disable Style/RescueStandardError
+      MCB::LOGGER.error("could not retrieve resource group for app #{app}, " \
+                        "is this the right subscription?")
     end
 
     def self.get_config(app, rgroup: nil)

--- a/lib/mcb/azure.rb
+++ b/lib/mcb/azure.rb
@@ -32,10 +32,16 @@ module MCB
 
     def self.configure_database(app, app_config: nil)
       app_config ||= MCB::Azure.get_config(app)
-      ENV['DB_HOSTNAME'] = app_config["MANAGE_COURSES_POSTGRESQL_SERVICE_HOST"]
-      ENV['DB_DATABASE'] = app_config["PG_DATABASE"]
-      ENV['DB_USERNAME'] = app_config["PG_USERNAME"]
-      ENV['DB_PASSWORD'] = app_config["PG_PASSWORD"]
+
+      [%w[DB_HOSTNAME MANAGE_COURSES_POSTGRESQL_SERVICE_HOST],
+       %w[DB_DATABASE PG_DATABASE],
+       %w[DB_USERNAME PG_USERNAME],
+       %w[DB_PASSWORD PG_PASSWORD]].each do |rails_env_var, csharp_env_var|
+        ENV[rails_env_var] = app_config.fetch(rails_env_var) do |key|
+          app_config.fetch(key)
+        end
+      end
+    end
 
     # Pull in the app config from Azure and prompt the user for the
     # RAILS_ENV to make sure they are running against the environment they

--- a/lib/mcb/azure.rb
+++ b/lib/mcb/azure.rb
@@ -37,8 +37,8 @@ module MCB
        %w[DB_DATABASE PG_DATABASE],
        %w[DB_USERNAME PG_USERNAME],
        %w[DB_PASSWORD PG_PASSWORD]].each do |rails_env_var, csharp_env_var|
-        ENV[rails_env_var] = app_config.fetch(rails_env_var) do |key|
-          app_config.fetch(key)
+        ENV[rails_env_var] = app_config.fetch(rails_env_var) do
+          app_config.fetch(csharp_env_var)
         end
       end
     end

--- a/lib/mcb/commands/az/apps/config.rb
+++ b/lib/mcb/commands/az/apps/config.rb
@@ -8,5 +8,5 @@ param :rgroup
 run do |_opts, args, _cmd|
   app = args[:app]
   rgroup = args[:rgroup]
-  puts MCB::Azure.get_config(app, rgroup)
+  puts MCB::Azure.get_config(app, rgroup: rgroup)
 end

--- a/lib/mcb/commands/az/apps/psql.rb
+++ b/lib/mcb/commands/az/apps/psql.rb
@@ -1,9 +1,15 @@
 name 'psql'
 summary 'connect to the psql server for an app'
-param :app
 
-run do |_opts, args, _cmd|
-  MCB::Azure.configure_database(args[:app])
+option :A, 'webapp',
+       'Connect to the database of this webapp',
+       argument: :required
+option :G, 'rgroup',
+       'Use resource group for app (can be auto-discovered)',
+       argument: :required
+
+run do |opts, _args, _cmd|
+  MCB::Azure.configure_for_webapp(opts) if opts.key? :webapp
 
   ENV['PGPASSWORD'] = ENV['DB_PASSWORD']
   psql = "psql -h #{ENV['DB_HOSTNAME']} -U #{ENV['DB_USERNAME']} -d #{ENV['DB_DATABASE']}"

--- a/lib/mcb/commands/providers.rb
+++ b/lib/mcb/commands/providers.rb
@@ -2,19 +2,9 @@ name 'provider'
 summary 'Operate on providers directly in db'
 default_subcommand 'list'
 
-option nil, 'webapp',
+option :A, 'webapp',
        'Connect to the database of this webapp',
-       argument: :required do |webapp|
-  app_config = MCB::Azure.get_config(webapp)
-
-  # TODO: we should only require confirmation on commands that write to the db
-  print "As a safety measure, please enter the expected RAILS_ENV for #{webapp}: "
-  expected_environment = $stdin.readline.chomp
-
-  if app_config['RAILS_ENV'] != expected_environment
-    raise "RAILS_ENV for #{webapp} does not match: " \
-          "#{app_config['RAILS_ENV']} != #{expected_environment}"
-  end
-
-  MCB::Azure.configure_database(webapp, app_config: app_config)
-end
+       argument: :required
+option :G, 'rgroup',
+       'Use resource group for app (can be auto-discovered)',
+       argument: :required

--- a/lib/mcb/commands/providers.rb
+++ b/lib/mcb/commands/providers.rb
@@ -5,7 +5,16 @@ default_subcommand 'list'
 option nil, 'webapp',
        'Connect to the database of this webapp',
        argument: :required do |webapp|
-  if webapp
-    MCB::Azure.configure_database(webapp)
+  app_config = MCB::Azure.get_config(webapp)
+
+  # TODO: we should only require confirmation on commands that write to the db
+  print "As a safety measure, please enter the expected RAILS_ENV for #{webapp}: "
+  expected_environment = $stdin.readline.chomp
+
+  if app_config['RAILS_ENV'] != expected_environment
+    raise "RAILS_ENV for #{webapp} does not match: " \
+          "#{app_config['RAILS_ENV']} != #{expected_environment}"
   end
+
+  MCB::Azure.configure_database(webapp, app_config: app_config)
 end

--- a/lib/mcb/commands/providers/list.rb
+++ b/lib/mcb/commands/providers/list.rb
@@ -1,8 +1,8 @@
 name 'list'
 summary 'List providers in db'
 
-run do |_opts, args, _cmd|
-  MCB.init_rails
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
 
   providers = if args.any?
                 Provider.where(provider_code: args.to_a)

--- a/lib/mcb/commands/providers/show.rb
+++ b/lib/mcb/commands/providers/show.rb
@@ -2,8 +2,8 @@ name 'show'
 summary 'Show information about provider'
 param :code
 
-run do |_opts, args, _cmd|
-  MCB.init_rails
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
 
   code = args[:code]
 

--- a/lib/mcb/commands/providers/ucas_preferences/import.rb
+++ b/lib/mcb/commands/providers/ucas_preferences/import.rb
@@ -67,7 +67,7 @@ def log_attribute_change(provider, attribute, new_value)
 end
 
 def commit_changes(changed_preferences, providers, changed_preference_count, opts)
-  if confirm_changes(changed_preferences, providers, changed_preference_count, opts)
+  if confirm_changes(providers, changed_preference_count, opts)
     ProviderUCASPreference.connection.transaction do
       changed_preferences.values.each(&:save!)
     end
@@ -76,14 +76,14 @@ def commit_changes(changed_preferences, providers, changed_preference_count, opt
   end
 end
 
-def confirm_changes(changed_preferences, providers, changed_preference_count, opts)
+def confirm_changes(providers, changed_preference_count, opts)
   summary = "#{changed_preference_count} changed preferences for " \
-            "#{providers.keys.count} providers"
+            "#{providers.keys.count} providers."
 
   if opts[:dry_run]
     puts "#{summary} Dry-run, finishing early."
     false
-  elsif changed_preferences.any?
+  elsif changed_preference_count.positive?
     print "#{summary} Continue? "
 
     response = $stdin.readline

--- a/lib/mcb/commands/providers/ucas_preferences/import.rb
+++ b/lib/mcb/commands/providers/ucas_preferences/import.rb
@@ -1,6 +1,15 @@
-summary 'Import UCAS preferences for providers. Requires a filename to import as an argument.'
+summary 'Import UCAS preferences for providers. ' \
+        'Requires a filename to import as an argument.'
 param :filename
+usage 'import [options] <preferences_csv_filename>'
 option :n, 'dry_run', "don't update anything, display what would be done"
+
+description <<-EODESCRIPTION
+  Use this command to import UCAS preferences for providers. It will display the
+  changes that will be performed and a summary of those changes before prompting
+  the user to continue. The -n/--dry-run` option can also be used to ensure no
+  changes are performed.
+EODESCRIPTION
 
 run do |opts, args, _cmd| # rubocop: disable Metrics/BlockLength
   MCB.init_rails(opts)

--- a/lib/mcb/commands/providers/ucas_preferences/import.rb
+++ b/lib/mcb/commands/providers/ucas_preferences/import.rb
@@ -3,7 +3,7 @@ param :filename
 option :n, 'dry_run', "don't update anything, display what would be done"
 
 run do |opts, args, _cmd| # rubocop: disable Metrics/BlockLength
-  MCB.init_rails
+  MCB.init_rails(opts)
 
   providers = Hash.new do |hash, code|
     hash[code] = Provider.find_by!(provider_code: code)

--- a/lib/mcb/commands/providers/ucas_preferences/import.rb
+++ b/lib/mcb/commands/providers/ucas_preferences/import.rb
@@ -26,17 +26,13 @@ run do |opts, args, _cmd| # rubocop: disable Metrics/BlockLength
       changed_preferences[provider][preference_type] = row['PREF_VALUE']
     end
   rescue ActiveRecord::RecordNotFound => e
-    if opts[:dry_run]
-      MCB::LOGGER.warn(
-        '[%<lineno>d] Message "%<message>s" while processing %<code>s' % {
-          lineno: csv.lineno,
-          message: e.message,
-          code: row['INST_CODE']
-        }
-      )
-    else
-      raise
-    end
+    MCB::LOGGER.warn(
+      '[%<lineno>d] Message "%<message>s" while processing %<code>s' % {
+        lineno: csv.lineno,
+        message: e.message,
+        code: row['INST_CODE']
+      }
+    )
   end
 
   commit_changes(changed_preferences, opts)

--- a/lib/mcb/commands/providers/ucas_preferences/show.rb
+++ b/lib/mcb/commands/providers/ucas_preferences/show.rb
@@ -1,8 +1,8 @@
 summary 'Show UCAS preferences for provider with given code'
 param :code
 
-run do |_opts, args, _cmd|
-  MCB.init_rails
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
 
   code = args[:code]
 

--- a/spec/lib/mcb/azure_spec.rb
+++ b/spec/lib/mcb/azure_spec.rb
@@ -83,7 +83,7 @@ describe MCB::Azure do
       EOCONFIG
     end
 
-    subject { MCB::Azure.get_config('some-app', 'some-rgroup') }
+    subject { MCB::Azure.get_config('some-app', rgroup: 'some-rgroup') }
 
     before :each do
       allow(MCB).to receive(:run_command).and_return(config_json)

--- a/spec/lib/mcb/commands/providers/ucas_preferences/import_spec.rb
+++ b/spec/lib/mcb/commands/providers/ucas_preferences/import_spec.rb
@@ -64,7 +64,7 @@ describe 'mcb providers ucas_preferences import' do
           PREF_TYPE: 'Copy Form Sequence',
           PREF_VALUE: 'Alphabetic coming'
   end
-  let(:output) { import_csv_file(tmpfile) }
+  let(:output) { import_csv_file(tmpfile).first }
 
   after :each do
     # NB: If ... IF ... something goes wrong in the spec before tmpfile gets
@@ -78,7 +78,7 @@ describe 'mcb providers ucas_preferences import' do
 
     it 'displays no changes' do
       expect(output).to match <<~EOMESSAGE
-        0 provider(s) changed. No changes, finishing early.
+        0 changed preferences for 0 providers. No changes, finishing early.
         Aborting without updating.
       EOMESSAGE
     end
@@ -117,7 +117,7 @@ describe 'mcb providers ucas_preferences import' do
       expect(output.squeeze(' ')).to match <<~EOEXPECTED.chomp
         \ #{provider.provider_code} type_of_gt12: Coming or Not -> Not coming\ 
         \ #{provider.provider_code} send_application_alerts: Yes, required -> No, not required\ 
-        1 provider(s) changed. Continue?\ 
+        2 changed preferences for 1 providers. Continue?\ 
       EOEXPECTED
       # rubocop: enable Layout/TrailingWhitespace
     end
@@ -155,16 +155,17 @@ describe 'mcb providers ucas_preferences import' do
       expect(provider.ucas_preferences.send_application_alerts).to eq 'none'
     end
 
-    it 'raises an error when a provider cannot be found' do
+    it 'displays a warning when a provider cannot be found' do
       tmpfile = write_csv_to_tmpfile(
         preferences_for_unknown_provider
       )
-      expect { import_csv_file(tmpfile) }.to(
-        raise_error(
-          ActiveRecord::RecordNotFound,
-          "Couldn't find Provider"
-        )
-      )
+
+      (_output, stderr) = import_csv_file(tmpfile)
+
+      expected_code = nonexistent_provider.provider_code
+      expect(stderr).to match <<~EOMESSAGE
+        WARN: [2] Message "Couldn't find Provider" while processing #{expected_code}
+      EOMESSAGE
     end
 
     context 'dry-run' do
@@ -184,13 +185,11 @@ describe 'mcb providers ucas_preferences import' do
           preferences_for_unknown_provider
         )
 
-        output = import_csv_file(tmpfile, opts)
+        (_output, stderr) = import_csv_file(tmpfile, opts)
 
         expected_code = nonexistent_provider.provider_code
-        expect(output).to match <<~EOMESSAGE
+        expect(stderr).to match <<~EOMESSAGE
           WARN: [2] Message "Couldn't find Provider" while processing #{expected_code}
-          0 provider(s) changed. Dry-run, finishing early.
-          Aborting without updating.
         EOMESSAGE
       end
     end

--- a/spec/lib/mcb/commands/providers/ucas_preferences/import_spec.rb
+++ b/spec/lib/mcb/commands/providers/ucas_preferences/import_spec.rb
@@ -15,9 +15,11 @@ describe 'mcb providers ucas_preferences import' do
   end
 
   def import_csv_file(tmpfile, opts = [])
-    with_stubbed_stdout(stdin: "yes\n") do
+    stderr = ""
+    output = with_stubbed_stdout(stdin: "yes\n", stderr: stderr) do
       cmd.run(opts + [tmpfile.path])
     end
+    [output, stderr]
   end
 
   let(:lib_dir) { "#{Rails.root}/lib" }

--- a/spec/lib/mcb/providers_spec.rb
+++ b/spec/lib/mcb/providers_spec.rb
@@ -13,6 +13,7 @@ describe 'mcb providers' do
     before do
       allow(MCB::Azure).to receive(:get_config).and_return(app_config)
       allow(MCB::Azure).to receive(:configure_database)
+      allow(MCB::Azure).to receive(:rgroup_for_app).and_return('banana-tree')
     end
 
     subject do
@@ -24,7 +25,8 @@ describe 'mcb providers' do
     it 'configures the database' do
       subject
 
-      expect(MCB::Azure).to have_received(:get_config).with('banana')
+      expect(MCB::Azure).to have_received(:get_config)
+                              .with('banana', rgroup: 'banana-tree')
       expect(MCB::Azure).to have_received(:configure_database)
                               .with('banana', app_config: app_config)
     end

--- a/spec/lib/providers_spec.rb
+++ b/spec/lib/providers_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+load 'bin/mcb'
+
+describe 'mcb providers' do
+  describe '--webapp option' do
+    let(:app_config) do
+      {
+        'RAILS_ENV' => 'aztest'
+      }
+    end
+    let(:expected_rails_env) { 'aztest' }
+
+    before do
+      allow(MCB::Azure).to receive(:get_config).and_return(app_config)
+      allow(MCB::Azure).to receive(:configure_database)
+    end
+
+    subject do
+      with_stubbed_stdout(stdin: expected_rails_env) do
+        $mcb.run(%w[providers --webapp=banana])
+      end
+    end
+
+    it 'configures the database' do
+      subject
+
+      expect(MCB::Azure).to have_received(:get_config).with('banana')
+      expect(MCB::Azure).to have_received(:configure_database)
+                              .with('banana', app_config: app_config)
+    end
+
+    it 'prompts for the expected RAILS_ENV' do
+      output = subject
+
+      expect(output).to match %r{enter the expected RAILS_ENV for banana:}
+    end
+
+    context 'expected RAILS_ENV does not match' do
+      let(:expected_rails_env) { 'qa' }
+
+      it 'raises an error if the expected RAILS_ENV does not match' do
+        expect { subject } .to raise_error(RuntimeError)
+      end
+    end
+  end
+end

--- a/spec/support/with_stubbed_stdout.rb
+++ b/spec/support/with_stubbed_stdout.rb
@@ -23,13 +23,13 @@ def with_stubbed_stdout(stdin: nil, stderr: nil)
   if stderr
     stderr_file = Tempfile.new('stderr.')
     original_stderr = STDERR.dup
-    STDERR.reopen(output_file)
+    STDERR.reopen(stderr_file)
     STDERR.sync
   end
 
   # Maybe we should do stdin in a similar way, but for now this works so we'll
   # leave it. That may change if we ever decide to use ReadLine.
-  unless stdin.nil?
+  if stdin
     original_stdin = $stdin
     $stdin = StringIO.new(stdin)
   end

--- a/spec/support/with_stubbed_stdout.rb
+++ b/spec/support/with_stubbed_stdout.rb
@@ -51,7 +51,6 @@ def with_stubbed_stdout(stdin: nil, stderr: nil)
   output_file.sync
   output_file.seek(0)
   output_file.read
-
 ensure
   # We need to restore STDOUT and remove the output file no matter what.
   STDOUT.reopen(original_stdout)

--- a/spec/support/with_stubbed_stdout.rb
+++ b/spec/support/with_stubbed_stdout.rb
@@ -7,7 +7,7 @@
 # from that pipe and write to a StringIO object. Unfortunately that
 # implementation isn't threads-safe but this one should be.
 
-def with_stubbed_stdout(stdin: nil)
+def with_stubbed_stdout(stdin: nil, stderr: nil)
   # Here is where we'll redirect STDOUT to temporarily. Using a StringIO
   # doesn't seem to work, it seems to require a proper file.
   output_file = Tempfile.new('stdout.')
@@ -19,6 +19,13 @@ def with_stubbed_stdout(stdin: nil)
   # Here's where the magic happens. STDOUT is now redirecting to our tempfile.
   STDOUT.reopen(output_file)
   STDOUT.sync
+
+  if stderr
+    stderr_file = Tempfile.new('stderr.')
+    original_stderr = STDERR.dup
+    STDERR.reopen(output_file)
+    STDERR.sync
+  end
 
   # Maybe we should do stdin in a similar way, but for now this works so we'll
   # leave it. That may change if we ever decide to use ReadLine.
@@ -33,14 +40,29 @@ def with_stubbed_stdout(stdin: nil)
   # can't just rely on the ensure block to do it.
   STDOUT.reopen(original_stdout)
 
+  if stderr
+    STDERR.reopen(original_stderr)
+
+    stderr_file.sync
+    stderr_file.seek(0)
+    stderr.replace stderr_file.read
+  end
+
   output_file.sync
   output_file.seek(0)
   output_file.read
+
 ensure
   # We need to restore STDOUT and remove the output file no matter what.
   STDOUT.reopen(original_stdout)
   STDOUT.sync
   output_file.unlink
+
+  if stderr
+    STDERR.reopen(original_stderr)
+    STDERR.sync
+    stderr_file.unlink
+  end
 
   $stdin = original_stdin if stdin
 end


### PR DESCRIPTION
### Context

When running against a remote app's db there is always the possibility that an unexpected result would be had should the wrong environment be targeted.

### Changes proposed in this pull request

Require the user to enter in the correct `RAILS_ENV` for the application that is being targeted.
