### PR TITLE
1210] Allow include parameter on courses index lookup

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -8,7 +8,7 @@ module API
         authorize @provider, :can_list_courses?
         authorize Course
 
-        render jsonapi: @provider.courses
+        render jsonapi: @provider.courses, include: params[:include]
       end
 
       def show

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -11,8 +11,8 @@ module API
         @object.start_date&.iso8601
       end
 
-      has_one :provider
-      has_one :accrediting_provider
+      belongs_to :provider
+      belongs_to :accrediting_provider
 
       has_many :site_statuses
     end


### PR DESCRIPTION
This will be used to fetch accrediting providers in the frontend.

Also reverse the has_one to belongs_to on the serializable_course, because that's more logical.