### PR TITLE
1429 snc serializer part 1

### DIFF
--- a/app/serializers/search_and_compare/course_serializer.rb
+++ b/app/serializers/search_and_compare/course_serializer.rb
@@ -1,5 +1,10 @@
 module SearchAndCompare
   class CourseSerializer < ActiveModel::Serializer
+    # Provider_serializer_Mapping
+    # Covered by
+    has_one :provider, key: :Provider, serializer: SearchAndCompare::ProviderSerializer
+    has_one :accrediting_provider, key: :AccreditingProvider, serializer: SearchAndCompare::ProviderSerializer
+
     # Course_default_value_Mapping
     attribute(:Id)                                    { 0 }
     attribute(:ProviderCodeName)                      { nil }

--- a/app/serializers/search_and_compare/course_serializer.rb
+++ b/app/serializers/search_and_compare/course_serializer.rb
@@ -1,0 +1,15 @@
+module SearchAndCompare
+  class CourseSerializer < ActiveModel::Serializer
+    # Course_default_value_Mapping
+    attribute(:Id)                                    { 0 }
+    attribute(:ProviderCodeName)                      { nil }
+    attribute(:ProviderId)                            { 0 }
+    attribute(:AccreditingProviderId)                 { nil }
+    attribute(:AgeRange)                              { 0 }
+    attribute(:RouteId)                               { 0 }
+    attribute(:ProviderLocationId)                    { nil }
+    attribute(:Distance)                              { nil }
+    attribute(:DistanceAddress)                       { nil }
+    attribute(:ContactDetailsId)                      { nil }
+  end
+end

--- a/app/serializers/search_and_compare/course_serializer.rb
+++ b/app/serializers/search_and_compare/course_serializer.rb
@@ -11,5 +11,11 @@ module SearchAndCompare
     attribute(:Distance)                              { nil }
     attribute(:DistanceAddress)                       { nil }
     attribute(:ContactDetailsId)                      { nil }
+
+    # Course_direct_simple_Mapping
+    attribute(:Name)                                  { object.name }
+    attribute(:ProgrammeCode)                         { object.course_code }
+    # using server time not utc, so it's local time?
+    attribute(:StartDate)                             { object.start_date.utc.strftime('%Y-%m-%dT%H:%M:%S') }
   end
 end

--- a/app/serializers/search_and_compare/provider_serializer.rb
+++ b/app/serializers/search_and_compare/provider_serializer.rb
@@ -1,0 +1,12 @@
+module SearchAndCompare
+  class ProviderSerializer < ActiveModel::Serializer
+    # Provider_default_value_Mapping
+    attribute(:Id)                                    { 0 }
+    attribute(:Courses)                               { nil }
+    attribute(:AccreditedCourses)                     { nil }
+
+    # Provider_direct_simple_Mapping
+    attribute(:Name)                                  { object.provider_name }
+    attribute(:ProviderCode)                          { object.provider_code }
+  end
+end

--- a/spec/serializers/search_and_compare/course_serializer_spec.rb
+++ b/spec/serializers/search_and_compare/course_serializer_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe SearchAndCompare::CourseSerializer do
+  let(:course) { create :course }
+
+  describe 'json output' do
+    let(:resource) { serialize(course, serializer_class: described_class) }
+
+    subject { resource }
+    context 'an existing course' do
+      let(:course) do
+        create :course
+      end
+      let(:expected_json) do
+        file = File.read("#{Dir.pwd}/spec/serializers/search_and_compare/test_data.json")
+        HashWithIndifferentAccess.new(JSON.parse(file))
+      end
+
+
+      describe 'Course_default_value_Mapping' do
+        it { should include(Id: 0) }
+        it { should include(ProviderCodeName: nil) }
+        it { should include(ProviderId: 0) }
+        it { should include(AccreditingProviderId: nil) }
+        it { should include(AgeRange: 0) }
+        it { should include(RouteId: 0) }
+        it { should include(ProviderLocationId: nil) }
+        it { should include(Distance: nil) }
+        it { should include(DistanceAddress: nil) }
+        it { should include(ContactDetailsId: nil) }
+      end
+
+      # should work fine once hardcoded/db ones are flushed out
+      xit { should eq expected_json }
+    end
+  end
+end

