### PR TITLE
[1265] Endpoint for updating sites

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,9 @@ gem 'terminal-table'
 # For querying third party APIs
 gem 'faraday'
 
+# UK postcode parsing and validation for Ruby
+gem 'uk_postcode'
+
 group :development, :test do
   # add info about db structure to models and other files
   gem 'annotate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,6 +331,7 @@ GEM
     trollop (1.16.2)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    uk_postcode (2.1.3)
     unicode-display_width (1.5.0)
     webmock (3.5.1)
       addressable (>= 2.3.6)
@@ -393,6 +394,7 @@ DEPENDENCIES
   terminal-table
   timecop
   tzinfo-data
+  uk_postcode
   webmock
 
 RUBY VERSION

--- a/app/controllers/api/v2/sites_controller.rb
+++ b/app/controllers/api/v2/sites_controller.rb
@@ -17,7 +17,7 @@ module API
         if @site.update(site_params)
           render jsonapi: @site
         else
-          render jsonapi_errors: @site.errors, status: 400
+          render jsonapi_errors: @site.errors, status: 422
         end
       end
 

--- a/app/controllers/api/v2/sites_controller.rb
+++ b/app/controllers/api/v2/sites_controller.rb
@@ -1,6 +1,8 @@
 module API
   module V2
     class SitesController < API::V2::ApplicationController
+      deserializable_resource :site, only: :update
+
       before_action :build_provider
       before_action :build_site, except: :index
 
@@ -11,11 +13,27 @@ module API
         render jsonapi: @provider.sites
       end
 
+      def update
+        @site.update(site_params)
+      end
+
       def show
         render jsonapi: @site
       end
 
     private
+
+      def site_params
+        params.require(:site).permit(
+          :location_name,
+          :address1,
+          :address2,
+          :address3,
+          :address4,
+          :postcode,
+          :region_code
+        )
+      end
 
       def build_provider
         @provider = Provider.find_by!(provider_code: params[:provider_code].upcase)

--- a/app/controllers/api/v2/sites_controller.rb
+++ b/app/controllers/api/v2/sites_controller.rb
@@ -15,6 +15,8 @@ module API
 
       def update
         @site.update(site_params)
+
+        render jsonapi: @site
       end
 
       def show

--- a/app/controllers/api/v2/sites_controller.rb
+++ b/app/controllers/api/v2/sites_controller.rb
@@ -14,9 +14,11 @@ module API
       end
 
       def update
-        @site.update(site_params)
-
-        render jsonapi: @site
+        if @site.update(site_params)
+          render jsonapi: @site
+        else
+          render jsonapi_errors: @site.errors, status: 400
+        end
       end
 
       def show

--- a/app/models/concerns/postcode_normalize.rb
+++ b/app/models/concerns/postcode_normalize.rb
@@ -2,7 +2,11 @@ module PostcodeNormalize
   extend ActiveSupport::Concern
   included do
     def postcode=(str)
-      super UKPostcode.parse(str).to_s
+      if str
+        super UKPostcode.parse(str).to_s
+      else
+        super str
+      end
     end
   end
 end

--- a/app/models/concerns/postcode_normalize.rb
+++ b/app/models/concerns/postcode_normalize.rb
@@ -1,0 +1,8 @@
+module PostcodeNormalize
+  extend ActiveSupport::Concern
+  included do
+    def postcode=(str)
+      super UKPostcode.parse(str).to_s
+    end
+  end
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -23,11 +23,11 @@ class Site < ApplicationRecord
 
   belongs_to :provider
 
-  validates :location_name, uniqueness: { scope: :provider }
-  validates :postcode, postcode: true
+  validates :location_name, uniqueness: { scope: :provider_id }
   validates :location_name,
             :address1,
             :address3,
             :postcode,
             presence: true
+  validates :postcode, postcode: true
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -21,4 +21,11 @@ class Site < ApplicationRecord
   include TouchProvider
 
   belongs_to :provider
