### PR TITLE
1364 Expose list of access requests in mcbe to mc support

### DIFF
--- a/app/controllers/api/v2/access_requests_controller.rb
+++ b/app/controllers/api/v2/access_requests_controller.rb
@@ -1,8 +1,7 @@
 module API
   module V2
     class AccessRequestsController < API::V2::ApplicationController
-      before_action :build_access_request, except: :list
-      before_action :build_list_of_access_requests, except: :approve
+      before_action :build_access_request, only: :approve
 
       def approve
         result = AccessRequestApprovalService.call(@access_request)
@@ -10,18 +9,17 @@ module API
         render status: 200, json: { result: result }
       end
 
-      def list
-        render status: 200, json: @list_of_access_requests
+      def index
+        authorize AccessRequest
+        @access_requests = AccessRequest.requested
+
+        render status: 200, json: @access_requests
       end
 
     private
 
       def build_access_request
         @access_request = authorize AccessRequest.requested.find(params[:id])
-      end
-
-      def build_list_of_access_requests
-        @list_of_access_requests = authorize AccessRequest.requested.all
       end
     end
   end

--- a/app/controllers/api/v2/access_requests_controller.rb
+++ b/app/controllers/api/v2/access_requests_controller.rb
@@ -13,7 +13,7 @@ module API
         authorize AccessRequest
         @access_requests = AccessRequest.requested
 
-        render status: 200, json: @access_requests
+        render jsonapi: @access_requests
       end
 
     private

--- a/app/controllers/api/v2/access_requests_controller.rb
+++ b/app/controllers/api/v2/access_requests_controller.rb
@@ -1,7 +1,8 @@
 module API
   module V2
     class AccessRequestsController < API::V2::ApplicationController
-      before_action :build_access_request
+      before_action :build_access_request, except: :list
+      before_action :build_list_of_access_requests, except: :approve
 
       def approve
         result = AccessRequestApprovalService.call(@access_request)
@@ -9,10 +10,18 @@ module API
         render status: 200, json: { result: result }
       end
 
+      def list
+        render status: 200, json: @list_of_access_requests
+      end
+
     private
 
       def build_access_request
         @access_request = authorize AccessRequest.requested.find(params[:id])
+      end
+
+      def build_list_of_access_requests
+        @list_of_access_requests = authorize AccessRequest.requested.all
       end
     end
   end

--- a/app/models/access_request.rb
+++ b/app/models/access_request.rb
@@ -24,6 +24,10 @@ class AccessRequest < ApplicationRecord
     declined
   ].freeze
 
+  def recipient
+    User.new(first_name: first_name, last_name: last_name, email: email_address)
+  end
+
   alias_method :approve, :completed!
 
   audited

--- a/app/policies/access_request_policy.rb
+++ b/app/policies/access_request_policy.rb
@@ -8,4 +8,6 @@ class AccessRequestPolicy
   def approve?
     @user.admin?
   end
+
+  alias_method :list?, :approve?
 end

--- a/app/policies/access_request_policy.rb
+++ b/app/policies/access_request_policy.rb
@@ -9,5 +9,5 @@ class AccessRequestPolicy
     @user.admin?
   end
 
-  alias_method :list?, :approve?
+  alias_method :index?, :approve?
 end

--- a/app/serializers/api/v2/serializable_access_request.rb
+++ b/app/serializers/api/v2/serializable_access_request.rb
@@ -1,0 +1,16 @@
+module API
+  module V2
+    class SerializableAccessRequest < JSONAPI::Serializable::Resource
+      type 'access_request'
+      belongs_to :requester, class_name: 'User'
+
+      attributes :email_address, :first_name, :last_name, :organisation,
+                 :reason, :requester_id, :status, :requester_email
+
+
+      attribute :request_date_utc do
+        Time.now.utc.iso8601
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,8 +75,9 @@ Rails.application.routes.draw do
       resource :sessions
       resources :site_statuses, only: :update
 
-      resources :access_requests, only: :update do
+      resources :access_requests, only: %i[update show] do
         post :approve, on: :member
+        get :list, on: :member
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,9 +75,8 @@ Rails.application.routes.draw do
       resource :sessions
       resources :site_statuses, only: :update
 
