### PR TITLE
[1345] Set enrichments as draft for new courses when opting in

### DIFF
--- a/lib/mcb/commands/providers/optin.rb
+++ b/lib/mcb/commands/providers/optin.rb
@@ -9,6 +9,11 @@ run do |opts, args, _cmd|
       provider = Provider.find_by!(provider_code: provider_code)
       verbose "updating provider #{provider_code}"
       provider.update(opted_in: true)
+
+      provider.courses.each do |course|
+        course.enrichments.update_all(status: :draft) if course.new?
+      end
+
       provider.courses.each do |c|
         verbose "  updating course #{c.course_code}"
         c.touch(:changed_at)

--- a/spec/lib/mcb/commands/providers/optin_spec.rb
+++ b/spec/lib/mcb/commands/providers/optin_spec.rb
@@ -51,5 +51,39 @@ describe 'mcb provider optin' do
       # These should be correct to the second, but not the nsec
       expect(course1.created_at.nsec).not_to eq course2.created_at.nsec
     end
+
+    context 'when the course has UCAS status "new"' do
+      let(:course1) do
+        create(
+          :course,
+          site_statuses: create_list(:site_status, 1, :new),
+          enrichments: enrichments
+        )
+      end
+
+      before do
+        enrichments.each do |enrichment|
+          enrichment.update(provider_code: provider.provider_code)
+        end
+      end
+
+      context 'when the course has publised course enrichments' do
+        let(:enrichments) { create_list(:course_enrichment, 1, :published) }
+
+        it 'changes the enrichment to draft' do
+          expect { subject }.to change { course1.enrichments.first.reload.status }
+            .from('published')
+            .to('draft')
+        end
+      end
+
+      context 'when the course does not have published enrichments' do
+        let(:enrichments) { create_list(:course_enrichment, 1, :initial_draft) }
+
+        it 'does not change the enrichment status' do
+          expect { subject }.not_to(change { course1.enrichments.first.reload.status })
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

After transition, a bunch (50+) courses will have a UCAS status 'new' but content status of 'published'. This state inconsistency has arisen because pre-transition, these steps were carried out on separate systems.

Since the "publish" button only appears on courses that are in "draft" or "published with unpublished changes" states, these aforementioned courses won't have a publish button, meaning it's not obvious how to publish them.

### Changes proposed in this pull request

When 'mcb provider optin' is run, it unpublishes the content enrichments for any course that's in the 'new' with 'published' enrichments state.

### Guidance to review