+
+  validates :location_name, uniqueness: { scope: :provider }
+  validates :location_name,
+            :address1,
+            :address3,
+            :postcode,
+            presence: true
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -17,6 +17,7 @@
 #
 
 class Site < ApplicationRecord
+  include PostcodeNormalize
   include RegionCode
   include TouchProvider
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -24,6 +24,7 @@ class Site < ApplicationRecord
   belongs_to :provider
 
   validates :location_name, uniqueness: { scope: :provider }
+  validates :postcode, postcode: true
   validates :location_name,
             :address1,
             :address3,

--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -1,5 +1,7 @@
 class PostcodeValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
+    return unless value
+
     postcode = UKPostcode.parse(value)
     unless postcode.full_valid?
       record.errors[attribute] << "not recognised as a UK postcode"

--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -1,0 +1,8 @@
+class PostcodeValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    postcode = UKPostcode.parse(value)
+    unless postcode.full_valid?
+      record.errors[attribute] << "not recognised as a UK postcode"
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,7 @@ Rails.application.routes.draw do
         resources :courses, param: :code, only: %i[index create show] do
           post :sync_with_search_and_compare, on: :member
         end
-        resources :sites, only: %i[index show]
+        resources :sites, only: %i[index update show]
       end
 
       resource :sessions

--- a/spec/models/concerns/postcode_normalize_spec.rb
+++ b/spec/models/concerns/postcode_normalize_spec.rb
@@ -1,0 +1,26 @@
+describe PostcodeNormalize do
+  # TODO: Create a test object to use this on instead.
+  let(:object) { Site.new }
+
+  subject { object }
+
+  describe '#postcode' do
+    let(:postcode) { 'sw1a1aa' }
+
+    before do
+      subject.postcode = postcode
+    end
+
+    it 'normalises postcode' do
+      expect(subject.postcode).to eq 'SW1A 1AA'
+    end
+
+    context 'with a bad postcode' do
+      let(:postcode) { 'really bad postcode dawg' }
+
+      it 'does not do formatting' do
+        expect(subject.postcode).to eq 'really bad postcode dawg'
+      end
+    end
+  end
+end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -21,6 +21,12 @@ require 'rails_helper'
 describe Provider, type: :model do
   subject { create(:site) }
 
+  it { is_expected.to validate_presence_of(:location_name) }
+  it { is_expected.to validate_presence_of(:address1) }
+  it { is_expected.to validate_presence_of(:address3) }
+  it { is_expected.to validate_presence_of(:postcode) }
+  it { is_expected.to validate_uniqueness_of(:location_name).scoped_to(:provider_id) }
+
   describe 'associations' do
     it { should belong_to(:provider) }
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,8 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
+Faker::Config.locale = 'en-GB'
+
 # configure shoulda matchers to use rspec as the test framework and full matcher libraries for rails
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -71,7 +71,7 @@ describe 'Providers API', type: :request do
       end
       let!(:site) do
         create(:site,
-              location_name: 'Main site',
+              location_name: 'Main site 1',
               code: '-',
               region_code: :london,
               provider: provider)
@@ -130,7 +130,7 @@ describe 'Providers API', type: :request do
       end
       let!(:site2) do
         create(:site,
-              location_name: 'Main site',
+              location_name: 'Main site 2',
               code: '-',
               region_code: :scotland,
               provider: provider2)
@@ -161,7 +161,7 @@ describe 'Providers API', type: :request do
               'campuses' => [
                 {
                   'campus_code' => '-',
-                  'name' => 'Main site',
+                  'name' => 'Main site 1',
                   'region_code' => '01',
                 }
               ],
@@ -222,7 +222,7 @@ describe 'Providers API', type: :request do
               'campuses' => [
                 {
                   'campus_code' => '-',
-                  'name' => 'Main site',
+                  'name' => 'Main site 2',
                   'region_code' => '11',
                 }
               ],

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -315,7 +315,7 @@ describe 'Sites API v2', type: :request do
               expect(response.body).to include('Postcode not recognised as a UK postcode')
             end
 
