### PR TITLE
[1413] Fix email already in use error during user sign in

### DIFF
--- a/app/services/authentication_service.rb
+++ b/app/services/authentication_service.rb
@@ -11,7 +11,7 @@ class AuthenticationService
 
   def call
     @user = user_by_sign_in_user_id || user_by_email
-    update_user_email if user_email_does_not_match_token?
+    update_user_email if update_user_email_needed?
 
     user
   end
@@ -49,10 +49,18 @@ private
     User.find_by(sign_in_user_id: sign_in_user_id_from_token)
   end
 
+  def update_user_email_needed?
+    user_email_does_not_match_token? && !email_in_use_by_another_user?
+  end
+
   def user_email_does_not_match_token?
     return unless user
 
     user.email&.downcase != email_from_token
+  end
+
+  def email_in_use_by_another_user?
+    User.exists?(email: email_from_token)
   end
 
   def update_user_email

--- a/app/services/authentication_service/duplicate_user_error.rb
+++ b/app/services/authentication_service/duplicate_user_error.rb
@@ -1,0 +1,13 @@
+class AuthenticationService
+  class DuplicateUserError < StandardError
+    def initialize(message, user_id:, user_sign_in_user_id:,
+                   existing_user_id:, existing_user_sign_in_user_id:)
+      @user_id                       = user_id
+      @user_sign_in_user_id          = user_sign_in_user_id
+      @existing_user_id              = existing_user_id
+      @existing_user_sign_in_user_id = existing_user_sign_in_user_id
+
+      super(message)
+    end
+  end
+end

--- a/spec/services/authentication_service_spec.rb
+++ b/spec/services/authentication_service_spec.rb
@@ -38,13 +38,19 @@ describe AuthenticationService do
       end
 
       context 'when the email is already in use' do
-        before do
-          create(:user, email: email)
-        end
+        let!(:existing_user) { create(:user, email: email) }
 
         it { should eq user }
         it "does not update the user's email" do
           expect { subject }.not_to(change { user.reload.email })
+        end
+
+        it 'generates an exception which is captured by Sentry' do
+          expect(Raven).to receive(:capture).with(
+            instance_of(AuthenticationService::DuplicateUserError)
+          )
+
+          subject
         end
       end
     end

--- a/spec/services/authentication_service_spec.rb
+++ b/spec/services/authentication_service_spec.rb
@@ -36,6 +36,17 @@ describe AuthenticationService do
       it "update's the user's email" do
         expect { subject }.to(change { user.reload.email }.to(email))
       end
+
+      context 'when the email is already in use' do
+        before do
+          create(:user, email: email)
+        end
+
+        it { should eq user }
+        it "does not update the user's email" do
+          expect { subject }.not_to(change { user.reload.email })
+        end
+      end
     end
 
     context 'with a valid email but an invalid DfE-SignIn ID' do


### PR DESCRIPTION
### Context

The database constraint for email uniqeness on users causes ActiveRecord
to raise an error whenever we try to update the email to one that
already exists.

This happens for some users that have a DfE-SignIn ID on a user record
with an email address different from the one that we get from
DfE-SignIn, and the email from DfE-SignIn matches another record.

When we look up the user by the ID and the email doesn't match the
user's email, we want to update their email to the one we get from
DfE-SignIn.

Sometimes though, there's already another user on the system with the
same email, so we get an error. Instead of just not updating and moving
on with authenticatation, we want to send an exception to Sentry with
the details of the users.

### Changes proposed in this pull request

This allows us to start collecting some data about the users affected by
this, which will help us come up with a plan to resolve this, wheter
that is manually or automatically.

This also authenticates the user as normal, rather than failing.

### Guidance to review

I think we need to test the Sentry reporting on QA?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally