### PR TITLE
[1269] Simplify subject mapper

### DIFF
--- a/app/services/subject_mapper.rb
+++ b/app/services/subject_mapper.rb
@@ -87,7 +87,7 @@ class SubjectMapper
     },
   }.freeze
 
-  class GroupedSubjectMapping
+  class StaticMapping
     def initialize(included_ucas_subjects, resulting_dfe_subject)
       @included_ucas_subjects = included_ucas_subjects
       @resulting_dfe_subject = resulting_dfe_subject
@@ -174,7 +174,7 @@ class SubjectMapper
 
   def self.map_to_secondary_subjects(course_title, ucas_subjects)
     secondary_subject_mappings = MAPPINGS[:secondary].map do |ucas_input_subjects, dfe_subject|
-      GroupedSubjectMapping.new(ucas_input_subjects, dfe_subject)
+      StaticMapping.new(ucas_input_subjects, dfe_subject)
     end
 
     secondary_subject_mappings += [
@@ -207,7 +207,7 @@ class SubjectMapper
 
   def self.map_to_primary_subjects(ucas_subjects)
     primary_subject_mappings = MAPPINGS[:primary].map do |ucas_input_subjects, dfe_subject|
-      GroupedSubjectMapping.new(ucas_input_subjects, dfe_subject)
+      StaticMapping.new(ucas_input_subjects, dfe_subject)
     end
 
     %w[Primary] + primary_subject_mappings.map { |mapping|

--- a/app/services/subject_mapper.rb
+++ b/app/services/subject_mapper.rb
@@ -98,11 +98,6 @@ class SubjectMapper
     },
   }.freeze
 
-  def self.is_further_education(subjects)
-    subjects = subjects.map { |subject| (subject.strip! || subject).downcase }
-    (subjects & SUBJECT_LEVEL[:ucas_further_education]).any?
-  end
-
   class GroupedSubjectMapping
     def initialize(included_ucas_subjects, resulting_dfe_subject)
       @included_ucas_subjects = included_ucas_subjects

--- a/app/services/subject_mapper.rb
+++ b/app/services/subject_mapper.rb
@@ -20,10 +20,6 @@ class SubjectMapper
                       "law"]
   }.freeze
 
