### PR TITLE
[1432] Handle access requests with mixed-case recipient addresses

### DIFF
--- a/app/services/access_request_approval_service.rb
+++ b/app/services/access_request_approval_service.rb
@@ -8,7 +8,7 @@ class AccessRequestApprovalService
   end
 
   def call
-    target_user = User.find_or_create_by!(email: @access_request.email_address) do |user|
+    target_user = User.find_or_create_by!(email: @access_request.email_address.downcase) do |user|
       user.first_name      = @access_request.first_name
       user.last_name       = @access_request.last_name
       user.invite_date_utc = Time.now.utc


### PR DESCRIPTION
### Context

Access requests contain email addresses typed in by publishers. They can contain mixed case letters. Our database assumes that all emails in it are lower case.

The functionality for approving the access requests currently:

- doesn't match emails case-insensitively
- inserts email addresses with upper-case letters

The knock-on effects are:

- duplicate user records
- users not being able to log in

### Changes proposed in this pull request

- lowercase the recipient email from the access request
- add specs for this case 

