### PR TITLE
[1346] add user to audit info

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,9 @@ gem 'cri'
 gem 'table_print'
 #   terminal-table is a bit more flexible allowing us to use a headers column
 gem 'terminal-table'
+#   tabulo os even more flexible than terminal-table, used for the audit
+#   stuff for now, probably worth switching other commands to it later
+gem 'tabulo'
 
 # For querying third party APIs
 gem 'faraday'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,12 +327,15 @@ GEM
       diff-lcs
       patience_diff
     table_print (1.5.6)
+    tabulo (1.3.0)
+      tty-screen (= 0.6.5)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     timecop (0.9.1)
     trollop (1.16.2)
+    tty-screen (0.6.5)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uk_postcode (2.1.3)
@@ -398,6 +401,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   super_diff
   table_print
+  tabulo
   terminal-table
   timecop
   tzinfo-data

--- a/lib/mcb/commands/providers/audit.rb
+++ b/lib/mcb/commands/providers/audit.rb
@@ -1,0 +1,20 @@
+name 'show'
+summary 'Show information about provider'
+param :code
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
+  code = args[:code]
+  provider = Provider.find_by!(provider_code: code)
+  table = Tabulo::Table.new provider.audits do |t|
+    t.add_column(:user_id, header: "user\nid", width: 6)
+    t.add_column(:user, header: "user email") { |a| a.user&.email }
+    t.add_column(:action, width: 8)
+    t.add_column(:associated_id, header: "associated\nid", width: 10)
+    t.add_column(:associated_type, header: "associated\ntype", width: 10)
+    t.add_column(:audited_changes, header: "changes", width: 40)
+    t.add_column(:created_at, width: 23)
+  end
+  puts table.pack
+end

--- a/spec/lib/mcb_spec.rb
+++ b/spec/lib/mcb_spec.rb
@@ -2,6 +2,32 @@ require 'spec_helper'
 require 'mcb_helper'
 
 describe 'mcb command' do
+  describe '.init_rails' do
+    before do
+      allow(MCB::Azure).to receive(:configure_for_webapp)
+    end
+
+    context 'connecting to an Azure webapp' do
+      it 'configures for the webapp', stub_init_rails: false do
+        MCB.config[:email] = create(:user).email
+        allow(MCB::Azure).to receive(:configure_for_webapp)
+
+        MCB.init_rails(webapp: 'banana')
+
+        expect(MCB::Azure).to have_received(:configure_for_webapp)
+                                .with(webapp: 'banana')
+      end
+
+      it 'sets the audited user', stub_init_rails: false do
+        user = create :user
+        MCB.config[:email] = user.email
+        allow(ENV).to receive(:key?).with('DB_HOSTNAME').and_return(true)
+        MCB.init_rails
+        expect(Audited.store[:audited_user]).to eq user
+      end
+    end
+  end
+
   describe '.load_commands' do
     include FakeFS::SpecHelpers
 


### PR DESCRIPTION
https://trello.com/c/11v4CXhF/1346-mcb-provider-optin-should-audit-which-user-ran-the-command

### Context

When an admin makes changes to a remote system they should be added to the audit trail as the user that performed the change.

### Changes proposed in this pull request

Record the user making changes when connecting to a remote system.

### Guidance to review

This work is built off of the PR to add a configuration system (#319) which should be merged before this one is.

The gem `tabulo` has been added in addition to the 2 other table-printing gems. At least `table_print` should be superceded by this eventually, if not both of the table-printing gems.