-  @ucas_english = ["english",
-                   "english language",
-                   "english literature"]
-
   MAPPINGS = {
     primary: {
       ["english", "english language", "english literature"] => "Primary with English",
@@ -152,8 +148,15 @@ class SubjectMapper
       end
     end
 
+    # TODO: remove this bonkers logic once course mapping is done by one app!
+    # The user need for this is unclear
+    #
     # Does the subject list mention english, and it's mentioned in the title (or it's the only subject we know for this course)?
-    if (ucas_subjects & @ucas_english).any?
+    ucas_english = ["english",
+                    "english language",
+                    "english literature"]
+
+    if (ucas_subjects & ucas_english).any?
       if secondary_subjects.none? || course_title.index("english") != nil
         secondary_subjects.push("English")
       end

--- a/app/services/subject_mapper.rb
+++ b/app/services/subject_mapper.rb
@@ -212,9 +212,9 @@ class SubjectMapper
   # <param name="ucas_subjects">The subject tags from UCAS</param>
   # <returns>An enumerable of all the subjects the course should be findable by.</returns>
   def self.get_subject_list(course_title, ucas_subjects)
-    ucas_subjects = ucas_subjects.map { |subject| (subject.strip! || subject).downcase }
+    ucas_subjects = ucas_subjects.map(&:strip).map(&:downcase)
 
-    subject_level = get_subject_level(ucas_subjects);
+    subject_level = get_subject_level(ucas_subjects)
 
     case subject_level
     when :primary
@@ -222,8 +222,7 @@ class SubjectMapper
     when :further_education
       ["Further education"]
     when :secondary
-      course_title = (course_title.strip! || course_title).downcase
-      map_to_secondary_subjects(course_title, ucas_subjects)
+      map_to_secondary_subjects(course_title.strip.downcase, ucas_subjects)
     else
       raise subject_level
     end

--- a/app/services/subject_mapper.rb
+++ b/app/services/subject_mapper.rb
@@ -102,36 +102,51 @@ class SubjectMapper
     end
   end
 
+  class MFLOtherMapping
+    def applicable_to?(ucas_subjects)
+      (ucas_subjects & language_categories).any? &&
+        (ucas_subjects & mandarin).none? &&
+        (ucas_subjects & mfl_main).none?
+    end
+
+    def to_s
+      "Modern languages (other)"
+    end
+
+  private
+
+    def language_categories
+      ["languages", "languages (african)", "languages (asian)", "languages (european)"]
+    end
+
+    def mandarin
+      %w[chinese mandarin]
+    end
+
+    def mfl_main
+      ["english as a second or other language",
+       "french",
+       "german",
+       "italian",
+       "japanese",
+       "russian",
+       "spanish"]
+    end
+  end
+
   def self.map_to_secondary_subjects(course_title, ucas_subjects)
     secondary_subject_mappings = MAPPINGS[:secondary].map do |ucas_input_subjects, dfe_subject|
       GroupedSubjectMapping.new(ucas_input_subjects, dfe_subject)
     end
+
+    #  Does the subject list mention languages but hasn't already been covered?
+    secondary_subject_mappings << MFLOtherMapping.new
 
     secondary_subjects = []
 
     secondary_subjects += secondary_subject_mappings.map { |mapping|
       mapping.to_s if mapping.applicable_to?(ucas_subjects)
     }.compact
-
-    ucas_language_cat = ["languages",
-                         "languages (african)",
-                         "languages (asian)",
-                         "languages (european)"]
-
-    ucas_mfl_mandarin = %w[chinese mandarin]
-
-    ucas_mfl_main = ["english as a second or other language",
-                     "french",
-                     "german",
-                     "italian",
-                     "japanese",
-                     "russian",
-                     "spanish"]
-
-    #  Does the subject list mention languages but hasn't already been covered?
-    if (ucas_subjects & ucas_language_cat).any? && (ucas_subjects & ucas_mfl_mandarin).none? && (ucas_subjects & ucas_mfl_main).none?
-      secondary_subjects.push("Modern languages (other)")
-    end
 
     # TODO: remove this bonkers logic once course mapping is done by one app!
     # There is absolutely no user need for it!

--- a/app/services/subject_mapper.rb
+++ b/app/services/subject_mapper.rb
@@ -24,13 +24,6 @@ class SubjectMapper
                    "english language",
                    "english literature"]
 
-  @ucas_rename = { "science" => "balanced science" }
-
-  @ucas_needs_mention_in_title = {
-    "humanities" => /humanities/,
-    "science" => /(?<!social |computer )science/,
-  }
-
   MAPPINGS = {
     primary: {
       ["english", "english language", "english literature"] => "Primary with English",
@@ -144,10 +137,17 @@ class SubjectMapper
       secondary_subjects.push("Modern languages (other)")
     end
 
+    # TODO: remove this bonkers logic once course mapping is done by one app!
+    # There is absolutely no user need for it!
+    #
     # Does the subject list mention a subject we are happy to translate if the course title contains a mention?
-    (ucas_subjects & @ucas_needs_mention_in_title.keys).each do |ucas_subject|
-      if course_title.match?(@ucas_needs_mention_in_title[ucas_subject])
-        renamed_subject = @ucas_rename.fetch(ucas_subject, ucas_subject).capitalize
+    ucas_needs_mention_in_title = {
+      "humanities" => /humanities/,
+      "science" => /(?<!social |computer )science/,
+    }
+    (ucas_subjects & %w[humanities science]).each do |ucas_subject|
+      if course_title.match?(ucas_needs_mention_in_title[ucas_subject])
+        renamed_subject = (ucas_subject == "science" ? "balanced science" : ucas_subject).capitalize
         secondary_subjects << renamed_subject
       end
     end

--- a/app/services/subject_mapper.rb
+++ b/app/services/subject_mapper.rb
@@ -102,6 +102,7 @@ class SubjectMapper
     end
   end
 
+  #  Does the subject list mention languages but hasn't already been covered?
   class MFLOtherMapping
     def applicable_to?(ucas_subjects)
       (ucas_subjects & language_categories).any? &&
@@ -136,6 +137,8 @@ class SubjectMapper
 
   # TODO: remove this bonkers logic once course mapping is done by one app!
   # The user need for this is unclear
+  #
+  # Does the subject list mention english, and it's mentioned in the title (or it's the only subject we know for this course)?
   class SecondaryEnglishMapping
     def initialize(course_title)
       @course_title = course_title
@@ -174,18 +177,13 @@ class SubjectMapper
       GroupedSubjectMapping.new(ucas_input_subjects, dfe_subject)
     end
 
-    #  Does the subject list mention languages but hasn't already been covered?
-    secondary_subject_mappings << MFLOtherMapping.new
+    secondary_subject_mappings += [
+      MFLOtherMapping.new,
+      SecondaryEnglishMapping.new(course_title),
+      SecondaryWelshMapping.new,
+    ]
 
-    # Does the subject list mention english, and it's mentioned in the title (or it's the only subject we know for this course)?
-    secondary_subject_mappings << SecondaryEnglishMapping.new(course_title)
-
-    # if nothing else yet, try welsh
-    secondary_subject_mappings << SecondaryWelshMapping.new
-
-    secondary_subjects = []
-
-    secondary_subjects += secondary_subject_mappings.map { |mapping|
+    secondary_subjects = secondary_subject_mappings.map { |mapping|
       mapping.to_s if mapping.applicable_to?(ucas_subjects)
     }.compact
 

--- a/app/services/subject_mapper.rb
+++ b/app/services/subject_mapper.rb
@@ -159,6 +159,16 @@ class SubjectMapper
     end
   end
 
+  class SecondaryWelshMapping
+    def applicable_to?(ucas_subjects)
+      ucas_subjects == %w[welsh]
+    end
+
+    def to_s
+      "Welsh"
+    end
+  end
+
   def self.map_to_secondary_subjects(course_title, ucas_subjects)
     secondary_subject_mappings = MAPPINGS[:secondary].map do |ucas_input_subjects, dfe_subject|
       GroupedSubjectMapping.new(ucas_input_subjects, dfe_subject)
@@ -169,6 +179,9 @@ class SubjectMapper
 
     # Does the subject list mention english, and it's mentioned in the title (or it's the only subject we know for this course)?
     secondary_subject_mappings << SecondaryEnglishMapping.new(course_title)
+
+    # if nothing else yet, try welsh
+    secondary_subject_mappings << SecondaryWelshMapping.new
 
     secondary_subjects = []
 
@@ -189,11 +202,6 @@ class SubjectMapper
         renamed_subject = (ucas_subject == "science" ? "balanced science" : ucas_subject).capitalize
         secondary_subjects << renamed_subject
       end
-    end
-
-    # if nothing else yet, try welsh
-    if secondary_subjects.none? && (ucas_subjects & %w[welsh]).any?
-      secondary_subjects.push("Welsh")
     end
 
     secondary_subjects

--- a/app/services/subject_mapper.rb
+++ b/app/services/subject_mapper.rb
@@ -103,10 +103,6 @@ class SubjectMapper
     (subjects & SUBJECT_LEVEL[:ucas_further_education]).any?
   end
 
-  def self.map_to_subject_name(ucas_subject)
-    @ucas_rename.fetch(ucas_subject, ucas_subject).capitalize
-  end
-
   class GroupedSubjectMapping
     def initialize(included_ucas_subjects, resulting_dfe_subject)
       @included_ucas_subjects = included_ucas_subjects
@@ -156,7 +152,8 @@ class SubjectMapper
     # Does the subject list mention a subject we are happy to translate if the course title contains a mention?
     (ucas_subjects & @ucas_needs_mention_in_title.keys).each do |ucas_subject|
       if course_title.match?(@ucas_needs_mention_in_title[ucas_subject])
-        secondary_subjects.push(map_to_subject_name(ucas_subject))
+        renamed_subject = @ucas_rename.fetch(ucas_subject, ucas_subject).capitalize
+        secondary_subjects << renamed_subject
       end
     end
 

--- a/app/services/subject_mapper.rb
+++ b/app/services/subject_mapper.rb
@@ -24,21 +24,11 @@ class SubjectMapper
                    "english language",
                    "english literature"]
 
-  @ucas_rename = {
-    "chinese" => "mandarin",
-    "art / art & design" => "art and design",
-    "business education" => "business studies",
-    "computer studies" => "computing",
-    "science" => "balanced science",
-    "dance and performance" => "dance",
-    "drama and theatre studies" => "drama",
-    "social science" => "social sciences"
-  }
+  @ucas_rename = { "science" => "balanced science" }
 
   @ucas_needs_mention_in_title = {
     "humanities" => /humanities/,
     "science" => /(?<!social |computer )science/,
-    "modern studies" => /modern studies/,
   }
 
   MAPPINGS = {
@@ -114,9 +104,7 @@ class SubjectMapper
   end
 
   def self.map_to_subject_name(ucas_subject)
-    res = (@ucas_rename[ucas_subject] || ucas_subject).capitalize
-
-    (res.sub "english", "English" || res)
+    @ucas_rename.fetch(ucas_subject, ucas_subject).capitalize
   end
 
   class GroupedSubjectMapping

--- a/app/services/subject_mapper.rb
+++ b/app/services/subject_mapper.rb
@@ -162,16 +162,6 @@ class SubjectMapper
     end
   end
 
-  class SecondaryWelshMapping
-    def applicable_to?(ucas_subjects)
-      ucas_subjects == %w[welsh]
-    end
-
-    def to_s
-      "Welsh"
-    end
-  end
-
   def self.map_to_secondary_subjects(course_title, ucas_subjects)
     secondary_subject_mappings = MAPPINGS[:secondary].map do |ucas_input_subjects, dfe_subject|
       StaticMapping.new(ucas_input_subjects, dfe_subject)
@@ -180,7 +170,6 @@ class SubjectMapper
     secondary_subject_mappings += [
       MFLOtherMapping.new,
       SecondaryEnglishMapping.new(course_title),
-      SecondaryWelshMapping.new,
     ]
 
     secondary_subjects = secondary_subject_mappings.map { |mapping|

--- a/spec/services/subject_mapper_spec.rb
+++ b/spec/services/subject_mapper_spec.rb
@@ -159,11 +159,14 @@ describe SubjectMapper do
       hashed_data = data.map(&:to_hash)
 
       hashed_data.each_with_index do |spec, index|
-        describe "Test case '#{index}''" do
-          delimiter = "[d]" #This delimiter is used as the actual subject name may contain a comma
-          subject { SubjectMapper.get_subject_list(spec[:course_title], spec[:ucas_subjects].split(delimiter)) }
+        delimiter = "[d]" #This delimiter is used as the actual subject name may contain a comma
+        ucas_subjects_to_map = spec[:ucas_subjects].split(delimiter)
+        expected_dfe_subjects = spec[:expected_subjects].split(delimiter)
+        title = spec[:course_title]
 
-          it { should match_array spec[:expected_subjects].split(delimiter) }
+        describe "Test case row '#{index}': subjects #{ucas_subjects_to_map.join(', ')}, title: #{title}" do
+          subject { SubjectMapper.get_subject_list(title, ucas_subjects_to_map) }
+          it { should match_array expected_dfe_subjects }
         end
       end
     end

--- a/spec/services/subject_mapper_spec.rb
+++ b/spec/services/subject_mapper_spec.rb
@@ -2,42 +2,6 @@ require "spec_helper"
 require "csv"
 
 describe SubjectMapper do
-  further_education_subjects = [
-    "further education",
-    "higher education",
-    "post-compulsory",
-  ]
-
-  ucas_mfl_main = [
-    "english as a second or other language",
-    "french",
-    "german",
-    "italian",
-    "japanese",
-    "russian",
-    "spanish"
-  ]
-
-  describe "#is_further_education" do
-    all_further_education_subjects = further_education_subjects + further_education_subjects.map(&:upcase) + further_education_subjects.map { |subject_name| " #{subject_name} " }
-
-    all_further_education_subjects.each do |subject_name|
-      describe "'#{subject_name}''" do
-        subject { SubjectMapper.is_further_education([subject_name]) }
-
-        it { should be true }
-      end
-    end
-
-    ucas_mfl_main.each do |subject_name|
-      describe "'#{subject_name}''" do
-        subject { SubjectMapper.is_further_education([subject_name]) }
-
-        it { should be false }
-      end
-    end
-  end
-
   # Port of https://github.com/DFE-Digital/manage-courses-api/blob/master/tests/ManageCourses.Tests/UnitTesting/SubjectMapperTests.cs
   describe "#get_subject_list" do
     specs = [

--- a/spec/services/subject_mapper_spec.rb
+++ b/spec/services/subject_mapper_spec.rb
@@ -73,7 +73,7 @@ describe SubjectMapper do
       },
       {
         course_title: "",
-        ucas_subjects: %w[secondary welsh],
+        ucas_subjects: %w[welsh],
         expected_subjects: %w[Welsh],
         test_case: "an example of welsh, which only triggers if nothing else goes"
       },

--- a/spec/services/subject_mapper_spec.rb
+++ b/spec/services/subject_mapper_spec.rb
@@ -38,33 +38,6 @@ describe SubjectMapper do
     end
   end
 
-  describe "#map_to_subject_name" do
-    ucas_rename = {
-      "chinese" => "Mandarin",
-      "art / art & design" => "Art and design",
-      "business education" => "Business studies",
-      "computer studies" => "Computing",
-      "science" => "Balanced science",
-      "dance and performance" => "Dance",
-      "drama and theatre studies" => "Drama",
-      "social science" => "Social sciences",
-    }
-
-    ucas_rename.each do |key, expected_value|
-      describe "ucasRename '#{key}''" do
-        subject { SubjectMapper.map_to_subject_name(key) }
-
-        it { should eq expected_value }
-      end
-    end
-
-    describe "bad english" do
-      subject { SubjectMapper.map_to_subject_name("bad english") }
-
-      it { should eq "Bad English" }
-    end
-  end
-
   # Port of https://github.com/DFE-Digital/manage-courses-api/blob/master/tests/ManageCourses.Tests/UnitTesting/SubjectMapperTests.cs
   describe "#get_subject_list" do
     specs = [

--- a/spec/services/subject_mapper_spec.rb
+++ b/spec/services/subject_mapper_spec.rb
@@ -24,8 +24,8 @@ describe SubjectMapper do
         test_case: "an example of early years (which is absorbed into primary)"
       },
       {
-        course_title: "Physics (Welsh medium)",
-        ucas_subjects: ["physics (abridged)", "welsh", "secondary", "science"],
+        course_title: "Physics",
+        ucas_subjects: ["physics (abridged)", "secondary", "science"],
         expected_subjects: %w[Physics],
         test_case: "an example where science should be excluded because it's used as a category"
       },
@@ -70,12 +70,6 @@ describe SubjectMapper do
         ucas_subjects: ["secondary", "languages", "languages (asian)", "chinese"],
         expected_subjects: %w[Mandarin],
         test_case: "a rename"
-      },
-      {
-        course_title: "",
-        ucas_subjects: %w[welsh],
-        expected_subjects: %w[Welsh],
-        test_case: "an example of welsh, which only triggers if nothing else goes"
       },
       {
         course_title: "Computer science",


### PR DESCRIPTION
## Context

The `SubjectMapper` is difficult to understand and reason about.

## Proposed changes

- extract `*Mapping` classes for particularly gnarly bits of logic so they're a lot more encapsulated
- bring the code closer to common ruby conventions (it started its life as C#)

## Code review guidance

![image](https://user-images.githubusercontent.com/23801/56354315-4c6d5600-61cb-11e9-9f53-eb489409c4a0.png)
