### PR TITLE
[1345] optin mcb command handles new courses without enrichments

### DIFF
--- a/lib/mcb/commands/providers/optin.rb
+++ b/lib/mcb/commands/providers/optin.rb
@@ -14,7 +14,7 @@ run do |opts, args, _cmd|
         next unless course.new?
 
         enrichment = course.enrichments.latest_first.first
-        next unless enrichment.published?
+        next unless enrichment&.published?
 
         verbose "  resetting enrichment #{enrichment.id} for course #{course.course_code} to draft"
         enrichment.update(status: :draft)

--- a/spec/lib/mcb/commands/providers/optin_spec.rb
+++ b/spec/lib/mcb/commands/providers/optin_spec.rb
@@ -93,6 +93,14 @@ describe 'mcb provider optin' do
           expect { subject }.not_to(change { course1.enrichments.first.reload.status })
         end
       end
+
+      context 'when the course has no enrichments' do
+        let(:enrichments) { [] }
+
+        it 'skips the course' do
+          expect { subject }.not_to raise_error
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
`optin` command was blowing up when processing new courses without enrichments.
