### PR TITLE
[1327] Added level to the course serializer

### DIFF
--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -16,6 +16,11 @@ module API
         SubjectMapper.get_subject_list(@object.name, ucas_subjects)
       end
 
+      attribute :level do
+        ucas_subjects = @object.subjects.map(&:subject_name)
+        SubjectMapper.get_subject_level(ucas_subjects)
+      end
+
       attribute :is_send? do
         @object.subjects.any? { |subject| subject.subject_code.casecmp('U3').zero? }
       end

--- a/app/services/subject_mapper.rb
+++ b/app/services/subject_mapper.rb
@@ -198,6 +198,7 @@ class SubjectMapper
   end
 
   def self.get_subject_level(ucas_subjects)
+    ucas_subjects = ucas_subjects.map { |subject| (subject.strip! || subject).downcase }
     if (ucas_subjects & SUBJECT_LEVEL[:ucas_unexpected]).any?
       "found unsupported subject name(s): #{(ucas_subjects & SUBJECT_LEVEL[:ucas_unexpected]) * ', '}"
     elsif (ucas_subjects & SUBJECT_LEVEL[:ucas_primary]).any?

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -107,6 +107,7 @@ describe 'Courses API v2', type: :request do
               "is_send?" => true,
               "subjects" => ["Primary",
                              "Primary with mathematics"],
+              "level" => "primary",
               "applications_open_from" => "2019-01-01T00:00:00Z",
             },
             "relationships" => {
@@ -277,6 +278,7 @@ describe 'Courses API v2', type: :request do
               "is_send?" => true,
               "subjects" => ["Primary",
                              "Primary with mathematics"],
+              "level" => "primary",
               "applications_open_from" => "2019-01-01T00:00:00Z",
             },
             "relationships" => {

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -18,7 +18,7 @@ describe API::V2::SerializableCourse do
   it { should have_type('courses') }
   it {
     should have_attributes(:start_date, :content_status, :ucas_status,
-    :funding, :subjects, :applications_open_from, :is_send?)
+    :funding, :subjects, :applications_open_from, :is_send?, :level)
   }
 
   context 'with a provider' do
@@ -91,6 +91,32 @@ describe API::V2::SerializableCourse do
     context "with a SEND subject" do
       let(:course) { create(:course, subject_count: 0, subjects: [create(:send_subject)]) }
       it { expect(subject["attributes"]).to include("is_send?" => true) }
+    end
+  end
+
+  context "subjects & level" do
+    context 'with no subjects' do
+      let(:course) { create(:course, subject_count: 0) }
+      it { expect(subject["attributes"]).to include("level" => "secondary") }
+      it { expect(subject["attributes"]).to include("subjects" => []) }
+    end
+
+    context 'with primary subjects' do
+      let(:course) { create(:course, subject_count: 0, subjects: [create(:subject, subject_name: "primary")]) }
+      it { expect(subject["attributes"]).to include("level" => "primary") }
+      it { expect(subject["attributes"]).to include("subjects" => %w[Primary]) }
+    end
+
+    context 'with secondary subjects' do
+      let(:course) { create(:course, subject_count: 0, subjects: [create(:subject, subject_name: "english")]) }
+      it { expect(subject["attributes"]).to include("level" => "secondary") }
+      it { expect(subject["attributes"]).to include("subjects" => %w[English]) }
+    end
+
+    context 'with further education subjects' do
+      let(:course) { create(:course, subject_count: 0, subjects: [create(:further_education_subject)]) }
+      it { expect(subject["attributes"]).to include("level" => "further_education") }
+      it { expect(subject["attributes"]).to include("subjects" => ["Further education"]) }
     end
   end
 end


### PR DESCRIPTION
### Context
Course level can only be really one of 3, `primary`, `secondary` and `further education`

### Changes proposed in this pull request
Added course level derived from course subject and/or course title
