### PR TITLE
[1288] Fixed publishing courses typo in endpoint

### DIFF
--- a/app/services/manage_courses_api.rb
+++ b/app/services/manage_courses_api.rb
@@ -26,7 +26,7 @@ module ManageCoursesAPI
 
       def sync_courses_with_search_and_compare(email, provider_code)
         response = api.post(
-          "/api/Publish/internal/course/#{provider_code}",
+          "/api/Publish/internal/courses/#{provider_code}",
           { email: email }.to_json
         )
         if response.success?

--- a/spec/services/manage_courses_api_spec.rb
+++ b/spec/services/manage_courses_api_spec.rb
@@ -47,7 +47,7 @@ describe ManageCoursesAPI do
       end
 
       describe 'sync_courses_with_search_and_compare' do
-        let(:endpoint) { "api/Publish/internal/course/#{provider_code}" }
+        let(:endpoint) { "api/Publish/internal/courses/#{provider_code}" }
 
         describe "with a normal response" do
           it "returns true" do


### PR DESCRIPTION
### Context
https://github.com/DFE-Digital/manage-courses-api/blob/1e84f8b42e4b365e43fef0109ddbd34efc747b21/src/ManageCourses.Api/Controllers/PublishController.cs#L76

### Changes proposed in this pull request

Fixed publishing courses typo in endpoint (there should be a `s` for course)