### PR TITLE
[1247] add update endpoint to user

### DIFF
--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -1,12 +1,37 @@
 module API
   module V2
     class UsersController < API::V2::ApplicationController
-      def show
-        user = User.find(params[:id])
-        authorize user
+      before_action :build_user
+      deserializable_resource :user, only: :update
 
-        render jsonapi: user,
+      def show
+        render jsonapi: @user,
                include: params[:includes]
+      end
+
+      def update
+        @user.update(user_params)
+        render jsonapi: @user
+      end
+
+    private
+
+      def build_user
+        @user = authorize User.find(params[:id])
+      end
+
+      def user_params
+        params.require(:user).permit(
+          :email,
+          :first_name,
+          :last_name,
+          :first_login_date_utc,
+          :last_login_date_utc,
+          :sign_in_user_id,
+          :welcome_email_date_utc,
+          :invite_date_utc,
+          :accept_terms_date_utc,
+        )
       end
     end
   end

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -10,8 +10,11 @@ module API
       end
 
       def update
-        @user.update(user_params)
-        render jsonapi: @user
+        if @user.update(user_params)
+          render jsonapi: @user
+        else
+          render jsonapi_errors: @user.errors, status: 422
+        end
       end
 
     private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,5 +18,7 @@ class User < ApplicationRecord
   has_and_belongs_to_many :organisations
   has_many :providers, through: :organisations
 
+  validates :email, presence: true
+
   audited
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -9,4 +9,6 @@ class UserPolicy
   def show?
     user == accessed_user
   end
+
+  alias_method :update?, :show?
 end

--- a/app/serializers/api/v2/serializable_user.rb
+++ b/app/serializers/api/v2/serializable_user.rb
@@ -3,7 +3,7 @@ module API
     class SerializableUser < JSONAPI::Serializable::Resource
       type 'users'
 
-      attributes :first_name, :last_name, :email
+      attributes :first_name, :last_name, :email, :accept_terms_date_utc
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,7 +57,7 @@ Rails.application.routes.draw do
     end
 
     namespace :v2 do
-      resources :users do
+      resources :users, only: %i[update show] do
         resources :providers
       end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -19,6 +19,6 @@ FactoryBot.define do
     email { Faker::Internet.email }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
-    accept_terms_date_utc { Faker::Date.backward(1) }
+    accept_terms_date_utc { Faker::Time.backward(1).utc }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe User, type: :model do
     it { should have_many(:providers).through(:organisations) }
   end
 
+  it { is_expected.to validate_presence_of(:email) }
+
   describe 'auditing' do
     it { should be_audited }
   end

--- a/spec/requests/api/v2/session_spec.rb
+++ b/spec/requests/api/v2/session_spec.rb
@@ -67,21 +67,11 @@ describe '/api/v2/sessions', type: :request do
       end
 
       describe "the returned json" do
-        it 'returns the user record' do
-          expect(returned_json_response).to eq(
-            "data" => {
-              "id" => user.id.to_s,
-              "type" => "users",
-              "attributes" => {
-                "first_name" => user.first_name,
-                "last_name" => user.last_name,
-                "email" => user.email,
-              }
-            },
-            "jsonapi" => {
-              "version" => "1.0"
-            }
-          )
+        it 'has a data section with the correct attributes' do
+          data_attributes = returned_json_response['data']['attributes']
+          expect(data_attributes['email']).to eq(user.email)
+          expect(data_attributes['first_name']).to eq(user.first_name)
+          expect(data_attributes['last_name']).to eq(user.last_name)
         end
       end
 

--- a/spec/requests/api/v2/users_spec.rb
+++ b/spec/requests/api/v2/users_spec.rb
@@ -72,7 +72,7 @@ describe '/api/v2/users', type: :request do
       Timecop.return
     end
 
-    context 'with accept_terms_date_utc' do
+    context 'when authenticated and authorised' do
       let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
       let(:params) do
         {
@@ -146,6 +146,21 @@ describe '/api/v2/users', type: :request do
             :last_name,
             :accept_terms_date_utc
           )
+        end
+
+        context 'with validation errors' do
+          let(:json_data) { JSON.parse(response.body)['errors'] }
+
+          context 'with missing attributes' do
+            let(:email) { '' }
+
+            it { should have_http_status(:unprocessable_entity) }
+
+            it 'checks the email is present' do
+              expect(response.body).to include('Invalid email')
+              expect(response.body).to include("Email can't be blank")
+            end
+          end
         end
       end
     end

--- a/spec/requests/api/v2/users_spec.rb
+++ b/spec/requests/api/v2/users_spec.rb
@@ -60,16 +60,13 @@ describe '/api/v2/users', type: :request do
     let(:params) { {} }
 
     def perform_request
