### PR TITLE
[1289] Publish course when location is edited

### DIFF
--- a/app/controllers/api/v2/sites_controller.rb
+++ b/app/controllers/api/v2/sites_controller.rb
@@ -15,6 +15,8 @@ module API
 
       def update
         if @site.update(site_params)
+          sync_courses_with_search_and_compare
+
           render jsonapi: @site
         else
           render jsonapi_errors: @site.errors, status: 422
@@ -46,6 +48,15 @@ module API
       def build_site
         @site = @provider.sites.find(params[:id])
         authorize @site
+      end
+
+      def sync_courses_with_search_and_compare
+        ManageCoursesAPI::Request.sync_courses_with_search_and_compare(
+          @current_user.email,
+          @provider.provider_code
+        )
+      rescue StandardError
+        false
       end
     end
   end

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -156,6 +156,12 @@ describe 'Sites API v2', type: :request do
     end
     let(:site_params) { params.dig :_jsonapi, :data, :attributes }
 
+    before do
+      allow(ManageCoursesAPI::Request).to(
+        receive(:sync_courses_with_search_and_compare).and_return(true)
+      )
+    end
+
     context 'when unauthenticated' do
       let(:payload) { { email: 'foo@bar' } }
 
@@ -258,6 +264,13 @@ describe 'Sites API v2', type: :request do
         subject { response }
 
         it { should have_http_status(:success) }
+
+        it 'publishes courses on manage-courses-api' do
+          expect(ManageCoursesAPI::Request).to(
+            have_received(:sync_courses_with_search_and_compare)
+            .with(user.email, provider.provider_code)
+          )
+        end
 
         it 'returns a JSON repsentation of the updated site' do
           expect(json_data).to have_id(site1.id.to_s)


### PR DESCRIPTION
### Context

Courses should be published to find when we edit a site.

### Changes proposed in this pull request

Call the service to publish the course once a site has been successfully edited.

### Guidance to review

We don't care if this fails, so we silently handle it.