### PR TITLE
[1358] add current user id to Raven user context for Sentry

### DIFF
--- a/app/controllers/api/v2/application_controller.rb
+++ b/app/controllers/api/v2/application_controller.rb
@@ -10,8 +10,14 @@ module API
           email = email_from_token(token)
 
           @current_user = User.find_by("lower(email) = ?", email.downcase)
-
-          @current_user.present?
+          if @current_user.present?
+            Raven.user_context(id: @current_user.id)
+            true
+          else
+            # Once DFE Sign-In ID is passed in, add that to the Raven user
+            # context.
+            false
+          end
         end
       end
 


### PR DESCRIPTION
### Context

We are getting sporadic Pundit::NotAuthorisedError. This change tries to up our visibility to try to understand the cause.

### Changes proposed in this pull request

Add the id for the current user to the Raven user context.

### Guidance to review

Wasn't sure this change was worth testing, the rest of the tests should (hopefully) ensure we don't break anything.
