### PR TITLE
1310 fixed missing validations for pub

### DIFF
--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -45,7 +45,7 @@ class CourseEnrichment < ApplicationRecord
   # mandatory validation for any course to be published
   validates :about_course, presence: true, words_count: { maximum: 400 }, on: :publish
   validates :interview_process, words_count: { maximum: 250 }, on: :publish
-  validates :how_school_placements_work, words_count: { maximum: 350 }, on: :publish
+  validates :how_school_placements_work, presence: true, words_count: { maximum: 350 }, on: :publish
   validates :qualifications, presence: true, words_count: { maximum: 100 }, on: :publish
 
   # mandatory validation for fee based course to be published

--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -43,9 +43,10 @@ class CourseEnrichment < ApplicationRecord
   scope :latest_first, -> { order(created_at: :desc) }
 
   # mandatory validation for any course to be published
-  validates :about_course, words_count: { maximum: 400 }, on: :publish
+  validates :about_course, presence: true, words_count: { maximum: 400 }, on: :publish
   validates :interview_process, words_count: { maximum: 250 }, on: :publish
   validates :how_school_placements_work, words_count: { maximum: 350 }, on: :publish
+  validates :qualifications, presence: true, words_count: { maximum: 100 }, on: :publish
 
   # mandatory validation for fee based course to be published
   validates :fee_uk_eu, presence: true, on: :publish, if: :is_fee_based?

--- a/spec/factories/course_enrichments.rb
+++ b/spec/factories/course_enrichments.rb
@@ -99,16 +99,21 @@ FactoryBot.define do
     last_published_timestamp_utc { 5.days.ago }
   end
 
-  trait :with_invalid_content do
+  trait :with_invalid_content_exceed_word_count_fields do
     about_course { Faker::Lorem.sentence(400 + 1) }
     interview_process { Faker::Lorem.sentence(250 + 1) }
+    qualifications { Faker::Lorem.sentence(100 + 1) }
     how_school_placements_work { Faker::Lorem.sentence(350 + 1) }
 
     fee_details { Faker::Lorem.sentence(250 + 1) }
     salary_details { Faker::Lorem.sentence(250 + 1) }
+  end
 
-    fee_uk_eu { 100001 }
-    fee_international { 100001 }
+  trait :with_invalid_content_lack_presence_fields do
+    fee_uk_eu { nil }
+    about_course { nil }
+    qualifications { nil }
+    salary_details { nil }
   end
 
   trait :with_fee_based_course do

--- a/spec/factories/course_enrichments.rb
+++ b/spec/factories/course_enrichments.rb
@@ -99,17 +99,7 @@ FactoryBot.define do
     last_published_timestamp_utc { 5.days.ago }
   end
 
-  trait :with_invalid_content_exceed_word_count_fields do
-    about_course { Faker::Lorem.sentence(400 + 1) }
-    interview_process { Faker::Lorem.sentence(250 + 1) }
-    qualifications { Faker::Lorem.sentence(100 + 1) }
-    how_school_placements_work { Faker::Lorem.sentence(350 + 1) }
-
-    fee_details { Faker::Lorem.sentence(250 + 1) }
-    salary_details { Faker::Lorem.sentence(250 + 1) }
-  end
-
-  trait :with_invalid_content_lack_presence_fields do
+  trait :without_content do
     fee_uk_eu { nil }
     about_course { nil }
     qualifications { nil }

--- a/spec/factories/course_enrichments.rb
+++ b/spec/factories/course_enrichments.rb
@@ -113,6 +113,7 @@ FactoryBot.define do
     fee_uk_eu { nil }
     about_course { nil }
     qualifications { nil }
+    how_school_placements_work { nil }
     salary_details { nil }
   end
 

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -91,50 +91,75 @@ describe CourseEnrichment, type: :model do
   end
 
   describe 'validation for publish' do
-    subject { create(:course_enrichment, *course_enrichment_traits) }
+    let(:course_enrichment) do
+      create(:course_enrichment, :with_fee_based_course)
+    end
+    subject { course_enrichment }
 
     context 'fee based course' do
-      let(:course_enrichment_traits) { [:with_fee_based_course] }
-
       it { should_not validate_presence_of(:salary_details).on(:publish) }
       it { should validate_presence_of(:fee_uk_eu).on(:publish) }
       it { should validate_presence_of(:about_course).on(:publish) }
       it { should validate_presence_of(:qualifications).on(:publish) }
 
