### PR TITLE
[1354] Remove sensitive information from Sentry

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -5,4 +5,6 @@ Raven.configure do |config|
   # https://github.com/getsentry/raven-ruby/wiki/Advanced-Configuration#excluding-exceptions
   config.excluded_exceptions = Raven::Configuration::IGNORE_DEFAULT -
     ['ActiveRecord::RecordNotFound']
+
+  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
 end


### PR DESCRIPTION
### Context

The parameters we filter out for sensitive information in logs, etc. isn't respected by Sentry.

### Changes proposed in this pull request

Make Sentry filter out the same attributes as Rails does.

### Guidance to review

Need to test if this actually works.