### PR TITLE
[1491] Create endpoint returns the created access request

### DIFF
--- a/app/controllers/api/v2/access_requests_controller.rb
+++ b/app/controllers/api/v2/access_requests_controller.rb
@@ -22,6 +22,8 @@ module API
         access_request.update(requester: @current_user,
                               request_date_utc: Time.now.utc,
                               status: :requested)
+
+        render jsonapi: access_request
       end
 
     private

--- a/spec/requests/api/v2/access_request_spec.rb
+++ b/spec/requests/api/v2/access_request_spec.rb
@@ -221,6 +221,23 @@ describe 'Access Request API V2', type: :request do
         Timecop.return
       end
 
+      it 'returns the correct id' do
+        string_id = JSON.parse(response.body)["data"]['id']
+        id = Integer(string_id)
+
+        expect(id).to be > 0
+      end
+
+      describe 'JSON returns the correct attributes' do
+        subject { JSON.parse(response.body)["data"]['attributes'] }
+
+        its(%w[email_address]) { should eq('bob@example.org') }
+        its(%w[first_name]) { should eq('bob') }
+        its(%w[last_name]) { should eq('monkhouse') }
+        its(%w[organisation]) { should eq('bbc') }
+        its(%w[reason]) { should eq('star qualities') }
+      end
+
       context 'with a user that does not already exist' do
         it 'should create the access_request record' do
           expect(response).to have_http_status(:success)

--- a/spec/requests/api/v2/access_request_spec.rb
+++ b/spec/requests/api/v2/access_request_spec.rb
@@ -60,8 +60,14 @@ describe 'Access Request API V2', type: :request do
       let!(:second_access_request) { create(:access_request) }
 
       before do
+        Timecop.freeze
         access_requests_index_route
       end
+
+      after do
+        Timecop.return
+      end
+
 
       it 'JSON displays the correct attributes' do
         json_response = JSON.parse response.body


### PR DESCRIPTION

### Context
The create endpoint should return an access request when hit. This is needed in the support app to hit the approve endpoint.

### Changes proposed in this pull request
Returns the access request created via jsonapi.
