### PR TITLE
[1441] fix -E option on az psql command

### DIFF
--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -276,6 +276,15 @@ module MCB
       }
     end
 
+    def load_env_azure_settings(opts)
+      if opts.key?(:env)
+        env_settings = env_to_azure_map.fetch(opts[:env])
+        opts[:webapp] = env_settings[:webapp] unless opts.key? :webapp
+        opts[:rgroup] = env_settings[:rgroup] unless opts.key? :rgroup
+        opts[:subscription] = env_settings[:subscription] unless opts.key? :subscription
+      end
+    end
+
   private
 
     def configure_audited_user
@@ -311,15 +320,6 @@ module MCB
         changed_since ||= DateTime.parse(opts[:'changed-since'])
         changed_since_param = CGI.escape(changed_since.strftime('%FT%T.%6NZ'))
         url.query = "changed_since=#{changed_since_param}"
-      end
-    end
-
-    def load_env_azure_settings(opts)
-      if opts.key?(:env)
-        env_settings = env_to_azure_map.fetch(opts[:env])
-        opts[:webapp] = env_settings[:webapp] unless opts.key? :webapp
-        opts[:rgroup] = env_settings[:rgroup] unless opts.key? :rgroup
-        opts[:subscription] = env_settings[:subscription] unless opts.key? :subscription
       end
     end
   end

--- a/lib/mcb/commands/az/apps/psql.rb
+++ b/lib/mcb/commands/az/apps/psql.rb
@@ -4,6 +4,7 @@ summary 'connect to the psql server for an app'
 instance_eval(&MCB.remote_connect_options)
 
 run do |opts, _args, _cmd|
+  MCB.load_env_azure_settings(opts)
   if MCB.requesting_remote_connection? opts
     MCB::Azure.configure_for_webapp(opts)
   end


### PR DESCRIPTION
### Context

-E wasn't working for `mcb az psql`

### Changes proposed in this pull request

It is fixed.

### Guidance to review

```
                               _ooOoo_                             
                              o8888888o                            
                              88" . "88                            
                              (| -_- |)                            
                              O\  =  /O                            
                           ____/`---'\____                         
                         .'  \\|     |//  `.                       
                        /  \\|||  :  |||//  \                      
                       /  _||||| -:- |||||_  \                     
                       |   | \\\  -  /'| |   |                     
                       | \_|  `\`---'//  |_/ |                     
                       \  .-\__ `-. -'__/-.  /                     
                     ___`. .'  /--.--\  `. .'___                   
                  ."" '<  `.___\_<|>_/___.' _> \"".                
                 | | :  `- \`. ;`. _/; .'/ /  .' ; |               
                 \  \ `-.   \_\_`. _.'_/_/  -' _.' /               
       ===========`-.`___`-.__\ \___  /__.-'_.'_.-'================
                               `=--=-'                         
```

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
