### PR TITLE
[1251] Add state machine to users for terms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,9 @@ gem 'uk_postcode'
 # For change history on provider, courses, sites, etc
 gem 'audited', '~> 4.7'
 
+# State machine to track users through their onboarding journey
+gem 'aasm'
+
 group :development, :test do
   # add info about db structure to models and other files
   gem 'annotate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (5.0.2)
+      concurrent-ruby (~> 1.0)
     abstract_class (1.0.1)
     actioncable (5.2.3)
       actionpack (= 5.2.3)
@@ -347,6 +349,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aasm
   active_model_serializers
   annotate
   api-pagination

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,4 +24,13 @@ class User < ApplicationRecord
   validates :email, presence: true
 
   audited
+
+  aasm do
+    state :new, initial: true
+    state :active
+
+    event :activated do
+      transitions from: :new, to: :active
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,9 +12,12 @@
 #  welcome_email_date_utc :datetime
 #  invite_date_utc        :datetime
 #  accept_terms_date_utc  :datetime
+#  aasm_state             :string
 #
 
 class User < ApplicationRecord
+  include AASM
+
   has_and_belongs_to_many :organisations
   has_many :providers, through: :organisations
 

--- a/app/serializers/api/v2/serializable_user.rb
+++ b/app/serializers/api/v2/serializable_user.rb
@@ -4,6 +4,10 @@ module API
       type 'users'
 
       attributes :first_name, :last_name, :email, :accept_terms_date_utc
+
+      attribute :state do
+        @object.aasm_state
+      end
     end
   end
 end

--- a/db/migrate/20190416093524_add_aasm_state_to_users.rb
+++ b/db/migrate/20190416093524_add_aasm_state_to_users.rb
@@ -1,0 +1,5 @@
+class AddAasmStateToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :user, :aasm_state, :string
+  end
+end

--- a/db/migrate/20190416190949_initialize_state_for_users.rb
+++ b/db/migrate/20190416190949_initialize_state_for_users.rb
@@ -1,0 +1,18 @@
+class InitializeStateForUsers < ActiveRecord::Migration[5.2]
+  def up
+    User.find_each do |user|
+      user.activated! if user.accept_terms_date_utc.present?
+    end
+  end
+
+  def down
+    User.find_each do |user|
+      next unless user.active?
+
+      user.update(
+        accept_terms_date_utc: Time.current,
+        aasm_state:            'new'
+      )
+    end
+  end
+end

--- a/db/migrate/20190417111420_change_aasm_state_default_and_nullable_on_users.rb
+++ b/db/migrate/20190417111420_change_aasm_state_default_and_nullable_on_users.rb
@@ -1,0 +1,5 @@
+class ChangeAasmStateDefaultAndNullableOnUsers < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :user, :aasm_state, false, User.aasm.initial_state
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_09_230916) do
+ActiveRecord::Schema.define(version: 2019_04_16_093524) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -246,6 +246,7 @@ ActiveRecord::Schema.define(version: 2019_04_09_230916) do
     t.datetime "welcome_email_date_utc"
     t.datetime "invite_date_utc"
     t.datetime "accept_terms_date_utc"
+    t.string "aasm_state"
     t.index ["email"], name: "IX_user_email", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_16_190949) do
+ActiveRecord::Schema.define(version: 2019_04_17_111420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -246,7 +246,7 @@ ActiveRecord::Schema.define(version: 2019_04_16_190949) do
     t.datetime "welcome_email_date_utc"
     t.datetime "invite_date_utc"
     t.datetime "accept_terms_date_utc"
-    t.string "aasm_state"
+    t.string "aasm_state", null: false
     t.index ["email"], name: "IX_user_email", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_16_093524) do
+ActiveRecord::Schema.define(version: 2019_04_16_190949) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -12,6 +12,7 @@
 #  welcome_email_date_utc :datetime
 #  invite_date_utc        :datetime
 #  accept_terms_date_utc  :datetime
+#  aasm_state             :string
 #
 
 FactoryBot.define do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,6 +12,7 @@
 #  welcome_email_date_utc :datetime
 #  invite_date_utc        :datetime
 #  accept_terms_date_utc  :datetime
+#  aasm_state             :string
 #
 
 require 'rails_helper'

--- a/spec/requests/api/v2/session_spec.rb
+++ b/spec/requests/api/v2/session_spec.rb
@@ -72,6 +72,7 @@ describe '/api/v2/sessions', type: :request do
           expect(data_attributes['email']).to eq(user.email)
           expect(data_attributes['first_name']).to eq(user.first_name)
           expect(data_attributes['last_name']).to eq(user.last_name)
+          expect(data_attributes['state']).to eq(user.aasm_state)
         end
       end
 

--- a/spec/requests/api/v2/users_spec.rb
+++ b/spec/requests/api/v2/users_spec.rb
@@ -53,6 +53,7 @@ describe '/api/v2/users', type: :request do
       expect(data_attributes['email']).to eq(user.email)
       expect(data_attributes['first_name']).to eq(user.first_name)
       expect(data_attributes['last_name']).to eq(user.last_name)
+      expect(data_attributes['state']).to eq(user.aasm_state)
     end
   end
 

--- a/spec/serializers/api/v2/serializable_user_spec.rb
+++ b/spec/serializers/api/v2/serializable_user_spec.rb
@@ -11,4 +11,5 @@ describe API::V2::SerializableUser do
   subject { resource.as_jsonapi.to_json }
 
   it { should be_json.with_content(type: 'users') }
+  it { should be_json.with_content(attributes: { state: user.aasm_state }) }
 end


### PR DESCRIPTION
### Context
To track when a user has accepted terms & conditions and confirmed transition information

### Changes proposed in this pull request
- Add [State machine](https://github.com/aasm/aasm)
- Setup "event" that can be called when a user accepted the t&c's `@current_user.accept_terms`
- I propose we get this merged then move the t&c's into this stack

> For the transition screen, we can simply add a new event to set the state to `accepted_transition` once the user has hit continue

### Guidance to review
```ruby
u = User.find_by(email: "tim.abell+4@digital.education.gov.uk")
u.accept_terms
u

{
    "data": {
        "id": "10396",
        "type": "users",
        "attributes": {
            "first_name": "Tim4",
            "last_name": "Abell",
            "email": "tim.abell+4@digital.education.gov.uk",
            "aasm_state": "accepted_terms"
        }
    },
    "jsonapi": {
        "version": "1.0"
    }
}

```