### PR TITLE
[1345] optin should unpublish to initial draft

### DIFF
--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -43,4 +43,10 @@ class CourseEnrichment < ApplicationRecord
   def has_been_published_before?
     last_published_timestamp_utc.present?
   end
+
+  def unpublish(initial_draft: true)
+    data = { status: :draft }
+    data[:last_published_timestamp_utc] = nil if initial_draft
+    update(data)
+  end
 end

--- a/lib/mcb/commands/providers/optin.rb
+++ b/lib/mcb/commands/providers/optin.rb
@@ -17,7 +17,7 @@ run do |opts, args, _cmd|
         next unless enrichment&.published?
 
         verbose "  resetting enrichment #{enrichment.id} for course #{course.course_code} to draft"
-        enrichment.update(status: :draft)
+        enrichment.unpublish(initial_draft: true)
       end
 
       provider.courses.each do |c|

--- a/spec/lib/mcb/commands/providers/optin_spec.rb
+++ b/spec/lib/mcb/commands/providers/optin_spec.rb
@@ -68,10 +68,11 @@ describe 'mcb provider optin' do
       end
 
       context 'when the course has publised course enrichments' do
+        let(:a_date_in_the_past) { Date.new(2017, 1, 1) }
         let(:enrichments) do
           [
             create(:course_enrichment, :published, created_at: Date.yesterday),
-            create(:course_enrichment, :published)
+            create(:course_enrichment, :published, last_published_timestamp_utc: a_date_in_the_past)
           ]
         end
 
@@ -79,6 +80,12 @@ describe 'mcb provider optin' do
           expect { subject }.to change { enrichments.last.reload.status }
             .from('published')
             .to('draft')
+        end
+
+        it 'blows away the last publication timestamp on the latest enrichment' do
+          expect { subject }.to change { enrichments.last.reload.last_published_timestamp_utc }
+            .from(a_date_in_the_past)
+            .to(nil)
         end
 
         it 'does not change the status of the second enrichment' do

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -57,4 +57,42 @@ describe CourseEnrichment, type: :model do
       expect(CourseEnrichment.latest_first.last).to eq old_enrichment
     end
   end
+
+  describe '#unpublish' do
+    let(:provider) { create(:provider) }
+    let(:course) { create(:course, provider: provider) }
+    let(:last_published_timestamp_utc) { Date.new(2017, 1, 1) }
+    subject {
+      create(:course_enrichment, :published,
+        last_published_timestamp_utc: last_published_timestamp_utc,
+        course: course,
+        provider: provider)
+    }
+
+    describe "to initial draft" do
+      it 'sets the course to draft' do
+        expect { subject.unpublish(initial_draft: true) }.to change { subject.reload.status }
+          .from("published")
+          .to("draft")
+      end
+
+      it 'sets the last_published_timestamp_utc to nil' do
+        expect { subject.unpublish(initial_draft: true) }.to change { subject.reload.last_published_timestamp_utc }
+          .from(last_published_timestamp_utc)
+          .to(nil)
+      end
+    end
+
+    describe "to subsequent draft" do
+      it 'sets the course to draft' do
+        expect { subject.unpublish(initial_draft: false) }.to change { subject.reload.status }
+          .from("published")
+          .to("draft")
+      end
+
+      it 'keeps the last_published_timestamp_utc as is' do
+        expect { subject.unpublish(initial_draft: false) }.not_to(change { subject.reload.last_published_timestamp_utc })
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context
There are two flavours of draft, it's appropriate for optin to set published
enrichments for new courses back to initial draft.

### Changes proposed in this pull request
- encapsulate unpublishing on the `CourseEnrichment` model
- `optin` should unpublish back to initial draft

