### PR TITLE
[1223] Workaround for missing DNS entry

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,3 +1,3 @@
 manage_api:
-  base_url: https://api.publish-teacher-training-courses.service.gov.uk
+  base_url: https://bat-prod-manage-courses-api-app.azurewebsites.net
   secret: please_change_me


### PR DESCRIPTION
As part of the work of using Settings instead of envvars for non-secret settings,
bring the settings file in line with the environment variable value.

