### PR TITLE
[1260] Rename institution_name to provider_name

### DIFF
--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -3,11 +3,7 @@ module API
     class SerializableProvider < JSONAPI::Serializable::Resource
       type 'providers'
 
-      attributes :provider_code
-
-      attribute :institution_name do
-        @object.provider_name
-      end
+      attributes :provider_code, :provider_name
 
       attribute :opted_in do
         @object.opted_in

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -43,7 +43,7 @@ describe 'Providers API v2', type: :request do
             "type" => "providers",
             "attributes" => {
               "provider_code" => provider.provider_code,
-              "institution_name" => provider.provider_name,
+              "provider_name" => provider.provider_name,
               "opted_in" => true
             },
             "relationships" => {
@@ -79,7 +79,7 @@ describe 'Providers API v2', type: :request do
             "type" => "providers",
             "attributes" => {
               "provider_code" => provider.provider_code,
-              "institution_name" => provider.provider_name,
+              "provider_name" => provider.provider_name,
               "opted_in" => true
             },
             "relationships" => {
@@ -128,7 +128,7 @@ describe 'Providers API v2', type: :request do
       end
 
       let(:provider_names_in_response) {
-        JSON.parse(response.body)["data"].map { |provider| provider["attributes"]["institution_name"] }
+        JSON.parse(response.body)["data"].map { |provider| provider["attributes"]["provider_name"] }
       }
 
       it 'returns them in alphabetical order' do
@@ -161,7 +161,7 @@ describe 'Providers API v2', type: :request do
           "type" => "providers",
           "attributes" => {
             "provider_code" => provider.provider_code,
-            "institution_name" => provider.provider_name,
+            "provider_name" => provider.provider_name,
             "opted_in" => true
           },
           "relationships" => {
@@ -199,7 +199,7 @@ describe 'Providers API v2', type: :request do
               "type" => "providers",
               "attributes" => {
                 "provider_code" => provider.provider_code,
-                "institution_name" => provider.provider_name,
+                "provider_name" => provider.provider_name,
                 "opted_in" => true
               },
               "relationships" => {


### PR DESCRIPTION
### Context

The frontend is wired up to use `provider_name` to connect courses and providers, but the backend was returning an `institution_name` instead of a `provider_name`.

### Changes proposed in this pull request

Provider resources now have a `provider_name` instead of an `institution_name`.

### Guidance to review
Frontend PR to follow