### PR TITLE
[1497] Add can_add_more_sites? to provider serializer

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -94,4 +94,8 @@ class Provider < ApplicationRecord
   def unassigned_site_codes
     Site::POSSIBLE_CODES - sites.pluck(:code)
   end
+
+  def can_add_more_sites?
+    sites.size < Site::POSSIBLE_CODES.size
+  end
 end

--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -3,7 +3,7 @@ module API
     class SerializableProvider < JSONAPI::Serializable::Resource
       type 'providers'
 
-      attributes :provider_code, :provider_name, :accredited_body?
+      attributes :provider_code, :provider_name, :accredited_body?, :can_add_more_sites?
 
       has_many :sites
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -140,4 +140,16 @@ describe Provider, type: :model do
 
     its(:unassigned_site_codes) { should eq(expected_unassigned_codes) }
   end
+
+  describe "#can_add_more_sites?" do
+    context "when provider has less sites than max allowed" do
+      subject { create(:provider, site_count: 0) }
+      its(:can_add_more_sites?) { should be_truthy }
+    end
+
+    context "when provider has the max sites allowed" do
+      subject { create(:provider, site_count: Site::POSSIBLE_CODES.size) }
+      its(:can_add_more_sites?) { should be_falsey }
+    end
+  end
 end

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -45,6 +45,7 @@ describe 'Providers API v2', type: :request do
               "provider_code" => provider.provider_code,
               "provider_name" => provider.provider_name,
               "accredited_body?" => false,
+              "can_add_more_sites?" => true
             },
             "relationships" => {
               "sites" => {
@@ -81,6 +82,7 @@ describe 'Providers API v2', type: :request do
               "provider_code" => provider.provider_code,
               "provider_name" => provider.provider_name,
               "accredited_body?" => false,
+              "can_add_more_sites?" => true
             },
             "relationships" => {
               "sites" => {
@@ -163,6 +165,7 @@ describe 'Providers API v2', type: :request do
             "provider_code" => provider.provider_code,
             "provider_name" => provider.provider_name,
             "accredited_body?" => false,
+            "can_add_more_sites?" => true
           },
           "relationships" => {
             "sites" => {
@@ -201,6 +204,7 @@ describe 'Providers API v2', type: :request do
                 "provider_code" => provider.provider_code,
                 "provider_name" => provider.provider_name,
                 "accredited_body?" => false,
+                "can_add_more_sites?" => true
               },
               "relationships" => {
                 "sites" => {
@@ -233,6 +237,20 @@ describe 'Providers API v2', type: :request do
             }
           )
         end
+      end
+    end
+
+    context "with the maximum number of sites" do
+      let(:provider) { create(:provider, course_count: 0, site_count: Site::POSSIBLE_CODES.size, organisations: [organisation]) }
+
+      before do
+        get "/api/v2/providers/#{provider.provider_code}",
+            headers: { 'HTTP_AUTHORIZATION' => credentials }
+      end
+
+      it 'has can_add_more_sites? set to false' do
+        json_response = JSON.parse(response.body)
+        expect(json_response["data"]["attributes"]["can_add_more_sites?"]).to eq(false)
       end
     end
 

--- a/spec/serializers/api/v2/serializable_provider_spec.rb
+++ b/spec/serializers/api/v2/serializable_provider_spec.rb
@@ -14,6 +14,7 @@ describe API::V2::SerializableProvider do
   it {
     should be_json.with_content(attributes: { provider_code: provider.provider_code,
                                               provider_name: provider.provider_name,
-                                              accredited_body?: true })
+                                              accredited_body?: true,
+                                              can_add_more_sites?: true })
   }
 end


### PR DESCRIPTION
### Context

We need to hide the button to add new locations when this is false.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally