### PR TITLE
[1464] raise error when assigning to unpermitted attributes

### DIFF
--- a/app/controllers/api/v2/sessions_controller.rb
+++ b/app/controllers/api/v2/sessions_controller.rb
@@ -22,7 +22,13 @@ module API
       def create_params
         validate_jsonapi_type(params, 'sessions')
 
-        params.require(:session).permit(:first_name, :last_name)
+        params
+          .require(:session)
+          .except(:id, :type)
+          .permit(
+            :first_name,
+            :last_name
+          )
       end
     end
   end

--- a/app/controllers/api/v2/site_statuses_controller.rb
+++ b/app/controllers/api/v2/site_statuses_controller.rb
@@ -13,12 +13,15 @@ module API
     private
 
       def site_status_params
-        params.require(:site_status).permit(
-          :applications_accepted_from,
-          :publish,
-          :status,
-          :vac_status
-        )
+        params
+          .require(:site_status)
+          .except(:id, :type, :site_id, :site_type)
+          .permit(
+            :applications_accepted_from,
+            :publish,
+            :status,
+            :vac_status
+          )
       end
     end
   end

--- a/app/controllers/api/v2/sites_controller.rb
+++ b/app/controllers/api/v2/sites_controller.rb
@@ -42,15 +42,18 @@ module API
     private
 
       def site_params
-        params.require(:site).permit(
-          :location_name,
-          :address1,
-          :address2,
-          :address3,
-          :address4,
-          :postcode,
-          :region_code
-        )
+        params
+          .require(:site)
+          .except(:id, :type)
+          .permit(
+            :location_name,
+            :address1,
+            :address2,
+            :address3,
+            :address4,
+            :postcode,
+            :region_code
+          )
       end
 
       def build_provider

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -28,17 +28,20 @@ module API
       end
 
       def user_params
-        params.require(:user).permit(
-          :email,
-          :first_name,
-          :last_name,
-          :first_login_date_utc,
-          :last_login_date_utc,
-          :sign_in_user_id,
-          :welcome_email_date_utc,
-          :invite_date_utc,
-          :accept_terms_date_utc,
-        )
+        params
+          .require(:user)
+          .except(:id, :type)
+          .permit(
+            :email,
+            :first_name,
+            :last_name,
+            :first_login_date_utc,
+            :last_login_date_utc,
+            :sign_in_user_id,
+            :welcome_email_date_utc,
+            :invite_date_utc,
+            :accept_terms_date_utc,
+          )
       end
     end
   end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,7 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
+
+Rails.application.configure do
+  config.action_controller.action_on_unpermitted_parameters = :raise
+end

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -144,13 +144,15 @@ describe 'Sites API v2', type: :request do
 
     let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
     let(:params) do
+      # simulate the JSONAPI params we would send in, but be sure to remove
+      # 'code' which is automatically included by the serialiser
       {
         _jsonapi: jsonapi_renderer.render(
           site1,
           class: {
             Site: API::V2::SerializableSite
           }
-        )
+        ).tap { |json| json[:data][:attributes].delete :code }
       }
     end
     let(:site_params) { params.dig :_jsonapi, :data, :attributes }
@@ -196,7 +198,6 @@ describe 'Sites API v2', type: :request do
 
       before do
         site_params.merge!(
-          code: code,
           location_name: location_name,
           address1: address1,
           address2: address2,
@@ -370,13 +371,15 @@ describe 'Sites API v2', type: :request do
 
     let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
     let(:params) do
+      # simulate the JSONAPI params we would send in, but be sure to remove
+      # 'code' which is automatically included by the serialiser
       {
         _jsonapi: jsonapi_renderer.render(
           site1,
           class: {
             Site: API::V2::SerializableSite
           }
-        )
+        ).tap { |json| json[:data][:attributes].delete :code }
       }
     end
     let(:site_params) { params.dig :_jsonapi, :data, :attributes }
@@ -405,56 +408,76 @@ describe 'Sites API v2', type: :request do
 
       let(:site) { provider.sites.last }
 
