### PR TITLE
Always show subcommands in help

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,13 +180,5 @@ or
 bin/mcb -h
 ```
 
-For a full list of subcommands:
-
-```
-bin/mcb --verbose --help
-or
-bin/mcb -v -h
-```
-
 Commands for mcb are defined in `lib/mcb/commands` and any new commands should
 be organised in an appropriate sub-folder there.

--- a/bin/mcb
+++ b/bin/mcb
@@ -37,11 +37,9 @@ $mcb = Cri::Command.define do
 
   flag :h, :help, 'show help for this command' do |_value, cmd|
     puts cmd.help
-    if $verbosity == :verbose
-      puts
-      puts Rainbow("SUBCOMMANDS").red.bright
-      show_all_commands(cmd, "")
-    end
+    puts
+    puts Rainbow("SUBCOMMANDS").red.bright
+    show_all_commands(cmd, "")
     exit 0
   end
 


### PR DESCRIPTION
Having slept on it I realise the final output isn't that long anyway.
When I did the -v thing I was imagining showing the full help for every
subcommand.

See #360 for screenshot