### PR TITLE
[1256] remove manage api base url from azure template

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -114,12 +114,6 @@
             "description": "Auth secret for manage back-end."
         }
     },
-    "settingsManageApiBaseUrl": {
-        "type": "string",
-        "metadata": {
-            "description": "The base URL for manage-courses-api."
-        }
-    },
     "settingsManageApiSecret": {
         "type": "string",
         "metadata": {
@@ -245,10 +239,6 @@
               {
                   "name": "SETTINGS__AUTHENTICATION__SECRET",
                   "value": "[parameters('settingsAuthenticationSecret')]"
-              },
-              {
-                  "name": "SETTINGS__MANAGE_API__BASE_URL",
-                  "value": "[parameters('settingsManageApiBaseUrl')]"
               },
               {
                   "name": "SETTINGS__MANAGE_API__SECRET",


### PR DESCRIPTION
Second part to transitioning to ucas rails env environment, this env var in the template is causing errors on deploys in VSTS