### PR TITLE
[1248] Expose course enrichments

### DIFF
--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -15,6 +15,7 @@ module API
       belongs_to :accrediting_provider
 
       has_many :site_statuses
+      has_many :enrichments
     end
   end
 end

--- a/app/serializers/api/v2/serializable_course_enrichment.rb
+++ b/app/serializers/api/v2/serializable_course_enrichment.rb
@@ -1,0 +1,11 @@
+module API
+  module V2
+    class SerializableCourseEnrichment < JSONAPI::Serializable::Resource
+      type 'course_enrichments'
+
+      attributes :json_data, :status, :has_been_published_before?
+
+      belongs_to :course
+    end
+  end
+end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -101,6 +101,7 @@ describe 'Courses API v2', type: :request do
               "accrediting_provider" => { "meta" => { "included" => false } },
               "provider" => { "meta" => { "included" => false } },
               "site_statuses" => { "data" => [{ "type" => "site_statuses", "id" => site_status.id.to_s }] },
+              "enrichments" => { "meta" => { "included" => false } },
             },
           },
           "jsonapi" => {
@@ -266,6 +267,7 @@ describe 'Courses API v2', type: :request do
               "accrediting_provider" => { "meta" => { "included" => false } },
               "provider" => { "meta" => { "included" => false } },
               "site_statuses" => { "meta" => { "included" => false } },
+              "enrichments" => { "meta" => { "included" => false } },
             },
           }],
           "jsonapi" => {

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -25,7 +25,8 @@ describe API::V2::SerializableCourse do
         course,
         class: {
           Course:   API::V2::SerializableCourse,
-          Provider: API::V2::SerializableProvider
+          Provider: API::V2::SerializableProvider,
+          CourseEnrichment: API::V2::SerializableCourseEnrichment
         },
         include: [
           :provider
@@ -50,7 +51,8 @@ describe API::V2::SerializableCourse do
         course,
         class: {
           Course:   API::V2::SerializableCourse,
-          Provider: API::V2::SerializableProvider
+          Provider: API::V2::SerializableProvider,
+          CourseEnrichment: API::V2::SerializableCourseEnrichment
         },
         include: [
           :accrediting_provider


### PR DESCRIPTION
### Context
Course enrichment data, this is required for the frontend course details view

### Changes proposed in this pull request
- Optional include on courses endpoint

### Guidance to review
example: `http://localhost:3001/api/v2/providers/2AT/courses/35L8?include=enrichments`

TODO: Specs