### PR TITLE
[1266] add address to sites serializer

### DIFF
--- a/app/controllers/api/v2/sites_controller.rb
+++ b/app/controllers/api/v2/sites_controller.rb
@@ -1,0 +1,30 @@
+module API
+  module V2
+    class SitesController < API::V2::ApplicationController
+      before_action :build_provider
+      before_action :build_site, except: :index
+
+      def index
+        authorize @provider, :can_list_courses?
+        authorize Site
+
+        render jsonapi: @provider.sites
+      end
+
+      def show
+        render jsonapi: @site
+      end
+
+    private
+
+      def build_provider
+        @provider = Provider.find_by!(provider_code: params[:provider_code].upcase)
+      end
+
+      def build_site
+        @site = @provider.sites.find(params[:id])
+        authorize @site
+      end
+    end
+  end
+end

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -28,4 +28,5 @@ class ProviderPolicy
   end
 
   alias_method :can_list_courses?, :show?
+  alias_method :can_list_sites?, :show?
 end

--- a/app/policies/site_policy.rb
+++ b/app/policies/site_policy.rb
@@ -1,0 +1,18 @@
+class SitePolicy
+  attr_reader :user, :site
+
+  def initialize(user, site)
+    @user = user
+    @site = site
+  end
+
+  def index?
+    user.present?
+  end
+
+  def show?
+    user.providers.include? site.provider
+  end
+
+  alias_method :update?, :show?
+end

--- a/app/serializers/api/v2/serializable_site.rb
+++ b/app/serializers/api/v2/serializable_site.rb
@@ -3,7 +3,8 @@ module API
     class SerializableSite < JSONAPI::Serializable::Resource
       type 'sites'
 
-      attributes :code, :location_name
+      attributes :code, :location_name, :address1, :address2,
+      :address3, :address4, :postcode, :region_code
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,7 @@ Rails.application.routes.draw do
         resources :courses, param: :code, only: %i[index create show] do
           post :sync_with_search_and_compare, on: :member
         end
+        resources :sites, only: %i[index show]
       end
 
       resource :sessions

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -20,6 +20,12 @@ FactoryBot.define do
   factory :site do
     sequence(:code, &:to_s)
     location_name { 'Main Site' + rand(1000000).to_s }
+    address1 { Faker::Address.street_address }
+    address2 { Faker::Address.community }
+    address3 { Faker::Address.city }
+    address4 { Faker::Address.state }
+    postcode { Faker::Address.postcode }
+    region_code { ProviderEnrichment.region_codes['London'] }
     association(:provider)
 
     transient do

