### PR TITLE
[1503] Extend providers endpoint

### DIFF
--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -1,9 +1,84 @@
 module API
   module V2
     class SerializableProvider < JSONAPI::Serializable::Resource
+      class << self
+        def enrichment_attribute(name, enrichment_name = name)
+          attribute name do
+            @object.enrichments.last&.__send__(enrichment_name)
+          end
+        end
+      end
+
       type 'providers'
 
       attributes :provider_code, :provider_name, :accredited_body?, :can_add_more_sites?
+
+      attribute :website do
+        if @object.enrichments.last&.__send__(:website).present?
+          @object.enrichments.last&.__send__(:website)
+        else
+          @object.url
+        end
+      end
+
+      attribute :email do
+        if @object.enrichments.last&.__send__(:email).present?
+          @object.enrichments.last&.__send__(:email)
+        else
+          @object.email
+        end
+      end
+
+      attribute :telephone do
+        if @object.enrichments.last&.__send__(:telephone).present?
+          @object.enrichments.last&.__send__(:telephone)
+        else
+          @object.telephone
+        end
+      end
+
+      attribute :address1 do
+        if @object.enrichments.last&.__send__(:address1).present?
+          @object.enrichments.last&.__send__(:address1)
+        else
+          @object.address1
+        end
+      end
+
+      attribute :address2 do
+        if @object.enrichments.last&.__send__(:address2).present?
+          @object.enrichments.last&.__send__(:address2)
+        else
+          @object.address2
+        end
+      end
+
+      attribute :address3 do
+        if @object.enrichments.last&.__send__(:address3).present?
+          @object.enrichments.last&.__send__(:address3)
+        else
+          @object.address3
+        end
+      end
+
+      attribute :address4 do
+        if @object.enrichments.last&.__send__(:address4).present?
+          @object.enrichments.last&.__send__(:address4)
+        else
+          @object.address4
+        end
+      end
+
+      attribute :postcode do
+        if @object.enrichments.last&.__send__(:postcode).present?
+          @object.enrichments.last&.__send__(:postcode)
+        else
+          @object.postcode
+        end
+      end
+
+      enrichment_attribute :train_with_us
+      enrichment_attribute :train_with_disability
 
       has_many :sites
 

--- a/spec/factories/provider_enrichments.rb
+++ b/spec/factories/provider_enrichments.rb
@@ -28,10 +28,16 @@ FactoryBot.define do
     address3 { Faker::Address.city }
     address4 { Faker::Address.state }
     postcode { Faker::Address.postcode }
+    telephone { Faker::PhoneNumber.phone_number }
     region_code { 'eastern' }
     train_with_us { Faker::Lorem.sentence.to_s }
     train_with_disability { Faker::Lorem.sentence.to_s }
     created_at { Faker::Date.between 2.days.ago, 1.days.ago }
+
+    trait :published do
+      status { :published }
+      last_published_at { 5.days.ago }
+    end
 
     after(:build) do |enrichment, evaluator|
       if evaluator.age.present?

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -14,7 +14,11 @@ describe 'Providers API v2', type: :request do
       ActionController::HttpAuthentication::Token.encode_credentials(token)
     end
 
-    let!(:provider) { create(:provider, course_count: 0, site_count: 0, organisations: [organisation]) }
+    let!(:provider) { create(:provider,
+                             course_count: 0,
+                             site_count: 0,
+                             enrichments: [],
+                             organisations: [organisation]) }
 
     subject { response }
 
@@ -45,7 +49,17 @@ describe 'Providers API v2', type: :request do
               "provider_code" => provider.provider_code,
               "provider_name" => provider.provider_name,
               "accredited_body?" => false,
