### PR TITLE
[1362] Access requests shouldn't duplicate orgs for a user

### DIFF
--- a/app/services/access_request_approval_service.rb
+++ b/app/services/access_request_approval_service.rb
@@ -14,7 +14,8 @@ class AccessRequestApprovalService
       user.invite_date_utc = Time.now.utc
     end
 
-    target_user.organisations << @access_request.requester.organisations
+    orgs_missing_on_target_user = @access_request.requester.organisations - target_user.organisations
+    target_user.organisations << orgs_missing_on_target_user
     @access_request.approve
   end
 end

--- a/spec/services/access_request_approval_service_spec.rb
+++ b/spec/services/access_request_approval_service_spec.rb
@@ -81,9 +81,13 @@ describe AccessRequestApprovalService do
         let!(:target_user) do
           create(
             :user,
-            :opted_in,
+            email: access_request.email_address,
             organisations: access_request.requester.organisations
           )
+        end
+
+        it 'does not change the orgnisations of the target user' do
+          expect { subject }.not_to(change { target_user.organisations.reload })
         end
 
         it "shouldn't duplicate the records" do
@@ -91,7 +95,7 @@ describe AccessRequestApprovalService do
           target_user.organisations.reload
 
           expect(target_user.organisations).to(
-            match_array(target_user.organisations.uniq)
+            match_array(access_request.requester.organisations)
           )
         end
       end


### PR DESCRIPTION
### Context
Only add new orgs to the target user. This comes up in production because publishers lodge duplicate access requests that get approved.

### Changes proposed in this pull request
- fix unit test that was obscuring the issue
- fix issue