-      context 'valid content' do
-        it { should be_valid :publish }
-      end
 
       context 'invalid content exceed word count fields' do
-        let(:course_enrichment_traits) { %i[with_fee_based_course with_invalid_content_exceed_word_count_fields] }
-        it { should_not be_valid :publish }
-      end
+        let(:course_enrichment) do
+          create(:course_enrichment, :with_fee_based_course,
+                 about_course:  Faker::Lorem.sentence(400 + 1),
+                 interview_process:  Faker::Lorem.sentence(250 + 1),
+                 qualifications:  Faker::Lorem.sentence(100 + 1),
+                 how_school_placements_work:  Faker::Lorem.sentence(350 + 1),
+                 fee_details:  Faker::Lorem.sentence(250 + 1),
+                 salary_details:  Faker::Lorem.sentence(250 + 1))
+        end
 
-      context 'invalid content lack presence fields' do
-        let(:course_enrichment_traits) { %i[with_fee_based_course with_invalid_content_lack_presence_fields] }
-        it { should_not be_valid :publish }
+        subject do
+          course_enrichment.valid? :publish
+          course_enrichment.errors
+        end
+
+        its([:about_course]) { should match_array ['^Reduce the word count for about course'] }
+        its([:interview_process]) { should match_array ['^Reduce the word count for interview process'] }
+        its([:qualifications]) { should match_array ['^Reduce the word count for qualifications'] }
+        its([:how_school_placements_work]) { should match_array ['^Reduce the word count for how school placements work'] }
+        its([:fee_details]) { should match_array ['^Reduce the word count for fee details'] }
+        its([:salary_details]) { should be_empty }
       end
     end
 
     context 'salary based course' do
-      let(:course_enrichment_traits) { [:with_salary_based_course] }
+      let(:course_enrichment) do
+        create(:course_enrichment, :with_salary_based_course)
+      end
 
       it { should validate_presence_of(:salary_details).on(:publish) }
       it { should validate_presence_of(:about_course).on(:publish) }
       it { should validate_presence_of(:qualifications).on(:publish) }
       it { should_not validate_presence_of(:fee_uk_eu).on(:publish) }
-      context 'valid content' do
-        it { should be_valid :publish }
-      end
 
       context 'invalid content exceed word count fields' do
-        let(:course_enrichment_traits) { %i[with_salary_based_course with_invalid_content_exceed_word_count_fields] }
-        it { should_not be_valid :publish }
-      end
+        let(:course_enrichment) do
+          create(:course_enrichment, :with_salary_based_course,
+                 about_course:  Faker::Lorem.sentence(400 + 1),
+                 interview_process:  Faker::Lorem.sentence(250 + 1),
+                 qualifications:  Faker::Lorem.sentence(100 + 1),
+                 how_school_placements_work:  Faker::Lorem.sentence(350 + 1),
+                 fee_details:  Faker::Lorem.sentence(250 + 1),
+                 salary_details:  Faker::Lorem.sentence(250 + 1))
+        end
 
-      context 'invalid content lack presence fields' do
-        let(:course_enrichment_traits) { %i[with_salary_based_course with_invalid_content_lack_presence_fields] }
-        it { should_not be_valid :publish }
+        subject do
+          course_enrichment.valid? :publish
+          course_enrichment.errors
+        end
+
+        its([:about_course]) { should match_array ['^Reduce the word count for about course'] }
+        its([:interview_process]) { should match_array ['^Reduce the word count for interview process'] }
+        its([:qualifications]) { should match_array ['^Reduce the word count for qualifications'] }
+        its([:how_school_placements_work]) { should match_array ['^Reduce the word count for how school placements work'] }
+        its([:fee_details]) { should be_empty }
+        its([:salary_details]) { should match_array ['^Reduce the word count for salary details'] }
       end
     end
   end

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -91,77 +91,116 @@ describe CourseEnrichment, type: :model do
   end
 
   describe 'validation for publish' do
-    let(:course_enrichment) do
-      build(:course_enrichment, :with_fee_based_course)
-    end
+    let(:course_enrichment) { build(:course_enrichment, :with_fee_based_course) }
     subject { course_enrichment }
 
     context 'fee based course' do
