### PR TITLE
[1407] Course model improvements

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -160,6 +160,18 @@ class Course < ApplicationRecord
     end
   end
 
+  def dfe_subjects
+    SubjectMapperService.get_subject_list(name, subjects.map(&:subject_name))
+  end
+
+  def level
+    SubjectMapperService.get_subject_level(subjects.map(&:subject_name))
+  end
+
+  def is_send?
+    subjects.any?(&:is_send?)
+  end
+
   def last_published_at
     newest_enrichment = enrichments.latest_first.first
     newest_enrichment&.last_published_timestamp_utc

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -28,6 +28,7 @@ class Course < ApplicationRecord
 
   has_associated_audits
   audited except: :changed_at
+  validates :course_code, uniqueness: { scope: :provider_id }
 
   enum program_type: {
     higher_education_programme: "HE",

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -11,4 +11,8 @@ class Subject < ApplicationRecord
   has_and_belongs_to_many :courses, join_table: :course_subject
 
   scope :further_education, -> { where(subject_name: 'Further Education') }
+
+  def is_send?
+    subject_code.casecmp('U3').zero?
+  end
 end

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -13,7 +13,8 @@ module API
 
       attributes :findable?, :open_for_applications?, :has_vacancies?,
                  :course_code, :name, :study_mode, :qualifications, :description,
-                 :content_status, :ucas_status, :funding, :applications_open_from
+                 :content_status, :ucas_status, :funding, :applications_open_from,
+                 :level, :is_send?
 
       attribute :start_date do
         @object.start_date&.iso8601
@@ -24,17 +25,7 @@ module API
       end
 
       attribute :subjects do
-        ucas_subjects = @object.subjects.map(&:subject_name)
-        SubjectMapperService.get_subject_list(@object.name, ucas_subjects)
-      end
-
-      attribute :level do
-        ucas_subjects = @object.subjects.map(&:subject_name)
-        SubjectMapperService.get_subject_level(ucas_subjects)
-      end
-
-      attribute :is_send? do
-        @object.subjects.any? { |subject| subject.subject_code.casecmp('U3').zero? }
+        @object.dfe_subjects
       end
 
       belongs_to :provider

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -385,4 +385,40 @@ RSpec.describe Course, type: :model do
       it { should_not include(course) }
     end
   end
+
+  context "subjects & level" do
+    context 'with no subjects' do
+      subject { create(:course, subject_count: 0) }
+      its(:level) { should eq(:secondary) }
+      its(:dfe_subjects) { should be_empty }
+    end
+
+    context 'with primary subjects' do
+      subject { create(:course, subject_count: 0, subjects: [create(:subject, subject_name: "primary")]) }
+      its(:level) { should eq(:primary) }
+      its(:dfe_subjects) { should eq(%w[Primary]) }
+    end
+
+    context 'with secondary subjects' do
+      subject { create(:course, subject_count: 0, subjects: [create(:subject, subject_name: "physical education")]) }
+      its(:level) { should eq(:secondary) }
+      its(:dfe_subjects) { should eq(["Physical education"]) }
+    end
+
+    context 'with further education subjects' do
+      subject { create(:course, subject_count: 0, subjects: [create(:further_education_subject)]) }
+      its(:level) { should eq(:further_education) }
+      its(:dfe_subjects) { should eq(["Further education"]) }
+    end
+
+    describe "#is_send?" do
+      subject { create(:course, subject_count: 0) }
+      its(:is_send?) { should be_falsey }
+
+      context "with a SEND subject" do
+        subject { create(:course, subject_count: 0, subjects: [create(:send_subject)]) }
+        its(:is_send?) { should be_truthy }
+      end
+    end
+  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe Course, type: :model do
     it { should have_many(:sites) }
   end
 
+  describe 'validations' do
+    it { should validate_uniqueness_of(:course_code).scoped_to(:provider_id) }
+  end
+
   describe 'changed_at' do
     it 'is set on create' do
       course = create(:course)

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -98,28 +98,10 @@ describe API::V2::SerializableCourse do
   end
 
   context "subjects & level" do
-    context 'with no subjects' do
-      let(:course) { create(:course, subject_count: 0) }
-      it { expect(subject["attributes"]).to include("level" => "secondary") }
-      it { expect(subject["attributes"]).to include("subjects" => []) }
-    end
-
-    context 'with primary subjects' do
+    describe 'are taken from the course' do
       let(:course) { create(:course, subject_count: 0, subjects: [create(:subject, subject_name: "primary")]) }
       it { expect(subject["attributes"]).to include("level" => "primary") }
       it { expect(subject["attributes"]).to include("subjects" => %w[Primary]) }
-    end
-
-    context 'with secondary subjects' do
-      let(:course) { create(:course, subject_count: 0, subjects: [create(:subject, subject_name: "physical education")]) }
-      it { expect(subject["attributes"]).to include("level" => "secondary") }
-      it { expect(subject["attributes"]).to include("subjects" => ["Physical education"]) }
-    end
-
-    context 'with further education subjects' do
-      let(:course) { create(:course, subject_count: 0, subjects: [create(:further_education_subject)]) }
-      it { expect(subject["attributes"]).to include("level" => "further_education") }
-      it { expect(subject["attributes"]).to include("subjects" => ["Further education"]) }
     end
   end
 


### PR DESCRIPTION
### Context
The `Course` model will be called from `mcb` in order to build and create new courses.

### Changes proposed in this pull request
- pull subject-related logic (`dfe_subjects`, `level` and `is_send?`) into model code out of the serializer, so it can be reused
- add a validation for course codes to reduce the risk of duplicates being added

