### PR TITLE
[1422] Don't validate numericality for fees

### DIFF
--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -48,7 +48,6 @@ class CourseEnrichment < ApplicationRecord
   validates :how_school_placements_work, words_count: { maximum: 350 }, on: :publish
 
   # mandatory validation for fee based course to be published
-  validates :fee_international, :fee_uk_eu, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100000 }, on: :publish, if: :is_fee_based?
   validates :fee_uk_eu, presence: true, on: :publish, if: :is_fee_based?
   validates :fee_details, words_count: { maximum: 250 }, on: :publish, if: :is_fee_based?
   validates :financial_support, words_count: { maximum: 250 }, on: :publish, if: :is_fee_based?

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -98,8 +98,6 @@ describe CourseEnrichment, type: :model do
 
       it { should_not validate_presence_of(:salary_details).on(:publish) }
       it { should validate_presence_of(:fee_uk_eu).on(:publish) }
-      it { should validate_numericality_of(:fee_international).on(:publish) }
-      it { should validate_numericality_of(:fee_international).on(:publish) }
 
       context 'valid content' do
         it { should be_valid :publish }
@@ -116,8 +114,6 @@ describe CourseEnrichment, type: :model do
 
       it { should validate_presence_of(:salary_details).on(:publish) }
       it { should_not validate_presence_of(:fee_uk_eu).on(:publish) }
-      it { should_not validate_numericality_of(:fee_international).on(:publish) }
-      it { should_not validate_numericality_of(:fee_international).on(:publish) }
       context 'valid content' do
         it { should be_valid :publish }
       end

--- a/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
+++ b/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
@@ -100,13 +100,11 @@ describe 'Courses API v2', type: :request do
         it { should have_http_status(:unprocessable_entity) }
 
         it 'has validation errors' do
-          expect(json_data.count).to eq 6
+          expect(json_data.count).to eq 4
           expect(json_data[0]["detail"]).to eq("Reduce the word count for about course")
           expect(json_data[1]["detail"]).to eq("Reduce the word count for interview process")
           expect(json_data[2]["detail"]).to eq("Reduce the word count for how school placements work")
-          expect(json_data[3]["detail"]).to eq("Course fees for international students must be less than or equal to £100,000")
-          expect(json_data[4]["detail"]).to eq("Course fees for UK and EU students must be less than or equal to £100,000")
-          expect(json_data[5]["detail"]).to eq("Reduce the word count for fee details")
+          expect(json_data[3]["detail"]).to eq("Reduce the word count for fee details")
         end
       end
     end


### PR DESCRIPTION
### Context
Courses are not being sent to "find" because are "publish" validation rules don't match with the current implementation in the UI.

### Changes proposed in this pull request
Remove numerical validation from fees since this is handled by the input itself at present (not ideal) and the current behavior of our c# implementation