-      before do
-        site_params.merge!(
-          code: code,
-          location_name: location_name,
-          address1: address1,
-          address2: address2,
-          address3: address3,
-          address4: address4,
-          postcode: postcode,
-          region_code: region_code
-        )
-        perform_site_create
+      describe 'permitted parameters' do
+        before do
+          site_params.merge!(
+            location_name: location_name,
+            address1: address1,
+            address2: address2,
+            address3: address3,
+            address4: address4,
+            postcode: postcode,
+            region_code: region_code
+          )
+          perform_site_create
+        end
+
+        it 'sets the location name of the site' do
+          expect(site.location_name).to eq(location_name)
+        end
+
+        it 'sets the address1 of the site' do
+          expect(site.address1).to eq(address1)
+        end
+
+        it 'sets the address2 of the site' do
+          expect(site.address2).to eq(address2)
+        end
+
+        it 'sets the address3 of the site' do
+          expect(site.address3).to eq(address3)
+        end
+
+        it 'sets the address4 of the site' do
+          expect(site.address4).to eq(address4)
+        end
+
+        it 'sets the postcode of the site' do
+          expect(site.postcode).to eq(postcode)
+        end
+
+        it 'sets the region_code of the site' do
+          expect(site.region_code).to eq(region_code)
+        end
       end
 
-      it 'sets the location name of the site' do
-        expect(site.location_name).to eq(location_name)
+      describe 'unpermitted parameters' do
+        before do
+          site_params.merge!(
+            code: code
+          )
+        end
+
+        it 'raises an error when trying to set the site code' do
+          expect {
+            perform_site_create
+          }.to raise_error(ActionController::UnpermittedParameters)
+        end
       end
 
-      it 'does not set the code of the site' do
-        expect(site.code).to_not eq(code)
-      end
-
-      it 'sets the address1 of the site' do
-        expect(site.address1).to eq(address1)
-      end
-
-      it 'sets the address2 of the site' do
-        expect(site.address2).to eq(address2)
-      end
-
-      it 'sets the address3 of the site' do
-        expect(site.address3).to eq(address3)
-      end
-
-      it 'sets the address4 of the site' do
-        expect(site.address4).to eq(address4)
-      end
-
-      it 'sets the postcode of the site' do
-        expect(site.postcode).to eq(postcode)
-      end
-
-      it 'sets the region_code of the site' do
-        expect(site.region_code).to eq(region_code)
-      end
-
-      context 'response output with validation errors' do
+      describe 'response output with validation errors' do
         let(:json_data) { JSON.parse(response.body)['errors'] }
 
         before do
+          site_params.merge!(
+            location_name: location_name,
+            address1: address1,
+            address2: address2,
+            address3: address3,
+            address4: address4,
+            postcode: postcode,
+            region_code: region_code
+          )
           perform_site_create
         end
 

--- a/spec/requests/api/v2/session_spec.rb
+++ b/spec/requests/api/v2/session_spec.rb
@@ -95,17 +95,22 @@ describe '/api/v2/sessions', type: :request do
           expect(user.last_name).to eq "updated last_name"
         end
       end
+    end
 
-      context "unpermitted fields" do
-        let(:attributes) do
-          {
-            "email" => "updated first_name",
-          }
-        end
+    context 'unpermitted parameters' do
+      let(:type) { "sessions" }
+      let(:attributes) do
+        {
+          "email" => "updated first_name",
+        }
+      end
 
-        it 'returns the user record with old email' do
-          expect(returned_json_response['data']).to have_attribute(:email).with_value(user.email)
-        end
+      it 'returns the user record with old email' do
+        expect {
+          post '/api/v2/sessions',
+               headers: { 'HTTP_AUTHORIZATION' => credentials },
+               params: params
+        }.to raise_error(ActionController::UnpermittedParameters)
       end
     end
 

--- a/spec/requests/api/v2/users_spec.rb
+++ b/spec/requests/api/v2/users_spec.rb
@@ -73,13 +73,15 @@ describe '/api/v2/users', type: :request do
     context 'when authenticated and authorised' do
       let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
       let(:params) do
+        # simulate the JSONAPI params we would send in, but be sure to remove
+        # 'state' which is automatically included by the serialiser
         {
           _jsonapi: jsonapi_renderer.render(
             user,
             class: {
               User: API::V2::SerializableUser
             }
-          )
+          ).tap { |json| json[:data][:attributes].delete :state }
         }
       end
       let(:user_params)           { params.dig :_jsonapi, :data, :attributes }


### PR DESCRIPTION
This changes the behaviour from the default which ignores mass-assigns to
unpermitted attribute, to one that raises an error. For an API it seems
sensible to be more strict about what's coming in and going out this way.

### Context

This really starts to make sense for course updates where we are only allowed to update attributes that are in the enrichments, but even so there are fields such as code that we won't allow updating.

By raising an exceptions here it'll be more obvious in our testing that we haven't enabled it. If this gets noisy in production with false negatives, then we can always revert to just logging there.

### Changes proposed in this pull request

Change configuration to raise when an unpermitted parameter is being set. Change tests that broke as a result.

### Guidance to review

Some testing was done locally to ensure that sign-ins, location updates and vacancy updates still worked. So far everything appears to be good.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
