### PR TITLE
[1470] allow mcb user audit to use email or sign-in id

### DIFF
--- a/lib/mcb/commands/users/audit.rb
+++ b/lib/mcb/commands/users/audit.rb
@@ -1,12 +1,11 @@
 summary 'Show changes made to a user record'
-param :id
+param :id_or_email_or_sign_in_id
 usage 'audit <id>'
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
-  user_id = args[:id]
-  user = User.find(user_id)
+  user = MCB.find_user_by_identifier args[:id_or_email_or_sign_in_id]
 
   table = Tabulo::Table.new user.audits do |t|
     t.add_column(:user_id, header: "user\nid", width: 6)
@@ -20,5 +19,5 @@ run do |opts, args, _cmd|
                  width: 40)
     t.add_column(:created_at, width: 23)
   end
-  puts table.pack
+  puts table.pack(max_table_width: nil)
 end

--- a/spec/lib/mcb/commands/users/audit_spec.rb
+++ b/spec/lib/mcb/commands/users/audit_spec.rb
@@ -16,11 +16,52 @@ describe 'mcb users audit' do
     user.update(email: 'b@b')
 
     output = with_stubbed_stdout do
-      cmd.run([user.id])
+      cmd.run([user.id.to_s])
     end
 
-    # This test is a bit vague, it doesn't test what is being changed, but I was
-    # having trouble getting that to pass in Travis when I tried it.
-    expect(output).to have_text_table_row(admin_user.id, 'h@i', 'update')
+    expect(output).to have_text_table_row(admin_user.id,
+                                          'h@i',
+                                          'update',
+                                          '',
+                                          '',
+                                          '{"email"=>\["a@a", "b@b"\]}')
+  end
+
+  it 'allows specifying user by email' do
+    user = create(:user, email: 'a@a')
+    admin_user = create :user, :admin, email: 'h@i'
+
+    Audited.store[:audited_user] = admin_user
+    user.update(email: 'b@b')
+
+    output = with_stubbed_stdout do
+      cmd.run([user.email])
+    end
+
+    expect(output).to have_text_table_row(admin_user.id,
+                                          'h@i',
+                                          'update',
+                                          '',
+                                          '',
+                                          '{"email"=>\["a@a", "b@b"\]}')
+  end
+
+  it 'allows specifying user by sign-in id' do
+    user = create(:user, email: 'a@a')
+    admin_user = create :user, :admin, email: 'h@i'
+
+    Audited.store[:audited_user] = admin_user
+    user.update(email: 'b@b')
+
+    output = with_stubbed_stdout do
+      cmd.run([user.sign_in_user_id])
+    end
+
+    expect(output).to have_text_table_row(admin_user.id,
+                                          'h@i',
+                                          'update',
+                                          '',
+                                          '',
+                                          '{"email"=>\["a@a", "b@b"\]}')
   end
 end


### PR DESCRIPTION
### Context

This was done for `mcb user show` and `mcb user list` in a previous PR, but forgot to do it with `audit`.

### Changes proposed in this pull request

Allow users to be specified by email address or sign-in user id with the `mcb user audit` command. 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
