### PR TITLE
[1346] add mcb config system

### DIFF
--- a/bin/mcb
+++ b/bin/mcb
@@ -18,6 +18,7 @@ lib_dir = File.expand_path 'lib'
 $LOAD_PATH << lib_dir
 require 'mcb'
 require 'mcb/azure'
+require 'mcb/config'
 
 tp.set :capitalize_headers, false
 
@@ -35,6 +36,11 @@ $mcb = Cri::Command.define do
   flag :h, :help, 'show help for this command' do |_value, cmd|
     puts cmd.help
     exit 0
+  end
+
+  option :c, :config, 'use provided config file',
+         argument: :required do |config_file|
+    MCB.config_file = config_file
   end
 end
 

--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -184,6 +184,26 @@ module MCB
     end
   end
 
+  def self.config_dir=(dir)
+    @config_dir = dir
+  end
+
+  def self.config_dir
+    @config_dir ||= File.expand_path '~/.config/mcb-dfe/'
+  end
+
+  def self.config_file=(file)
+    @config_file = file
+  end
+
+  def self.config_file
+    @config_file ||= File.join config_dir, 'config.yml'
+  end
+
+  def self.config
+    @config ||= MCB::Config.new(config_file: config_file)
+  end
+
   class << self
   private # rubocop: disable Layout/IndentationWidth
 

--- a/lib/mcb/commands/config.rb
+++ b/lib/mcb/commands/config.rb
@@ -1,0 +1,2 @@
+name 'config'
+summary 'View and change config information'

--- a/lib/mcb/commands/config.rb
+++ b/lib/mcb/commands/config.rb
@@ -1,2 +1,3 @@
 name 'config'
 summary 'View and change config information'
+default_subcommand 'show'

--- a/lib/mcb/commands/config/set.rb
+++ b/lib/mcb/commands/config/set.rb
@@ -1,5 +1,6 @@
 name 'set'
 summary 'Set a config value'
+usage 'set <key> <value>'
 param :name
 param :value
 

--- a/lib/mcb/commands/config/set.rb
+++ b/lib/mcb/commands/config/set.rb
@@ -1,0 +1,10 @@
+name 'set'
+summary 'Set a config value'
+param :name
+param :value
+
+run do |_opts, args, _cmd|
+  verbose "setting config #{args[:name]} to #{args[:value]}}"
+  MCB.config[args[:name]] = args[:value]
+  MCB.config.save
+end

--- a/lib/mcb/commands/config/show.rb
+++ b/lib/mcb/commands/config/show.rb
@@ -1,0 +1,12 @@
+name 'show'
+summary 'View a config value, or all config'
+
+run do |_opts, args, _cmd|
+  if args.any?
+    args.each do |name|
+      puts MCB.config[name.to_sym]
+    end
+  else
+    puts MCB.config.to_h.to_yaml
+  end
+end

--- a/lib/mcb/config.rb
+++ b/lib/mcb/config.rb
@@ -1,0 +1,28 @@
+require 'active_support/hash_with_indifferent_access'
+
+module MCB
+  class Config < ActiveSupport::HashWithIndifferentAccess
+    def initialize(config_file:)
+      @config_file = config_file if config_file
+      @config_dir  = File.dirname(File.expand_path(config_file))
+      load
+    end
+
+    def save
+      FileUtils.mkdir_p(File.expand_path(@config_dir))
+
+      File.open(File.expand_path(@config_file), 'w', 0o600) do |f|
+        f.write(YAML.dump(to_h))
+      end
+    end
+
+  private
+
+    def load
+      if File.exist? @config_file
+        new_config = YAML.safe_load(File.read(@config_file))
+        update(new_config || {})
+      end
+    end
+  end
+end