-            it 'checks the region_code is present' do
+            xit 'checks the region_code is present' do
             end
           end
 

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -284,7 +284,7 @@ describe 'Sites API v2', type: :request do
             let(:postcode)      { '' }
             let(:region_code)   { '' }
 
-            it { should have_http_status(:bad_request) }
+            it { should have_http_status(:unprocessable_entity) }
 
             it 'has the right amount of errors' do
               expect(json_data.count).to eq 5

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -177,15 +177,15 @@ describe 'Sites API v2', type: :request do
       end
     end
 
-    context 'when authenticted and authorised' do
-      let(:code) { 'A3' }
+    context 'when authenticated and authorised' do
+      let(:code)          { 'A3' }
       let(:location_name) { 'New location name' }
-      let(:address1) { Faker::Address.street_address }
-      let(:address2) { Faker::Address.community }
-      let(:address3) { Faker::Address.city }
-      let(:address4) { Faker::Address.state }
-      let(:postcode) { Faker::Address.postcode }
-      let(:region_code) { 'west_midlands' }
+      let(:address1)      { 'New street 1' }
+      let(:address2)      { 'New street 2' }
+      let(:address3)      { 'New city' }
+      let(:address4)      { 'New state' }
+      let(:postcode)      { 'SW1A 1AA' }
+      let(:region_code)   { 'west_midlands' }
 
       subject { perform_site_update }
 
@@ -287,7 +287,7 @@ describe 'Sites API v2', type: :request do
             it { should have_http_status(:bad_request) }
 
             it 'has the right amount of errors' do
-              expect(json_data.count).to eq 4
+              expect(json_data.count).to eq 5
             end
 
             it 'checks the location_name is present' do
@@ -308,6 +308,11 @@ describe 'Sites API v2', type: :request do
             it 'checks the postcode is present' do
               expect(response.body).to include('Invalid postcode')
               expect(response.body).to include("Postcode can't be blank")
+            end
+
+            it 'checks the postcode is present' do
+              expect(response.body).to include('Invalid postcode')
+              expect(response.body).to include('Postcode not recognised as a UK postcode')
             end
 
             it 'checks the region_code is present' do

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -157,18 +157,73 @@ describe 'Sites API v2', type: :request do
     let(:site_params) { params.dig :_jsonapi, :data, :attributes }
 
     context 'when authenticted and authorised' do
+      let(:code) { 'A3' }
+      let(:location_name) { 'New location name' }
+      let(:address1) { Faker::Address.street_address }
+      let(:address2) { Faker::Address.community }
+      let(:address3) { Faker::Address.city }
+      let(:address4) { Faker::Address.state }
+      let(:postcode) { Faker::Address.postcode }
+      let(:region_code) { 'west_midlands' }
       before do
         site_params.merge!(
-          location_name: 'New location name'
+          code: code,
+          location_name: location_name,
+          address1: address1,
+          address2: address2,
+          address3: address3,
+          address4: address4,
+          postcode: postcode,
+          region_code: region_code
         )
       end
 
       subject { perform_site_update }
 
       it 'updates the location name of the site' do
-        expect { perform_site_update }.to change { site1.reload.location_name }
-          .from('Main site 1')
-          .to('New location name')
+        expect { subject }.to change { site1.reload.location_name }
+          .from(site1.location_name)
+          .to(location_name)
+      end
+
+      it 'updates the code of the site' do
+        expect { subject }.not_to(change { site1.reload.code })
+      end
+
+      it 'updates the address1 of the site' do
+        expect { subject }.to change { site1.reload.address1 }
+          .from(site1.address1)
+          .to(address1)
+      end
+
+      it 'updates the address2 of the site' do
+        expect { subject }.to change { site1.reload.address2 }
+          .from(site1.address2)
+          .to(address2)
+      end
+
+      it 'updates the address3 of the site' do
+        expect { subject }.to change { site1.reload.address3 }
+          .from(site1.address3)
+          .to(address3)
+      end
+
+      it 'updates the address4 of the site' do
+        expect { subject }.to change { site1.reload.address4 }
+          .from(site1.address4)
+          .to(address4)
+      end
+
+      it 'updates the post code of the site' do
+        expect { subject }.to change { site1.reload.postcode }
+          .from(site1.postcode)
+          .to(postcode)
+      end
+
+      it 'updates the region code of the site' do
+        expect { subject }.to change { site1.reload.region_code }
+          .from(site1.region_code)
+          .to(region_code)
       end
     end
   end

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -208,7 +208,7 @@ describe 'Sites API v2', type: :request do
           .to(location_name)
       end
 
