### PR TITLE
[1400] Remove unnecessary disabling of Metrics/BlockLength in Guardfile

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -25,7 +25,6 @@
 #  * 'just' rspec: 'rspec'
 
 
-# rubocop:disable Metrics/BlockLength
 group :red_green_refactor, halt_on_fail: true do
   guard :rspec, cmd: 'bundle exec spring rspec', failed_mode: :keep do
     require "guard/rspec/dsl"
@@ -65,4 +64,3 @@ group :red_green_refactor, halt_on_fail: true do
     watch(%r{(?:.+/)?\.rubocop(?:_todo)?\.yml$}) { |m| File.dirname(m[0]) }
   end
 end
-# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Stop linter errors when running `guard`.

## Before

```bash
$ bundle exec rubocop app config db lib spec Guardfile Gemfile --format clang
[Warn] Performance Cops will be removed from RuboCop 0.68. Use rubocop-performance gem instead.
       https://github.com/rubocop-hq/rubocop/tree/master/manual/migrate_performance_cops.md

Guardfile:28:1: W: Lint/UnneededCopDisableDirective: Unnecessary disabling of Metrics/BlockLength.
# rubocop:disable Metrics/BlockLength
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

222 files inspected, 1 offense detected
```

### After

```bash
$ bundle exec rubocop app config db lib spec Guardfile Gemfile --format clang
[Warn] Performance Cops will be removed from RuboCop 0.68. Use rubocop-performance gem instead.
       https://github.com/rubocop-hq/rubocop/tree/master/manual/migrate_performance_cops.md


222 files inspected, no offenses detected
```