### PR TITLE
[1470] add mcb user show

### DIFF
--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -285,6 +285,16 @@ module MCB
       end
     end
 
+    def find_user_by_identifier(identifier)
+      if identifier.include? '@'
+        User.find_by(email: identifier)
+      elsif identifier.match %r{^\d+$}
+        User.find(identifier.to_i)
+      else
+        User.find_by(sign_in_user_id: identifier)
+      end
+    end
+
   private
 
     def configure_audited_user

--- a/lib/mcb/commands/users.rb
+++ b/lib/mcb/commands/users.rb
@@ -1,0 +1,5 @@
+name 'user'
+summary 'Operate on users directly in the db'
+default_subcommand 'list'
+
+instance_eval(&MCB.remote_connect_options)

--- a/lib/mcb/commands/users/audit.rb
+++ b/lib/mcb/commands/users/audit.rb
@@ -1,12 +1,14 @@
 summary 'Show changes made to a user record'
-param :code
+param :id
+usage 'audit <id>'
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
-  code = args[:code]
-  provider = Provider.find_by!(provider_code: code)
-  table = Tabulo::Table.new provider.audits do |t|
+  user_id = args[:id]
+  user = User.find(user_id)
+
+  table = Tabulo::Table.new user.audits do |t|
     t.add_column(:user_id, header: "user\nid", width: 6)
     t.add_column(:user, header: "user email") { |a| a.user&.email }
     t.add_column(:action, width: 8)

--- a/lib/mcb/commands/users/list.rb
+++ b/lib/mcb/commands/users/list.rb
@@ -4,7 +4,7 @@ run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
   users = if args.any?
-            User.where(id: args.to_a)
+            args.map { |id| MCB.find_user_by_identifier id }
           else
             User.all
           end
@@ -12,5 +12,11 @@ run do |opts, args, _cmd|
   tp.set :capitalize_headers, false
 
   puts "\nUsers:"
-  tp users, 'id', 'email', 'first_name', 'last_name', 'last_login_date_utc'
+  puts Tabulo::Table.new(users,
+                         :id,
+                         :email,
+                         :sign_in_user_id,
+                         :first_name,
+                         :last_name,
+                         :last_login_date_utc).pack(max_table_width: nil)
 end

--- a/lib/mcb/commands/users/list.rb
+++ b/lib/mcb/commands/users/list.rb
@@ -1,0 +1,16 @@
+summary 'List users in the tb'
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
+  users = if args.any?
+            User.where(id: args.to_a)
+          else
+            User.all
+          end
+
+  tp.set :capitalize_headers, false
+
+  puts "\nUsers:"
+  tp users, 'id', 'email', 'first_name', 'last_name', 'last_login_date_utc'
+end

--- a/lib/mcb/commands/users/show.rb
+++ b/lib/mcb/commands/users/show.rb
@@ -1,15 +1,13 @@
 summary 'Show users info'
-param :id
-usage 'show <id>'
+param :id_or_email_or_sign_in_id
+usage 'show <id or email or sign-in id>'
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
-  user_id = args[:id]
-  user = User.find(user_id)
-
+  user = MCB.find_user_by_identifier args[:id_or_email_or_sign_in_id]
   if user.nil?
-    error "User not found: #{user_id}"
+    error "User not found: #{args[:id_or_email_or_sign_in_id]}"
   else
     puts "User:"
     puts Terminal::Table.new rows: user.attributes

--- a/lib/mcb/commands/users/show.rb
+++ b/lib/mcb/commands/users/show.rb
@@ -1,0 +1,23 @@
+summary 'Show users info'
+param :id
+usage 'show <id>'
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
+  user_id = args[:id]
+  user = User.find(user_id)
+
+  if user.nil?
+    error "User not found: #{user_id}"
+  else
+    puts "User:"
+    puts Terminal::Table.new rows: user.attributes
+    puts ''
+    puts "Providers:"
+    puts Tabulo::Table.new(user.providers,
+                           :id,
+                           :provider_name,
+                           :provider_code).pack
+  end
+end

--- a/spec/lib/mcb/commands/users/audit_spec.rb
+++ b/spec/lib/mcb/commands/users/audit_spec.rb
@@ -1,0 +1,26 @@
+require 'mcb_helper'
+
+describe 'mcb users audit' do
+  let(:lib_dir) { "#{Rails.root}/lib" }
+  let(:cmd) do
+    Cri::Command.load_file(
+      "#{lib_dir}/mcb/commands/users/audit.rb"
+    )
+  end
+
+  it 'shows the list of changes for a given user' do
+    user = create(:user, email: 'a@a')
+    admin_user = create :user, :admin, email: 'h@i'
+
+    Audited.store[:audited_user] = admin_user
+    user.update(email: 'b@b')
+
+    output = with_stubbed_stdout do
+      cmd.run([user.id])
+    end
+
+    # This test is a bit vague, it doesn't test what is being changed, but I was
+    # having trouble getting that to pass in Travis when I tried it.
+    expect(output).to have_text_table_row(admin_user.id, 'h@i', 'update')
+  end
+end

