### PR TITLE
[1307] add course enrichments to the api v2 courses endpoint

### DIFF
--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -17,6 +17,27 @@
 class CourseEnrichment < ApplicationRecord
   enum status: %i[draft published]
 
+  jsonb_accessor :json_data,
+                 about_course: [:string, store_key: 'AboutCourse'],
+                 course_length: [:string, store_key: 'CourseLength'],
+                 fee_details: [:string, store_key: 'FeeDetails'],
+                 fee_international: [:string, store_key: 'FeeInternational'],
+                 fee_uk_eu: [:string, store_key: 'FeeUkEu'],
+                 financial_support: [:string, store_key: 'FinancialSupport'],
+                 how_school_placements_work: [:string,
+                                              store_key: 'HowSchoolPlacementsWork'],
+                 interview_process: [:string, store_key: 'InterviewProcess'],
+                 other_requirements: [:string, store_key: 'OtherRequirements'],
+                 personal_qualities: [:string, store_key: 'PersonalQualities'],
+                 qualifications: [:string, store_key: 'Qualifications'],
+                 salary_details: [:string, store_key: 'SalaryDetails']
+
+  belongs_to :provider, foreign_key: :provider_code, primary_key: :provider_code
+  belongs_to :course,
+             ->(enrichment) { where(provider_id: enrichment.provider.id) },
+             foreign_key: :ucas_course_code,
+             primary_key: :course_code
+
   def has_been_published_before?
     last_published_timestamp_utc.present?
   end

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -1,6 +1,14 @@
 module API
   module V2
     class SerializableCourse < JSONAPI::Serializable::Resource
+      class << self
+        def enrichment_attribute(name, enrichment_name = name)
+          attribute name do
+            @object.enrichments.last&.__send__(enrichment_name)
+          end
+        end
+      end
+
       type 'courses'
 
       attributes :findable?, :open_for_applications?, :has_vacancies?,
@@ -29,6 +37,19 @@ module API
       belongs_to :accrediting_provider
 
       has_many :site_statuses
+
+      enrichment_attribute :about_course
+      enrichment_attribute :course_length
+      enrichment_attribute :fee_details
+      enrichment_attribute :fee_international
+      enrichment_attribute :fee_uk_eu
+      enrichment_attribute :financial_support
+      enrichment_attribute :how_school_placements_work
+      enrichment_attribute :interview_process
+      enrichment_attribute :other_requirements
+      enrichment_attribute :personal_qualities
+      enrichment_attribute :required_qualifications, :qualifications
+      enrichment_attribute :salary_details
     end
   end
 end

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,64 @@
+# Creating Factories
+
+* Created objects should be valid by default, so ensure that required
+  associations are built/created.
+* Avoid building/creating associations that aren't necessary.
+* Provide a way to overide associated objects, for has_* relationships this will
+  need to build associated objects by default, and add them to the parent object
+  in an `after_create` hook.
+* Providing a way to specify exactly what associated object(s) override the
+  default is better than using `*_count` transients (more flexible).
+* When creating a memoized object that is included in the creation of another
+  object, use `build` to prevent secondary objects from being created.
+
+# Using Factories
+
+* Only create the objects you need, when memoizing (using `let`) prefer to pull
+  out the object if it's already created as a part of another object, unless you
+  need to create it in a specific way. eg.
+
+```
+let(:course)  { create :course }
+let(:subject) { course.subject }
+```
+
+  or if a specific subject needs to be created:
+
+```
+let(:english_subject) { create :subject, :english }
+let(:course)          { create :course, subjects: [english_subject] }
+```
+* When creating associated data, keep in mind which object is the `belongs_to`
+  side. The object that has the `belongs_to` association should be the one that
+  associates the two objects.
+  
+  Example:
+  
+```
+# CORRECT
+let(:provider) { create :provider }
+let(:course)   { create :course, provider: provider }
+# CORRECT
+```
+
+  If done this way, then two providers will be created in the DB, one as the
+  memoized provider and second as part of the `create :course` (a course is not
+  valid without a provider so the factory creates a provider for us, unless
+  overidden like above):
+  
+```
+# WRONG
+let(:provider) { create :provider, courses: [course] }
+let(:course)   { create :course }
+# WRONG
+```
+
+
+
+* Use find_or_create for objects that should be singletons (e.g. "English"
+  subject)
+  
+
+# Describe vs Context vs Feature vs Scenario
+
+# Using 'let' and 'begin'