--- a/spec/bin/mcb_spec.rb
+++ b/spec/bin/mcb_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'mcb_helper'
+
+describe 'running the mcb script' do
+  describe 'config flag' do
+    let(:config_file) { Tempfile.new(['new_config_file', '.yml']) }
+    let(:config)      { { 'new' => 'day' } }
+
+    it 'can set the path to the config file' do
+      result = with_stubbed_stdout do
+        File.write config_file.path, config.to_yaml
+        $mcb.run(%W[-c #{config_file.path} config show])
+      end
+
+      expect(MCB.config_file).to eq config_file.path
+      expect(result).to eq config.to_yaml
+    end
+  end
+end

--- a/spec/lib/mcb/azure_spec.rb
+++ b/spec/lib/mcb/azure_spec.rb
@@ -131,4 +131,39 @@ describe MCB::Azure do
       expect(ENV).to have_received(:[]=).with('DB_PASSWORD', 'pass')
     end
   end
+
+  describe '.configure_for_webapp' do
+    let(:app_config) do
+      {
+        'RAILS_ENV' => 'aztest'
+      }
+    end
+    let(:expected_rails_env) { 'aztest' }
+    let(:output) do
+      with_stubbed_stdout(stdin: expected_rails_env) do
+        MCB::Azure.configure_for_webapp(webapp: 'banana')
+      end
+    end
+
+
+    before do
+      allow(MCB::Azure).to receive(:get_config).and_return(app_config)
+      allow(MCB::Azure).to receive(:configure_database)
+      allow(MCB::Azure).to receive(:rgroup_for_app).and_return('banana-tree')
+    end
+
+    subject { output }
+
+    it 'prompts for the expected RAILS_ENV' do
+      expect(output).to match %r{enter the expected RAILS_ENV for banana:}
+    end
+
+    context 'expected RAILS_ENV does not match' do
+      let(:expected_rails_env) { 'qa' }
+
+      it 'raises an error if the expected RAILS_ENV does not match' do
+        expect { subject } .to raise_error(RuntimeError)
+      end
+    end
+  end
 end

--- a/spec/lib/mcb/commands/apiv1/token/show_spec.rb
+++ b/spec/lib/mcb/commands/apiv1/token/show_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-load 'bin/mcb'
+require 'mcb_helper'
 
 describe 'mcb apiv1 token show' do
   context 'with no args' do

--- a/spec/lib/mcb/commands/apiv2/token/generate_spec.rb
+++ b/spec/lib/mcb/commands/apiv2/token/generate_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-load 'bin/mcb'
+require 'mcb_helper'
 
 describe 'mcb apiv2 token generate' do
   describe 'generating a token with a secret' do

--- a/spec/lib/mcb/commands/az/apps/config_spec.rb
+++ b/spec/lib/mcb/commands/az/apps/config_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-load 'bin/mcb'
+require 'mcb_helper'
 
 describe 'mcb az apps config' do
   before :each do

--- a/spec/lib/mcb/commands/az/apps/list_spec.rb
+++ b/spec/lib/mcb/commands/az/apps/list_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-load 'bin/mcb'
+require 'mcb_helper'
 
 describe 'mcb az apps list' do
   before :each do

--- a/spec/lib/mcb/commands/config/set_spec.rb
+++ b/spec/lib/mcb/commands/config/set_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+require 'mcb_helper'
+
+describe 'mcb config set' do
+  let(:name) { Faker::Name.name }
+
+  describe 'the generated config' do
+    let(:config) { YAML.safe_load(File.read(MCB.config_file)) }
+
+    it 'allows setting of config variable' do
+      $mcb.run(['config', 'set', 'name', name])
+
+      expect(config['name']).to eq name
+    end
+  end
+end

--- a/spec/lib/mcb/commands/providers/optin_spec.rb
+++ b/spec/lib/mcb/commands/providers/optin_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-load 'bin/mcb'
+require 'mcb_helper'
 
 describe 'mcb provider optin' do
   let(:provider) { create :provider, opted_in: false }

--- a/spec/lib/mcb/commands/providers/optout_spec.rb
+++ b/spec/lib/mcb/commands/providers/optout_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-load 'bin/mcb'
+require 'mcb_helper'
 
 describe 'mcb provider optin' do
   let(:provider) { create :provider, opted_in: true }

--- a/spec/lib/mcb/config_spec.rb
+++ b/spec/lib/mcb/config_spec.rb
@@ -1,0 +1,46 @@
+require 'mcb_helper'
+
+describe MCB::Config do
+  let(:config_file) { Tempfile.new(['mcb_cli_config_', '.yml']) }
+
+  describe 'accessing keys' do
+    it 'keys are accessible as strings or symbols' do
+      config = MCB::Config.new(config_file: config_file.path)
+      config['cat'] = 'meow'
+      expect(config[:cat]).to eq 'meow'
+    end
+  end
+
+  describe 'writing keys' do
+    it 'converts keys to strings' do
+      config = MCB::Config.new(config_file: config_file.path)
+      config[:dog] = 'woof'
+      expect(config['dog']).to eq 'woof'
+    end
+  end
+
+  describe 'initialize' do
+    let(:config) { { 'foo' => 'bar' } }
+
+    it 'loads the config file' do
+      config_file.write(config.to_yaml)
+      config_file.close
+
+      conf = MCB::Config.new(config_file: config_file.path)
+      expect(conf['foo']).to eq 'bar'
+    end
+  end
+
+  describe '.save' do
+    it 'writes safe YAML to the config file' do
+      config_file.close
+
+      config = MCB::Config.new(config_file: config_file.path)
+      config[:door] = 'knob'
+      config.save
+
+      saved_config = YAML.safe_load(File.read(config_file.path))
+      expect(saved_config['door']).to eq 'knob'
+    end
+  end
+end

--- a/spec/lib/mcb/providers_spec.rb
+++ b/spec/lib/mcb/providers_spec.rb
@@ -1,48 +1,14 @@
 require 'spec_helper'
-load 'bin/mcb'
+require 'mcb_helper'
 
 describe 'mcb providers' do
-  describe '--webapp option' do
-    let(:app_config) do
-      {
-        'RAILS_ENV' => 'aztest'
-      }
-    end
-    let(:expected_rails_env) { 'aztest' }
+  it 'configures the database', mcb_cli: true do
+    allow(MCB).to receive(:init_rails)
 
-    before do
-      allow(MCB::Azure).to receive(:get_config).and_return(app_config)
-      allow(MCB::Azure).to receive(:configure_database)
-      allow(MCB::Azure).to receive(:rgroup_for_app).and_return('banana-tree')
+    with_stubbed_stdout do
+      $mcb.run(%w[providers --webapp=banana])
     end
 
-    subject do
-      with_stubbed_stdout(stdin: expected_rails_env) do
-        $mcb.run(%w[providers --webapp=banana])
-      end
-    end
-
-    it 'configures the database' do
-      subject
-
-      expect(MCB::Azure).to have_received(:get_config)
-                              .with('banana', rgroup: 'banana-tree')
-      expect(MCB::Azure).to have_received(:configure_database)
-                              .with('banana', app_config: app_config)
-    end
-
-    it 'prompts for the expected RAILS_ENV' do
-      output = subject
-
-      expect(output).to match %r{enter the expected RAILS_ENV for banana:}
-    end
-
-    context 'expected RAILS_ENV does not match' do
-      let(:expected_rails_env) { 'qa' }
-
-      it 'raises an error if the expected RAILS_ENV does not match' do
-        expect { subject } .to raise_error(RuntimeError)
-      end
-    end
+    expect(MCB).to have_received(:init_rails).with(webapp: 'banana')
   end
 end

--- a/spec/lib/mcb_spec.rb
+++ b/spec/lib/mcb_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
-require "#{Rails.root}/lib/mcb"
-require "#{Rails.root}/lib/mcb/azure"
+require 'mcb_helper'
 
 describe 'mcb command' do
   describe '#load_commands' do

--- a/spec/lib/mcb_spec.rb
+++ b/spec/lib/mcb_spec.rb
@@ -104,4 +104,15 @@ describe 'mcb command' do
       end
     end
   end
+
+  describe '.config' do
+    it 'creates a config object with config_file setting' do
+      allow(MCB::Config).to receive(:new).and_return('foo' => 'bar')
+
+      MCB.config['foo']
+
+      expect(MCB::Config)
+        .to have_received(:new).with(config_file: MCB.config_file)
+    end
+  end
 end

--- a/spec/lib/mcb_spec.rb
+++ b/spec/lib/mcb_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'mcb_helper'
 
 describe 'mcb command' do
-  describe '#load_commands' do
+  describe '.load_commands' do
     include FakeFS::SpecHelpers
 
     it 'loads the files in a directory' do
@@ -54,7 +54,7 @@ describe 'mcb command' do
     end
   end
 
-  describe '#apiv1_token' do
+  describe '.apiv1_token' do
     it 'returns the token' do
       expect(MCB.apiv1_token).to eq 'bats'
     end
@@ -73,7 +73,7 @@ describe 'mcb command' do
     end
   end
 
-  describe '#generate_apiv2_token' do
+  describe '.generate_apiv2_token' do
     let(:email)    { 'foo@local' }
     let(:secret)   { 'bar' }
 

--- a/spec/mcb_helper.rb
+++ b/spec/mcb_helper.rb
@@ -1,0 +1,28 @@
+load 'bin/mcb'
+
+RSpec.configure do |config|
+  # Ensure all mcb specs are tagged up so that the below hooks run to stub out
+  # the dangerous things that we wouldn't want to leak through to the user's
+  # system or dirty the test environment.
+  config.define_derived_metadata(
+    file_path: %r{spec/lib/mcb.* | bin/mcb_spec.rb}x
+  ) do |metadata|
+    metadata[:mcb_cli] = true
+  end
+
+
+  # Certain methods can change stuff permanently in tests, causing intermittent
+  # false positives or false negatives, or other issues. Any spec that tests
+  # the mcb CLI should, to be safe, have the 'mcb_cli: true' metadata to ensure
+  # it's safe.
+  config.before(:each, mcb_cli: true) do |example|
+    unless example.metadata[:stub_init_rails] == false
+      # "init_rails" will try to exec the Rails runner if Rails isn't already
+      # loaded.
+      allow(MCB).to receive(:init_rails)
+    end
+    # "run_command" is used to run "az" and maybe more. Any test relying on
+    # this must stub for it specifically.
+    allow(MCB).to receive(:run_command)
+  end
+end


### PR DESCRIPTION
https://trello.com/c/11v4CXhF/1346-mcb-provider-optin-should-audit-which-user-ran-the-command

### Context

When admins make changes via `mcb` we want to ensure there is an audit trail for who did the changes. This also requires some kind of a config system to keep track of the admin's email address, and which will also be useful for future features.

### Changes proposed in this pull request

This PR introduces a config mechanism that will be used in a near-future PR to add the audit stuff. It also does a little bit of specs tidying up that fell out of the work of adding the config stuff.

### Guidance to review

Config mechanism has it's own PR since it's grown a bit big. Another PR for auditing system to follow later.