-      resources :access_requests, only: %i[update show] do
+      resources :access_requests, only: %i[update index] do
         post :approve, on: :member
-        get :list, on: :member
       end
     end
   end

--- a/spec/factories/access_requests.rb
+++ b/spec/factories/access_requests.rb
@@ -22,8 +22,24 @@ FactoryBot.define do
     email_address { Faker::Internet.email }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
-    organisation { create(:organisation) }
+    organisation { requester.organisations.first }
     reason { Faker::Lorem.sentence.to_s }
     requester_email { requester.email }
+  end
+
+  trait :requested do
+    status { :requested }
+  end
+
+  trait :approved do
+    status { :approved }
+  end
+
+  trait :completed do
+    status { :completed }
+  end
+
+  trait :declined do
+    status { :declined }
   end
 end

--- a/spec/models/access_request_spec.rb
+++ b/spec/models/access_request_spec.rb
@@ -50,4 +50,19 @@ describe AccessRequest, type: :model do
         .to('completed')
     end
   end
+
+  describe '#index' do
+    context 'with all types of access requests' do
+      let!(:access_request1) { create(:access_request, :requested) }
+      let!(:access_request2) { create(:access_request, :requested) }
+      let!(:access_request3) { create(:access_request, :declined) }
+      let!(:access_request4) { create(:access_request, :approved) }
+      let!(:access_request5) { create(:access_request, :completed) }
+
+      subject { AccessRequest.requested }
+
+      it { should include access_request1, access_request2 }
+      it { should_not include access_request3, access_request4, access_request5 }
+    end
+  end
 end

--- a/spec/policies/access_request_policy_spec.rb
+++ b/spec/policies/access_request_policy_spec.rb
@@ -3,19 +3,19 @@ require "rails_helper"
 describe AccessRequestPolicy do
   subject { described_class }
 
-  permissions :approve? do
+  permissions :approve?, :index? do
     let(:access_request) { build(:access_request) }
 
     context 'non-admin user' do
       let(:user) { build(:user) }
 
-      it { should_not permit(user, access_request) }
+      it { should_not permit(user) }
     end
 
     context 'admin user' do
       let(:user) { build(:user, :admin) }
 
-      it { should permit(user, access_request) }
+      it { should permit(user) }
     end
   end
 end

--- a/spec/requests/api/v2/access_request_spec.rb
+++ b/spec/requests/api/v2/access_request_spec.rb
@@ -55,8 +55,8 @@ describe 'Access Request API V2', type: :request do
     end
 
     context 'when authorised' do
-      let!(:first_access_request) { create(:access_request, request_date_utc: '2019-05-05 00:10:47 UTC') }
-      let!(:second_access_request) { create(:access_request, request_date_utc: '2019-05-05 00:10:48 UTC') }
+      let!(:first_access_request) { create(:access_request) }
+      let!(:second_access_request) { create(:access_request) }
 
       before do
         access_requests_index_route
