### PR TITLE
[1407] Fix mcb azure integration on Windows

### DIFF
--- a/lib/mcb/azure.rb
+++ b/lib/mcb/azure.rb
@@ -23,8 +23,8 @@ module MCB
 
     def self.get_config(app, rgroup: nil, subscription: nil)
       rgroup ||= rgroup_for_app(app)
-      cmd = "az webapp config appsettings list -g '#{rgroup}' -n '#{app}'"
-      cmd += " --subscription '#{subscription}'" if subscription
+      cmd = "az webapp config appsettings list -g \"#{rgroup}\" -n \"#{app}\""
+      cmd += " --subscription \"#{subscription}\"" if subscription
       raw_json = MCB::run_command(cmd)
       config = JSON.parse(raw_json)
       config.map { |c| [c["name"], c["value"]] }.to_h

--- a/spec/lib/mcb/azure_spec.rb
+++ b/spec/lib/mcb/azure_spec.rb
@@ -93,7 +93,7 @@ describe MCB::Azure do
       subject
       expect(MCB).to(
         have_received(:run_command).with(
-          "az webapp config appsettings list -g 'some-rgroup' -n 'some-app'"
+          'az webapp config appsettings list -g "some-rgroup" -n "some-app"'
         )
       )
     end

--- a/spec/lib/mcb/commands/az/apps/config_spec.rb
+++ b/spec/lib/mcb/commands/az/apps/config_spec.rb
@@ -4,7 +4,7 @@ require 'mcb_helper'
 describe 'mcb az apps config' do
   before :each do
     allow(MCB).to receive(:run_command)
-                    .with('az webapp config appsettings list -g \'aregrp\' -n \'dapp\'')
+                    .with('az webapp config appsettings list -g "aregrp" -n "dapp"')
                     .and_return(<<~EOCONFIG)
                       [
                         {


### PR DESCRIPTION
### Context
When attempting to run `mcb` on windows, spaces in the subscription name were tripping the command up on Windows.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
