### PR TITLE
[1281] add mcb provider opt in

### DIFF
--- a/lib/mcb/commands/providers/optin.rb
+++ b/lib/mcb/commands/providers/optin.rb
@@ -1,13 +1,18 @@
 summary 'Opt-in the provider'
-param :code
-usage 'optin <provider_code>'
+usage 'optin <provider_code1 [provider_code2 ...]>'
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
-  provider_code = args[:code]
-
-  provider = Provider.find_by!(provider_code: provider_code)
-  provider.update(opted_in: true)
-  provider.courses.each { |c| c.touch(:changed_at) }
+  Provider.connection.transaction do
+    args.each do |provider_code|
+      provider = Provider.find_by!(provider_code: provider_code)
+      verbose "updating provider #{provider_code}"
+      provider.update(opted_in: true)
+      provider.courses.each do |c|
+        verbose "  updating course #{c.course_code}"
+        c.touch(:changed_at)
+      end
+    end
+  end
 end

--- a/lib/mcb/commands/providers/optin.rb
+++ b/lib/mcb/commands/providers/optin.rb
@@ -1,0 +1,13 @@
+summary 'Opt-in the provider'
+param :code
+usage 'optin <provider_code>'
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
+  provider_code = args[:code]
+
+  provider = Provider.find_by!(provider_code: provider_code)
+  provider.update(opted_in: true)
+  provider.courses.each { |c| c.touch(:changed_at) }
+end

--- a/lib/mcb/commands/providers/optout.rb
+++ b/lib/mcb/commands/providers/optout.rb
@@ -1,13 +1,18 @@
 summary 'Opt-out the provider'
-param :code
-usage 'optout <provider_code>'
+usage 'optin <provider_code1 [provider_code2 ...]>'
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
-  provider_code = args[:code]
-
-  provider = Provider.find_by!(provider_code: provider_code)
-  provider.update(opted_in: false)
-  provider.courses.each { |c| c.touch(:changed_at) }
+  Provider.connection.transaction do
+    args.each do |provider_code|
+      provider = Provider.find_by!(provider_code: provider_code)
+      verbose "updating provider #{provider_code}"
+      provider.update(opted_in: false)
+      provider.courses.each do |c|
+        verbose "  updating course #{c.course_code}"
+        c.touch(:changed_at)
+      end
+    end
+  end
 end

--- a/lib/mcb/commands/providers/optout.rb
+++ b/lib/mcb/commands/providers/optout.rb
@@ -1,0 +1,13 @@
+summary 'Opt-out the provider'
+param :code
+usage 'optout <provider_code>'
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
+  provider_code = args[:code]
+
+  provider = Provider.find_by!(provider_code: provider_code)
+  provider.update(opted_in: false)
+  provider.courses.each { |c| c.touch(:changed_at) }
+end

--- a/spec/lib/mcb/commands/providers/optin_spec.rb
+++ b/spec/lib/mcb/commands/providers/optin_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+load 'bin/mcb'
+
+describe 'mcb provider optin' do
+  let(:provider) { create :provider, opted_in: false }
+
+  let(:subject) do
+    with_stubbed_stdout do
+      $mcb.run(%W[provider optin #{provider.provider_code}])
+    end
+  end
+
+  it 'sets the provider to be opted-in' do
+    expect { subject }.to change {
+      provider.reload.opted_in
+    }.from(false)
+     .to(true)
+  end
+
+  it 'updates the changed_at for the provider' do
+    expect { subject } .to(
+      change {
+        provider.reload.changed_at
+      }
+    )
+  end
+
+  context 'provider with courses' do
+    let(:course1) { build :course }
+    let(:course2) { build :course }
+    let(:provider) do
+      create :provider,
+             opted_in: false,
+             courses: [course1, course2]
+    end
+
+    it 'updates the changed_at for all the provider courses' do
+      expect { subject }.to(
+        change {
+          provider.reload.courses.pluck(:changed_at)
+        }
+      )
+    end
+
+    it 'does not set the created_at times to be exactly the same' do
+      # Yes, this is testing the implementation of 'touch', but this is a
+      # business requirement so it ensures we don't implement the same
+      # mechanism wrongly.
+      subject
+
+      # These should be correct to the second, but not the nsec
+      expect(course1.created_at.nsec).not_to eq course2.created_at.nsec
+    end
+  end
+end

--- a/spec/lib/mcb/commands/providers/optout_spec.rb
+++ b/spec/lib/mcb/commands/providers/optout_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+load 'bin/mcb'
+
+describe 'mcb provider optin' do
+  let(:provider) { create :provider, opted_in: true }
+
+  let(:subject) do
+    with_stubbed_stdout do
+      $mcb.run(%W[provider optout #{provider.provider_code}])
+    end
+  end
+
+  it 'sets the provider to be opted-out' do
+    expect { subject }.to change {
+      provider.reload.opted_in
+    }.from(true)
+     .to(false)
+  end
+
+  it 'updates the changed_at for the provider' do
+    expect { subject } .to(
+      change {
+        provider.reload.changed_at
+      }
+    )
+  end
+
+  context 'provider with courses' do
+    let(:course1) { build :course }
+    let(:course2) { build :course }
+    let(:provider) do
+      create :provider,
+             opted_in: true,
+             courses: [course1, course2]
+    end
+
+    it 'updates the changed_at for all the provider courses' do
+      expect { subject }.to(
+        change {
+          provider.reload.courses.pluck(:changed_at)
+        }
+      )
+    end
+
+    it 'does not set the created_at times to be exactly the same' do
+      # Yes, this is testing the implementation of 'touch', but this is a
+      # business requirement so it ensures we don't implement the same
+      # mechanism wrongly.
+      subject
+
+      # These should be correct to the second, but not the nsec
+      expect(course1.created_at.nsec).not_to eq course2.created_at.nsec
+    end
+  end
+end


### PR DESCRIPTION
### Context

We want to have a convenient method to optin/optout providers to the DfE find platform.

### Changes proposed in this pull request

Add the mcb commands:

```
mcb provider optin <provider_code>
mcb provider optout <provider_code>
```

### Guidance to review

We need to start opting in tomorrow morning. Just sayin'.