### PR TITLE
[1255] expose course changed at

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -159,4 +159,9 @@ class Course < ApplicationRecord
       'fee'
     end
   end
+
+  def last_published_at
+    newest_enrichment = enrichments.latest_first.first
+    newest_enrichment&.last_published_timestamp_utc
+  end
 end

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -19,6 +19,10 @@ module API
         @object.start_date&.iso8601
       end
 
+      attribute :changed_at do
+        @object.changed_at&.iso8601
+      end
+
       attribute :subjects do
         ucas_subjects = @object.subjects.map(&:subject_name)
         SubjectMapper.get_subject_list(@object.name, ucas_subjects)

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -19,8 +19,8 @@ module API
         @object.start_date&.iso8601
       end
 
-      attribute :changed_at do
-        @object.changed_at&.iso8601
+      attribute :last_published_at do
+        @object.last_published_at&.iso8601
       end
 
       attribute :subjects do

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -25,7 +25,7 @@ describe 'Courses API v2', type: :request do
            enrichments: [enrichment])
   }
 
-  let(:enrichment)     { build :course_enrichment }
+  let(:enrichment)     { build :course_enrichment, :published }
   let(:provider)       { create :provider, organisations: [organisation] }
   let(:course_subject) { course.subjects.first }
   let(:site_status)    { findable_open_course.site_statuses.first }
@@ -99,7 +99,7 @@ describe 'Courses API v2', type: :request do
               "study_mode" => "full_time",
               "qualifications" => %w[qts pgce],
               "description" => "PGCE with QTS full time teaching apprenticeship",
-              "content_status" => "draft",
+              "content_status" => "published",
               "ucas_status" => "running",
               "funding" => "apprenticeship",
               "is_send?" => true,
@@ -119,7 +119,7 @@ describe 'Courses API v2', type: :request do
               "personal_qualities" => enrichment.personal_qualities,
               "required_qualifications" => enrichment.qualifications,
               "salary_details" => enrichment.salary_details,
-              "changed_at" => provider.courses[0].changed_at.iso8601,
+              "last_published_at" => enrichment.last_published_timestamp_utc.iso8601,
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },
@@ -354,7 +354,7 @@ describe 'Courses API v2', type: :request do
               "study_mode" => "full_time",
               "qualifications" => %w[qts pgce],
               "description" => "PGCE with QTS full time teaching apprenticeship",
-              "content_status" => "draft",
+              "content_status" => "published",
               "ucas_status" => "running",
               "funding" => "apprenticeship",
               "is_send?" => true,
@@ -374,7 +374,7 @@ describe 'Courses API v2', type: :request do
               "personal_qualities" => enrichment.personal_qualities,
               "required_qualifications" => enrichment.qualifications,
               "salary_details" => enrichment.salary_details,
-              "changed_at" => provider.courses[0].changed_at.iso8601,
+              "last_published_at" => enrichment.last_published_timestamp_utc.iso8601,
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -118,7 +118,8 @@ describe 'Courses API v2', type: :request do
               "other_requirements" => enrichment.other_requirements,
               "personal_qualities" => enrichment.personal_qualities,
               "required_qualifications" => enrichment.qualifications,
-              "salary_details" => enrichment.salary_details
+              "salary_details" => enrichment.salary_details,
+              "changed_at" => provider.courses[0].changed_at.iso8601,
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },
@@ -372,7 +373,8 @@ describe 'Courses API v2', type: :request do
               "other_requirements" => enrichment.other_requirements,
               "personal_qualities" => enrichment.personal_qualities,
               "required_qualifications" => enrichment.qualifications,
-              "salary_details" => enrichment.salary_details
+              "salary_details" => enrichment.salary_details,
+              "changed_at" => provider.courses[0].changed_at.iso8601,
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },


### PR DESCRIPTION
### Context
Course last published date

### Changes proposed in this pull request
Expose `last_published_at` for courses which is the `last_published_timestamp_utc` value from the latest `course_enrichment`.

### Guidance to review
Example - http://localhost:3001/api/v2/providers/2AT/courses/35L8
