### PR TITLE
[1417] remove opted_in from provider

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -24,7 +24,6 @@
 #  accrediting_provider :text
 #  last_published_at    :datetime
 #  changed_at           :datetime         not null
-#  opted_in             :boolean          default(FALSE)
 #
 
 class Provider < ApplicationRecord

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -24,7 +24,6 @@
 #  accrediting_provider :text
 #  last_published_at    :datetime
 #  changed_at           :datetime         not null
-#  opted_in             :boolean          default(FALSE)
 #
 
 class ProviderSerializer < ActiveModel::Serializer

--- a/db/migrate/20190507150812_remove_opted_in_from_provider.rb
+++ b/db/migrate/20190507150812_remove_opted_in_from_provider.rb
@@ -1,0 +1,5 @@
+class RemoveOptedInFromProvider < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :provider, :opted_in, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_18_114021) do
+ActiveRecord::Schema.define(version: 2019_05_07_150812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -179,7 +179,6 @@ ActiveRecord::Schema.define(version: 2019_04_18_114021) do
     t.text "accrediting_provider"
     t.datetime "last_published_at"
     t.datetime "changed_at", default: -> { "timezone('utc'::text, now())" }, null: false
-    t.boolean "opted_in", default: false
     t.index ["changed_at"], name: "index_provider_on_changed_at", unique: true
     t.index ["last_published_at"], name: "IX_provider_last_published_at"
     t.index ["provider_code"], name: "IX_provider_provider_code", unique: true

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -24,7 +24,6 @@
 #  accrediting_provider :text
 #  last_published_at    :datetime
 #  changed_at           :datetime         not null
-#  opted_in             :boolean          default(FALSE)
 #
 
 FactoryBot.define do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -24,7 +24,6 @@
 #  accrediting_provider :text
 #  last_published_at    :datetime
 #  changed_at           :datetime         not null
-#  opted_in             :boolean          default(FALSE)
 #
 
 require 'rails_helper'

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -24,7 +24,6 @@
 #  accrediting_provider :text
 #  last_published_at    :datetime
 #  changed_at           :datetime         not null
-#  opted_in             :boolean          default(FALSE)
 #
 
 require "rails_helper"


### PR DESCRIPTION
### Context
All providers are now opted in

### Changes proposed in this pull request
Remove `opted_in` column from the provider table

### Guidance to review
`rails db:migrate`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
