### PR TITLE
[1337] Make development authentication consistent with production

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,3 +1,2 @@
 authentication:
-  algorithm: plain-text
-  secret: nil
+  secret: secret

--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -82,19 +82,12 @@ module MCB
     require 'jwt'
 
     payload = { email: email }
-    if encoding == 'plain-text'
-      unless secret.nil?
-        raise 'Secret provided, only valid when encoding is NOT plain-text'
-      end
 
-      payload.to_json
-    else
-      if secret.nil?
-        raise 'Secret not provided, only valid when encoding is plain-text'
-      end
-
-      JWT.encode(payload.to_json, secret, encoding)
+    if secret.nil?
+      raise 'Secret not provided'
     end
+
+    JWT.encode(payload.to_json, secret, encoding)
   end
 
   def self.each_v1_course(opts)

--- a/lib/mcb/commands/apiv2/token/generate.rb
+++ b/lib/mcb/commands/apiv2/token/generate.rb
@@ -2,7 +2,6 @@ name 'generate'
 summary 'Generate a JWT token using the secret'
 usage 'generate [options] <code>'
 param :email
-option :p, 'plain-text', 'Use plain-text encoding'
 option :S, :secret, 'the JWT secret',
        argument: :required
 option nil, :encoding, 'the encoding to use for the JWT',
@@ -11,13 +10,8 @@ option nil, :encoding, 'the encoding to use for the JWT',
 
 
 run do |opts, args, _cmd|
-  if opts[:'plain-text']
-    encoding = 'plain-text'
-    secret   = nil
-  else
-    encoding = opts[:encoding]
-    secret   = opts[:secret]
-  end
+  encoding = opts[:encoding]
+  secret   = opts[:secret]
 
   email = args[:email]
   token = MCB.generate_apiv2_token(

--- a/spec/lib/mcb/commands/apiv2/token/generate_spec.rb
+++ b/spec/lib/mcb/commands/apiv2/token/generate_spec.rb
@@ -14,14 +14,4 @@ describe 'mcb apiv2 token generate' do
       )
     end
   end
-
-  describe 'generating a plain-text token' do
-    it 'returns a plain-text JSON string' do
-      result = with_stubbed_stdout do
-        $mcb.run(%w[apiv2 token generate -p user@local])
-      end
-
-      expect(result.chomp).to eq '{"email":"user@local"}'
-    end
-  end
 end

--- a/spec/lib/mcb_spec.rb
+++ b/spec/lib/mcb_spec.rb
@@ -100,32 +100,7 @@ describe 'mcb command' do
             secret: nil
           )
         }.to raise_error(
-          "Secret not provided, only valid when encoding is plain-text"
-        )
-      end
-    end
-
-    context 'plain-text encoding' do
-      let(:encoding) { 'plain-text' }
-
-      it 'returns the payload as JSON' do
-        token = MCB.generate_apiv2_token(
-          email: email,
-          encoding: encoding,
-          secret: nil
-        )
-        expect(token).to eq "{\"email\":\"#{email}\"}"
-      end
-
-      it 'gives a friendly error when secret is NOT nil' do
-        expect {
-          MCB.generate_apiv2_token(
-            email: email,
-            encoding: encoding,
-            secret: secret
-          )
-        }.to raise_error(
-          'Secret provided, only valid when encoding is NOT plain-text'
+          "Secret not provided"
         )
       end
     end


### PR DESCRIPTION
### Context

Previously we handled authentication without JWT decoding on the backend when running in development.

If you need to create a secret for some reason, then there's an mcb command for that.

### Changes proposed in this pull request

Now it works the same as prod, with the secret set to `secret`.
Also removed the MCB command option for plain-text tokens.

### Guidance to review

Tested on Mac OS Mojave (10.14.4)

Frontend still needs updating for this to work.