### PR TITLE
[1322] Added send field on course serializer

### DIFF
--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -16,6 +16,10 @@ module API
         SubjectMapper.get_subject_list(@object.name, ucas_subjects)
       end
 
+      attribute :is_send? do
+        @object.subjects.any? { |subject| subject.subject_code.casecmp('U3').zero? }
+      end
+
       belongs_to :provider
       belongs_to :accrediting_provider
 

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     sequence(:subject_code, &:to_s)
     subject_name { Faker::ProgrammingLanguage.name }
 
-    factory :futher_education_subject do
+    factory :further_education_subject do
       subject_name { 'Further Education' }
     end
 

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -15,5 +15,10 @@ FactoryBot.define do
     factory :futher_education_subject do
       subject_name { 'Further Education' }
     end
+
+    factory :send_subject do
+      subject_name { 'Special Educational Needs' }
+      subject_code { 'U3' }
+    end
   end
 end

--- a/spec/factory_specs/subject_spec.rb
+++ b/spec/factory_specs/subject_spec.rb
@@ -1,12 +1,23 @@
 require 'rails_helper'
 
-describe "Subject 'Further Education' Factory" do
-  let(:subject) { create(:futher_education_subject) }
+describe "Subject Factory" do
+  describe "Subject 'Further Education' Factory" do
+    let(:subject) { create(:futher_education_subject) }
 
-  it "created subject" do
-    expect(subject).to be_instance_of(Subject)
-    expect(subject).to be_valid
-    expect(subject.subject_name).to eq 'Further Education'
-    expect(subject.in?(Subject.further_education)).to be true
+    it "created subject" do
+      expect(subject).to be_instance_of(Subject)
+      expect(subject).to be_valid
+      expect(subject.subject_name).to eq 'Further Education'
+      expect(subject.in?(Subject.further_education)).to be true
+    end
+  end
+
+  describe "Subject 'Send' Factory" do
+    let(:subject) { create(:send_subject) }
+
+    it { should be_instance_of(Subject) }
+    it { should be_valid }
+    its(:subject_name) { should eq 'Special Educational Needs' }
+    its(:subject_code) { should eq 'U3' }
   end
 end

--- a/spec/factory_specs/subject_spec.rb
+++ b/spec/factory_specs/subject_spec.rb
@@ -2,14 +2,12 @@ require 'rails_helper'
 
 describe "Subject Factory" do
   describe "Subject 'Further Education' Factory" do
-    let(:subject) { create(:futher_education_subject) }
+    let(:subject) { create(:further_education_subject) }
 
-    it "created subject" do
-      expect(subject).to be_instance_of(Subject)
-      expect(subject).to be_valid
-      expect(subject.subject_name).to eq 'Further Education'
-      expect(subject.in?(Subject.further_education)).to be true
-    end
+    it { should be_instance_of(Subject) }
+    it { should be_valid }
+    its(:subject_name) { should eq 'Further Education' }
+    it { should be_in(Subject.further_education) }
   end
 
   describe "Subject 'Send' Factory" do

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -11,6 +11,7 @@ describe 'Courses API v2', type: :request do
 
   let(:course_subject_primary) { create(:subject, subject_name: 'Primary', subject_code: 'P') }
   let(:course_subject_mathematics) { create(:subject, subject_name: 'Mathematics', subject_code: 'M') }
+  let(:course_subject_send) { create(:send_subject) }
 
   let(:findable_open_course) {
     create(:course, :resulting_in_pgce_with_qts, :with_apprenticeship,
@@ -18,7 +19,7 @@ describe 'Courses API v2', type: :request do
            start_date: Time.now.utc,
            study_mode: :full_time,
            subject_count: 0,
-           subjects: [course_subject_primary, course_subject_mathematics],
+           subjects: [course_subject_primary, course_subject_mathematics, course_subject_send],
            with_site_statuses: [%i[findable with_any_vacancy applications_being_accepted_from_2019]])
   }
 
@@ -103,6 +104,7 @@ describe 'Courses API v2', type: :request do
               "content_status" => "empty",
               "ucas_status" => "running",
               "funding" => "apprenticeship",
+              "is_send?" => true,
               "subjects" => ["Primary",
                              "Primary with mathematics"],
               "applications_open_from" => "2019-01-01T00:00:00Z",
@@ -272,6 +274,7 @@ describe 'Courses API v2', type: :request do
               "content_status" => "empty",
               "ucas_status" => "running",
               "funding" => "apprenticeship",
+              "is_send?" => true,
               "subjects" => ["Primary",
                              "Primary with mathematics"],
               "applications_open_from" => "2019-01-01T00:00:00Z",

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -18,7 +18,7 @@ describe API::V2::SerializableCourse do
   it { should have_type('courses') }
   it {
     should have_attributes(:start_date, :content_status, :ucas_status,
-    :funding, :subjects, :applications_open_from)
+    :funding, :subjects, :applications_open_from, :is_send?)
   }
 
   context 'with a provider' do
@@ -81,6 +81,16 @@ describe API::V2::SerializableCourse do
       let(:course) { create(:course, :with_salary) }
 
       it { expect(subject["attributes"]).to include("funding" => "salary") }
+    end
+  end
+
+  describe "#is_send?" do
+    let(:course) { create(:course, subject_count: 0) }
+    it { expect(subject["attributes"]).to include("is_send?" => false) }
+
+    context "with a SEND subject" do
+      let(:course) { create(:course, subject_count: 0, subjects: [create(:send_subject)]) }
+      it { expect(subject["attributes"]).to include("is_send?" => true) }
     end
   end
 end


### PR DESCRIPTION
### Context
Send field

### Changes proposed in this pull request
Added bool to denote is a course a Sen/Send course

### Guidance to review
retained the naming of `Sen` vs `Send` this is partly due to original naming as well as `Send` is an acronym and an actual word.

subject_code is hardcoded as it was from 
https://github.com/DFE-Digital/manage-courses-api/blob/e5c4f2a6ebe3644e322c4ff71d65ce7e83b3e403/src/ManageCourses.Domain/Models/Course.cs#L37