### PR TITLE
Add env username

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,12 +37,14 @@ steps:
   displayName: 'Execute tests'
   env:
     DOCKER_OVERRIDE: $(dockerOverride)
+    dockerHubUsername: $(dockerHubUsername)
 
 - script: |
     $DOCKER_OVERRIDE exec -T web /bin/sh -c "bundle exec rubocop app config db lib spec --format clang"
   displayName: 'Execute linters'
   env:
     DOCKER_OVERRIDE: $(dockerOverride)
+    dockerHubUsername: $(dockerHubUsername)
 
 - task: Docker@1
   displayName: Tag image with current build number $(Build.BuildNumber)


### PR DESCRIPTION
### Context
Some tasks were reporting the dockerHubUsername variable was not set

### Changes proposed in this pull request
Add env var for this value

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