--- a/spec/lib/mcb/commands/users/list_spec.rb
+++ b/spec/lib/mcb/commands/users/list_spec.rb
@@ -1,0 +1,49 @@
+require 'mcb_helper'
+
+RSpec::Matchers.define :have_table_row do |*column_values|
+  match do |actual|
+    actual.match? column_values.join('\s+\|\s+')
+  end
+end
+
+
+describe 'mcb users list' do
+  let(:lib_dir) { "#{Rails.root}/lib" }
+  let(:cmd) do
+    Cri::Command.load_file(
+      "#{lib_dir}/mcb/commands/users/list.rb"
+    )
+  end
+
+  it 'lists all the users by default' do
+    user1 = create(:user)
+    user2 = create(:user)
+
+    output = with_stubbed_stdout do
+      cmd.run([])
+    end
+
+    expect(output).to have_text_table_row(user1.id,
+                                          user1.email,
+                                          user1.first_name,
+                                          user1.last_name)
+    expect(output).to have_text_table_row(user2.id,
+                                          user2.email,
+                                          user2.first_name,
+                                          user2.last_name)
+  end
+
+  it 'lists the users given users by id' do
+    user1 = create(:user)
+    user2 = create(:user)
+    user3 = create(:user)
+
+    output = with_stubbed_stdout do
+      cmd.run([user1.id, user2.id])
+    end
+
+    expect(output).to have_table_row(user1.id)
+    expect(output).to have_table_row(user2.id)
+    expect(output).not_to have_table_row(user3.id)
+  end
+end

--- a/spec/lib/mcb/commands/users/list_spec.rb
+++ b/spec/lib/mcb/commands/users/list_spec.rb
@@ -8,6 +8,21 @@ describe 'mcb users list' do
     )
   end
 
+  it 'lists all the columns' do
+    user = create(:user)
+
+    output = with_stubbed_stdout do
+      cmd.run([])
+    end
+
+    expect(output).to have_text_table_row(user.id,
+                                          user.email,
+                                          user.sign_in_user_id,
+                                          user.first_name,
+                                          user.last_name,
+                                          user.last_login_date_utc)
+  end
+
   it 'lists all the users by default' do
     user1 = create(:user)
     user2 = create(:user)
@@ -16,27 +31,33 @@ describe 'mcb users list' do
       cmd.run([])
     end
 
-    expect(output).to have_text_table_row(user1.id,
-                                          user1.email,
-                                          user1.first_name,
-                                          user1.last_name)
-    expect(output).to have_text_table_row(user2.id,
-                                          user2.email,
-                                          user2.first_name,
-                                          user2.last_name)
+    expect(output).to have_text_table_row(user1.id)
+    expect(output).to have_text_table_row(user2.id)
   end
 
-  it 'lists the users given users by id' do
+  it 'lists the given users by id' do
     user1 = create(:user)
     user2 = create(:user)
     user3 = create(:user)
 
     output = with_stubbed_stdout do
-      cmd.run([user1.id, user2.id])
+      cmd.run([user1.id.to_s, user2.id.to_s])
     end
 
     expect(output).to have_text_table_row(user1.id)
     expect(output).to have_text_table_row(user2.id)
     expect(output).not_to have_text_table_row(user3.id)
+  end
+
+  it 'lists the given users by email' do
+    user1 = create(:user)
+    user2 = create(:user)
+
+    output = with_stubbed_stdout do
+      cmd.run([user1.email])
+    end
+
+    expect(output).to have_text_table_row(user1.id)
+    expect(output).not_to have_text_table_row(user2.id)
   end
 end

--- a/spec/lib/mcb/commands/users/list_spec.rb
+++ b/spec/lib/mcb/commands/users/list_spec.rb
@@ -1,12 +1,5 @@
 require 'mcb_helper'
 
-RSpec::Matchers.define :have_table_row do |*column_values|
-  match do |actual|
-    actual.match? column_values.join('\s+\|\s+')
-  end
-end
-
-
 describe 'mcb users list' do
   let(:lib_dir) { "#{Rails.root}/lib" }
   let(:cmd) do
@@ -42,8 +35,8 @@ describe 'mcb users list' do
       cmd.run([user1.id, user2.id])
     end
 
