### PR TITLE
[1272] fix region codes in factories

### DIFF
--- a/spec/factories/provider_enrichments.rb
+++ b/spec/factories/provider_enrichments.rb
@@ -13,6 +13,7 @@
 #  status             :integer          default("draft"), not null
 #
 
+
 FactoryBot.define do
   factory :provider_enrichment do
     transient do
@@ -27,7 +28,7 @@ FactoryBot.define do
     address3 { Faker::Address.city }
     address4 { Faker::Address.state }
     postcode { Faker::Address.postcode }
-    region_code { ProviderEnrichment.region_codes['Eastern'] }
+    region_code { 'eastern' }
     train_with_us { Faker::Lorem.sentence.to_s }
     train_with_disability { Faker::Lorem.sentence.to_s }
     created_at { Faker::Date.between 2.days.ago, 1.days.ago }

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
     email { Faker::Internet.email }
     telephone { Faker::PhoneNumber.phone_number }
     accrediting_provider { 'N' }
-    region_code { ProviderEnrichment.region_codes['London'] }
+    region_code { 'london' }
     opted_in { true }
     organisations { build_list :organisation, 1 }
 

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
     address3 { Faker::Address.city }
     address4 { Faker::Address.state }
     postcode { Faker::Address.postcode }
-    region_code { ProviderEnrichment.region_codes['London'] }
+    region_code { 'london' }
     association(:provider)
 
     transient do

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -30,7 +30,7 @@
 require "rails_helper"
 
 describe ProviderSerializer do
-  let(:provider) { create :provider }
+  let(:provider) { create :provider, site_count: 0 }
 
   subject { serialize(provider) }
 
@@ -41,7 +41,7 @@ describe ProviderSerializer do
   it { should include(address3: provider.address3) }
   it { should include(address4: provider.address4) }
   it { should include(postcode: provider.postcode) }
-  it { should include(region_code: provider.region_code) }
+  it { should include(region_code: "%02d" % provider.region_code_before_type_cast) }
   it { should include(institution_type: provider.provider_type) }
   it { should include(accrediting_provider: provider.accrediting_provider) }
 
@@ -74,7 +74,7 @@ describe ProviderSerializer do
 
     context 'if nil' do
       let(:ucas_preferences) { create :ucas_preferences, application_alert_email: nil }
-      let(:provider) { create :provider, ucas_preferences: ucas_preferences }
+      let(:provider) { create :provider, ucas_preferences: ucas_preferences, site_count: 0 }
       let(:contacts) do
         serialize(provider)['contacts'].map { |contact| contact[:type] }
       end
@@ -102,7 +102,7 @@ describe ProviderSerializer do
   describe 'contacts' do
     describe 'generate provider object returns the providers contacts' do
       let(:contact)  { create :contact }
-      let(:provider) { create :provider, contacts: [contact] }
+      let(:provider) { create :provider, contacts: [contact], site_count: 0 }
 
       subject { serialize(provider)['contacts'].first }
 
@@ -113,8 +113,6 @@ describe ProviderSerializer do
 
     describe 'admin contact' do
       context 'exists on provider record and not in contacts table' do
-        let(:provider) { create :provider }
-
         subject { serialize(provider)['contacts'].find { |c| c[:type] == 'admin' } }
 
         its([:name]) { should eq provider.contact_name }
@@ -124,7 +122,7 @@ describe ProviderSerializer do
 
       context 'exists in contacts table' do
         let(:contact)  { create :contact, type: 'admin' }
-        let(:provider) { create :provider, contacts: [contact] }
+        let(:provider) { create :provider, contacts: [contact], site_count: 0 }
 
         subject { serialize(provider)['contacts'].find { |c| c[:type] == 'admin' } }
 

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe SiteSerializer do
   subject { serialize(site) }
 
   it { is_expected.to include(name: site.location_name, campus_code: site.code) }
-  it { is_expected.to include(region_code: site.region_code) }
+  it { is_expected.to include(region_code: "%02d" % site.region_code_before_type_cast) }
 
   describe 'SiteSerializer#region_code' do
     subject do
@@ -34,6 +34,7 @@ RSpec.describe SiteSerializer do
     describe "region code is set" do
       let(:site) { create :site, region_code: region_code }
       let(:region_code) { 1 }
+
       it { is_expected.to eql("%02d" % region_code) }
     end
   end


### PR DESCRIPTION
### Context
The factories were calling a region_code method on the provider enrichment model with `ProviderEnrichment.region_code['London']`. As it was returning `nil` the serialiser tests were still passing. 

The provider factory has a default site count of 1. This causes factory bot issues that don't occur on live.
When the provider serialiser attempts to build the course it cannot convert the enum key ie. london into an integer.

This bug only affects our tests and not live.

### Changes proposed in this pull request

- Changes the factories to generate region code by the enum key ie. london, eastern etc.
- Alters the providers in the provider serialiser spec to have `site_count 0` allowing serialisation without errors occurring 

### Guidance to review

Bit more context.

In the console 

`s = Site.create(region_code: 1)`
`p = Provider.create(site: [s])`
`p.sites.first.region_code`
returns 
`'london'` 
and 
`p.sites.first.region_code_before_type_cast` 
returns 
`1`

When you replicate this using factory bots create(:object) it returns 'london' for region_code and region_code_before_type_cast. 


