### PR TITLE
[1279] add audited for providers and contacts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,9 @@ gem 'faraday'
 # UK postcode parsing and validation for Ruby
 gem 'uk_postcode'
 
+# For change history on provider, courses, sites, etc
+gem 'audited', '~> 4.7'
+
 group :development, :test do
   # add info about db structure to models and other files
   gem 'annotate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,8 @@ GEM
     application_insights (0.5.6)
     arel (9.0.0)
     ast (2.4.0)
+    audited (4.8.0)
+      activerecord (>= 4.0, < 5.3)
     awesome_print (1.8.0)
     bootsnap (1.4.3)
       msgpack (~> 1.0)
@@ -349,6 +351,7 @@ DEPENDENCIES
   annotate
   api-pagination
   application_insights
+  audited (~> 4.7)
   awesome_print
   bootsnap (>= 1.1.0)
   byebug

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -17,6 +17,8 @@ class Contact < ApplicationRecord
 
   belongs_to :provider
 
+  audited associated_with: :provider
+
   enum type: {
          admin: 'admin',
          utt: 'utt',

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -26,6 +26,9 @@ class Course < ApplicationRecord
   include WithQualifications
   include ChangedAt
 
+  has_associated_audits
+  audited except: :changed_at
+
   enum program_type: {
     higher_education_programme: "HE",
     school_direct_training_programme: "SD",

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -31,6 +31,9 @@ class Provider < ApplicationRecord
   include RegionCode
   include ChangedAt
 
+  has_associated_audits
+  audited except: :changed_at
+
   enum provider_type: {
     scitt: "B",
     lead_school: "Y",

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -21,6 +21,8 @@ class Site < ApplicationRecord
   include RegionCode
   include TouchProvider
 
+  audited associated_with: :provider
+
   belongs_to :provider
 
   validates :location_name, uniqueness: { scope: :provider_id }

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -16,6 +16,8 @@ class SiteStatus < ApplicationRecord
 
   self.table_name = "course_site"
 
+  audited associated_with: :course
+
   validate :vac_status_must_be_consistent_with_course_study_mode,
     if: Proc.new { |s| s.course&.study_mode.present? }
 

--- a/db/migrate/20190409230916_install_audited.rb
+++ b/db/migrate/20190409230916_install_audited.rb
@@ -1,0 +1,30 @@
+class InstallAudited < ActiveRecord::Migration[5.2]
+  def self.up
+    create_table :audit, force: true do |t|
+      t.integer  :auditable_id
+      t.string   :auditable_type
+      t.integer  :associated_id
+      t.string   :associated_type
+      t.integer  :user_id
+      t.string   :user_type
+      t.string   :username
+      t.string   :action
+      t.jsonb    :audited_changes
+      t.integer  :version, default: 0
+      t.string   :comment
+      t.string   :remote_address
+      t.string   :request_uuid
+      t.datetime :created_at
+    end
+
+    add_index :audit, %i[auditable_type auditable_id version], name: 'auditable_index'
+    add_index :audit, %i[associated_type associated_id], name: 'associated_index'
+    add_index :audit, %i[user_id user_type], name: 'user_index'
+    add_index :audit, :request_uuid
+    add_index :audit, :created_at
+  end
+
+  def self.down
+    drop_table :audit
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_20_144534) do
+ActiveRecord::Schema.define(version: 2019_04_09_230916) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -32,6 +32,28 @@ ActiveRecord::Schema.define(version: 2019_03_20_144534) do
     t.integer "status", null: false
     t.text "requester_email"
     t.index ["requester_id"], name: "IX_access_request_requester_id"
+  end
+
+  create_table "audit", force: :cascade do |t|
+    t.integer "auditable_id"
+    t.string "auditable_type"
+    t.integer "associated_id"
+    t.string "associated_type"
+    t.integer "user_id"
+    t.string "user_type"
+    t.string "username"
+    t.string "action"
+    t.jsonb "audited_changes"
+    t.integer "version", default: 0
+    t.string "comment"
+    t.string "remote_address"
+    t.string "request_uuid"
+    t.datetime "created_at"
+    t.index ["associated_type", "associated_id"], name: "associated_index"
+    t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index"
+    t.index ["created_at"], name: "index_audit_on_created_at"
+    t.index ["request_uuid"], name: "index_audit_on_request_uuid"
+    t.index ["user_id", "user_type"], name: "user_index"
   end
 
   create_table "contact", force: :cascade do |t|

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -27,6 +27,11 @@ require 'rails_helper'
 RSpec.describe Course, type: :model do
   let(:subject) { create(:course) }
 
+  describe 'auditing' do
+    it { should be_audited.except(:changed_at) }
+    it { should have_associated_audits }
+  end
+
   describe 'associations' do
     it { should belong_to(:provider) }
     it { should belong_to(:accrediting_provider).optional }

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -32,6 +32,11 @@ require 'rails_helper'
 describe Provider, type: :model do
   subject { create(:provider) }
 
+  describe 'auditing' do
+    it { should be_audited.except(:changed_at) }
+    it { should have_associated_audits }
+  end
+
   describe 'associations' do
     it { should have_many(:sites) }
     it { should have_many(:users).through(:organisations) }

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -21,6 +21,10 @@ require 'rails_helper'
 describe Provider, type: :model do
   subject { create(:site) }
 
+  describe 'auditing' do
+    it { should be_audited.associated_with(:provider) }
+  end
+
   it { is_expected.to validate_presence_of(:location_name) }
   it { is_expected.to validate_presence_of(:address1) }
   it { is_expected.to validate_presence_of(:address3) }

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe SiteStatus, type: :model do
     end
   end
 
+  describe 'auditing' do
+    it { should be_audited.associated_with(:course) }
+  end
+
   describe 'associations' do
     it { should belong_to(:site) }
     it { should belong_to(:course) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'jsonapi/rspec'
 require "super_diff/rspec"
 require 'fakefs/spec_helpers'
 require 'webmock/rspec'
+require 'audited-rspec'
 
 # Pull in all the files in spec/support automatically.
 Dir['./spec/support/**/*.rb'].each { |file| require file }


### PR DESCRIPTION
https://trello.com/c/exkrR2wQ/1279-add-auditing

### Context

We need to have some kind of auditing tool so that we can see what's changing on providers.

### Changes proposed in this pull request

Add the `audited` gem and enable auditing for `providers` and `contacts`.