-      Timecop.freeze
-      patch(
-        api_v2_user_path(user),
-        headers: { 'HTTP_AUTHORIZATION' => credentials },
-        params: params
-      )
-    end
-
-    after do
-      Timecop.return
+      Timecop.freeze do
+        patch(
+          api_v2_user_path(user),
+          headers: { 'HTTP_AUTHORIZATION' => credentials },
+          params: params
+        )
+      end
     end
 
     context 'when authenticated and authorised' do

--- a/spec/requests/api/v2/users_spec.rb
+++ b/spec/requests/api/v2/users_spec.rb
@@ -110,8 +110,8 @@ describe '/api/v2/users', type: :request do
 
       it 'updates accept_terms_date_utc on the user' do
         expect { subject }.to(change { user.reload.accept_terms_date_utc }
-          .from(user.accept_terms_date_utc)
-          .to(be_within(1.second).of(accept_terms_date_utc)))
+          .from(user.accept_terms_date_utc.change(usec: 0))
+          .to(accept_terms_date_utc.change(usec: 0)))
       end
 
       it 'updates first_name on the user' do

--- a/spec/requests/api/v2/users_spec.rb
+++ b/spec/requests/api/v2/users_spec.rb
@@ -48,21 +48,106 @@ describe '/api/v2/users', type: :request do
     it { should have_http_status(:success) }
 
     it 'has a data section with the correct attributes' do
-      json_response = JSON.parse response.body
-      expect(json_response).to eq(
-        "data" => {
-          "id" => user.id.to_s,
-          "type" => "users",
-          "attributes" => {
-            "first_name" => user.first_name,
-            "last_name" => user.last_name,
-            "email" => user.email
-          }
-        },
-        "jsonapi" => {
-          "version" => "1.0"
-        }
+      json_response = JSON.parse(response.body)
+      data_attributes = json_response['data']['attributes']
+      expect(data_attributes['email']).to eq(user.email)
+      expect(data_attributes['first_name']).to eq(user.first_name)
+      expect(data_attributes['last_name']).to eq(user.last_name)
+    end
+  end
+
+  describe 'PATCH update' do
+    let(:params) { {} }
+
+    def perform_request
+      Timecop.freeze
+      patch(
+        api_v2_user_path(user),
+        headers: { 'HTTP_AUTHORIZATION' => credentials },
+        params: params
       )
+    end
+
+    after do
+      Timecop.return
+    end
+
+    context 'with accept_terms_date_utc' do
+      let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+      let(:params) do
+        {
+          _jsonapi: jsonapi_renderer.render(
+            user,
+            class: {
+              User: API::V2::SerializableUser
+            }
+          )
+        }
+      end
+      let(:user_params)           { params.dig :_jsonapi, :data, :attributes }
+      let(:accept_terms_date_utc) { DateTime.now.utc }
+      let(:email)                 { 'dave.smith@gmail.com' }
+      let(:first_name)            { 'Dave' }
+      let(:last_name)             { 'Smith' }
+      let(:json_data)             { JSON.parse(response.body)['data'] }
+
+      before do
+        user_params.merge!(
+          email: email,
+          accept_terms_date_utc: accept_terms_date_utc,
+          first_name: first_name,
+          last_name: last_name,
+        )
+      end
+
+      subject { perform_request }
+
+      it 'updates email on the user' do
+        expect { subject }.to(change { user.reload.email }
+          .from(user.email)
+          .to(email))
+      end
+
+      it 'updates accept_terms_date_utc on the user' do
+        expect { subject }.to(change { user.reload.accept_terms_date_utc }
+          .from(user.accept_terms_date_utc)
+          .to(be_within(1.second).of(accept_terms_date_utc)))
+      end
+
+      it 'updates first_name on the user' do
+        expect { subject }.to(change { user.reload.first_name }
+          .from(user.first_name)
+          .to(first_name))
+      end
+
+      it 'updates last_name on the user' do
+        expect { subject }.to(change { user.reload.last_name }
+          .from(user.last_name)
+          .to(last_name))
+      end
+
+      context 'response output' do
+        before do
+          perform_request
+        end
+
+        subject { response }
+
+        it { should have_http_status(:success) }
+
+        it 'returns a JSON repsentation of the updated user' do
+          subject
+
+          expect(json_data).to have_id(user.id.to_s)
+          expect(json_data).to have_type('users')
+          expect(json_data).to have_attributes(
+            :email,
+            :first_name,
+            :last_name,
+            :accept_terms_date_utc
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
In readiness for the transition screen (and t&c's) that will require a user to "update" their record.

### Changes proposed in this pull request
- Add `users#update` controller action

### Guidance to review
Testing "time" is hard so had to remove the json match and check for individual attributes. Then using the `be_within` matcher is impossible to test when the json output is a string 🤷‍♂️ 

Open to feedback/suggestions..