-      it { should_not validate_presence_of(:salary_details).on(:publish) }
       it { should validate_presence_of(:fee_uk_eu).on(:publish) }
       it { should validate_presence_of(:about_course).on(:publish) }
       it { should validate_presence_of(:qualifications).on(:publish) }
 
-      context 'invalid content exceed word count fields' do
-        let(:course_enrichment) do
-          build(:course_enrichment, :with_fee_based_course,
-                about_course:  Faker::Lorem.sentence(400 + 1),
-                interview_process:  Faker::Lorem.sentence(250 + 1),
-                qualifications:  Faker::Lorem.sentence(100 + 1),
-                how_school_placements_work:  Faker::Lorem.sentence(350 + 1),
-                fee_details:  Faker::Lorem.sentence(250 + 1),
-                salary_details:  Faker::Lorem.sentence(250 + 1))
+      it 'validates maximum word count for about_course' do
+        course_enrichment.about_course = Faker::Lorem.sentence(400 + 1)
+
+        expect(course_enrichment).not_to be_valid :publish
+        expect(course_enrichment.errors[:about_course]).to be_present
+      end
+
+      it 'validates maximum word count for interview_process' do
+        course_enrichment.interview_process = Faker::Lorem.sentence(250 + 1)
+
+        expect(course_enrichment).not_to be_valid :publish
+        expect(course_enrichment.errors[:interview_process]).to be_present
+      end
+
+      it 'validates maximum word count for qualifications' do
+        course_enrichment.qualifications = Faker::Lorem.sentence(100 + 1)
+
+        expect(course_enrichment).not_to be_valid :publish
+        expect(course_enrichment.errors[:qualifications]).to be_present
+      end
+
+      it 'validates maximum word count for how_school_placements_work' do
+        course_enrichment.how_school_placements_work = Faker::Lorem.sentence(350 + 1)
+
+        expect(course_enrichment).not_to be_valid :publish
+        expect(course_enrichment.errors[:how_school_placements_work]).to be_present
+      end
+
+      it 'validates maximum word count for fee_details' do
+        course_enrichment.fee_details = Faker::Lorem.sentence(250 + 1)
+
+        expect(course_enrichment).not_to be_valid :publish
+        expect(course_enrichment.errors[:fee_details]).to be_present
+      end
+
+      context 'salary based fields' do
+        it 'does not validates maximum word count for salary_details' do
+          course_enrichment.salary_details = Faker::Lorem.sentence(250 + 1)
+
+          expect(course_enrichment).to be_valid :publish
+          expect(course_enrichment.errors[:salary_details]).to be_empty
         end
 
-        subject do
-          course_enrichment.valid? :publish
-          course_enrichment.errors
-        end
-
-        its([:about_course]) { should match_array ['^Reduce the word count for about course'] }
-        its([:interview_process]) { should match_array ['^Reduce the word count for interview process'] }
-        its([:qualifications]) { should match_array ['^Reduce the word count for qualifications'] }
-        its([:how_school_placements_work]) { should match_array ['^Reduce the word count for how school placements work'] }
-        its([:fee_details]) { should match_array ['^Reduce the word count for fee details'] }
-        its([:salary_details]) { should be_empty }
+        it { should_not validate_presence_of(:salary_details).on(:publish) }
       end
     end
 
     context 'salary based course' do
-      let(:course_enrichment) do
-        build(:course_enrichment, :with_salary_based_course)
-      end
+      let(:course_enrichment) { build(:course_enrichment, :with_salary_based_course) }
 
       it { should validate_presence_of(:salary_details).on(:publish) }
       it { should validate_presence_of(:about_course).on(:publish) }
       it { should validate_presence_of(:qualifications).on(:publish) }
-      it { should_not validate_presence_of(:fee_uk_eu).on(:publish) }
 