-              "can_add_more_sites?" => true
+              "can_add_more_sites?" => true,
+              "website" => provider.url,
+              "email" => provider.email,
+              "telephone" => provider.telephone,
+              "address1" => provider.address1,
+              "address2" => provider.address2,
+              "address3" => provider.address3,
+              "address4" => provider.address4,
+              "postcode" => provider.postcode,
+              "train_with_us" => nil,
+              "train_with_disability" => nil,
             },
             "relationships" => {
               "sites" => {
@@ -82,7 +96,17 @@ describe 'Providers API v2', type: :request do
               "provider_code" => provider.provider_code,
               "provider_name" => provider.provider_name,
               "accredited_body?" => false,
-              "can_add_more_sites?" => true
+              "can_add_more_sites?" => true,
+              "website" => provider.url,
+              "email" => provider.email,
+              "telephone" => provider.telephone,
+              "address1" => provider.address1,
+              "address2" => provider.address2,
+              "address3" => provider.address3,
+              "address4" => provider.address4,
+              "postcode" => provider.postcode,
+              "train_with_us" => nil,
+              "train_with_disability" => nil,
             },
             "relationships" => {
               "sites" => {
@@ -137,6 +161,61 @@ describe 'Providers API v2', type: :request do
         expect(provider_names_in_response).to eq(%w(Acme Zork))
       end
     end
+
+    context 'with provider enrichments' do
+      before do
+        get "/api/v2/users/#{user.id}/providers", headers: { 'HTTP_AUTHORIZATION' => credentials }
+      end
+
+      let(:organisation) { create(:organisation) }
+      let(:enrichment)   { build :provider_enrichment, :published }
+      let(:provider)    { create(:provider,
+                                  course_count: 0,
+                                  site_count: 0,
+                                  enrichments: [enrichment],
+                                  organisations: [organisation]) }
+
+      it 'has a data section with the correct attributes' do
+        json_response = JSON.parse(response.body)
+        expect(json_response).to eq(
+          "data" => [{
+            "id" => provider.id.to_s,
+            "type" => "providers",
+            "attributes" => {
+              "provider_code" => provider.provider_code,
+              "provider_name" => provider.provider_name,
+              "accredited_body?" => false,
+              "can_add_more_sites?" => true,
+              "website" => enrichment.website,
+              "email" => enrichment.email,
+              "telephone" => enrichment.telephone,
+              "address1" => enrichment.address1,
+              "address2" => enrichment.address2,
+              "address3" => enrichment.address3,
+              "address4" => enrichment.address4,
+              "postcode" => enrichment.postcode,
+              "train_with_us" => enrichment.train_with_us,
+              "train_with_disability" => enrichment.train_with_disability
+            },
+            "relationships" => {
+              "sites" => {
+                "meta" => {
+                  "included" => false
+                }
+              },
+              "courses" => {
+                "meta" => {
+                  "count" => provider.courses.count
+                }
+              }
+            }
+          }],
+          "jsonapi" => {
+            "version" => "1.0"
+          }
+        )
+      end
+    end
   end
 
   describe 'GET /providers#show' do
@@ -152,7 +231,11 @@ describe 'Providers API v2', type: :request do
       ActionController::HttpAuthentication::Token.encode_credentials(token)
     end
 
-    let!(:provider) { create(:provider, course_count: 0, site_count: 1, organisations: [organisation]) }
+    let!(:provider) { create(:provider,
+                             course_count: 0,
+                             site_count: 1,
+                             enrichments: [],
+                             organisations: [organisation]) }
 
     subject { response }
 
@@ -165,7 +248,17 @@ describe 'Providers API v2', type: :request do
             "provider_code" => provider.provider_code,
             "provider_name" => provider.provider_name,
             "accredited_body?" => false,
-            "can_add_more_sites?" => true
+            "can_add_more_sites?" => true,
+            "website" => provider.url,
+            "email" => provider.email,
+            "telephone" => provider.telephone,
+            "address1" => provider.address1,
+            "address2" => provider.address2,
+            "address3" => provider.address3,
+            "address4" => provider.address4,
+            "postcode" => provider.postcode,
+            "train_with_us" => nil,
+            "train_with_disability" => nil,
           },
           "relationships" => {
             "sites" => {
@@ -204,7 +297,17 @@ describe 'Providers API v2', type: :request do
                 "provider_code" => provider.provider_code,
                 "provider_name" => provider.provider_name,
                 "accredited_body?" => false,
-                "can_add_more_sites?" => true
+                "can_add_more_sites?" => true,
+                "website" => provider.url,
+                "email" => provider.email,
+                "telephone" => provider.telephone,
+                "address1" => provider.address1,
+                "address2" => provider.address2,
+                "address3" => provider.address3,
+                "address4" => provider.address4,
+                "postcode" => provider.postcode,
+                "train_with_us" => nil,
+                "train_with_disability" => nil,
               },
               "relationships" => {
                 "sites" => {


### PR DESCRIPTION
### Context
Our frontend requires more of the provider data for course#preview and further down the line; editing of provider enrichments

### Changes proposed in this pull request
Expose more provider data

### Guidance to review
i.e. `/api/v2/providers/1CS`

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
