### PR TITLE
[1314] reenable and fix specs

### DIFF
--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -97,10 +97,10 @@ describe 'Courses API v2', type: :request do
               "start_date" => provider.courses[0].start_date.iso8601,
               "study_mode" => "full_time",
               "qualifications" => %w[qts pgce],
-              "description" => "PGCE with QTS full time",
+              "description" => "PGCE with QTS full time teaching apprenticeship",
               "content_status" => "empty",
               "ucas_status" => "running",
-              "funding" => "teaching_apprenticeship"
+              "funding" => "apprenticeship",
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },
@@ -271,10 +271,10 @@ describe 'Courses API v2', type: :request do
               "start_date" => provider.courses[0].start_date.iso8601,
               "study_mode" => "full_time",
               "qualifications" => %w[qts pgce],
-              "description" => "PGCE with QTS full time",
+              "description" => "PGCE with QTS full time teaching apprenticeship",
               "content_status" => "empty",
               "ucas_status" => "running",
-              "funding" => "teaching_apprenticeship"
+              "funding" => "apprenticeship",
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -61,7 +61,7 @@ describe API::V2::SerializableCourse do
     it { should have_relationship(:accrediting_provider) }
   end
 
-  fcontext "funding" do
+  context "funding" do
     context "fee-paying" do
       let(:course) { create(:course) }
 


### PR DESCRIPTION
### Context
#272 inadvertently introduced filtering to the spec suite which meant only 3 specs were running after it was merged:

![image](https://user-images.githubusercontent.com/23801/56230518-56c90c00-6074-11e9-8477-51249e25495c.png)

This was also obscuring some failing specs.

### Changes proposed in this pull request
- remove the filtering
- fix the failures