--- a/spec/serializers/search_and_compare/course_serializer_spec.rb
+++ b/spec/serializers/search_and_compare/course_serializer_spec.rb
@@ -8,8 +8,16 @@ describe SearchAndCompare::CourseSerializer do
 
     subject { resource }
     context 'an existing course' do
+      let(:course_factory_args) do
+        {
+          name: expected_json[:Name],
+          course_code: expected_json[:ProgrammeCode],
+          start_date: expected_json[:StartDate],
+        }
+      end
+
       let(:course) do
-        create :course
+        create :course, **course_factory_args
       end
       let(:expected_json) do
         file = File.read("#{Dir.pwd}/spec/serializers/search_and_compare/test_data.json")
@@ -28,6 +36,12 @@ describe SearchAndCompare::CourseSerializer do
         it { should include(Distance: nil) }
         it { should include(DistanceAddress: nil) }
         it { should include(ContactDetailsId: nil) }
+      end
+
+      describe 'Course_direct_Mapping' do
+        it { should include(Name: course.name) }
+        it { should include(ProgrammeCode: course.course_code) }
+        it { should include(StartDate: course.start_date) }
       end
 
       # should work fine once hardcoded/db ones are flushed out

--- a/spec/serializers/search_and_compare/course_serializer_spec.rb
+++ b/spec/serializers/search_and_compare/course_serializer_spec.rb
@@ -1,15 +1,16 @@
 require 'rails_helper'
 
 describe SearchAndCompare::CourseSerializer do
-  let(:course) { create :course }
-
   describe 'json output' do
     let(:resource) { serialize(course, serializer_class: described_class) }
 
     subject { resource }