-      context 'invalid content exceed word count fields' do
-        let(:course_enrichment) do
-          build(:course_enrichment, :with_salary_based_course,
-                about_course:  Faker::Lorem.sentence(400 + 1),
-                interview_process:  Faker::Lorem.sentence(250 + 1),
-                qualifications:  Faker::Lorem.sentence(100 + 1),
-                how_school_placements_work:  Faker::Lorem.sentence(350 + 1),
-                fee_details:  Faker::Lorem.sentence(250 + 1),
-                salary_details:  Faker::Lorem.sentence(250 + 1))
+      it 'validates maximum word count for about_course' do
+        course_enrichment.about_course = Faker::Lorem.sentence(400 + 1)
+
+        expect(course_enrichment).not_to be_valid :publish
+        expect(course_enrichment.errors[:about_course]).to be_present
+      end
+
+      it 'validates maximum word count for interview_process' do
+        course_enrichment.interview_process = Faker::Lorem.sentence(250 + 1)
+
+        expect(course_enrichment).not_to be_valid :publish
+        expect(course_enrichment.errors[:interview_process]).to be_present
+      end
+
+      it 'validates maximum word count for qualifications' do
+        course_enrichment.qualifications = Faker::Lorem.sentence(100 + 1)
+
+        expect(course_enrichment).not_to be_valid :publish
+        expect(course_enrichment.errors[:qualifications]).to be_present
+      end
+
+      it 'validates maximum word count for how_school_placements_work' do
+        course_enrichment.how_school_placements_work = Faker::Lorem.sentence(350 + 1)
+
+        expect(course_enrichment).not_to be_valid :publish
+        expect(course_enrichment.errors[:how_school_placements_work]).to be_present
+      end
+
+      it 'validates maximum word count for salary_details' do
+        course_enrichment.salary_details = Faker::Lorem.sentence(250 + 1)
+
+        expect(course_enrichment).not_to be_valid :publish
+        expect(course_enrichment.errors[:salary_details]).to be_present
+      end
+
+      context 'fee based fields' do
+        it 'does not validates maximum word count for fee_details' do
+          course_enrichment.fee_details = Faker::Lorem.sentence(250 + 1)
+
+          expect(course_enrichment).to be_valid :publish
+          expect(course_enrichment.errors[:fee_details]).to be_empty
         end
 
-        subject do
-          course_enrichment.valid? :publish
-          course_enrichment.errors
-        end
-
-        its([:about_course]) { should match_array ['^Reduce the word count for about course'] }
-        its([:interview_process]) { should match_array ['^Reduce the word count for interview process'] }
-        its([:qualifications]) { should match_array ['^Reduce the word count for qualifications'] }
-        its([:how_school_placements_work]) { should match_array ['^Reduce the word count for how school placements work'] }
-        its([:fee_details]) { should be_empty }
-        its([:salary_details]) { should match_array ['^Reduce the word count for salary details'] }
+        it { should_not validate_presence_of(:fee_uk_eu).on(:publish) }
       end
     end
   end
+
   describe '#unpublish' do
     let(:provider) { create(:provider) }
     let(:course) { create(:course, provider: provider) }

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -92,7 +92,7 @@ describe CourseEnrichment, type: :model do
 
   describe 'validation for publish' do
     let(:course_enrichment) do
-      create(:course_enrichment, :with_fee_based_course)
+      build(:course_enrichment, :with_fee_based_course)
     end
     subject { course_enrichment }
 
@@ -102,16 +102,15 @@ describe CourseEnrichment, type: :model do
       it { should validate_presence_of(:about_course).on(:publish) }
       it { should validate_presence_of(:qualifications).on(:publish) }
 
-
       context 'invalid content exceed word count fields' do
         let(:course_enrichment) do
-          create(:course_enrichment, :with_fee_based_course,
-                 about_course:  Faker::Lorem.sentence(400 + 1),
-                 interview_process:  Faker::Lorem.sentence(250 + 1),
-                 qualifications:  Faker::Lorem.sentence(100 + 1),
-                 how_school_placements_work:  Faker::Lorem.sentence(350 + 1),
-                 fee_details:  Faker::Lorem.sentence(250 + 1),
-                 salary_details:  Faker::Lorem.sentence(250 + 1))
+          build(:course_enrichment, :with_fee_based_course,
+                about_course:  Faker::Lorem.sentence(400 + 1),
+                interview_process:  Faker::Lorem.sentence(250 + 1),
+                qualifications:  Faker::Lorem.sentence(100 + 1),
+                how_school_placements_work:  Faker::Lorem.sentence(350 + 1),
+                fee_details:  Faker::Lorem.sentence(250 + 1),
+                salary_details:  Faker::Lorem.sentence(250 + 1))
         end
 
         subject do
