### PR TITLE
[1351] Only mark latest enrichment as draft

### DIFF
--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -38,6 +38,8 @@ class CourseEnrichment < ApplicationRecord
              foreign_key: :ucas_course_code,
              primary_key: :course_code
 
+  scope :latest_first, -> { order(created_at: :desc) }
+
   def has_been_published_before?
     last_published_timestamp_utc.present?
   end

--- a/lib/mcb/commands/providers/optin.rb
+++ b/lib/mcb/commands/providers/optin.rb
@@ -11,7 +11,13 @@ run do |opts, args, _cmd|
       provider.update(opted_in: true)
 
       provider.courses.each do |course|
-        course.enrichments.update_all(status: :draft) if course.new?
+        next unless course.new?
+
+        enrichment = course.enrichments.latest_first.first
+        next unless enrichment.published?
+
+        puts "resetting enrichment #{enrichment.id} for course #{course.course_code} to draft"
+        enrichment.update(status: :draft)
       end
 
       provider.courses.each do |c|

--- a/lib/mcb/commands/providers/optin.rb
+++ b/lib/mcb/commands/providers/optin.rb
@@ -16,7 +16,7 @@ run do |opts, args, _cmd|
         enrichment = course.enrichments.latest_first.first
         next unless enrichment.published?
 
-        puts "resetting enrichment #{enrichment.id} for course #{course.course_code} to draft"
+        verbose "  resetting enrichment #{enrichment.id} for course #{course.course_code} to draft"
         enrichment.update(status: :draft)
       end
 

--- a/spec/lib/mcb/commands/providers/optin_spec.rb
+++ b/spec/lib/mcb/commands/providers/optin_spec.rb
@@ -68,12 +68,21 @@ describe 'mcb provider optin' do
       end
 
       context 'when the course has publised course enrichments' do
-        let(:enrichments) { create_list(:course_enrichment, 1, :published) }
+        let(:enrichments) do
+          [
+            create(:course_enrichment, :published, created_at: Date.yesterday),
+            create(:course_enrichment, :published)
+          ]
+        end
 
-        it 'changes the enrichment to draft' do
-          expect { subject }.to change { course1.enrichments.first.reload.status }
+        it 'changes the latest enrichment to draft' do
+          expect { subject }.to change { enrichments.last.reload.status }
             .from('published')
             .to('draft')
+        end
+
+        it 'does not change the status of the second enrichment' do
+          expect { subject }.not_to(change { enrichments.first.reload.status })
         end
       end
 

--- a/spec/lib/mcb/commands/providers/ucas_preferences/import_spec.rb
+++ b/spec/lib/mcb/commands/providers/ucas_preferences/import_spec.rb
@@ -113,13 +113,12 @@ describe 'mcb providers ucas_preferences import' do
         cmd.run([tmpfile.path])
       end
 
-      # rubocop: disable Layout/TrailingWhitespace
-      expect(output.squeeze(' ')).to match <<~EOEXPECTED.chomp
-        \ #{provider.provider_code} type_of_gt12: Coming or Not -> Not coming\ 
-        \ #{provider.provider_code} send_application_alerts: Yes, required -> No, not required\ 
-        2 changed preferences for 1 providers. Continue?\ 
-      EOEXPECTED
-      # rubocop: enable Layout/TrailingWhitespace
+      expected_output_regexp = Regexp.new([
+        "\s*#{provider.provider_code}\s*type_of_gt12:\s*Coming or Not -> Not coming\s*",
+        "\s*#{provider.provider_code}\s*send_application_alerts:\s*Yes, required -> No, not required\s*",
+        "2 changed preferences for 1 providers. Continue?"
+      ].join("\n"))
+      expect(output).to match(expected_output_regexp)
     end
 
     it 'changes the given preferences when confirmation is given' do

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -45,4 +45,16 @@ describe CourseEnrichment, type: :model do
     subject { create(:course_enrichment, :subsequent_draft) }
     it { should have_been_published_before }
   end
+
+  describe '.latest_first' do
+    let!(:old_enrichment) do
+      create(:course_enrichment, :published, created_at: Date.yesterday)
+    end
+    let!(:new_enrichment) { create(:course_enrichment, :published) }
+
+    it 'returns the new enrichment first' do
+      expect(CourseEnrichment.latest_first.first).to eq new_enrichment
+      expect(CourseEnrichment.latest_first.last).to eq old_enrichment
+    end
+  end
 end


### PR DESCRIPTION
### Context

When we opt in providers that have a course that is new in UCAS, we mark all of the enrichments as draft. We only want to mark the latest enrichment as draft, if it's published.

### Changes proposed in this pull request

- Only latest enrichment gets marked as draft, not all of them
- Some text is output to the screen to indicate what happened

### Guidance to review

There's a failing test, will fix tomorrow. I have no idea why it fails. :(