### PR TITLE
Expose opted in providers

### DIFF
--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -11,6 +11,10 @@ module API
         @object.provider_name
       end
 
+      attribute :opted_in do
+        @object.opted_in
+      end
+
       has_many :sites
 
       has_many :courses do

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -43,7 +43,8 @@ describe 'Providers API v2', type: :request do
             "type" => "providers",
             "attributes" => {
               "institution_code" => provider.provider_code,
-              "institution_name" => provider.provider_name
+              "institution_name" => provider.provider_name,
+              "opted_in" => true
             },
             "relationships" => {
               "sites" => {
@@ -78,7 +79,8 @@ describe 'Providers API v2', type: :request do
             "type" => "providers",
             "attributes" => {
               "institution_code" => provider.provider_code,
-              "institution_name" => provider.provider_name
+              "institution_name" => provider.provider_name,
+              "opted_in" => true
             },
             "relationships" => {
               "sites" => {
@@ -159,7 +161,8 @@ describe 'Providers API v2', type: :request do
           "type" => "providers",
           "attributes" => {
             "institution_code" => provider.provider_code,
-            "institution_name" => provider.provider_name
+            "institution_name" => provider.provider_name,
+            "opted_in" => true
           },
           "relationships" => {
             "sites" => {
@@ -196,7 +199,8 @@ describe 'Providers API v2', type: :request do
               "type" => "providers",
               "attributes" => {
                 "institution_code" => provider.provider_code,
-                "institution_name" => provider.provider_name
+                "institution_name" => provider.provider_name,
+                "opted_in" => true
               },
               "relationships" => {
                 "sites" => {


### PR DESCRIPTION
### Context
We need to know if a provider is opted in to display different functionality for users on the frontend

### Changes proposed in this pull request
Expose opted in attribute to providers endpoint