@@ -130,7 +129,7 @@ describe CourseEnrichment, type: :model do
 
     context 'salary based course' do
       let(:course_enrichment) do
-        create(:course_enrichment, :with_salary_based_course)
+        build(:course_enrichment, :with_salary_based_course)
       end
 
       it { should validate_presence_of(:salary_details).on(:publish) }
@@ -140,13 +139,13 @@ describe CourseEnrichment, type: :model do
 
       context 'invalid content exceed word count fields' do
         let(:course_enrichment) do
-          create(:course_enrichment, :with_salary_based_course,
-                 about_course:  Faker::Lorem.sentence(400 + 1),
-                 interview_process:  Faker::Lorem.sentence(250 + 1),
-                 qualifications:  Faker::Lorem.sentence(100 + 1),
-                 how_school_placements_work:  Faker::Lorem.sentence(350 + 1),
-                 fee_details:  Faker::Lorem.sentence(250 + 1),
-                 salary_details:  Faker::Lorem.sentence(250 + 1))
+          build(:course_enrichment, :with_salary_based_course,
+                about_course:  Faker::Lorem.sentence(400 + 1),
+                interview_process:  Faker::Lorem.sentence(250 + 1),
+                qualifications:  Faker::Lorem.sentence(100 + 1),
+                how_school_placements_work:  Faker::Lorem.sentence(350 + 1),
+                fee_details:  Faker::Lorem.sentence(250 + 1),
+                salary_details:  Faker::Lorem.sentence(250 + 1))
         end
 
         subject do

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -98,13 +98,20 @@ describe CourseEnrichment, type: :model do
 
       it { should_not validate_presence_of(:salary_details).on(:publish) }
       it { should validate_presence_of(:fee_uk_eu).on(:publish) }
+      it { should validate_presence_of(:about_course).on(:publish) }
+      it { should validate_presence_of(:qualifications).on(:publish) }
 
       context 'valid content' do
         it { should be_valid :publish }
       end
 
-      context 'invalid content' do
-        let(:course_enrichment_traits) { %i[with_fee_based_course with_invalid_content] }
+      context 'invalid content exceed word count fields' do
+        let(:course_enrichment_traits) { %i[with_fee_based_course with_invalid_content_exceed_word_count_fields] }
+        it { should_not be_valid :publish }
+      end
+
+      context 'invalid content lack presence fields' do
+        let(:course_enrichment_traits) { %i[with_fee_based_course with_invalid_content_lack_presence_fields] }
         it { should_not be_valid :publish }
       end
     end
@@ -113,13 +120,20 @@ describe CourseEnrichment, type: :model do
       let(:course_enrichment_traits) { [:with_salary_based_course] }
 
       it { should validate_presence_of(:salary_details).on(:publish) }
+      it { should validate_presence_of(:about_course).on(:publish) }
+      it { should validate_presence_of(:qualifications).on(:publish) }
       it { should_not validate_presence_of(:fee_uk_eu).on(:publish) }
       context 'valid content' do
         it { should be_valid :publish }
       end
 
-      context 'invalid content' do
-        let(:course_enrichment_traits) { %i[with_salary_based_course with_invalid_content] }
+      context 'invalid content exceed word count fields' do
+        let(:course_enrichment_traits) { %i[with_salary_based_course with_invalid_content_exceed_word_count_fields] }
+        it { should_not be_valid :publish }
+      end
+
+      context 'invalid content lack presence fields' do
+        let(:course_enrichment_traits) { %i[with_salary_based_course with_invalid_content_lack_presence_fields] }
         it { should_not be_valid :publish }
       end
     end

--- a/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
+++ b/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
@@ -117,10 +117,11 @@ describe 'Courses API v2', type: :request do
           it { should have_http_status(:unprocessable_entity) }
 
           it 'has validation errors' do
-            expect(json_data.count).to eq 3
+            expect(json_data.count).to eq 4
             expect(json_data[0]["detail"]).to eq("About course can't be blank")
