### PR TITLE
[1491] Add deserializable_resource call to AccessRequestsController

### DIFF
--- a/app/controllers/api/v2/access_requests_controller.rb
+++ b/app/controllers/api/v2/access_requests_controller.rb
@@ -1,6 +1,7 @@
 module API
   module V2
     class AccessRequestsController < API::V2::ApplicationController
+      deserializable_resource :access_request, only: %i[create]
       before_action :build_access_request, only: :approve
 
       def approve


### PR DESCRIPTION
This is necessary to correctly interpret the parameters sent in by the support app.

Paired with @davidgisbey.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally