### PR TITLE
[1318] Show languages used in modern language courses on the API

### DIFF
--- a/app/services/list_languages_taught_in_modern_language_course.rb
+++ b/app/services/list_languages_taught_in_modern_language_course.rb
@@ -1,17 +1,15 @@
 class ListLanguagesTaughtInModernLanguageCourse
-  LANGUAGES = [
-    'english as a foreign language',
-    'french',
-    'german',
-    'italian',
-    'japanese',
-    'mandarin',
-    'russian',
-    'spanish',
-    'urdu'
+  LANGUAGE_SUBJECTS = [
+    'English as a foreign language',
+    'French',
+    'German',
+    'Italian',
+    'Japanese',
+    'Mandarin',
+    'Russian',
+    'Spanish',
+    'Urdu'
   ].freeze
-
-  MODERN_LANGUAGE_COURSE_PATTERN = /mfl|modern language|modern foreign language/.freeze
 
   attr_reader :course_name, :ucas_subject_names
 
@@ -25,20 +23,17 @@ class ListLanguagesTaughtInModernLanguageCourse
   end
 
   def call
-    return [] unless modern_language_course?
-
-    LANGUAGES.select do |language|
-      language.in? normalized_ucas_subject_names
+    dfe_subject_names.select do |subject_name|
+      subject_name.in? LANGUAGE_SUBJECTS
     end
   end
 
 private
 
-  def normalized_ucas_subject_names
-    @normalized_ucas_subject_names ||= ucas_subject_names.strip.downcase
-  end
-
-  def modern_language_course?
-    course_name.downcase.match?(MODERN_LANGUAGE_COURSE_PATTERN)
+  def dfe_subject_names
+    SubjectMapper.get_subject_list(
+      course_name,
+      ucas_subject_names
+    )
   end
 end

--- a/app/services/list_languages_taught_in_modern_language_course.rb
+++ b/app/services/list_languages_taught_in_modern_language_course.rb
@@ -1,0 +1,44 @@
+class ListLanguagesTaughtInModernLanguageCourse
+  LANGUAGES = [
+    'english as a foreign language',
+    'french',
+    'german',
+    'italian',
+    'japanese',
+    'mandarin',
+    'russian',
+    'spanish',
+    'urdu'
+  ].freeze
+
+  MODERN_LANGUAGE_COURSE_PATTERN = /mfl|modern language|modern foreign language/.freeze
+
+  attr_reader :course_name, :ucas_subject_names
+
+  def self.call(course_name, ucas_subject_names)
+    new(course_name, ucas_subject_names).call
+  end
+
+  def initialize(course_name, ucas_subject_names)
+    @course_name        = course_name
+    @ucas_subject_names = ucas_subject_names
+  end
+
+  def call
+    return [] unless modern_language_course?
+
+    LANGUAGES.select do |language|
+      language.in? normalized_ucas_subject_names
+    end
+  end
+
+private
+
+  def normalized_ucas_subject_names
+    @normalized_ucas_subject_names ||= ucas_subject_names.strip.downcase
+  end
+
+  def modern_language_course?
+    course_name.downcase.match?(MODERN_LANGUAGE_COURSE_PATTERN)
+  end
+end

--- a/app/services/list_languages_taught_in_modern_language_course.rb
+++ b/app/services/list_languages_taught_in_modern_language_course.rb
@@ -11,18 +11,20 @@ class ListLanguagesTaughtInModernLanguageCourse
     'Urdu'
   ].freeze
 
-  attr_reader :course_name, :ucas_subject_names
+  attr_reader :course, :ucas_subject_names
 
-  def self.call(course_name, ucas_subject_names)
-    new(course_name, ucas_subject_names).call
+  def self.call(course, ucas_subject_names)
+    new(course, ucas_subject_names).call
   end
 
-  def initialize(course_name, ucas_subject_names)
-    @course_name        = course_name
+  def initialize(course, ucas_subject_names)
+    @course             = course
     @ucas_subject_names = ucas_subject_names
   end
 
   def call
+    return [] unless course.secondary?
+
     dfe_subject_names.select do |subject_name|
       subject_name.in? LANGUAGE_SUBJECTS
     end
@@ -32,7 +34,7 @@ private
 
   def dfe_subject_names
     SubjectMapper.get_subject_list(
-      course_name,
+      course.name,
       ucas_subject_names
     )
   end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -113,5 +113,13 @@ FactoryBot.define do
     trait :with_salary do
       program_type { :school_direct_salaried_training_programme }
     end
+
+    trait :primary do
+      age_range { 'P' }
+    end
+
+    trait :secondary do
+      age_range { 'S' }
+    end
   end
 end

--- a/spec/services/list_languages_taught_in_modern_language_course_spec.rb
+++ b/spec/services/list_languages_taught_in_modern_language_course_spec.rb
@@ -1,0 +1,59 @@
+describe ListLanguagesTaughtInModernLanguageCourse do
+  describe '#call' do
+    context "when the course isn't for modern languages" do
+      let(:course_name) { 'Physical Education with French' }
+
+      context 'with two language subjects' do
+        let(:ucas_subject_names) do
+          'French, German, Languages, Languages (European), Secondary'
+        end
+
+        subject { described_class.call(course_name, ucas_subject_names) }
+
+        it { should eq([]) }
+      end
+    end
+
+    context "when the course name contains MFL" do
+      let(:course_name) { 'MFL - Spanish' }
+
+      context 'with two language subjects' do
+        let(:ucas_subject_names) do
+          'French, German, Languages, Languages (European), Secondary'
+        end
+
+        subject { described_class.call(course_name, ucas_subject_names) }
+
+        it { should eq(%w[french german]) }
+      end
+    end
+
+    context 'when the course name contains "Modern Foreign Language"' do
+      let(:course_name) { 'Modern Foreign Language (French)' }
+
+      context 'with two language subjects' do
+        let(:ucas_subject_names) do
+          'French, German, Languages, Languages (European), Secondary'
+        end
+
+        subject { described_class.call(course_name, ucas_subject_names) }
+
+        it { should eq(%w[french german]) }
+      end
+    end
+
+    context 'when the course name contains "Modern Language"' do
+      let(:course_name) { 'Modern Languages (Spanish with German)' }
+
+      context 'with two language subjects' do
+        let(:ucas_subject_names) do
+          'French, German, Languages, Languages (European), Secondary'
+        end
+
+        subject { described_class.call(course_name, ucas_subject_names) }
+
+        it { should eq(%w[french german]) }
+      end
+    end
+  end
+end

--- a/spec/services/list_languages_taught_in_modern_language_course_spec.rb
+++ b/spec/services/list_languages_taught_in_modern_language_course_spec.rb
@@ -1,59 +1,20 @@
 describe ListLanguagesTaughtInModernLanguageCourse do
   describe '#call' do
-    context "when the course isn't for modern languages" do
-      let(:course_name) { 'Physical Education with French' }
-
-      context 'with two language subjects' do
-        let(:ucas_subject_names) do
-          'French, German, Languages, Languages (European), Secondary'
-        end
-
-        subject { described_class.call(course_name, ucas_subject_names) }
-
-        it { should eq([]) }
-      end
-    end
-
-    context "when the course name contains MFL" do
-      let(:course_name) { 'MFL - Spanish' }
-
-      context 'with two language subjects' do
-        let(:ucas_subject_names) do
-          'French, German, Languages, Languages (European), Secondary'
-        end
-
-        subject { described_class.call(course_name, ucas_subject_names) }
-
-        it { should eq(%w[french german]) }
-      end
-    end
-
-    context 'when the course name contains "Modern Foreign Language"' do
-      let(:course_name) { 'Modern Foreign Language (French)' }
-
-      context 'with two language subjects' do
-        let(:ucas_subject_names) do
-          'French, German, Languages, Languages (European), Secondary'
-        end
-
-        subject { described_class.call(course_name, ucas_subject_names) }
-
-        it { should eq(%w[french german]) }
-      end
-    end
-
-    context 'when the course name contains "Modern Language"' do
+    context 'when the course is for Modern Languages (Spanish with German)' do
       let(:course_name) { 'Modern Languages (Spanish with German)' }
-
-      context 'with two language subjects' do
-        let(:ucas_subject_names) do
-          'French, German, Languages, Languages (European), Secondary'
-        end
-
-        subject { described_class.call(course_name, ucas_subject_names) }
-
-        it { should eq(%w[french german]) }
+      let(:ucas_subject_names) do
+        [
+          'Spanish',
+          'Secondary',
+          'Languages',
+          'German',
+          'Languages (European)'
+        ]
       end
+
+      subject { described_class.call(course_name, ucas_subject_names) }
+
+      it { should match_array(%w[Spanish German]) }
     end
   end
 end

--- a/spec/services/list_languages_taught_in_modern_language_course_spec.rb
+++ b/spec/services/list_languages_taught_in_modern_language_course_spec.rb
@@ -1,20 +1,50 @@
 describe ListLanguagesTaughtInModernLanguageCourse do
   describe '#call' do
-    context 'when the course is for Modern Languages (Spanish with German)' do
-      let(:course_name) { 'Modern Languages (Spanish with German)' }
-      let(:ucas_subject_names) do
-        [
-          'Spanish',
-          'Secondary',
-          'Languages',
-          'German',
-          'Languages (European)'
-        ]
+    let(:ucas_subject_names) do
+      [
+        'Spanish',
+        'Secondary',
+        'Languages',
+        'German',
+        'Languages (European)'
+      ]
+    end
+
+    subject { described_class.call(course, ucas_subject_names) }
+
+    context 'with a secondary course' do
+      context 'when the course is for Modern Languages (Spanish with German)' do
+        let(:course) do
+          build(
+            :course,
+            :secondary,
+            name: 'Modern Languages (Spanish with German)'
+          )
+        end
+        let(:ucas_subject_names) do
+          [
+            'Spanish',
+            'Secondary',
+            'Languages',
+            'German',
+            'Languages (European)'
+          ]
+        end
+
+        it { should match_array(%w[Spanish German]) }
+      end
+    end
+
+    context 'with a primary course' do
+      let(:course) do
+        build(
+          :course,
+          :primary,
+          name: 'Modern Languages (Spanish with German)'
+        )
       end
 
-      subject { described_class.call(course_name, ucas_subject_names) }
-
-      it { should match_array(%w[Spanish German]) }
+      it { should eq([]) }
     end
   end
 end


### PR DESCRIPTION
This service class extracts languages, given a course name and a list of
UCAS subject names.

It only works on modern language courses.

### Context

We need to list the languages a course uses on the backend API.

### Changes proposed in this pull request

Add a service to extract languages used in modern language courses and use it on the backend.

### Guidance to review

This is a draft.
