### PR TITLE
[1259] Expose provider in courses

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -12,7 +12,7 @@ module API
       end
 
       def show
-        render jsonapi: @course, include: [site_statuses: [:site]]
+        render jsonapi: @course, include: params[:include]
       end
 
       def sync_with_search_and_compare

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -84,5 +84,9 @@ FactoryBot.define do
     trait :resulting_in_pgde do
       qualification { :pgde }
     end
+
+    trait :with_accrediting_provider do
+      association(:accrediting_provider, factory: :provider)
+    end
   end
 end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -73,7 +73,7 @@ describe 'Courses API v2', type: :request do
       before do
         get "/api/v2/providers/#{provider.provider_code.downcase}/courses/#{findable_open_course.course_code.downcase}",
             headers: { 'HTTP_AUTHORIZATION' => credentials },
-            params: { includes: "site_statuses" }
+            params: { include: 'site_statuses.site' }
       end
 
       it { should have_http_status(:success) }

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -1,17 +1,31 @@
 require "rails_helper"
 
 describe API::V2::SerializableCourse do
-  let(:course) { create(:course, start_date: Time.now.utc) }
-  let(:resource) { API::V2::SerializableCourse.new object: course }
-
-  it 'sets type to courses' do
-    expect(resource.jsonapi_type).to eq :courses
+  let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+  let(:course)           { create(:course, start_date: Time.now.utc) }
+  let(:provider)         { course.provider }
+  let(:course_json) do
+    jsonapi_renderer.render(
+      course,
+      class: {
+        Course: API::V2::SerializableCourse,
+        Provider: API::V2::SerializableProvider
+      },
+      include: [
+        :provider
+      ]
+    ).to_json
   end
+  let(:parsed_json) { JSON.parse(course_json) }
 
-  subject { resource.as_jsonapi.to_json }
+  subject { parsed_json['included'] }
 
-  it { should be_json.with_content(type: 'courses') }
-  it { should be_json.with_content(course.start_date.iso8601).at_path("attributes.start_date") }
-  it { should be_json.with_content(course.content_status.to_s).at_path("attributes.content_status") }
-  it { should be_json.with_content(course.ucas_status.to_s).at_path("attributes.ucas_status") }
+  it { should include(have_type('providers').and(have_id(provider.id.to_s))) }
+
+  describe 'data' do
+    subject { parsed_json['data'] }
+
+    it { should have_type('courses') }
+    it { should have_attributes(:start_date, :content_status, :ucas_status) }
+  end
 end

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -3,29 +3,61 @@ require "rails_helper"
 describe API::V2::SerializableCourse do
   let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
   let(:course)           { create(:course, start_date: Time.now.utc) }
-  let(:provider)         { course.provider }
   let(:course_json) do
     jsonapi_renderer.render(
       course,
       class: {
-        Course: API::V2::SerializableCourse,
-        Provider: API::V2::SerializableProvider
-      },
-      include: [
-        :provider
-      ]
+        Course: API::V2::SerializableCourse
+      }
     ).to_json
   end
   let(:parsed_json) { JSON.parse(course_json) }
 
-  subject { parsed_json['included'] }
+  subject { parsed_json['data'] }
 
-  it { should include(have_type('providers').and(have_id(provider.id.to_s))) }
+  it { should have_type('courses') }
+  it { should have_attributes(:start_date, :content_status, :ucas_status) }
 
-  describe 'data' do
-    subject { parsed_json['data'] }
+  context 'with a provider' do
+    let(:provider) { course.provider }
+    let(:course_json) do
+      jsonapi_renderer.render(
+        course,
+        class: {
+          Course:   API::V2::SerializableCourse,
+          Provider: API::V2::SerializableProvider
+        },
+        include: [
+          :provider
+        ]
+      ).to_json
+    end
 
-    it { should have_type('courses') }
-    it { should have_attributes(:start_date, :content_status, :ucas_status) }
+    it { should have_relationship(:provider) }
+
+    it 'includes the provider' do
+      expect(parsed_json['included'])
+        .to(include(have_type('providers')
+          .and(have_id(provider.id.to_s))))
+    end
+  end
+
+  context 'with an accrediting_provider' do
+    let(:course) { create(:course, :with_accrediting_provider) }
+    let(:accrediting_provider) { course.accrediting_provider }
+    let(:course_json) do
+      jsonapi_renderer.render(
+        course,
+        class: {
+          Course:   API::V2::SerializableCourse,
+          Provider: API::V2::SerializableProvider
+        },
+        include: [
+          :accrediting_provider
+        ]
+      ).to_json
+    end
+
+    it { should have_relationship(:accrediting_provider) }
   end
 end


### PR DESCRIPTION
### Context

We need to expose `provider` and `accrediting_provider` on the course endpoint.

### Changes proposed in this pull request

Rather than hard coding the course endpoint to return `site_statuses` and `sites`, we now rely on the `include` parameter.

Added a bunch of tests for the serializer to make sure we can render out everything we need.

### Guidance to review

I originally included a request spec in this that brings in provider and accredited_provider, but decided it was overkill in the end.