-            expect(json_data[1]["detail"]).to eq("Qualifications can't be blank")
-            expect(json_data[2]["detail"]).to eq("Enter course fees for UK and EU students")
+            expect(json_data[1]["detail"]).to eq("How school placements work can't be blank")
+            expect(json_data[2]["detail"]).to eq("Qualifications can't be blank")
+            expect(json_data[3]["detail"]).to eq("Enter course fees for UK and EU students")
           end
         end
       end
@@ -147,10 +148,11 @@ describe 'Courses API v2', type: :request do
           it { should have_http_status(:unprocessable_entity) }
 
           it 'has validation errors' do
-            expect(json_data.count).to eq 3
+            expect(json_data.count).to eq 4
             expect(json_data[0]["detail"]).to eq("About course can't be blank")
-            expect(json_data[1]["detail"]).to eq("Qualifications can't be blank")
-            expect(json_data[2]["detail"]).to eq("Enter salary details")
+            expect(json_data[1]["detail"]).to eq("How school placements work can't be blank")
+            expect(json_data[2]["detail"]).to eq("Qualifications can't be blank")
+            expect(json_data[3]["detail"]).to eq("Enter salary details")
           end
         end
       end

--- a/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
+++ b/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
@@ -93,18 +93,65 @@ describe 'Courses API v2', type: :request do
         end
       end
 
-      context 'invalid enrichment' do
-        let(:invalid_enrichment) { create(:course_enrichment, :with_invalid_content) }
-
+      context 'fee type based course' do
         let(:course) { create(:course, :fee_type_based, provider: provider, enrichments: [invalid_enrichment]) }
-        it { should have_http_status(:unprocessable_entity) }
 
-        it 'has validation errors' do
-          expect(json_data.count).to eq 4
-          expect(json_data[0]["detail"]).to eq("Reduce the word count for about course")
-          expect(json_data[1]["detail"]).to eq("Reduce the word count for interview process")
-          expect(json_data[2]["detail"]).to eq("Reduce the word count for how school placements work")
-          expect(json_data[3]["detail"]).to eq("Reduce the word count for fee details")
+        context 'invalid enrichment with invalid content exceed word count fields' do
+          let(:invalid_enrichment) { create(:course_enrichment, :with_invalid_content_exceed_word_count_fields) }
+
+          it { should have_http_status(:unprocessable_entity) }
+
+          it 'has validation errors' do
+            expect(json_data.count).to eq 5
+            expect(json_data[0]["detail"]).to eq("Reduce the word count for about course")
+            expect(json_data[1]["detail"]).to eq("Reduce the word count for interview process")
+            expect(json_data[2]["detail"]).to eq("Reduce the word count for how school placements work")
+            expect(json_data[3]["detail"]).to eq("Reduce the word count for qualifications")
+            expect(json_data[4]["detail"]).to eq("Reduce the word count for fee details")
+          end
+        end
+
+        context 'invalid enrichment with invalid content lack_presence fields' do
+          let(:invalid_enrichment) { create(:course_enrichment, :with_invalid_content_lack_presence_fields) }
+
+          it { should have_http_status(:unprocessable_entity) }
+
+          it 'has validation errors' do
+            expect(json_data.count).to eq 3
+            expect(json_data[0]["detail"]).to eq("About course can't be blank")
+            expect(json_data[1]["detail"]).to eq("Qualifications can't be blank")
+            expect(json_data[2]["detail"]).to eq("Enter course fees for UK and EU students")
+          end
+        end
+      end
+      context 'salary type based course' do
+        let(:course) { create(:course, :salary_type_based, provider: provider, enrichments: [invalid_enrichment]) }
+
+        context 'invalid enrichment with invalid content exceed word count fields' do
+          let(:invalid_enrichment) { create(:course_enrichment, :with_invalid_content_exceed_word_count_fields) }
+
+          it { should have_http_status(:unprocessable_entity) }
+
+          it 'has validation errors' do
+            expect(json_data.count).to eq 5
+            expect(json_data[0]["detail"]).to eq("Reduce the word count for about course")
+            expect(json_data[1]["detail"]).to eq("Reduce the word count for interview process")
+            expect(json_data[2]["detail"]).to eq("Reduce the word count for how school placements work")
+            expect(json_data[3]["detail"]).to eq("Reduce the word count for qualifications")
+            expect(json_data[4]["detail"]).to eq("Reduce the word count for salary details")
+          end
+        end
+        context 'invalid enrichment with invalid content lack_presence fields' do
+          let(:invalid_enrichment) { create(:course_enrichment, :with_invalid_content_lack_presence_fields) }
+
+          it { should have_http_status(:unprocessable_entity) }
+
+          it 'has validation errors' do
+            expect(json_data.count).to eq 3
+            expect(json_data[0]["detail"]).to eq("About course can't be blank")
+            expect(json_data[1]["detail"]).to eq("Qualifications can't be blank")
+            expect(json_data[2]["detail"]).to eq("Enter salary details")
+          end
         end
       end
     end