+
     context 'an existing course' do
       let(:course_factory_args) do
         {
+          provider: provider,
+          accrediting_provider: accrediting_provider,
           name: expected_json[:Name],
           course_code: expected_json[:ProgrammeCode],
           start_date: expected_json[:StartDate],
@@ -19,11 +20,52 @@ describe SearchAndCompare::CourseSerializer do
       let(:course) do
         create :course, **course_factory_args
       end
+
+      let(:provider) do
+        create :provider,
+               provider_code: expected_json[:Provider][:ProviderCode],
+               provider_name: expected_json[:Provider][:Name]
+      end
+      let(:accrediting_provider) do
+        create :provider,
+               provider_code: expected_json[:AccreditingProvider][:ProviderCode],
+               provider_name: expected_json[:AccreditingProvider][:Name]
+      end
+
       let(:expected_json) do
         file = File.read("#{Dir.pwd}/spec/serializers/search_and_compare/test_data.json")
         HashWithIndifferentAccess.new(JSON.parse(file))
       end
 
+      describe 'Provider_serializer_Mapping' do
+        # testing the provider serializer, its part of the json
+        describe 'Provider' do
+          subject { resource[:Provider] }
+          describe 'Provider_default_value_Mapping' do
+            it { should include(Id: 0) }
+            it { should include(Courses: nil) }
+            it { should include(AccreditedCourses: nil) }
+          end
+          describe 'Provider_direct_simple_Mappting' do
+            it { should include(Name: provider.provider_name) }
+            it { should include(ProviderCode: provider.provider_code) }
+          end
+        end
+
+        describe 'AccreditingProvider' do
+          subject { resource[:AccreditingProvider] }
+
+          describe 'Provider_default_value_Mapping' do
+            it { should include(Id: 0) }
+            it { should include(Courses: nil) }
+            it { should include(AccreditedCourses: nil) }
+          end
+          describe 'Provider_direct_simple_Mappting' do
+            it { should include(Name: accrediting_provider.provider_name) }
+            it { should include(ProviderCode: accrediting_provider.provider_code) }
+          end
+        end
+      end
 
       describe 'Course_default_value_Mapping' do
         it { should include(Id: 0) }

--- a/spec/serializers/search_and_compare/mappings.yaml
+++ b/spec/serializers/search_and_compare/mappings.yaml
@@ -12,6 +12,12 @@ Course_default_value_Mapping: &Course_default_value
   DistanceAddress:
   ContactDetailsId:
 
+Course_direct_simple_Mapping: &Course_direct_simple
+  Name: "name"
+  ProgrammeCode: "course_code"
+  StartDate: "start_date"
+
   # Actual course
 Course_Full_Mapping:
   <<: *Course_default_value
+  <<: *Course_direct_simple

--- a/spec/serializers/search_and_compare/mappings.yaml
+++ b/spec/serializers/search_and_compare/mappings.yaml
@@ -1,0 +1,17 @@
+---
+#Course mappings
+Course_default_value_Mapping: &Course_default_value
+  Id: 0
+  ProviderCodeName:
+  ProviderId: 0
+  AccreditingProviderId:
+  AgeRange: 0
+  RouteId: 0
+  ProviderLocationId:
+  Distance:
+  DistanceAddress:
+  ContactDetailsId:
+
+  # Actual course
+Course_Full_Mapping:
+  <<: *Course_default_value

--- a/spec/serializers/search_and_compare/mappings.yaml
+++ b/spec/serializers/search_and_compare/mappings.yaml
@@ -17,7 +17,28 @@ Course_direct_simple_Mapping: &Course_direct_simple
   ProgrammeCode: "course_code"
   StartDate: "start_date"
 
-  # Actual course
+#Provider mappings
+Provider_default_value_Mapping: &Provider_default_value
+  Id: 0
+  Courses:
+  AccreditedCourses:
+
+Provider_direct_simple_Mapping: &Provider_direct_simple
+  Name: provider_name
+  ProviderCode: provider_code
+
+Provider_Mapping: &Provider # Has a provider
+  <<: *Provider_default_value
+  <<: *Provider_direct_simple
+
+Provider_serializer_Mapping: &Provider_serializer
+  Provider: # Has a provider
+    <<: *Provider
+  AccreditingProvider: # Optional accrediting provider (provider type)
+    <<: *Provider
+
+# Actual course
 Course_Full_Mapping:
+  <<: *Provider_serializer
   <<: *Course_default_value
   <<: *Course_direct_simple

--- a/spec/serializers/search_and_compare/provider_serializer_spec.rb
+++ b/spec/serializers/search_and_compare/provider_serializer_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe SearchAndCompare::ProviderSerializer do
+  let(:provider) { create :provider }
+
+  describe 'json output' do
+    let(:resource) { serialize(provider, serializer_class: described_class) }
+
+    subject { resource }
+
+    describe 'Provider_default_value_Mapping' do
+      it { should include(Id: 0) }
+      it { should include(Courses: nil) }
+      it { should include(AccreditedCourses: nil) }
+    end
+
+    describe 'Provider_direct_simple_Mappting' do
+      it { should include(Name: provider.provider_name) }
+      it { should include(ProviderCode: provider.provider_code) }
+    end
+  end
+end

--- a/spec/serializers/search_and_compare/test_data.json
+++ b/spec/serializers/search_and_compare/test_data.json
@@ -1,0 +1,204 @@
+{
+  "Id": 0,
+  "Name": "Primary",
+  "ProgrammeCode": "22FV",
+  "ProviderCodeName": null,
+  "ProviderId": 0,
+  "Provider": {
+    "Id": 0,
+    "Name": "Bowes Primary School",
+    "ProviderCode": "189",
+    "Courses": null,
+    "AccreditedCourses": null
+  },
+  "AccreditingProviderId": null,
+  "AccreditingProvider": {
+    "Id": 0,
+    "Name": "Middlesex University",
+    "ProviderCode": "M80",
+    "Courses": null,
+    "AccreditedCourses": null
+  },
+  "AgeRange": 0,
+  "RouteId": 0,
+  "Route": {
+    "Id": 0,
+    "Name": "School Direct (salaried) training programme",
+    "IsSalaried": true,
+    "Courses": null
+  },
+  "IncludesPgce": 1,
+  "DescriptionSections": [
+    {
+      "Id": 0,
+      "Ordinal": 0,
+      "Name": "about this training programme",
+      "Text": "School Direct is a school-led teacher training route where the majority of your time will be spent in your training school. The content and the focus of the training programme will be targeted to meet your individual needs. You will also have the benefit of receiving training from Middlesex University and making use of their extensive resources, including the library and student support services. \r\n\r\nOur School Direct programme also provides you with the opportunity to gain a postgraduate qualification (PGCert Teaching), which can be used towards a Masters award in the future. This will enable you to develop your skills for teaching and for understanding the interrelationship between learning and teaching, as you develop into a critically reflective practitioner. ",
+      "CourseId": 0,
+      "Course": null
+    },
+    {
+      "Id": 0,
+      "Ordinal": 0,
+      "Name": "interview process",
+      "Text": "Bowes Primary School, as the Lead school in the partnership, will coordinate the selection and recruitment process. If shortlisted for interview, candidates will spend a full day in school participating in the following: \r\n\r\n* A 20 minute observed session with a small group of children \r\n* A written task\r\n* Presentation\r\n* Group discussion\r\n* A formal individual interview\r\n\r\nMembers of the partnership and Middlesex University will be involved throughout the day and will have an equal say in the selection. It is a rigorous and thorough process to ensure applicants are matched to the employing school.  ",
+      "CourseId": 0,
+      "Course": null
+    },
+    {
+      "Id": 0,
+      "Ordinal": 0,
+      "Name": "about fees",
+      "Text": null,
+      "CourseId": 0,
+      "Course": null
+    },
+    {
+      "Id": 0,
+      "Ordinal": 0,
+      "Name": "about salary",
+      "Text": "All of our School Direct (salaried) trainees are paid on the Unqualified Teacher Pay Scale (Outer London) at a minimum of Point 1. \r\n\r\nThere are no fees to be paid by the candidate. \r\n\r\nThe PGCert element of the programme does not involve a cost to the candidate. ",
+      "CourseId": 0,
+      "Course": null
+    },
+    {
+      "Id": 0,
+      "Ordinal": 0,
+      "Name": "entry requirements",
+      "Text": "You should be a graduate with the following qualifications: \r\n\r\n* A bachelor degree (2:2 or higher)\r\n* GCSE grade C/grade 4, or equivalent, in English, Mathematics and Science. \r\n* We also accept equivalency tests by Equivalency Testing and A Star Teachers. ",
+      "CourseId": 0,
+      "Course": null
+    },
+    {
+      "Id": 0,
+      "Ordinal": 0,
+      "Name": "entry requirements personal qualities",
+      "Text": "We are looking for creative, enthusiastic and hard working trainee teachers who can bring learning to life for our children. Every day in school is different so you will need to be flexible and adaptable. We would like you to have had some experience of working with young people of primary age, but this does not need to be paid work. It could be helping with a sports team, drama group, youth group or voluntary work in schools. We welcome career changers and the skills that can be transferred between professions. ",
+      "CourseId": 0,
+      "Course": null
+    },
+    {
+      "Id": 0,
+      "Ordinal": 0,
+      "Name": "entry requirements other",
+      "Text": null,
+      "CourseId": 0,
+      "Course": null
+    },
+    {
+      "Id": 0,
+      "Ordinal": 0,
+      "Name": "financial support",
+      "Text": null,
+      "CourseId": 0,
+      "Course": null
+    },
+    {
+      "Id": 0,
+      "Ordinal": 0,
+      "Name": "about school placements",
+      "Text": "The schools within our partnership are all located within the London Borough of Enfield. When identifying schools for each candidate we consider home locations and travel options. All of our schools have good public transport links. \r\nThe teaching age ranges that we can offer are within the primary phase (3 -11). \r\nOur current partnership includes approx. 10 Enfield primary schools. \r\nThe majority of your training year will be spent in your employing school, however there is a second setting placement in one of our partnership schools for half a term (6 weeks). \r\n",
+      "CourseId": 0,
+      "Course": null
+    },
+    {
+      "Id": 0,
+      "Ordinal": 0,
+      "Name": "about this training provider",
+      "Text": null,
+      "CourseId": 0,
+      "Course": null
+    },
+    {
+      "Id": 0,
+      "Ordinal": 0,
+      "Name": "about this training provider accrediting",
+      "Text": "",
+      "CourseId": 0,
+      "Course": null
+    },
+    {
+      "Id": 0,
+      "Ordinal": 0,
+      "Name": "training with disabilities",
+      "Text": null,
+      "CourseId": 0,
+      "Course": null
+    }
+  ],
+  "Campuses": [
+    {
+      "Id": 0,
+      "Name": "Bowes Primary School",
+      "CampusCode": "B",
+      "LocationId": null,
+      "VacStatus": "F",
+      "Location": {
+        "Id": 0,
+        "Address": "Bowes Road, London N11 2HL",
+        "FormattedAddress": null,
+        "GeoAddress": null,
+        "Latitude": null,
+        "Longitude": null,
+        "LastGeocodedUtc": "0001-01-01T00:00:00"
+      },
+      "Course": null
+    }
+  ],
+  "CourseSubjects": [
+    {
+      "CourseId": 0,
+      "Course": null,
+      "SubjectId": 0,
+      "Subject": {
+        "Id": 0,
+        "SubjectArea": null,
+        "FundingId": null,
+        "Funding": null,
+        "Name": "Primary",
+        "IsSubjectKnowledgeEnhancementAvailable": false,
+        "CourseSubjects": null
+      }
+    }
+  ],
+  "Fees": {
+    "Uk": 0,
+    "Eu": 0,
+    "International": 0
+  },
+  "IsSalaried": true,
+  "Salary": {
+    "Minimum": null,
+    "Maximum": null
+  },
+  "ProviderLocationId": null,
+  "ProviderLocation": {
+    "Id": 0,
+    "Address": "Bowes Road\nNew Southgate\nLondon\nN11 2HL",
+    "FormattedAddress": null,
+    "GeoAddress": null,
+    "Latitude": null,
+    "Longitude": null,
+    "LastGeocodedUtc": "0001-01-01T00:00:00"
+  },
+  "Distance": null,
+  "DistanceAddress": null,
+  "ContactDetailsId": null,
+  "ContactDetails": {
+    "Id": 0,
+    "Phone": "0208 368 2552",
+    "Fax": null,
+    "Email": "kelly.hitchcock@bowesprimaryelt.org",
+    "Website": "http://www.bowesprimaryschool.org",
+    "Address": "Bowes Road\nNew Southgate\nLondon\nN11 2HL",
+    "Course": null
+  },
+  "FullTime": 1,
+  "PartTime": 3,
+  "ApplicationsAcceptedFrom": "2018-10-09T00:00:00",
+  "StartDate": "2019-09-01T00:00:00",
+  "Duration": "1 year",
+  "Mod": "PGCE with QTS full time with salary",
+  "HasVacancies": true,
+  "IsSen": false
+}


### PR DESCRIPTION
### Context
search and compare serialiizer part 1

### Changes proposed in this pull request
Added the easy part for a course serializing inclusive of
the course default values, 
the course direct simple values,
the course's provider
the course's accrediting provider

### Guidance to review
part 1 ot x

Refer to the almost complete
https://github.com/DFE-Digital/manage-courses-backend/pull/377

For the full whack

Probably easier to follow the commits

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