--- a/spec/factories/course_enrichments.rb
+++ b/spec/factories/course_enrichments.rb
@@ -16,9 +16,73 @@
 
 FactoryBot.define do
   factory :course_enrichment do
-    sequence(:provider_code) { |n| "A#{n}" }
-    sequence(:ucas_course_code) { |n| "C#{n}D3" }
+    provider
+    course
     status { :draft }
+
+    about_course { Faker::Books::Dune.quote }
+    course_length do
+      # samples taken from real data
+      [
+        "36 weeks",
+        "38 weeks",
+        "1 year Full-time or 2 years Part-time",
+        "Sept  - End July",
+        "4 school terms",
+        "9 months",
+        "1 Year for Full Time / Up to 2 Years",
+        "4 academic terms",
+        "9 Months",
+        "1 year plus ",
+        "Other",
+        "10 Months",
+        "OneYear",
+        "This programme is offered as a one year full-time programme or as a two year part-time programme.  The P/T programme is typically 3 days a week.",
+        "September 2019- December 2020",
+        "September to June",
+        "Approximately 15 months",
+        "1 year and 1 day minimum",
+        "Academic Year",
+      ].sample
+    end
+    fee_details do
+      [
+        "This apprenticeship programme is funded via the apprentice levy from eligible schools.",
+        "You will not have to pay these fees upfront. Eligible UK and EU students can apply for a tuition fee loan to cover the cost of tuition fees from the government.",
+        "Student grants are available to eligible applicants.",
+        "Fees are made payable to the University.",
+      ].sample
+    end
+    fee_uk_eu         { fee_international * 2 }
+    fee_international { rand(100) * 10 }
+    financial_support do
+      [
+        "Please get in contact with the school for any further details.",
+        "The course is Non-Salaried only. ",
+        "Find out more about the financial support available within our [financial information section](http://localhost:5000/about/financial_support)",
+        "Bursaries and scholarships are available to trainees",
+        "You may be eligible for a government bursary if you are applying to teach one of our secondary subjects",
+        "DfE bursaries are available for select trainees ",
+        "You can find information about tuition fee loans and other financial help on the Gov.uk website - (https://www.gov.uk/student-finance)"
+      ].sample
+    end
+    how_school_placements_work { Faker::TvShows::GameOfThrones.quote }
+    interview_process { Faker::TvShows::Seinfeld.quote }
+    other_requirements { Faker::TvShows::TheITCrowd.quote }
+    personal_qualities { Faker::Hipster.paragraph }
+    qualifications { Faker::Educator.degree }
+    # Technically, salary_details should align with whether the course is
+    # salaried or not. Maybe worth implementing this somehow at some point.
+    salary_details do
+      [
+        "Trainees should expcet to be paid as an Unqualified Teacher.",
+        "For more information on salary please contact us",
+        "Salary negotiable.",
+        "Applicants will be paid as an unqualified teacher.",
+        "The trainee will be paid and taxed as an unqualified teacher.",
+        "Using the unqualified teachers scale"
+      ].sample
+    end
   end
 
   trait :initial_draft do

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -30,6 +30,7 @@ FactoryBot.define do
     with_higher_education
 
     association(:provider)
+
     study_mode { :full_time }
     resulting_in_pgce_with_qts
 
@@ -37,8 +38,9 @@ FactoryBot.define do
       subject_count      { 1 }
       subjects           { build_list(:subject, subject_count) }
       with_site_statuses { [] }
-      with_enrichments { [] }
-      age { nil }
+      with_enrichments   { [] }
+      age                { nil }
+      enrichments        { [] }
     end
 
     after(:build) do |course, evaluator|
@@ -69,6 +71,10 @@ FactoryBot.define do
           provider_code: course.provider.provider_code,
         }
         create(:course_enrichment, trait, attributes.merge(defaults))
