### PR TITLE
[1407] Add mcb command to sync a particular course to Find

### DIFF
--- a/lib/mcb/commands/courses.rb
+++ b/lib/mcb/commands/courses.rb
@@ -1,0 +1,4 @@
+name 'courses'
+summary 'Operate on courses directly in db'
+
+instance_eval(&MCB.remote_connect_options)

--- a/lib/mcb/commands/courses/sync_to_find.rb
+++ b/lib/mcb/commands/courses/sync_to_find.rb
@@ -1,0 +1,23 @@
+name 'sync_to_find'
+summary 'Send a course to Find'
+usage 'sync_to_find <provider_code> <course_code>'
+param :provider_code
+param :course_code
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
+  provider = Provider.find_by!(provider_code: args[:provider_code])
+  course = provider.courses.find_by!(course_code: args[:course_code])
+  user = User.find_by!(email: MCB.config[:email])
+  unless CoursePolicy.new(user, course).show?
+    puts "User #{user.email} cannot edit course #{provider.provider_code}/#{course.course_code}"
+    raise CriExitException.new(is_error: true)
+  end
+
+  ManageCoursesAPIService::Request.sync_course_with_search_and_compare(
+    user.email,
+    provider.provider_code,
+    course.course_code
+  )
+end

--- a/spec/lib/mcb/commands/courses/sync_to_find_spec.rb
+++ b/spec/lib/mcb/commands/courses/sync_to_find_spec.rb
@@ -1,0 +1,78 @@
+require 'mcb_helper'
+
+describe 'mcb courses sync_to_find' do
+  def sync_to_find(provider_code, course_code)
+    with_stubbed_stdout do
+      cmd.run([provider_code, course_code])
+    end
+  end
+
+  let(:lib_dir) { "#{Rails.root}/lib" }
+  let(:cmd) do
+    Cri::Command.load_file(
+      "#{lib_dir}/mcb/commands/courses/sync_to_find.rb"
+    )
+  end
+  let(:provider_code) { 'X12' }
+  let(:course_code) { '3FC4' }
+  let(:email) { 'user@education.gov.uk' }
+  let(:provider) { create(:provider, provider_code: provider_code) }
+  let!(:course) { create(:course, provider: provider, course_code: course_code) }
+  let!(:manage_api_request) {
+    stub_request(:post, "#{Settings.manage_api.base_url}/api/Publish/internal/course/#{provider_code}/#{course_code}")
+      .with { |req| req.body == { "email": email }.to_json }
+      .to_return(
+        status: 200,
+        body: '{ "result": true }'
+      )
+  }
+
+  before do
+    allow(MCB).to receive(:config).and_return(email: email)
+  end
+
+  context 'when an authorised user syncs an existing course' do
+    let!(:requester) { create(:user, email: email, organisations: provider.organisations) }
+
+    it 'calls Manage API successfully' do
+      expect { sync_to_find(provider_code, course_code) }.to_not raise_error
+      expect(manage_api_request).to have_been_made
+    end
+  end
+
+  context 'when an authorised user tries to sync a nonexistent provider' do
+    let!(:requester) { create(:user, email: email) }
+
+    it 'raises an error' do
+      expect { sync_to_find("ABC", course_code) }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find Provider/)
+      expect(manage_api_request).to_not have_been_made
+    end
+  end
+
+  context 'when an authorised user tries to sync a nonexistent course' do
+    let!(:requester) { create(:user, email: email) }
+
+    it 'raises an error' do
+      expect { sync_to_find(provider_code, "ABCD") }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find Course/)
+      expect(manage_api_request).to_not have_been_made
+    end
+  end
+
+  context 'when a non-existent user tries to sync an existing provider' do
+    let!(:requester) { create(:user, email: 'someother@email.com') }
+
+    it 'raises an error' do
+      expect { sync_to_find(provider_code, course_code) }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find User/)
+      expect(manage_api_request).to_not have_been_made
+    end
+  end
+
+  context 'when an unauthorised user tries to sync an existing provider' do
+    let!(:requester) { create(:user, email: email, organisations: []) }
+
+    it 'raises an error' do
+      expect { sync_to_find(provider_code, course_code) }.to raise_error(SystemExit)
+      expect(manage_api_request).to_not have_been_made
+    end
+  end
+end


### PR DESCRIPTION
### Context
Similar to #347.

Tech support needs to help providers with course and training location editing because not all that functionality is available as self-serve.

When tech support changes a particular course and wants to push it to Find, they'd rather do it on the command line rather than through Publish.

### Changes proposed in this pull request
Add an mcb task to sync a single course to Find.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
