### PR TITLE
[1407] Add mcb command to sync all of a provider's courses to Find

### DIFF
--- a/lib/mcb/commands/providers/sync_to_find.rb
+++ b/lib/mcb/commands/providers/sync_to_find.rb
@@ -1,0 +1,20 @@
+name 'sync_to_find'
+summary 'Send all courses for a particular provider to Find'
+usage 'sync_to_find <provider_code>'
+param :provider_code
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
+  provider = Provider.find_by!(provider_code: args[:provider_code])
+  user = User.find_by!(email: MCB.config[:email])
+  unless ProviderPolicy.new(user, provider).show?
+    puts "User #{user.email} cannot edit provider #{provider.provider_code}"
+    raise CriExitException.new(is_error: true)
+  end
+
+  ManageCoursesAPIService::Request.sync_courses_with_search_and_compare(
+    user.email,
+    provider.provider_code
+  )
+end

--- a/spec/lib/mcb/commands/providers/sync_to_find_spec.rb
+++ b/spec/lib/mcb/commands/providers/sync_to_find_spec.rb
@@ -1,0 +1,68 @@
+require 'mcb_helper'
+require 'stringio'
+
+describe 'mcb providers sync_to_find' do
+  def sync_to_find(provider_code)
+    with_stubbed_stdout do
+      cmd.run([provider_code])
+    end
+  end
+
+  let(:lib_dir) { "#{Rails.root}/lib" }
+  let(:cmd) do
+    Cri::Command.load_file(
+      "#{lib_dir}/mcb/commands/providers/sync_to_find.rb"
+    )
+  end
+  let(:provider_code) { 'X12' }
+  let(:email) { 'user@education.gov.uk' }
+  let!(:provider) { create(:provider, provider_code: provider_code) }
+  let!(:manage_api_request) {
+    stub_request(:post, "#{Settings.manage_api.base_url}/api/Publish/internal/courses/#{provider_code}")
+      .with { |req| req.body == { "email": email }.to_json }
+      .to_return(
+        status: 200,
+        body: '{ "result": true }'
+      )
+  }
+
+  before do
+    allow(MCB).to receive(:config).and_return(email: email)
+  end
+
+  context 'when an authorised user syncs an existing provider' do
+    let!(:requester) { create(:user, email: email, organisations: provider.organisations) }
+
+    it 'calls Manage API successfully' do
+      expect { sync_to_find(provider_code) }.to_not raise_error
+      expect(manage_api_request).to have_been_made
+    end
+  end
+
+  context 'when an authorised user tries to sync a nonexistent provider' do
+    let!(:requester) { create(:user, email: email) }
+
+    it 'raises an error' do
+      expect { sync_to_find("ABC") }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find Provider/)
+      expect(manage_api_request).to_not have_been_made
+    end
+  end
+
+  context 'when a non-existent user tries to sync an existing provider' do
+    let!(:requester) { create(:user, email: 'someother@email.com') }
+
+    it 'raises an error' do
+      expect { sync_to_find(provider_code) }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find User/)
+      expect(manage_api_request).to_not have_been_made
+    end
+  end
+
+  context 'when an unauthorised user tries to sync an existing provider' do
+    let!(:requester) { create(:user, email: email, organisations: []) }
+
+    it 'raises an error' do
+      expect { sync_to_find(provider_code) }.to raise_error(SystemExit)
+      expect(manage_api_request).to_not have_been_made
+    end
+  end
+end


### PR DESCRIPTION
### Context
Tech support needs to help providers with course and training location editing because not all that functionality is available as self-serve.

When tech support makes several changes to courses of a particular provider and wants to update Find, they don't want to do it through Publish.

### Changes proposed in this pull request
Add an `mcb` task.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running ~locally~ repeatedly on production