@@ -66,32 +66,47 @@ describe 'Access Request API V2', type: :request do
         json_response = JSON.parse response.body
 
         expect(json_response).to eq(
-          [
+          "data" => [
             {
-              "id" => first_access_request.id,
-              "email_address" => first_access_request.recipient.email,
-              "first_name" => first_access_request.recipient.first_name,
-              "last_name" => first_access_request.recipient.last_name,
-              "requester_email" => first_access_request.requester.email,
-              "requester_id" => first_access_request.requester.id,
-              "organisation" => first_access_request.organisation,
-              "reason" => first_access_request.reason,
-              "request_date_utc" => '2019-05-05T00:10:47.000Z',
-              "status" => first_access_request.status
-            },
+              "id" => first_access_request.id.to_s,
+              "type" => "access_request",
+              "attributes" => {
+                "email_address" => first_access_request.recipient.email,
+                "first_name" => first_access_request.recipient.first_name,
+                "last_name" => first_access_request.recipient.last_name,
+                "requester_email" => first_access_request.requester.email,
+                "requester_id" => first_access_request.requester.id,
+                "organisation" => first_access_request.organisation,
+                "reason" => first_access_request.reason,
+                "request_date_utc" => first_access_request.request_date_utc.iso8601,
+                "status" => first_access_request.status
+              },
+              "relationships" => {
+                "requester" => { "meta" => { "included" => false } }
+                }
+              },
             {
-              "id" => second_access_request.id,
-              "email_address" => second_access_request.recipient.email,
-              "first_name" => second_access_request.recipient.first_name,
-              "last_name" => second_access_request.recipient.last_name,
-              "requester_email" => second_access_request.requester.email,
-              "requester_id" => second_access_request.requester.id,
-              "organisation" => second_access_request.organisation,
-              "reason" => second_access_request.reason,
-              "request_date_utc" => '2019-05-05T00:10:48.000Z',
-              "status" => second_access_request.status
+             "id" => second_access_request.id.to_s,
+             "type" => "access_request",
+             "attributes" => {
+               "email_address" => second_access_request.recipient.email,
+               "first_name" => second_access_request.recipient.first_name,
+               "last_name" => second_access_request.recipient.last_name,
+               "requester_email" => second_access_request.requester.email,
+               "requester_id" => second_access_request.requester.id,
+               "organisation" => second_access_request.organisation,
+               "reason" => second_access_request.reason,
+               "request_date_utc" => second_access_request.request_date_utc.iso8601,
+               "status" => second_access_request.status
+             },
+             "relationships" => {
+               "requester" => { "meta" => { "included" => false } }
+              }
             }
-          ]
+            ],
+        "jsonapi" => {
+          "version" => "1.0"
+        }
        )
       end
     end

--- a/spec/requests/api/v2/access_request_spec.rb
+++ b/spec/requests/api/v2/access_request_spec.rb
@@ -55,52 +55,14 @@ describe 'Access Request API V2', type: :request do
     end
 
     context 'when authorised' do
-      let(:first_organisation) { create(:organisation, name: 'First Organisation') }
-      let(:second_organisation) { create(:organisation, name: 'Second Organisation') }
-      let(:first_user) {
-        create(:user,
-               first_name: 'First',
-               last_name: 'User',
-               email: 'first_user@test.com',
-               organisations: [first_organisation])
-      }
-      let(:second_user) {
-        create(:user,
-               first_name: 'Second',
-               last_name: 'User',
-               email: "second_user@test.com",
-               organisations: [second_organisation])
-      }
-      let!(:first_access_request) {
-        create(:access_request,
-               first_name: first_user.first_name,
-               last_name: first_user.last_name,
-               email_address: first_user.email,
-               requester_email: second_user.email,
-               requester_id: second_user.id,
-               organisation: second_user.organisations.first.name,
-               reason: 'Need additional support',
-               request_date_utc: '2019-05-05 00:10:47 UTC',
-               status: 'requested')
-      }
-      let!(:second_access_request) {
-        create(:access_request,
-               first_name: second_user.first_name,
-               last_name: second_user.last_name,
-               email_address: second_user.email,
-               requester_email: first_user.email,
-               requester_id: first_user.id,
-               organisation: first_user.organisations.first.name,
-               reason: 'Leaving current role',
-               request_date_utc: '2019-05-05 00:10:48 UTC',
-               status: 'requested')
-      }
-      let!(:third_access_request) { create(:access_request, status: 'approved') }
+      let!(:first_access_request) { create(:access_request, request_date_utc: '2019-05-05 00:10:47 UTC') }
+      let!(:second_access_request) { create(:access_request, request_date_utc: '2019-05-05 00:10:48 UTC') }
+
       before do
         access_requests_index_route
       end
 
-      it 'JSON only includes requested access requests & displays the correct attributes' do
+      it 'JSON displays the correct attributes' do
         json_response = JSON.parse response.body
 
         expect(json_response).to eq(

--- a/spec/serializers/api/v2/serializable_access_request_spec.rb
+++ b/spec/serializers/api/v2/serializable_access_request_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+describe API::V2::SerializableAccessRequest do
+  let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+
+  let(:access_request) { create(:access_request) }
+  let(:access_request_json) do
+    jsonapi_renderer.render(
+      access_request,
+      class: {
+        AccessRequest: API::V2::SerializableAccessRequest
+      }
+    ).to_json
+  end
+  let(:parsed_json) { JSON.parse(access_request_json) }
+
+  subject { parsed_json['data'] }
+
+  it { should have_type('access_request') }
+
+  it {
+    should have_attributes(:email_address, :first_name, :last_name, :organisation,
+                           :request_date_utc, :requester_id, :status, :requester_email)
+  }
+
+  context 'with a requester' do
+    let(:requester) { User.find_by!(id: access_request.requester_id) }
+    let(:access_request_json) do
+      jsonapi_renderer.render(
+        access_request,
+        class: {
+          AccessRequest: API::V2::SerializableAccessRequest,
+          User: API::V2::SerializableUser
+        },
+        include: [
+          :requester
+        ]
+      ).to_json
+    end
+
+    it { should have_relationship(:requester) }
+
+    it 'includes the provider' do
+      expect(parsed_json['included'])
+        .to(include(have_type('users')
+          .and(have_id(requester.id.to_s))))
+    end
+  end
+  describe "has the correct attributes" do
+    it { expect(subject["attributes"]).to include("email_address" => access_request.email_address) }
+    it { expect(subject["attributes"]).to include("first_name" => access_request.first_name) }
+    it { expect(subject["attributes"]).to include("last_name" => access_request.last_name) }
+    it { expect(subject["attributes"]).to include("organisation" => access_request.organisation) }
+    it { expect(subject["attributes"]).to include("reason" => access_request.reason) }
+    it { expect(subject["attributes"]).to include("request_date_utc" => access_request.request_date_utc.iso8601) }
+    it { expect(subject["attributes"]).to include("requester_id" => access_request.requester_id) }
+    it { expect(subject["attributes"]).to include("status" => access_request.status) }
+    it { expect(subject["attributes"]).to include("requester_email" => access_request.requester_email) }
+  end
+end

--- a/spec/serializers/api/v2/serializable_access_request_spec.rb
+++ b/spec/serializers/api/v2/serializable_access_request_spec.rb
@@ -46,15 +46,15 @@ describe API::V2::SerializableAccessRequest do
           .and(have_id(requester.id.to_s))))
     end
   end
-  describe "has the correct attributes" do
-    it { expect(subject["attributes"]).to include("email_address" => access_request.email_address) }
-    it { expect(subject["attributes"]).to include("first_name" => access_request.first_name) }
-    it { expect(subject["attributes"]).to include("last_name" => access_request.last_name) }
-    it { expect(subject["attributes"]).to include("organisation" => access_request.organisation) }
-    it { expect(subject["attributes"]).to include("reason" => access_request.reason) }
-    it { expect(subject["attributes"]).to include("request_date_utc" => access_request.request_date_utc.iso8601) }
-    it { expect(subject["attributes"]).to include("requester_id" => access_request.requester_id) }
-    it { expect(subject["attributes"]).to include("status" => access_request.status) }
-    it { expect(subject["attributes"]).to include("requester_email" => access_request.requester_email) }
+  describe 'has the correct attributes' do
+    it { should have_attribute(:email_address).with_value(access_request.email_address) }
+    it { should have_attribute(:first_name).with_value(access_request.first_name) }
+    it { should have_attribute(:last_name).with_value(access_request.last_name) }
+    it { should have_attribute(:organisation).with_value(access_request.organisation) }
+    it { should have_attribute(:reason).with_value(access_request.reason) }
+    it { should have_attribute(:request_date_utc).with_value(access_request.request_date_utc.iso8601) }
+    it { should have_attribute(:requester_id).with_value(access_request.requester_id) }
+    it { should have_attribute(:status).with_value(access_request.status) }
+    it { should have_attribute(:requester_email).with_value(access_request.requester_email) }
   end
 end


### PR DESCRIPTION
### Context

MC support currently hits the db directly for to list the access requests.  This pr creates an endpoint on MCBE for the support app to hit instead

### Changes proposed in this pull request

- endpoint created
- list of 'requested' access requests returned when endpoint is hit

### Guidance to review
The support app still needs to be refactored to hit the mcbe endpoint.