### PR TITLE
[1355] include opted in attr on user endpoint

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,4 +33,8 @@ class User < ApplicationRecord
       transitions from: :new, to: :transitioned
     end
   end
+
+  def opted_in?
+    providers.any?(&:opted_in?)
+  end
 end

--- a/app/serializers/api/v2/serializable_user.rb
+++ b/app/serializers/api/v2/serializable_user.rb
@@ -3,7 +3,7 @@ module API
     class SerializableUser < JSONAPI::Serializable::Resource
       type 'users'
 
-      attributes :first_name, :last_name, :email, :accept_terms_date_utc, :state
+      attributes :first_name, :last_name, :email, :accept_terms_date_utc, :state, :opted_in?
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -21,5 +21,9 @@ FactoryBot.define do
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     accept_terms_date_utc { Faker::Time.backward(1).utc }
+
+    trait :opted_in do
+      organisations { [create(:organisation, providers: [create(:provider, opted_in: true)])] }
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -44,4 +44,18 @@ describe User, type: :model do
 
     it { should be_transitioned }
   end
+
+  describe '#opted_in?' do
+    context 'user is opted in' do
+      subject { create(:user, :opted_in) }
+
+      its(:opted_in?) { should be_truthy }
+    end
+
+    context 'user is not opted in' do
+      subject { create(:user) }
+
+      its(:opted_in?) { should be_falsey }
+    end
+  end
 end

--- a/spec/requests/api/v2/users_spec.rb
+++ b/spec/requests/api/v2/users_spec.rb
@@ -54,6 +54,7 @@ describe '/api/v2/users', type: :request do
       expect(data_attributes['first_name']).to eq(user.first_name)
       expect(data_attributes['last_name']).to eq(user.last_name)
       expect(data_attributes['state']).to eq(user.state)
+      expect(data_attributes['opted_in?']).to eq(user.opted_in?)
     end
   end
 


### PR DESCRIPTION
### Context
Is a user "opted_in" i.e. do they have access to any providers that are opted_in?

### Changes proposed in this pull request
Expose user#opted_in? 

### Guidance to review
Example - `http://localhost:3001/api/v2/users/10345`
