### PR TITLE
Don't jsonify the JWT payload in mcb

### DIFF
--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -87,7 +87,7 @@ module MCB
       raise 'Secret not provided'
     end
 
-    JWT.encode(payload.to_json, secret, encoding)
+    JWT.encode(payload, secret, encoding)
   end
 
   def self.each_v1_course(opts)

--- a/spec/lib/mcb/commands/apiv2/token/generate_spec.rb
+++ b/spec/lib/mcb/commands/apiv2/token/generate_spec.rb
@@ -8,7 +8,7 @@ describe 'mcb apiv2 token generate' do
         $mcb.run(%w[apiv2 token generate -S sekret user@local])
       end
 
-      payload = { email: 'user@local' }.to_json
+      payload = { email: 'user@local' }
       expect(result.chomp).to eq(
         JWT.encode(payload, 'sekret', 'HS256')
       )

--- a/spec/lib/mcb_spec.rb
+++ b/spec/lib/mcb_spec.rb
@@ -87,7 +87,7 @@ describe 'mcb command' do
           encoding: encoding,
           secret: secret
         )
-        expect(token).to eq JWT.encode({ email: email }.to_json,
+        expect(token).to eq JWT.encode({ email: email },
                                        secret,
                                        encoding)
       end


### PR DESCRIPTION
Local testing shows that auth fails when the email is wrapped in json
syntax, but the bare email address gets through to the next stage
(terms not accepted).
