### PR TITLE
[1431] Handle not found errors

### DIFF
--- a/app/controllers/api/v2/application_controller.rb
+++ b/app/controllers/api/v2/application_controller.rb
@@ -3,6 +3,8 @@ module API
     class ApplicationController < ::ApplicationController
       attr_reader :current_user
 
+      rescue_from ActiveRecord::RecordNotFound, with: :jsonapi_404
+
       before_action :check_terms_accepted
 
       def authenticate
@@ -11,6 +13,10 @@ module API
           assign_sentry_contexts
           @current_user.present?
         end
+      end
+
+      def jsonapi_404
+        render jsonapi: nil, status: 404
       end
 
     private

--- a/spec/requests/api/v2/application_spec.rb
+++ b/spec/requests/api/v2/application_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+describe 'API v2', type: :request do
+  describe 'Error 404' do
+    let(:user) { create(:user, organisations: [organisation]) }
+    let(:organisation) { create(:organisation) }
+    let(:payload) { { email: user.email } }
+    let(:token) do
+      JWT.encode payload,
+                 Settings.authentication.secret,
+                 Settings.authentication.algorithm
+    end
+    let(:credentials) do
+      ActionController::HttpAuthentication::Token.encode_credentials(token)
+    end
+
+    subject { response }
+
+    describe 'when a provider is not found' do
+      before do
+        get "/api/v2/providers/foo", headers: { 'HTTP_AUTHORIZATION' => credentials }
+      end
+
+      it { should have_http_status(:not_found) }
+
+      it 'has a data section with the correct attributes' do
+        json_response = JSON.parse(response.body)
+        expect(json_response[:data]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -63,9 +63,7 @@ describe 'Publish API v2', type: :request do
     context 'when course and provider is not related' do
       let(:course) { create(:course) }
 
-      it 'raises an error' do
-        expect { subject }.to raise_error ActiveRecord::RecordNotFound
-      end
+      it { should have_http_status(:not_found) }
     end
 
     context 'unpublished course with draft enrichment' do

--- a/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
+++ b/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
@@ -61,9 +61,7 @@ describe 'Courses API v2', type: :request do
     context 'when course and provider is not related' do
       let(:course) { create(:course) }
 
-      it 'raises an error' do
-        expect { subject }.to raise_error ActiveRecord::RecordNotFound
-      end
+      it { should have_http_status(:not_found) }
     end
 
     context 'when the api responds with a success' do

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -69,9 +69,8 @@ describe 'Courses API v2', type: :request do
 
     context 'when course and provider is not related' do
       let(:course) { create(:course) }
-      it "raises an error" do
-        expect { subject }.to raise_error ActiveRecord::RecordNotFound
-      end
+
+      it { should have_http_status(:not_found) }
     end
 
     describe 'JSON generated for courses' do
@@ -250,11 +249,13 @@ describe 'Courses API v2', type: :request do
       end
     end
 
-    it "raises a 'record not found' error when the provider doesn't exist" do
-      expect {
+    context "when the provider doesn't exist" do
+      before do
         get("/api/v2/providers/non-existent-provider/courses",
             headers: { 'HTTP_AUTHORIZATION' => credentials })
-      } .to raise_error ActiveRecord::RecordNotFound
+      end
+
+      it { should have_http_status(:not_found) }
     end
   end
 end

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -126,11 +126,13 @@ describe 'Sites API v2', type: :request do
       end
     end
 
-    it "raises a 'record not found' error when the provider doesn't exist" do
-      expect {
+    context "when the provider doesn't exist" do
+      before do
         get("/api/v2/providers/non-existent-provider/sites",
             headers: { 'HTTP_AUTHORIZATION' => credentials })
-      } .to raise_error ActiveRecord::RecordNotFound
+      end
+
+      it { should have_http_status(:not_found) }
     end
   end
 


### PR DESCRIPTION
### Context

Backend API doesn't handle 404s gracefully.

### Changes proposed in this pull request

Rescue from `ActiveRecord::RecordNotFound` and show an empty JSONAPI response with an HTTP status of 404.

### Guidance to review