--- a/spec/policies/site_policy_spec.rb
+++ b/spec/policies/site_policy_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+describe SitePolicy do
+  let(:user) { create(:user) }
+
+  subject { described_class }
+
+  permissions :index? do
+    it 'allows the :index action for any authenticated user' do
+      should permit(user)
+    end
+  end
+
+  permissions :show? do
+    let(:organisation) { create(:organisation, users: [user]) }
+    let(:site) { create(:site) }
+    let!(:provider) {
+      create(:provider,
+              course_count: 0,
+              site_count: 0,
+              sites: [site],
+              organisations: [organisation])
+    }
+
+    it { should permit(user, site) }
+
+    context 'with a user outside the organisation' do
+      let(:other_user) { create(:user) }
+      it { should_not permit(other_user, site) }
+    end
+  end
+end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -128,7 +128,13 @@ describe 'Courses API v2', type: :request do
             "type" => "sites",
             "attributes" => {
               "code" => site.code,
-              "location_name" => site.location_name
+              "location_name" => site.location_name,
+              "address1" => site.address1,
+              "address2" => site.address2,
+              "address3" => site.address3,
+              "address4" => site.address4,
+              "postcode" => site.postcode,
+              "region_code" => site.region_code
             }
           }]
         )

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -1,0 +1,136 @@
+require 'rails_helper'
+
+describe 'Sites API v2', type: :request do
+  let(:user) { create(:user) }
+  let(:organisation) { create(:organisation, users: [user]) }
+  let(:payload) { { email: user.email } }
+  let(:token) { build_jwt :apiv2, payload: payload }
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+
+  let(:site1) { create :site, location_name: 'Main site 1' }
+  let(:site2) { create :site, location_name: 'Main site 2' }
+  let(:sites) { [site1, site2] }
+
+  let!(:provider) {
+    create(:provider,
+           course_count: 0,
+           site_count: 0,
+           sites: sites,
+           organisations: [organisation])
+  }
+
+  subject { response }
+
+  describe 'GET show' do
+    let(:show_path) do
+      "/api/v2/providers/#{provider.provider_code}" +
+        "/sites/#{site1.id}"
+    end
+
+    subject do
+      get show_path, headers: { 'HTTP_AUTHORIZATION' => credentials }
+      response
+    end
+
+    context 'when unauthenticated' do
+      let(:payload) { { email: 'foo@bar' } }
+
+      it { should have_http_status(:unauthorized) }
+    end
+
+    context 'when user has not accepted terms' do
+      let(:user)         { create(:user, accept_terms_date_utc: nil) }
+      let(:organisation) { create(:organisation, users: [user]) }
+
+      it { should have_http_status(:forbidden) }
+    end
+
+    context 'when unauthorised' do
+      let(:unauthorised_user) { create(:user) }
+      let(:payload)           { { email: unauthorised_user.email } }
+
+      it "raises an error" do
+        expect { subject }.to raise_error Pundit::NotAuthorizedError
+      end
+    end
+  end
+
+  describe 'GET index' do
+    context 'when unauthenticated' do
+      let(:payload) { { email: 'foo@bar' } }
+
+      before do
+        get "/api/v2/providers/#{provider.provider_code}/sites",
+            headers: { 'HTTP_AUTHORIZATION' => credentials }
+      end
+
+      it { should have_http_status(:unauthorized) }
+    end
+
+    context 'when unauthorised' do
+      let(:unauthorised_user) { create(:user) }
+      let(:payload) { { email: unauthorised_user.email } }
+
+      it "raises an error" do
+        expect {
+          get "/api/v2/providers/#{provider.provider_code}/sites",
+            headers: { 'HTTP_AUTHORIZATION' => credentials }
+        }.to raise_error Pundit::NotAuthorizedError
+      end
+    end
+
+    describe 'JSON generated for sites' do
+      before do
+        get "/api/v2/providers/#{provider.provider_code}/sites",
+            headers: { 'HTTP_AUTHORIZATION' => credentials }
+      end
+
+      it { should have_http_status(:success) }
+
+      it 'has a data section with the correct attributes' do
+        json_response = JSON.parse response.body
+        expect(json_response).to eq(
+          "data" => [{
+            "id" => site1.id.to_s,
+            "type" => "sites",
+            "attributes" => {
+              "code" => site1.code,
+              "location_name" => site1.location_name,
+              "address1" => site1.address1,
+              "address2" => site1.address2,
+              "address3" => site1.address3,
+              "address4" => site1.address4,
+              "postcode" => site1.postcode,
+              "region_code" => site1.region_code
+            },
+          }, {
+            "id" => site2.id.to_s,
+            "type" => "sites",
+            "attributes" => {
+              "code" => site2.code,
+              "location_name" => site2.location_name,
+              "address1" => site2.address1,
+              "address2" => site2.address2,
+              "address3" => site2.address3,
+              "address4" => site2.address4,
+              "postcode" => site2.postcode,
+              "region_code" => site2.region_code
+            }
+          }],
+          "jsonapi" => {
+            "version" => "1.0"
+          }
+        )
+      end
+    end
+
+    it "raises a 'record not found' error when the provider doesn't exist" do
+      expect {
+        get("/api/v2/providers/non-existent-provider/sites",
+         headers: { 'HTTP_AUTHORIZATION' => credentials })
+      } .to raise_error ActiveRecord::RecordNotFound
+    end
+  end
+end

--- a/spec/serializers/api/v2/serializable_site_spec.rb
+++ b/spec/serializers/api/v2/serializable_site_spec.rb
@@ -11,4 +11,13 @@ describe API::V2::SerializableSite do
   subject { resource.as_jsonapi.to_json }
 
   it { should be_json.with_content(type: 'sites') }
+  it {
+    should be_json.with_content(attributes: { location_name: site.location_name,
+                                              address1: site.address1,
+                                              address2: site.address2,
+                                              address3: site.address3,
+                                              address4: site.address4,
+                                              postcode: site.postcode,
+                                              region_code: site.region_code })
+  }
 end


### PR DESCRIPTION
### Context
sites aka training locations

### Changes proposed in this pull request
- Add address data to sites serializer
- Setup `sites#index` and `sites#show`

### Guidance to review
e.g. `http://localhost:3001/api/v2/providers/T92?include=sites`

```ruby
{
  "id": "10324702",
  "type": "sites",
  "attributes": {
    "code": "O",
    "location_name": "Oakthorpe Primary School",
    "address1": "Tile Kiln Lane",
    "address2": "",
    "address3": "",
    "address4": "",
    "postcode": "N13 6BY",
    "region_code": "london"
  }
}
```
