### PR TITLE
[1472] Delete site status when removing site for new courses

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -234,7 +234,8 @@ class Course < ApplicationRecord
   end
 
   def remove_site!(site:)
-    site_statuses.find_by!(site: site).suspend!
+    site_status = site_statuses.find_by!(site: site)
+    new? ? site_status.destroy! : site_status.suspend!
   end
 
   def sites_not_associated_with_course

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -457,6 +457,11 @@ RSpec.describe Course, type: :model do
         expect { subject.add_site!(site: existing_site) }.
           to_not change { existing_site_status.reload.status }.from("new_status")
       end
+
+      it "removes the site status when an existing site is removed" do
+        expect { subject.remove_site!(site: existing_site) }.to change { subject.reload.site_statuses.size }.
+          from(1).to(0)
+      end
     end
 
     context "for suspended courses" do


### PR DESCRIPTION

### Context
If a publisher adds and then removes a training location on a course
before course is published, they wouldn't expect it to come back once
they've set the course to running.

### Changes proposed in this pull request
To achieve this, we need to delete the site status, but only when the
course is new. If it's being removed post-publication, it should be suspended
as before.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
