### PR TITLE
Add help for all subcommands with `-v -h`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ gem 'config'
 
 # For building cmdline apps (mcb)
 gem 'cri'
+gem 'rainbow'
 
 # Build pretty tables in the terminal
 #   table_print handles ActiveRecord objects and collections really nicely

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -423,6 +423,7 @@ DEPENDENCIES
   pundit
   rails (~> 5.2.3)
   rails-controller-testing
+  rainbow
   rb-readline
   rspec-its
   rspec-json_matchers

--- a/README.md
+++ b/README.md
@@ -176,6 +176,16 @@ commands available, and is accessable with the `--help` option:
 
 ```
 bin/mcb --help
+or
+bin/mcb -h
+```
+
+For a full list of subcommands:
+
+```
+bin/mcb --verbose --help
+or
+bin/mcb -v -h
 ```
 
 Commands for mcb are defined in `lib/mcb/commands` and any new commands should

--- a/bin/mcb
+++ b/bin/mcb
@@ -9,6 +9,7 @@
 
 require 'ap'
 require 'cri'
+require 'rainbow'
 require 'pry'
 require 'table_print'
 require 'terminal-table'
@@ -36,12 +37,26 @@ $mcb = Cri::Command.define do
 
   flag :h, :help, 'show help for this command' do |_value, cmd|
     puts cmd.help
+    if $verbosity == :verbose
+      puts
+      puts Rainbow("SUBCOMMANDS").red.bright
+      show_all_commands(cmd, "")
+    end
     exit 0
   end
 
   option :c, :config, 'use provided config file',
          argument: :required do |config_file|
     MCB.config_file = config_file
+  end
+end
+
+def show_all_commands(cmd, indent)
+  cmd.commands.each do |c|
+    aligned_cmd_name = (indent + c.name).ljust(20, ' ')
+    coloured_name = Rainbow(aligned_cmd_name).green
+    puts "    #{coloured_name} #{c.summary}"
+    show_all_commands(c, indent + "  ")
   end
 end
 


### PR DESCRIPTION
It's getting harder to find where a command is given the depth and
number of things. Run `bin/mcb -v -h` to see the full list.

![Selection_613](https://user-images.githubusercontent.com/19378/57619781-b8e73500-757e-11e9-8d1d-ff2ed20b75d1.png)