+      end
+
+      course.enrichments += evaluator.enrichments.map do |enrichment|
+        enrichment.tap { |e| e.provider_code = course.provider.provider_code }
       end
 
       # We've just created a course with this provider's code, so ensure it's

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -50,7 +50,9 @@ FactoryBot.define do
     end
 
     after(:create) do |course, evaluator|
-      course.subjects << evaluator.subjects
+      course.subjects << evaluator.subjects.map { |subject|
+        subject.is_a?(Subject) ? subject : create(*subject)
+      }
 
       evaluator.with_site_statuses.each do |traits|
         attrs = { course: course }
@@ -68,6 +70,10 @@ FactoryBot.define do
         }
         create(:course_enrichment, trait, attributes.merge(defaults))
       end
+
+      # We've just created a course with this provider's code, so ensure it's
+      # up-to-date and has this course loaded.
+      course.provider.reload
     end
 
     trait :resulting_in_qts do

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -54,15 +54,13 @@ FactoryBot.define do
     end
 
     after(:create) do |provider, evaluator|
-      create_list(:course, evaluator.course_count, provider: provider)
-
       provider.sites << evaluator.sites
 
       # Add the enrichments to the provider. Normally setting provider_code
       # would be the model's concern, but as we're still a read-only app we'll
       # have to do that here.
       provider.enrichments << evaluator.enrichments.each do |enrichment|
-        enrichment.provider_code ||= provider.provider_code
+        enrichment.provider_code = provider.provider_code
       end
 
       # Strangely, changed_at doesn't get set if we don't do this, even though

--- a/spec/factories/site_statuses.rb
+++ b/spec/factories/site_statuses.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
 
     transient do
       any_vancancy { false }
+      provider { build :provider }
     end
 
     trait :published do

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -16,6 +16,11 @@ FactoryBot.define do
       subject_name { 'Further Education' }
     end
 
+    trait :english do
+      subject_name { 'English' }
+      subject_code { 'E' }
+    end
+
     factory :send_subject do
       subject_name { 'Special Educational Needs' }
       subject_code { 'U3' }

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -17,6 +17,20 @@
 require 'rails_helper'
 
 describe CourseEnrichment, type: :model do
+  describe 'associations' do
+    it 'belongs to a provider' do
+      expect(subject).to belong_to(:provider)
+                           .with_foreign_key(:provider_code)
+                           .with_primary_key(:provider_code)
+    end
+
+    it 'belongs to a course' do
+      expect(subject).to belong_to(:course)
+                           .with_foreign_key(:ucas_course_code)
+                           .with_primary_key(:course_code)
+    end
+  end
+
   context 'when the enrichment is an initial draft' do
     subject { create(:course_enrichment, :initial_draft) }
     it { should_not have_been_published_before }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,9 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
+# Pull in all the files in spec/support automatically.
+Dir['./spec/strategies/**/*.rb'].each { |file| require file }
+
 Faker::Config.locale = 'en-GB'
 
 # configure shoulda matchers to use rspec as the test framework and full matcher libraries for rails

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -21,9 +21,11 @@ describe 'Courses API v2', type: :request do
            study_mode: :full_time,
            subject_count: 0,
            subjects: [course_subject_primary, course_subject_mathematics, course_subject_send],
-           with_site_statuses: [%i[findable with_any_vacancy applications_being_accepted_from_2019]])
+           with_site_statuses: [%i[findable with_any_vacancy applications_being_accepted_from_2019]],
+           enrichments: [enrichment])
   }
 
+  let(:enrichment)     { build :course_enrichment }
   let(:provider)       { create :provider, organisations: [organisation] }
   let(:course_subject) { course.subjects.first }
   let(:site_status)    { findable_open_course.site_statuses.first }
@@ -97,7 +99,7 @@ describe 'Courses API v2', type: :request do
               "study_mode" => "full_time",
               "qualifications" => %w[qts pgce],
               "description" => "PGCE with QTS full time teaching apprenticeship",
-              "content_status" => "empty",
+              "content_status" => "draft",
               "ucas_status" => "running",
               "funding" => "apprenticeship",
               "is_send?" => true,
@@ -105,6 +107,18 @@ describe 'Courses API v2', type: :request do
                              "Primary with mathematics"],
               "level" => "primary",
               "applications_open_from" => "2019-01-01T00:00:00Z",