-    expect(output).to have_table_row(user1.id)
-    expect(output).to have_table_row(user2.id)
-    expect(output).not_to have_table_row(user3.id)
+    expect(output).to have_text_table_row(user1.id)
+    expect(output).to have_text_table_row(user2.id)
+    expect(output).not_to have_text_table_row(user3.id)
   end
 end

--- a/spec/lib/mcb/commands/users/show_spec.rb
+++ b/spec/lib/mcb/commands/users/show_spec.rb
@@ -1,0 +1,37 @@
+require 'mcb_helper'
+
+describe 'mcb users show' do
+  let(:lib_dir) { "#{Rails.root}/lib" }
+  let(:cmd) do
+    Cri::Command.load_file(
+      "#{lib_dir}/mcb/commands/users/show.rb"
+    )
+  end
+
+  it 'shows the given user' do
+    user = create(:user)
+
+    output = with_stubbed_stdout do
+      cmd.run([user.id])
+    end
+
+    expect(output).to have_text_table_row('id', user.id)
+    expect(output).to have_text_table_row('email', user.email)
+    expect(output).to have_text_table_row('first_name', user.first_name)
+    expect(output).to have_text_table_row('last_name', user.last_name)
+  end
+
+  it "lists the user's providers" do
+    provider = create(:provider)
+    user = create(:user, organisations: [provider.organisations.first])
+
+    output = with_stubbed_stdout do
+      cmd.run([user.id])
+    end
+
+    provider = user.providers.first
+    expect(output).to have_text_table_row(provider.id,
+                                          provider.provider_name,
+                                          provider.provider_code)
+  end
+end

--- a/spec/lib/mcb/commands/users/show_spec.rb
+++ b/spec/lib/mcb/commands/users/show_spec.rb
@@ -8,11 +8,11 @@ describe 'mcb users show' do
     )
   end
 
-  it 'shows the given user' do
+  it 'shows the given user using id' do
     user = create(:user)
 
     output = with_stubbed_stdout do
-      cmd.run([user.id])
+      cmd.run([user.id.to_s])
     end
 
     expect(output).to have_text_table_row('id', user.id)
@@ -21,12 +21,45 @@ describe 'mcb users show' do
     expect(output).to have_text_table_row('last_name', user.last_name)
   end
 
+  it 'shows the given user using email' do
+    user = create(:user)
+
+    output = with_stubbed_stdout do
+      cmd.run([user.email])
+    end
+
+    expect(output).to have_text_table_row('id', user.id)
+    expect(output).to have_text_table_row('email', user.email)
+  end
+
+  it 'shows the given user using sign-in id' do
+    user = create(:user)
+
+    output = with_stubbed_stdout do
+      cmd.run([user.sign_in_user_id])
+    end
+
+    expect(output).to have_text_table_row('id', user.id)
+    expect(output).to have_text_table_row('email', user.email)
+  end
+
+  it "shows an error if user isn't found" do
+    user = create(:user)
+
+    output = with_stubbed_stdout do
+      cmd.run(%w[foobaz])
+    end
+
+    expect(output).to include "User not found: foobaz"
+    expect(output).not_to have_text_table_row('id', user.id)
+  end
+
   it "lists the user's providers" do
     provider = create(:provider)
     user = create(:user, organisations: [provider.organisations.first])
 
     output = with_stubbed_stdout do
-      cmd.run([user.id])
+      cmd.run([user.id.to_s])
     end
 
     provider = user.providers.first

--- a/spec/support/matchers/have_text_table_row.rb
+++ b/spec/support/matchers/have_text_table_row.rb
@@ -1,0 +1,5 @@
+RSpec::Matchers.define :have_text_table_row do |*column_values|
+  match do |actual|
+    actual.match? column_values.join('\s+\|\s+')
+  end
+end

--- a/spec/support/matchers/have_text_table_row.rb
+++ b/spec/support/matchers/have_text_table_row.rb
@@ -1,5 +1,5 @@
 RSpec::Matchers.define :have_text_table_row do |*column_values|
   match do |actual|
-    actual.match? column_values.join('\s+\|\s+')
+    actual.match? '(^\s*|\|\s+)' + column_values.join('\s+\|\s+') + '(\s+\||\s*$)'
   end
 end


### PR DESCRIPTION
### Context

When debugging production problems it's handy to be able to view the user info in production without having to make a db connection.

### Changes proposed in this pull request

Add commands to mcb:
- `mcb user list`
- `mcb user show <id>`
- `mcb user audit <id>`

### Guidance for review

Not sure why CodeClimate is failing, ignoring for now.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