--- a/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
+++ b/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
@@ -97,7 +97,15 @@ describe 'Courses API v2', type: :request do
         let(:course) { create(:course, :fee_type_based, provider: provider, enrichments: [invalid_enrichment]) }
 
         context 'invalid enrichment with invalid content exceed word count fields' do
-          let(:invalid_enrichment) { create(:course_enrichment, :with_invalid_content_exceed_word_count_fields) }
+          let(:invalid_enrichment) {
+            create(:course_enrichment, :with_fee_based_course,
+                   about_course:  Faker::Lorem.sentence(400 + 1),
+                             interview_process:  Faker::Lorem.sentence(250 + 1),
+                             qualifications:  Faker::Lorem.sentence(100 + 1),
+                             how_school_placements_work:  Faker::Lorem.sentence(350 + 1),
+                             fee_details:  Faker::Lorem.sentence(250 + 1),
+                             salary_details:  Faker::Lorem.sentence(250 + 1))
+          }
 
           it { should have_http_status(:unprocessable_entity) }
 
@@ -112,7 +120,7 @@ describe 'Courses API v2', type: :request do
         end
 
         context 'invalid enrichment with invalid content lack_presence fields' do
-          let(:invalid_enrichment) { create(:course_enrichment, :with_invalid_content_lack_presence_fields) }
+          let(:invalid_enrichment) { create(:course_enrichment, :without_content) }
 
           it { should have_http_status(:unprocessable_entity) }
 
@@ -129,7 +137,15 @@ describe 'Courses API v2', type: :request do
         let(:course) { create(:course, :salary_type_based, provider: provider, enrichments: [invalid_enrichment]) }
 
         context 'invalid enrichment with invalid content exceed word count fields' do
-          let(:invalid_enrichment) { create(:course_enrichment, :with_invalid_content_exceed_word_count_fields) }
+          let(:invalid_enrichment) {
+            create(:course_enrichment, :with_fee_based_course,
+                   about_course:  Faker::Lorem.sentence(400 + 1),
+                             interview_process:  Faker::Lorem.sentence(250 + 1),
+                             qualifications:  Faker::Lorem.sentence(100 + 1),
+                             how_school_placements_work:  Faker::Lorem.sentence(350 + 1),
+                             fee_details:  Faker::Lorem.sentence(250 + 1),
+                             salary_details:  Faker::Lorem.sentence(250 + 1))
+          }
 
           it { should have_http_status(:unprocessable_entity) }
 
@@ -143,7 +159,7 @@ describe 'Courses API v2', type: :request do
           end
         end
         context 'invalid enrichment with invalid content lack_presence fields' do
-          let(:invalid_enrichment) { create(:course_enrichment, :with_invalid_content_lack_presence_fields) }
+          let(:invalid_enrichment) { create(:course_enrichment, :without_content) }
 
           it { should have_http_status(:unprocessable_entity) }
 

--- a/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
+++ b/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
@@ -133,6 +133,7 @@ describe 'Courses API v2', type: :request do
           end
         end
       end
+
       context 'salary type based course' do
         let(:course) { create(:course, :salary_type_based, provider: provider, enrichments: [invalid_enrichment]) }
 


### PR DESCRIPTION
### Context
Validation for 

`qualification`
`about_course`
`how_school_placements_work`

### Changes proposed in this pull request


Added validation for 

`qualification`,  (presence & word count)
`about_course` (presence)
`how_school_placements_work` (presence)

Split the tests to smaller chucks for lack presence and exceed word count vs only invalid content

### Guidance to review
![image](https://user-images.githubusercontent.com/470137/57446646-157be480-724d-11e9-8f48-2dc0574e1505.png)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
