### PR TITLE
[1407] Course preview flag for 'mcb providers show'

### DIFF
--- a/bin/mcb
+++ b/bin/mcb
@@ -19,6 +19,7 @@ $LOAD_PATH << lib_dir
 require 'mcb'
 require 'mcb/azure'
 require 'mcb/config'
+require 'mcb/course_show'
 
 tp.set :capitalize_headers, false
 

--- a/lib/mcb/commands/providers/show.rb
+++ b/lib/mcb/commands/providers/show.rb
@@ -1,6 +1,8 @@
 name 'show'
 summary 'Show information about provider'
 param :code
+option :p, :'preview-courses', 'Show courses as a mini-preview of Find, instead of a database view.',
+      default: false
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
@@ -27,6 +29,10 @@ run do |opts, args, _cmd|
        'address2', 'address3', 'address4', 'postcode', 'telephone'
 
     puts "\nProvider Courses:"
-    tp provider.courses
+    if opts[:'preview-courses']
+      provider.courses.map { |course| puts Terminal::Table.new rows: MCB::CourseShow.new(course).to_h }
+    else
+      tp provider.courses
+    end
   end
 end

--- a/lib/mcb/course_show.rb
+++ b/lib/mcb/course_show.rb
@@ -1,0 +1,26 @@
+module MCB
+  class CourseShow
+    def initialize(course)
+      @course = course
+    end
+
+    def to_h
+      {
+        "Course code" => @course.course_code,
+        "Description" => @course.description,
+        "Provider" => @course.provider.provider_code,
+        "Accredited body" => @course.accrediting_provider&.provider_code || "Self-accrediting",
+        "Subjects" => @course.dfe_subjects.join(", "),
+        "Level" => @course.level,
+        "Training locations" => @course.site_statuses.map(&:site).map(&:location_name).join(", "),
+        "Start date" => @course.start_date.strftime("%b %Y"),
+        "Route" => @course.program_type,
+        "Age range" => @course.age_range,
+        "Modular" => @course.modular,
+        "English" => @course.english,
+        "Maths" => @course.maths,
+        "Science" => @course.science,
+      }
+    end
+  end
+end


### PR DESCRIPTION
### Context

`mcb` output for complex records (e.g. courses) can be hard to parse visually.

### Changes proposed in this pull request

Add an explicit renderer for courses, that can be reused across multiple `mcb` commands.

#### Without `-p` option

```sh
UCAS Preferences:
no preferences found

Provider Enrichments:
No data.

Provider Courses:
id | age_range | course_code | name          | profpost_flag             | program_type                   | qualification | start_date              | study_mode | accrediting_provider_id | provider_id | modular | english | maths | science | created_at              | updated_at              | changed_at
---|-----------|-------------|---------------|---------------------------|--------------------------------|---------------|-------------------------|------------|-------------------------|-------------|---------|---------|-------|---------|-------------------------|-------------------------|------------------------
10 |           | 825         | Mathematics   | postgraduate              | school_direct_training_prog... | pgce_with_qts | 2019-09-01 00:00:00     |            |                         | 18          | M       | 9       | 1     |         | 2019-02-23 23:45:24     | 2019-02-23 23:45:24     | 2019-04-11 20:15:08
11 |           | ECC         | Biology       | professional_postgraduate | higher_education_programme     | pgce_with_qts | 2019-09-01 00:00:00     | full_time  |                         | 18          |         | 9       | 3     |         | 2019-02-23 23:45:24     | 2019-02-23 23:45:24     | 2019-02-23 23:45:24
24 | primary   | 3XXD        | Primary (3-7) | postgraduate              | scitt_programme                | pgce_with_qts | 2019-09-01 00:00:00     | full_time  | 18                      | 18          |         | 3       | 3     |         | 2019-04-29 14:59:23     | 2019-04-29 14:59:23     | 2019-04-29 14:59:23
27 | primary   | 3XXE        | Primary (3-7) | postgraduate              | scitt_programme                | pgce_with_qts | 2019-09-01 00:00:00     | full_time  | 18                      | 18          |         | 3       | 3     |         | 2019-04-30 12:25:55     | 2019-04-30 12:25:55     | 2019-04-30 12:25:55
28 | primary   | CXXG        | Primaru       |                           |                                | pgce_with_qts | 2019-09-01 00:00:00     | full_time  |                         | 18          |         |         |       |         | 2019-04-30 16:42:24     | 2019-04-30 16:42:24     | 2019-04-30 16:42:24
```

#### With `-p` option

```sh
UCAS Preferences:
no preferences found

Provider Enrichments:
No data.

Provider Courses:
+--------------------+----------------------------------+
| Course code        | 825                              |
| Description        | PGCE with QTS                    |
| Provider           | A01                              |
| Accredited body    | Self-accrediting                 |
| Subjects           | Mathematics                      |
| Level              | secondary                        |
| Training locations | Wisozk, Predovic and Collier     |
| Start date         | Sep 2019                         |
| Route              | school_direct_training_programme |
| Age range          |                                  |
| Modular            | M                                |
| English            | 9                                |
| Maths              | 1                                |
| Science            |                                  |
+--------------------+----------------------------------+
+--------------------+------------------------------+
| Course code        | ECC                          |
| Description        | PGCE with QTS full time      |
| Provider           | A01                          |
| Accredited body    | Self-accrediting             |
| Subjects           | Biology                      |
| Level              | secondary                    |
| Training locations | Wisozk, Predovic and Collier |
| Start date         | Sep 2019                     |
| Route              | higher_education_programme   |
| Age range          |                              |
| Modular            |                              |
| English            | 9                            |
| Maths              | 3                            |
| Science            |                              |
+--------------------+------------------------------+
+--------------------+-------------------------+
| Course code        | 3XXD                    |
| Description        | PGCE with QTS full time |
| Provider           | A01                     |
| Accredited body    | A01                     |
| Subjects           |                         |
| Level              | secondary               |
| Training locations |                         |
...
```


### Guidance to review