+              "about_course" => enrichment.about_course,
+              "course_length" => enrichment.course_length,
+              "fee_details" => enrichment.fee_details,
+              "fee_international" => enrichment.fee_international,
+              "fee_uk_eu" => enrichment.fee_uk_eu,
+              "financial_support" => enrichment.financial_support,
+              "how_school_placements_work" => enrichment.how_school_placements_work,
+              "interview_process" => enrichment.interview_process,
+              "other_requirements" => enrichment.other_requirements,
+              "personal_qualities" => enrichment.personal_qualities,
+              "required_qualifications" => enrichment.qualifications,
+              "salary_details" => enrichment.salary_details
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },
@@ -269,7 +283,7 @@ describe 'Courses API v2', type: :request do
               "study_mode" => "full_time",
               "qualifications" => %w[qts pgce],
               "description" => "PGCE with QTS full time teaching apprenticeship",
-              "content_status" => "empty",
+              "content_status" => "draft",
               "ucas_status" => "running",
               "funding" => "apprenticeship",
               "is_send?" => true,
@@ -277,6 +291,18 @@ describe 'Courses API v2', type: :request do
                              "Primary with mathematics"],
               "level" => "primary",
               "applications_open_from" => "2019-01-01T00:00:00Z",
+              "about_course" => enrichment.about_course,
+              "course_length" => enrichment.course_length,
+              "fee_details" => enrichment.fee_details,
+              "fee_international" => enrichment.fee_international,
+              "fee_uk_eu" => enrichment.fee_uk_eu,
+              "financial_support" => enrichment.financial_support,
+              "how_school_placements_work" => enrichment.how_school_placements_work,
+              "interview_process" => enrichment.interview_process,
+              "other_requirements" => enrichment.other_requirements,
+              "personal_qualities" => enrichment.personal_qualities,
+              "required_qualifications" => enrichment.qualifications,
+              "salary_details" => enrichment.salary_details
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -1,21 +1,22 @@
 require 'rails_helper'
 
 describe 'Courses API v2', type: :request do
-  let(:user) { create(:user) }
+  let(:user)         { create(:user) }
   let(:organisation) { create(:organisation, users: [user]) }
-  let(:payload) { { email: user.email } }
-  let(:token) { build_jwt :apiv2, payload: payload }
+  let(:payload)      { { email: user.email } }
+  let(:token)        { build_jwt :apiv2, payload: payload }
   let(:credentials) do
     ActionController::HttpAuthentication::Token.encode_credentials(token)
   end
 
-  let(:course_subject_primary) { create(:subject, subject_name: 'Primary', subject_code: 'P') }
-  let(:course_subject_mathematics) { create(:subject, subject_name: 'Mathematics', subject_code: 'M') }
-  let(:course_subject_send) { create(:send_subject) }
+  let(:course_subject_primary) { find_or_create(:subject, subject_name: 'Primary', subject_code: 'P') }
+  let(:course_subject_mathematics) { find_or_create(:subject, subject_name: 'Mathematics', subject_code: 'M') }
+  let(:course_subject_send) { find_or_create(:send_subject) }
 
   let(:findable_open_course) {
     create(:course, :resulting_in_pgce_with_qts, :with_apprenticeship,
            name: "Primary (Mathematics Specialist)",
+           provider: provider,
            start_date: Time.now.utc,
            study_mode: :full_time,
            subject_count: 0,
@@ -23,15 +24,10 @@ describe 'Courses API v2', type: :request do
            with_site_statuses: [%i[findable with_any_vacancy applications_being_accepted_from_2019]])
   }
 
-  let!(:provider) {
-    create(:provider,
-           course_count: 0,
-           courses: [findable_open_course],
-           organisations: [organisation])
-  }
-
-  let(:site_status) { findable_open_course.site_statuses.first }
-  let(:site) { site_status.site }
+  let(:provider)       { create :provider, organisations: [organisation] }
+  let(:course_subject) { course.subjects.first }
+  let(:site_status)    { findable_open_course.site_statuses.first }
+  let(:site)           { site_status.site }
 
   subject { response }
 
@@ -250,6 +246,7 @@ describe 'Courses API v2', type: :request do
 
     describe 'JSON generated for courses' do
       before do
