### PR TITLE
[1493] Add create endpoint for sites

### DIFF
--- a/app/controllers/api/v2/sites_controller.rb
+++ b/app/controllers/api/v2/sites_controller.rb
@@ -1,16 +1,28 @@
 module API
   module V2
     class SitesController < API::V2::ApplicationController
-      deserializable_resource :site, only: :update
+      deserializable_resource :site, only: %i[update create]
 
       before_action :build_provider
-      before_action :build_site, except: :index
+      before_action :build_site, except: %i[index create]
 
       def index
         authorize @provider, :can_list_courses?
         authorize Site
 
         render jsonapi: @provider.sites
+      end
+
+      def create
+        @site = Site.new(site_params)
+        @site.provider = @provider
+        authorize @site
+
+        if @site.save!
+          render jsonapi: @site
+        else
+          render jsonapi_errors: @site.errors, status: :unprocessable_entity
+        end
       end
 
       def update

--- a/app/policies/site_policy.rb
+++ b/app/policies/site_policy.rb
@@ -15,4 +15,5 @@ class SitePolicy
   end
 
   alias_method :update?, :show?
+  alias_method :create?, :show?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,7 @@ Rails.application.routes.draw do
           post :sync_with_search_and_compare, on: :member
           post :publish, on: :member
         end
-        resources :sites, only: %i[index update show]
+        resources :sites, only: %i[index update show create]
       end
 
       resource :sessions

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -358,4 +358,98 @@ describe 'Sites API v2', type: :request do
       end
     end
   end
+
+  describe 'POST create' do
+    def perform_site_create
+      post(
+        api_v2_provider_sites_path(provider.provider_code),
+        headers: { 'HTTP_AUTHORIZATION' => credentials },
+        params: params
+      )
+    end
+
+    let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+    let(:params) do
+      {
+        _jsonapi: jsonapi_renderer.render(
+          site1,
+          class: {
+            Site: API::V2::SerializableSite
+          }
+        )
+      }
+    end
+    let(:site_params) { params.dig :_jsonapi, :data, :attributes }
+
+    context 'when unauthenticated' do
+      let(:payload) { { email: 'foo@bar' } }
+
+      subject { response }
+
+      before do
+        perform_site_create
+      end
+
+      it { should have_http_status(:unauthorized) }
+    end
+
+    context 'when authenticated and authorised' do
+      let(:code)          { 'FOO' }
+      let(:location_name) { 'Location name' }
+      let(:address1)      { 'Street 1' }
+      let(:address2)      { 'Street 2' }
+      let(:address3)      { 'City' }
+      let(:address4)      { 'State' }
+      let(:postcode)      { 'SW1A 1AA' }
+      let(:region_code)   { 'west_midlands' }
+
+      let(:site) { provider.sites.last }
+
+      before do
+        site_params.merge!(
+          code: code,
+          location_name: location_name,
+          address1: address1,
+          address2: address2,
+          address3: address3,
+          address4: address4,
+          postcode: postcode,
+          region_code: region_code
+        )
+        perform_site_create
+      end
+
+      it 'sets the location name of the site' do
+        expect(site.location_name).to eq(location_name)
+      end
+
+      it 'does not set the code of the site' do
+        expect(site.code).to_not eq(code)
+      end
+
+      it 'sets the address1 of the site' do
+        expect(site.address1).to eq(address1)
+      end
+
+      it 'sets the address2 of the site' do
+        expect(site.address2).to eq(address2)
+      end
+
+      it 'sets the address3 of the site' do
+        expect(site.address3).to eq(address3)
+      end
+
+      it 'sets the address4 of the site' do
+        expect(site.address4).to eq(address4)
+      end
+
+      it 'sets the postcode of the site' do
+        expect(site.postcode).to eq(postcode)
+      end
+
+      it 'sets the region_code of the site' do
+        expect(site.region_code).to eq(region_code)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

Adds a create endpoint which is similar to the other endpoints.

The validations and response are not exhaustively tested as the `update` endpoint already covers them and this endpoint does not differ significantly.

### Changes proposed in this pull request

- Adds the `sites#create` controller action, route, authorisation

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally