### PR TITLE
[1276] Vacancies should be derived only from open sites

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -88,7 +88,7 @@ class Course < ApplicationRecord
   end
 
   def has_vacancies?
-    site_statuses.with_vacancies.any?
+    site_statuses.open_for_applications.with_vacancies.any?
   end
 
   def update_changed_at(timestamp: Time.now.utc)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -88,7 +88,7 @@ class Course < ApplicationRecord
   end
 
   def has_vacancies?
-    site_statuses.open_for_applications.with_vacancies.any?
+    site_statuses.findable.with_vacancies.any?
   end
 
   def update_changed_at(timestamp: Time.now.utc)

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Course, type: :model do
     describe '#has_vacancies?' do
       context 'for a single site status that has vacancies' do
         let(:subject) {
-          create(:course, with_site_statuses: [[:with_any_vacancy]])
+          create(:course, with_site_statuses: [%i[findable applications_being_accepted_now with_any_vacancy]])
         }
 
         its(:has_vacancies?) { should be true }
@@ -112,8 +112,20 @@ RSpec.describe Course, type: :model do
       context 'when none of the sites have vacancies' do
         let(:subject) {
           create(:course, with_site_statuses: [
-            [:findable, :with_no_vacancies],
-            [:findable, :with_no_vacancies],
+            %i[findable with_no_vacancies],
+            %i[findable with_no_vacancies],
+          ])
+        }
+
+        its(:has_vacancies?) { should be false }
+      end
+
+      context 'when only discontinued and suspended site statuses have vacancies' do
+        let(:subject) {
+          create(:course, with_site_statuses: [
+            %i[published suspended with_any_vacancy],
+            %i[published discontinued with_any_vacancy],
+            %i[findable with_no_vacancies],
           ])
         }
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -120,6 +120,16 @@ RSpec.describe Course, type: :model do
         its(:has_vacancies?) { should be false }
       end
 
+      context 'when the site is findable but only opens in the future' do
+        let(:subject) {
+          create(:course, with_site_statuses: [
+            %i[findable with_any_vacancy applications_being_accepted_in_future],
+          ])
+        }
+
+        its(:has_vacancies?) { should be true }
+      end
+
       context 'when only discontinued and suspended site statuses have vacancies' do
         let(:subject) {
           create(:course, with_site_statuses: [

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -94,7 +94,6 @@ RSpec.describe Course, type: :model do
           create(:course, with_site_statuses: [[:with_any_vacancy]])
         }
 
-        its(:site_statuses) { should_not be_empty }
         its(:has_vacancies?) { should be true }
       end
 
@@ -107,7 +106,6 @@ RSpec.describe Course, type: :model do
           ])
         }
 
-        its(:site_statuses) { should_not be_empty }
         its(:has_vacancies?) { should be true }
       end
     end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -108,6 +108,17 @@ RSpec.describe Course, type: :model do
 
         its(:has_vacancies?) { should be true }
       end
+
+      context 'when none of the sites have vacancies' do
+        let(:subject) {
+          create(:course, with_site_statuses: [
+            [:findable, :with_no_vacancies],
+            [:findable, :with_no_vacancies],
+          ])
+        }
+
+        its(:has_vacancies?) { should be false }
+      end
     end
 
     describe 'open_for_applications?' do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -88,31 +88,27 @@ RSpec.describe Course, type: :model do
       end
     end
 
-    describe 'has_vacancies' do
-      context 'with at least one site status has vacancies' do
-        context 'single site status has vacancies' do
-          let(:subject) {
-            create(:course, with_site_statuses: [[:with_any_vacancy]])
-          }
+    describe '#has_vacancies?' do
+      context 'for a single site status that has vacancies' do
+        let(:subject) {
+          create(:course, with_site_statuses: [[:with_any_vacancy]])
+        }
 
-          its(:site_statuses) { should_not be_empty }
-          its(:has_vacancies?) { should be true }
-        end
+        its(:site_statuses) { should_not be_empty }
+        its(:has_vacancies?) { should be true }
+      end
 
-        context 'single site status has vacancies and mix site status with no vacancies' do
-          let(:subject) {
-            create(:course, with_site_statuses: [
-              [:findable],
-              [:with_any_vacancy],
-              [:default],
-              [:applications_being_accepted_now],
-              [:applications_being_accepted_in_future]
-            ])
-          }
+      context 'for a site status with vacancies and others without' do
+        let(:subject) {
+          create(:course, with_site_statuses: [
+            %i[findable applications_being_accepted_now with_any_vacancy],
+            %i[findable with_no_vacancies],
+            %i[findable with_no_vacancies],
+          ])
+        }
 
-          its(:site_statuses) { should_not be_empty }
-          its(:has_vacancies?) { should be true }
-        end
+        its(:site_statuses) { should_not be_empty }
+        its(:has_vacancies?) { should be true }
       end
     end
 


### PR DESCRIPTION
### Context
Course vacancy logic currently looks at suspended and discontinued sites.

### Changes proposed in this pull request
Fix the above, and make some spec improvements.
