### PR TITLE
[1406] Improve course enrichment and site validation errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --update --no-cache tzdata && \
     echo "Europe/London" > /etc/timezone
 
 RUN apk add --update --no-cache --virtual runtime-dependances \
- postgresql-dev
+ postgresql-dev git
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME

--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,9 @@ gem 'aasm'
 # Handle data migrations
 gem 'data_migrate'
 
+# Allows writing of error full_messages for validations that don't start with the attribute name
+gem 'custom_error_message', git: 'https://github.com/nanamkim/custom-err-msg.git', ref: 'd72fb18'
+
 group :development, :test do
   # add info about db structure to models and other files
   gem 'annotate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/nanamkim/custom-err-msg.git
+  revision: d72fb180d9dfd19f18622c978747dcc0aa5374e0
+  ref: d72fb18
+  specs:
+    custom_error_message (1.2.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -388,6 +395,7 @@ DEPENDENCIES
   byebug
   config
   cri
+  custom_error_message!
   data_migrate
   database_cleaner
   factory_bot_rails (~> 5.0)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -93,11 +93,18 @@ class Course < ApplicationRecord
   end
 
   def validate_enrichment
-    latest = enrichments.latest_first.first
-    if latest.present?
-      latest.valid? :publish
-      latest.errors.full_messages.each do |msg|
-        errors.add :latest_enrichment, msg.to_s
+    latest_enrichment = enrichments.latest_first.first
+    if latest_enrichment.present?
+      latest_enrichment.valid? :publish
+      latest_enrichment.errors.messages.each do |field, _error|
+        # Compute a key of `latest_enrichment__FIELD` to allow the frontend to determine
+        # which field should be linked to from the error title.
+        key = "latest_enrichment__#{field}".to_sym
+        # `full_messages_for` here will remove any `^`s defined in the validator or en.yml.
+        # We still need it for later, so re-add it.
+        # jsonapi_errors will throw if it's given an array, so we call `.first`.
+        message = "^" + latest_enrichment.errors.full_messages_for(field).first.to_s
+        errors.add key, message
       end
     end
   end

--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -4,7 +4,7 @@ class PostcodeValidator < ActiveModel::EachValidator
 
     postcode = UKPostcode.parse(value)
     unless postcode.full_valid?
-      record.errors[attribute] << "not recognised as a UK postcode"
+      record.errors[attribute] << "is not valid (for example, BN1 1AA)"
     end
   end
 end

--- a/app/validators/words_count_validator.rb
+++ b/app/validators/words_count_validator.rb
@@ -3,7 +3,7 @@ class WordsCountValidator < ActiveModel::EachValidator
     return if value.blank?
 
     unless /^\s*(\S+\s+|\S+$){0,#{options[:maximum]}}$/i.match?(value)
-      record.errors[attribute] << (options[:message] || "Reduce the word count for #{attribute.to_s.humanize(capitalize: false)}")
+      record.errors[attribute] << (options[:message] || "^Reduce the word count for #{attribute.to_s.humanize(capitalize: false)}")
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,19 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  activerecord:
+    attributes:
+      course_enrichment:
+        fee_uk_eu: "Course fees for UK and EU students"
+        fee_international: "Course fees for international students"
+    errors:
+      models:
+        course_enrichment:
+          attributes:
+            salary_details:
+              blank: "^Enter salary details"
+            fee_uk_eu:
+              blank: "^Enter course fees for UK and EU students"
+              greater_than_or_equal_to: "must be greater than or equal to £0"
+              less_than_or_equal_to: "must be less than or equal to £100,000"
+            fee_international:
+              greater_than_or_equal_to: "must be greater than or equal to £0"
+              less_than_or_equal_to: "must be less than or equal to £100,000"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,8 +4,23 @@ en:
       course_enrichment:
         fee_uk_eu: "Course fees for UK and EU students"
         fee_international: "Course fees for international students"
+      site:
+        location_name: "Name"
+        address1: "Building and street"
+        address3: "Town or city"
     errors:
       models:
+        site:
+          attributes:
+            location_name:
+              blank: "is missing"
+              taken: "is in use by another location"
+            address1:
+              blank: "is missing"
+            address3:
+              blank: "is missing"
+            postcode:
+              blank: "is missing"
         course_enrichment:
           attributes:
             salary_details:

--- a/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
+++ b/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
@@ -101,13 +101,12 @@ describe 'Courses API v2', type: :request do
 
         it 'has validation errors' do
           expect(json_data.count).to eq 6
-          expect(response.body).to include('Invalid latest_enrichment')
-          expect(response.body).to include("Latest enrichment About course Reduce the word count for about course")
-          expect(response.body).to include("Latest enrichment Interview process Reduce the word count for interview process")
-          expect(response.body).to include("Latest enrichment How school placements work Reduce the word count for how school placements work")
-          expect(response.body).to include("Latest enrichment Fee international must be less than or equal to 100000")
-          expect(response.body).to include("Latest enrichment Fee uk eu must be less than or equal to 100000")
-          expect(response.body).to include("Latest enrichment Fee details Reduce the word count for fee details")
+          expect(json_data[0]["detail"]).to eq("Reduce the word count for about course")
+          expect(json_data[1]["detail"]).to eq("Reduce the word count for interview process")
+          expect(json_data[2]["detail"]).to eq("Reduce the word count for how school placements work")
+          expect(json_data[3]["detail"]).to eq("Course fees for international students must be less than or equal to £100,000")
+          expect(json_data[4]["detail"]).to eq("Course fees for UK and EU students must be less than or equal to £100,000")
+          expect(json_data[5]["detail"]).to eq("Reduce the word count for fee details")
         end
       end
     end

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -307,27 +307,27 @@ describe 'Sites API v2', type: :request do
 
             it 'checks the location_name is present' do
               expect(response.body).to include('Invalid location_name')
-              expect(response.body).to include("Location name can't be blank")
+              expect(response.body).to include("Name is missing")
             end
 
             it 'checks the address1 is present' do
               expect(response.body).to include('Invalid address1')
-              expect(response.body).to include("Address1 can't be blank")
+              expect(response.body).to include("Building and street is missing")
             end
 
             it 'checks the address3 is present' do
               expect(response.body).to include('Invalid address3')
-              expect(response.body).to include("Address3 can't be blank")
+              expect(response.body).to include("Town or city is missing")
             end
 
             it 'checks the postcode is present' do
               expect(response.body).to include('Invalid postcode')
-              expect(response.body).to include("Postcode can't be blank")
+              expect(response.body).to include("Postcode is missing")
             end
 
             it 'checks the postcode is present' do
               expect(response.body).to include('Invalid postcode')
-              expect(response.body).to include('Postcode not recognised as a UK postcode')
+              expect(response.body).to include('Postcode is not valid (for example, BN1 1AA)')
             end
 
             xit 'checks the region_code is present' do
@@ -341,7 +341,7 @@ describe 'Sites API v2', type: :request do
               it 'checks the location_name is unique' do
                 expect(json_data.count).to eq 1
                 expect(response.body).to include('Invalid location_name')
-                expect(response.body).to include('Location name has already been taken')
+                expect(response.body).to include('Name is in use by another location')
               end
             end
 

--- a/spec/validators/words_count_validator_spec.rb
+++ b/spec/validators/words_count_validator_spec.rb
@@ -39,7 +39,7 @@ describe WordsCountValidator do
 
     it { should be false }
     it 'adds an error' do
-      expect(model.errors[:some_words]).to match_array ['Reduce the word count for some words']
+      expect(model.errors[:some_words]).to match_array ['^Reduce the word count for some words']
     end
   end
 end


### PR DESCRIPTION
### Context

This removes part of the work that the frontend has to do to display validation errors.

### Changes proposed in this pull request

Add `custom_error_message` as a dependency. It allows us to prefix error messages with `^` when they should not use the attribute as a prefix for the full_message.

This modifies the `course#validate_enrichment` method. Before, all enrichment errors would be hoisted under the `latest_enrichment` key. This isn't enough information to be able to determine which field this error belongs to. The new key is computed as `latest_enrichment__FIELD`.

Updated tests and adds better validation messages for course enrichments and sites via `en.yml` overrides.

### Guidance to review

I really tried to find a way to do this without `custom_error_message` which is a very dirty monkey patch of an unmaintained library, but I couldn't due to the double `full_messages` call that gets run on the nested `course_enrichment` validations... maybe it would be cleaner to reimplement the `jsonapi_error` renderer? Neither option seems particularly fun...