### PR TITLE
[1469] Training location code: validations and automatic assignment

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -90,4 +90,8 @@ class Provider < ApplicationRecord
   def accredited_body?
     accrediting_provider == 'Y'
   end
+
+  def unassigned_site_codes
+    Site::POSSIBLE_CODES - sites.pluck(:code)
+  end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -22,6 +22,8 @@ class Site < ApplicationRecord
   include TouchProvider
 
   POSSIBLE_CODES = (('A'..'Z').to_a + ('0'..'9').to_a + ['-']).freeze
+  EASILY_CONFUSED_CODES = %w[1 I 0 O -].freeze # these ought to be assigned last
+  DESIRABLE_CODES = (POSSIBLE_CODES - EASILY_CONFUSED_CODES).freeze
 
   before_validation :assign_code, unless: :persisted?
 
@@ -41,6 +43,14 @@ class Site < ApplicationRecord
                    presence: true
 
   def assign_code
-    self.code ||= provider&.unassigned_site_codes&.sample
+    self.code ||= pick_next_available_code(available_codes: provider&.unassigned_site_codes)
+  end
+
+private
+
+  def pick_next_available_code(available_codes: [])
+    available_desirable_codes = available_codes & DESIRABLE_CODES
+    available_undesirable_codes = available_codes & EASILY_CONFUSED_CODES
+    available_desirable_codes.sample || available_undesirable_codes.sample
   end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -32,5 +32,6 @@ class Site < ApplicationRecord
             :postcode,
             presence: true
   validates :postcode, postcode: true
-  validates :code, presence: true
+  validates :code, uniqueness: { scope: :provider_id, case_sensitive: false },
+                   presence: true
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -32,4 +32,5 @@ class Site < ApplicationRecord
             :postcode,
             presence: true
   validates :postcode, postcode: true
+  validates :code, presence: true
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -21,6 +21,10 @@ class Site < ApplicationRecord
   include RegionCode
   include TouchProvider
 
+  POSSIBLE_CODES = (('A'..'Z').to_a + ('0'..'9').to_a + ['-']).freeze
+
+  before_validation :assign_code, unless: :persisted?
+
   audited associated_with: :provider
 
   belongs_to :provider
@@ -33,5 +37,10 @@ class Site < ApplicationRecord
             presence: true
   validates :postcode, postcode: true
   validates :code, uniqueness: { scope: :provider_id, case_sensitive: false },
+                   inclusion: { in: POSSIBLE_CODES, message: "must be A-Z, 0-9 or -" },
                    presence: true
+
+  def assign_code
+    self.code ||= provider&.unassigned_site_codes&.sample
+  end
 end

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -18,7 +18,6 @@
 
 FactoryBot.define do
   factory :site do
-    sequence(:code, &:to_s)
     location_name { 'Main Site' + rand(1000000).to_s }
     address1 { Faker::Address.street_address }
     address2 { Faker::Address.community }

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -129,4 +129,15 @@ describe Provider, type: :model do
       expect(provider.updated_at).to eq timestamp
     end
   end
+
+  describe '#unassigned_site_codes' do
+    subject { create(:provider, site_count: 0) }
+
+    before do
+      %w[A B C D 1 2 3 -].each { |code| subject.sites << build(:site, code: code) }
+    end
+    let(:expected_unassigned_codes) { ('E'..'Z').to_a + %w[0] + ('4'..'9').to_a }
+
+    its(:unassigned_site_codes) { should eq(expected_unassigned_codes) }
+  end
 end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -32,6 +32,7 @@ describe Provider, type: :model do
   it { is_expected.to validate_uniqueness_of(:location_name).scoped_to(:provider_id) }
   it { is_expected.to validate_uniqueness_of(:code).case_insensitive.scoped_to(:provider_id) }
   it { is_expected.to validate_presence_of(:code) }
+  it { is_expected.to validate_inclusion_of(:code).in_array(Site::POSSIBLE_CODES).with_message('must be A-Z, 0-9 or -') }
 
   describe 'associations' do
     it { should belong_to(:provider) }
@@ -52,6 +53,16 @@ describe Provider, type: :model do
       site.provider.update updated_at: timestamp
       site.touch
       expect(site.provider.updated_at).to eq timestamp
+    end
+  end
+
+  describe 'after running validation' do
+    let(:provider) { create(:provider, site_count: 0) }
+    subject { build(:site, provider: provider) }
+
+    it 'is assigned a valid code by default' do
+      expect { subject.valid? }.to change { subject.code.blank? }.from(true).to(false)
+      expect(subject.errors[:code]).to be_empty
     end
   end
 end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -64,5 +64,11 @@ describe Provider, type: :model do
       expect { subject.valid? }.to change { subject.code.blank? }.from(true).to(false)
       expect(subject.errors[:code]).to be_empty
     end
+
+    it 'is assigned easily-confused codes only when all others have been used up' do
+      (Site::DESIRABLE_CODES - %w[A]).each { |code| create(:site, code: code, provider: provider) }
+      subject.validate
+      expect(subject.code).to eq('A')
+    end
   end
 end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -30,6 +30,7 @@ describe Provider, type: :model do
   it { is_expected.to validate_presence_of(:address3) }
   it { is_expected.to validate_presence_of(:postcode) }
   it { is_expected.to validate_uniqueness_of(:location_name).scoped_to(:provider_id) }
+  it { is_expected.to validate_presence_of(:code) }
 
   describe 'associations' do
     it { should belong_to(:provider) }

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -30,6 +30,7 @@ describe Provider, type: :model do
   it { is_expected.to validate_presence_of(:address3) }
   it { is_expected.to validate_presence_of(:postcode) }
   it { is_expected.to validate_uniqueness_of(:location_name).scoped_to(:provider_id) }
+  it { is_expected.to validate_uniqueness_of(:code).case_insensitive.scoped_to(:provider_id) }
   it { is_expected.to validate_presence_of(:code) }
 
   describe 'associations' do

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -9,15 +9,13 @@ describe 'Sites API v2', type: :request do
     ActionController::HttpAuthentication::Token.encode_credentials(token)
   end
 
-  let(:site1) { create :site, location_name: 'Main site 1' }
-  let(:site2) { create :site, location_name: 'Main site 2' }
-  let(:sites) { [site1, site2] }
-
+  let(:site1) { create :site, location_name: 'Main site 1', provider: provider }
+  let(:site2) { create :site, location_name: 'Main site 2', provider: provider }
+  let!(:sites) { [site1, site2] }
   let!(:provider) {
     create(:provider,
            course_count: 0,
            site_count: 0,
-           sites: sites,
            organisations: [organisation])
   }
 

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -89,8 +89,8 @@ describe 'Sites API v2', type: :request do
 
       it 'has a data section with the correct attributes' do
         json_response = JSON.parse response.body
-        expect(json_response).to eq(
-          "data" => [{
+        expect(json_response["data"]).to match_array([
+          {
             "id" => site1.id.to_s,
             "type" => "sites",
             "attributes" => {
@@ -103,7 +103,8 @@ describe 'Sites API v2', type: :request do
               "postcode" => site1.postcode,
               "region_code" => site1.region_code
             },
-          }, {
+          },
+          {
             "id" => site2.id.to_s,
             "type" => "sites",
             "attributes" => {
@@ -116,11 +117,9 @@ describe 'Sites API v2', type: :request do
               "postcode" => site2.postcode,
               "region_code" => site2.region_code
             }
-          }],
-          "jsonapi" => {
-            "version" => "1.0"
-          }
-        )
+          },
+        ])
+        expect(json_response["jsonapi"]).to eq("version" => "1.0")
       end
     end
 

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -183,7 +183,7 @@ describe 'Sites API v2', type: :request do
     end
 
     context 'when authenticated and authorised' do
-      let(:code)          { 'A3' }
+      let(:code)          { 'A' }
       let(:location_name) { 'New location name' }
       let(:address1)      { 'New street 1' }
       let(:address2)      { 'New street 2' }


### PR DESCRIPTION
### Context
The UCAS Apply system uses training location codes and so each training location assigned to a provider needs one. There's a maximum of 37 single-character codes per provider: `0-9`, `A-Z`, `-`

When a provider creates a new location:
- we need to assign that location a valid campus code
- we should also validate that the code is one that will be accepted downstream
- we want to assign easily-confused codes last

### Changes proposed in this pull request

- `Site` model sets `code` value by default
- active record validations added

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
