### PR TITLE
[1472] Add course.toggle_site method, and more

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -227,6 +227,16 @@ class Course < ApplicationRecord
     end
   end
 
+  def add_site!(site:)
+    is_course_new = new? # persist this before we change anything
+    site_status = site_statuses.find_or_create_by!(site: site)
+    site_status.start! unless is_course_new
+  end
+
+  def remove_site!(site:)
+    site_statuses.find_by!(site: site).suspend!
+  end
+
   def sites_not_associated_with_course
     provider.sites - sites
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -226,4 +226,8 @@ class Course < ApplicationRecord
       enrichment.publish(current_user)
     end
   end
+
+  def sites_not_associated_with_course
+    provider.sites - sites
+  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -217,7 +217,7 @@ class Course < ApplicationRecord
   end
 
   def publish_sites
-    site_statuses.status_new_status.each(&:status_running!)
+    site_statuses.status_new_status.each(&:start!)
     site_statuses.status_running.unpublished_on_ucas.each(&:published_on_ucas!)
   end
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -46,6 +46,10 @@ class Site < ApplicationRecord
     self.code ||= pick_next_available_code(available_codes: provider&.unassigned_site_codes)
   end
 
+  def description
+    "#{location_name} (code: #{code})"
+  end
+
 private
 
   def pick_next_available_code(available_codes: [])

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -16,6 +16,9 @@ class SiteStatus < ApplicationRecord
 
   self.table_name = "course_site"
 
+  after_initialize :set_defaults
+  before_validation :set_vac_status
+
   audited associated_with: :course
 
   validate :vac_status_must_be_consistent_with_course_study_mode,
@@ -69,6 +72,16 @@ class SiteStatus < ApplicationRecord
   end
 
 private
+
+  def set_defaults
+    self.status ||= :new_status
+    self.applications_accepted_from ||= Date.today
+    self.publish ||= :unpublished
+  end
+
+  def set_vac_status
+    self.vac_status ||= self.class.default_vac_status_given(study_mode: course.study_mode)
+  end
 
   def vac_status_must_be_consistent_with_course_study_mode
     unless vac_status_consistent_with_course_study_mode?

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -51,6 +51,19 @@ class SiteStatus < ApplicationRecord
   scope :with_vacancies, -> { where.not(vac_status: :no_vacancies) }
   scope :open_for_applications, -> { findable.applications_being_accepted_now.with_vacancies }
 
+  def self.default_vac_status_given(study_mode:)
+    case study_mode
+    when "full_time"
+      :full_time_vacancies
+    when "part_time"
+      :part_time_vacancies
+    when "full_time_or_part_time"
+      :both_full_time_and_part_time_vacancies
+    else
+      raise "Unexpected study mode #{study_mode}"
+    end
+  end
+
   def description
     "#{site.description} – #{status}/#{publish}"
   end

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -51,6 +51,10 @@ class SiteStatus < ApplicationRecord
   scope :with_vacancies, -> { where.not(vac_status: :no_vacancies) }
   scope :open_for_applications, -> { findable.applications_being_accepted_now.with_vacancies }
 
+  def description
+    "#{site.description} – #{status}/#{publish}"
+  end
+
 private
 
   def vac_status_must_be_consistent_with_course_study_mode

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -405,4 +405,14 @@ RSpec.describe Course, type: :model do
       end
     end
   end
+
+  describe "#sites_not_associated_with_course" do
+    let(:first_site) { create(:site) }
+    let(:second_site) { create(:site) }
+    let(:provider) { create(:provider, sites: [first_site, second_site]) }
+    let(:first_site_status) { create(:site_status, :findable, site: first_site) }
+    subject { create(:course, provider: provider, site_statuses: [first_site_status]) }
+
+    its(:sites_not_associated_with_course) { should eq([second_site]) }
+  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -183,22 +183,6 @@ RSpec.describe Course, type: :model do
           its(:site_statuses) { should_not be_empty }
           its(:open_for_applications?) { should be true }
         end
-
-        context 'site statuses applications_being_accepted_now as it open now & future and mix site status as non findable' do
-          let(:subject) {
-            create(:course, with_site_statuses: [
-                     [:findable],
-                     [:with_any_vacancy],
-                     [:default],
-                     [:applications_being_accepted_now],
-                     [:applications_being_accepted_in_future]
-                   ])
-          }
-
-          its(:site_statuses) { should_not be_empty }
-          its(:findable?) { should be true }
-          its(:open_for_applications?) { should be false }
-        end
       end
     end
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -71,4 +71,9 @@ describe Provider, type: :model do
       expect(subject.code).to eq('A')
     end
   end
+
+  describe "description" do
+    subject { build(:site, location_name: 'Foo', code: '1') }
+    its(:description) { should eq 'Foo (code: 1)' }
+  end
 end

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe SiteStatus, type: :model do
   end
 
   describe 'associations' do
+    subject { build(:site_status) }
+
     it { should belong_to(:site) }
     it { should belong_to(:course) }
   end

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -173,4 +173,14 @@ RSpec.describe SiteStatus, type: :model do
     subject { build(:site_status, :running, :unpublished, site: create(:site, location_name: 'Foo', code: '1')) }
     its(:description) { should eq 'Foo (code: 1) – running/unpublished' }
   end
+
+  describe "default_vac_status_given" do
+    subject { SiteStatus }
+    it "should return correct default_vac_status" do
+      expect(subject.default_vac_status_given(study_mode: 'full_time')).to eq :full_time_vacancies
+      expect(subject.default_vac_status_given(study_mode: 'part_time')).to eq :part_time_vacancies
+      expect(subject.default_vac_status_given(study_mode: 'full_time_or_part_time')).to eq :both_full_time_and_part_time_vacancies
+      expect { subject.default_vac_status_given(study_mode: 'foo') }.to raise_error("Unexpected study mode foo")
+    end
+  end
 end

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -185,4 +185,20 @@ RSpec.describe SiteStatus, type: :model do
       expect { subject.default_vac_status_given(study_mode: 'foo') }.to raise_error("Unexpected study mode foo")
     end
   end
+
+  describe "status changes" do
+    describe "when suspending a running, published site status" do
+      subject { create(:site_status, :running, :published).tap(&:suspend!).reload }
+      it { should be_status_suspended }
+      it { should be_unpublished_on_ucas }
+    end
+
+    %i[new suspended discontinued].each do |status|
+      describe "when starting a #{status}, unpublished site status" do
+        subject { create(:site_status, status, :unpublished).tap(&:start!).reload }
+        it { should be_status_running }
+        it { should be_published_on_ucas }
+      end
+    end
+  end
 end

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -168,4 +168,9 @@ RSpec.describe SiteStatus, type: :model do
       end
     end
   end
+
+  describe "description" do
+    subject { build(:site_status, :running, :unpublished, site: create(:site, location_name: 'Foo', code: '1')) }
+    its(:description) { should eq 'Foo (code: 1) – running/unpublished' }
+  end
 end


### PR DESCRIPTION
### Context

These are various model methods that are used by the forthcoming new MCB scripts.

This allows us to toggle sites on courses through MCB as well as present different kinds of data, such as the potential sites that can be attached to a course.

### Changes proposed in this pull request

Implements the new methods, alongside tests.

### Guidance to review

Easiest reviewed commit by commit.

I have not ticked the "Cleaned commit history" because I don't know if I should add more context to the existing 6 commits, or squash them into one. They all do one small method each which I find pleasing but maybe not all reviewers agree.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [ ] Cleaned commit history
- [x] Tested by running locally