### PR TITLE
1365 create access request endpoint in mc be

### DIFF
--- a/app/controllers/api/v2/access_requests_controller.rb
+++ b/app/controllers/api/v2/access_requests_controller.rb
@@ -16,10 +16,22 @@ module API
         render jsonapi: @access_requests
       end
 
+      def create
+        authorize AccessRequest # todo, generalise admin auth
+        access_request = AccessRequest.new(access_request_params)
+        access_request.update(requester: @current_user,
+                              request_date_utc: Time.now.utc,
+                              status: :requested)
+      end
+
     private
 
       def build_access_request
         @access_request = authorize AccessRequest.requested.find(params[:id])
+      end
+
+      def access_request_params
+        params.require(:access_request).permit(:email_address, :first_name, :last_name, :organisation, :reason)
       end
     end
   end

--- a/app/policies/access_request_policy.rb
+++ b/app/policies/access_request_policy.rb
@@ -10,4 +10,5 @@ class AccessRequestPolicy
   end
 
   alias_method :index?, :approve?
+  alias_method :create?, :approve?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,7 +75,7 @@ Rails.application.routes.draw do
       resource :sessions
       resources :site_statuses, only: :update
 
-      resources :access_requests, only: %i[update index] do
+      resources :access_requests, only: %i[update index create] do
         post :approve, on: :member
       end
     end

--- a/spec/policies/access_request_policy_spec.rb
+++ b/spec/policies/access_request_policy_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe AccessRequestPolicy do
   subject { described_class }
 
-  permissions :approve?, :index? do
+  permissions :approve?, :index?, :create? do
     let(:access_request) { build(:access_request) }
 
     context 'non-admin user' do


### PR DESCRIPTION
### Context

* C# based manual access request creation in the support console is broken

### Changes proposed in this pull request

* Add new rails endpoint for creating access requests

### Guidance to review

:ship: 

example payload for testing with postman:

```json
{
"email_address": "eee@example.org",
"first_name": "firsty first",
"last_name": "McSecond",
"organisation": "some org",
"reason": "just because"
}
```

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [ ] Cleaned commit history
- [x] Tested by running locally

This is an asynchronous tim/david collaboration