+        findable_open_course
         get "/api/v2/providers/#{provider.provider_code}/courses",
             headers: { 'HTTP_AUTHORIZATION' => credentials }
       end

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -2,7 +2,10 @@ require "rails_helper"
 
 describe API::V2::SerializableCourse do
   let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
-  let(:course)           { create(:course, start_date: Time.now.utc) }
+  let(:enrichment)       { build :course_enrichment }
+  let(:course)           do
+    create(:course, enrichments: [enrichment], start_date: Time.now.utc)
+  end
   let(:course_json) do
     jsonapi_renderer.render(
       course,
@@ -118,5 +121,22 @@ describe API::V2::SerializableCourse do
       it { expect(subject["attributes"]).to include("level" => "further_education") }
       it { expect(subject["attributes"]).to include("subjects" => ["Further education"]) }
     end
+  end
+
+  describe 'attributes retrieved from enrichments' do
+    subject { parsed_json['data']['attributes'] }
+
+    its(%w[about_course])               { should eq enrichment.about_course }
+    its(%w[course_length])              { should eq enrichment.course_length }
+    its(%w[fee_details])                { should eq enrichment.fee_details }
+    its(%w[fee_international])          { should eq enrichment.fee_international }
+    its(%w[fee_uk_eu])                  { should eq enrichment.fee_uk_eu }
+    its(%w[financial_support])          { should eq enrichment.financial_support }
+    its(%w[how_school_placements_work]) { should eq enrichment.how_school_placements_work }
+    its(%w[interview_process])          { should eq enrichment.interview_process }
+    its(%w[other_requirements])         { should eq enrichment.other_requirements }
+    its(%w[personal_qualities])         { should eq enrichment.personal_qualities }
+    its(%w[required_qualifications])    { should eq enrichment.qualifications }
+    its(%w[salary_details])             { should eq enrichment.salary_details }
   end
 end

--- a/spec/strategies/find_or_create_strategy.rb
+++ b/spec/strategies/find_or_create_strategy.rb
@@ -1,0 +1,61 @@
+require 'factory_bot'
+
+module FactoryBot
+  module Strategy
+    class Find
+      def association(runner)
+        runner.run
+      end
+
+      def result(evaluation)
+        build_class(evaluation).where(get_match_attributes(evaluation)).first
+      end
+
+    private
+
+      def build_class(evaluation)
+        @build_class ||= evaluation
+                           .instance_variable_get(:@attribute_assigner)
+                           .instance_variable_get(:@build_class)
+      end
+
+      def get_match_attributes(evaluation)
+        evaluation.hash.keep_if do |attr, _value|
+          attr.to_s.in? build_class(evaluation).column_names
+        end
+      end
+
+      def get_overrides(evaluation = nil)
+        evaluation.object
+        return @overrides unless @overrides.nil?
+
+        evaluation.instance_variable_get(:@attribute_assigner)
+          .instance_variable_get(:@evaluator)
+          .instance_variable_get(:@overrides)
+          .clone
+      end
+    end
+
+    class FindOrCreate
+      def initialize
+        @strategy = FactoryBot.strategy_by_name(:find).new
+      end
+
+      delegate :association, to: :@strategy
+
+      def result(evaluation)
+        found_object = @strategy.result(evaluation)
+
+        if found_object.nil?
+          @strategy = FactoryBot.strategy_by_name(:create).new
+          @strategy.result(evaluation)
+        else
+          found_object
+        end
+      end
+    end
+  end
+end
+
+FactoryBot.register_strategy(:find, FactoryBot::Strategy::Find)
+FactoryBot.register_strategy(:find_or_create, FactoryBot::Strategy::FindOrCreate)


### PR DESCRIPTION
https://trello.com/c/1wLgwBkl/1307-expose-latest-enrichment-on-the-course-api-v2

### Context

The course details page needs the course enrichments data.

### Changes proposed in this pull request

Add course enrichments to the course attributes on the API V2 endpoint.

### Code Review Guidance

This commit is a bit big, but there was much flailing about with the specs and
factories .... we need a separate card to actually fix this all up.

The file `spec/README.md` isn't quite complete, but I thought it was worth including in it's rough state and the new ticket to clean up the factories should include fixing up that REAMDE.
