### PR TITLE
Rename service classes to have Service suffix

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -16,7 +16,7 @@ module API
       end
 
       def sync_with_search_and_compare
-        response = ManageCoursesAPI::Request.sync_course_with_search_and_compare(
+        response = ManageCoursesAPIService::Request.sync_course_with_search_and_compare(
           @current_user.email,
           @provider.provider_code,
           @course.course_code
@@ -29,7 +29,7 @@ module API
         # todo: set running
         # todo: set enrichment published
 
-        response = ManageCoursesAPI::Request.sync_course_with_search_and_compare(
+        response = ManageCoursesAPIService::Request.sync_course_with_search_and_compare(
           @current_user.email,
           @provider.provider_code,
           @course.course_code

--- a/app/controllers/api/v2/sites_controller.rb
+++ b/app/controllers/api/v2/sites_controller.rb
@@ -51,7 +51,7 @@ module API
       end
 
       def sync_courses_with_search_and_compare
-        ManageCoursesAPI::Request.sync_courses_with_search_and_compare(
+        ManageCoursesAPIService::Request.sync_courses_with_search_and_compare(
           @current_user.email,
           @provider.provider_code
         )

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -21,12 +21,12 @@ module API
 
       attribute :subjects do
         ucas_subjects = @object.subjects.map(&:subject_name)
-        SubjectMapper.get_subject_list(@object.name, ucas_subjects)
+        SubjectMapperService.get_subject_list(@object.name, ucas_subjects)
       end
 
       attribute :level do
         ucas_subjects = @object.subjects.map(&:subject_name)
-        SubjectMapper.get_subject_level(ucas_subjects)
+        SubjectMapperService.get_subject_level(ucas_subjects)
       end
 
       attribute :is_send? do

--- a/app/services/manage_courses_api_service.rb
+++ b/app/services/manage_courses_api_service.rb
@@ -1,4 +1,4 @@
-module ManageCoursesAPI
+module ManageCoursesAPIService
   class Connection
     def self.api
       Faraday.new(url: Settings.manage_api.base_url) do |faraday|

--- a/app/services/subject_mapper_service.rb
+++ b/app/services/subject_mapper_service.rb
@@ -1,6 +1,6 @@
 # This is a port of https://github.com/DFE-Digital/manage-courses-api/blob/master/src/ManageCourses.Api/Mapping/SubjectMapper.cs
 
-class SubjectMapper
+class SubjectMapperService
   SUBJECT_LEVEL = {
     ucas_further_education: ["further education",
                              "higher education",

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -157,7 +157,7 @@ describe 'Sites API v2', type: :request do
     let(:site_params) { params.dig :_jsonapi, :data, :attributes }
 
     before do
-      allow(ManageCoursesAPI::Request).to(
+      allow(ManageCoursesAPIService::Request).to(
         receive(:sync_courses_with_search_and_compare).and_return(true)
       )
     end
@@ -266,7 +266,7 @@ describe 'Sites API v2', type: :request do
         it { should have_http_status(:success) }
 
         it 'publishes courses on manage-courses-api' do
-          expect(ManageCoursesAPI::Request).to(
+          expect(ManageCoursesAPIService::Request).to(
             have_received(:sync_courses_with_search_and_compare)
             .with(user.email, provider.provider_code)
           )

--- a/spec/services/manage_courses_api_service_spec.rb
+++ b/spec/services/manage_courses_api_service_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
-describe ManageCoursesAPI do
+describe ManageCoursesAPIService do
   describe "Connection.api" do
-    subject { ManageCoursesAPI::Connection.api }
+    subject { described_class::Connection.api }
 
     it "exposes an Faraday connection" do
       should be_instance_of(Faraday::Connection)
@@ -18,7 +18,7 @@ describe ManageCoursesAPI do
   end
 
   describe "Request" do
-    subject { ManageCoursesAPI::Request }
+    subject { described_class::Request }
     let(:provider_code) { 'X12' }
     let(:email) { 'foo@bar' }
     let(:body) { { "email": email } }

--- a/spec/services/subject_mapper_service_spec.rb
+++ b/spec/services/subject_mapper_service_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require "csv"
 
-describe SubjectMapper do
+describe SubjectMapperService do
   # Port of https://github.com/DFE-Digital/manage-courses-api/blob/master/tests/ManageCourses.Tests/UnitTesting/SubjectMapperTests.cs
   describe "#get_subject_list" do
     specs = [
@@ -141,7 +141,7 @@ describe SubjectMapper do
 
     specs.each do |spec|
       describe "Test case '#{spec[:test_case]}''" do
-        subject { SubjectMapper.get_subject_list(spec[:course_title], spec[:ucas_subjects]) }
+        subject { described_class.get_subject_list(spec[:course_title], spec[:ucas_subjects]) }
 
         it { should match_array spec[:expected_subjects] }
       end
@@ -149,7 +149,7 @@ describe SubjectMapper do
 
     describe "regression test" do
       xcontext "english" do
-        subject { SubjectMapper.get_subject_list(title, %w[english]) }
+        subject { described_class.get_subject_list(title, %w[english]) }
         it { should match_array %w[English] }
       end
     end
@@ -166,7 +166,7 @@ describe SubjectMapper do
         title = spec[:course_title]
 
         describe "Test case row '#{index}': subjects #{ucas_subjects_to_map.join(', ')}, title: #{title}" do
-          subject { SubjectMapper.get_subject_list(title, ucas_subjects_to_map) }
+          subject { described_class.get_subject_list(title, ucas_subjects_to_map) }
           it { should match_array expected_dfe_subjects }
         end
       end


### PR DESCRIPTION
### Context

It's confusing af to not have this as only models in Rails don't have a suffix. 🤔 

### Changes proposed in this pull request

All service classes are now renamed to end with `Service`.

### Guidance to review