### PR TITLE
[1259] Rename institution_code to provider_code

### DIFF
--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -3,9 +3,7 @@ module API
     class SerializableProvider < JSONAPI::Serializable::Resource
       type 'providers'
 
-      attribute :institution_code do
-        @object.provider_code
-      end
+      attributes :provider_code
 
       attribute :institution_name do
         @object.provider_name

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -42,7 +42,7 @@ describe 'Providers API v2', type: :request do
             "id" => provider.id.to_s,
             "type" => "providers",
             "attributes" => {
-              "institution_code" => provider.provider_code,
+              "provider_code" => provider.provider_code,
               "institution_name" => provider.provider_name,
               "opted_in" => true
             },
@@ -78,7 +78,7 @@ describe 'Providers API v2', type: :request do
             "id" => provider.id.to_s,
             "type" => "providers",
             "attributes" => {
-              "institution_code" => provider.provider_code,
+              "provider_code" => provider.provider_code,
               "institution_name" => provider.provider_name,
               "opted_in" => true
             },
@@ -160,7 +160,7 @@ describe 'Providers API v2', type: :request do
           "id" => provider.id.to_s,
           "type" => "providers",
           "attributes" => {
-            "institution_code" => provider.provider_code,
+            "provider_code" => provider.provider_code,
             "institution_name" => provider.provider_name,
             "opted_in" => true
           },
@@ -198,7 +198,7 @@ describe 'Providers API v2', type: :request do
               "id" => provider.id.to_s,
               "type" => "providers",
               "attributes" => {
-                "institution_code" => provider.provider_code,
+                "provider_code" => provider.provider_code,
                 "institution_name" => provider.provider_name,
                 "opted_in" => true
               },

--- a/spec/serializers/api/v2/serializable_provider_spec.rb
+++ b/spec/serializers/api/v2/serializable_provider_spec.rb
@@ -11,4 +11,5 @@ describe API::V2::SerializableProvider do
   subject { resource.as_jsonapi.to_json }
 
   it { should be_json.with_content(type: 'providers') }
+  it { should be_json.with_content(attributes: { provider_code: provider.provider_code }) }
 end


### PR DESCRIPTION
### Context

The frontend is wired up to use `provider_code` to connect courses and providers, but the backend was returning an `institution_code` instead of a `provider_code`.

### Changes proposed in this pull request

Provider resources now have a `provider_code` instead of an `institution_code`.

### Guidance to review

Frontend PR https://github.com/DFE-Digital/manage-courses-frontend/pull/154