-      it 'updates the code of the site' do
+      it 'does not update the code of the site' do
         expect { subject }.not_to(change { site1.reload.code })
       end
 

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -247,6 +247,33 @@ describe 'Sites API v2', type: :request do
           .from(site1.region_code)
           .to(region_code)
       end
+
+      context 'response output' do
+        let(:json_data) { JSON.parse(response.body)['data'] }
+
+        before do
+          perform_site_update
+        end
+
+        subject { response }
+
+        it { should have_http_status(:success) }
+
+        it 'returns a JSON repsentation of the updated site' do
+          expect(json_data).to have_id(site1.id.to_s)
+          expect(json_data).to have_type('sites')
+          expect(json_data).to have_attributes(
+            :code,
+            :location_name,
+            :address1,
+            :address2,
+            :address3,
+            :address4,
+            :postcode,
+            :region_code
+          )
+        end
+      end
     end
   end
 end

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -133,4 +133,43 @@ describe 'Sites API v2', type: :request do
       } .to raise_error ActiveRecord::RecordNotFound
     end
   end
+
+  describe 'PATCH update' do
+    def perform_site_update
+      patch(
+        api_v2_provider_site_path(provider.provider_code, site1),
+        headers: { 'HTTP_AUTHORIZATION' => credentials },
+        params: params
+      )
+    end
+
+    let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+    let(:params) do
+      {
+        _jsonapi: jsonapi_renderer.render(
+          site1,
+          class: {
+            Site: API::V2::SerializableSite
+          }
+        )
+      }
+    end
+    let(:site_params) { params.dig :_jsonapi, :data, :attributes }
+
+    context 'when authenticted and authorised' do
+      before do
+        site_params.merge!(
+          location_name: 'New location name'
+        )
+      end
+
+      subject { perform_site_update }
+
+      it 'updates the location name of the site' do
+        expect { perform_site_update }.to change { site1.reload.location_name }
+          .from('Main site 1')
+          .to('New location name')
+      end
+    end
+  end
 end

--- a/spec/validators/postcode_validator_spec.rb
+++ b/spec/validators/postcode_validator_spec.rb
@@ -1,0 +1,25 @@
+describe PostcodeValidator do
+  # TODO: Use a dummy model here, instead of site.
+  let(:site) { build(:site) }
+
+  before do
+    site.postcode = postcode
+  end
+
+  context 'with a valid UK postcode' do
+    let(:postcode) { 'SW1A 1AA' }
+
+    it 'does not add an error' do
+      expect(site).to be_valid
+    end
+  end
+
+  context 'with an invalid UK postcode' do
+    let(:postcode) { 'not really a postcode' }
+
+    it 'adds an error' do
+      expect(site).not_to be_valid
+      expect(site.errors[:postcode]).not_to be_blank
+    end
+  end
+end

--- a/spec/validators/postcode_validator_spec.rb
+++ b/spec/validators/postcode_validator_spec.rb
@@ -22,4 +22,13 @@ describe PostcodeValidator do
       expect(site.errors[:postcode]).not_to be_blank
     end
   end
+
+  context 'without a postcode' do
+    let(:postcode) { nil }
+
+    it 'adds an error' do
+      expect(site).not_to be_valid
+      expect(site.errors[:postcode]).not_to be_blank
+    end
+  end
 end


### PR DESCRIPTION
### Context

Provider needs to be able to update site information.

### Changes proposed in this pull request

And update endpoint for sites that allows updating all attributes, except `code`.

### Guidance to review
