### PR TITLE
[1502] Automate comms list

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@
 class User < ApplicationRecord
   include AASM
 
-  DFE_EMAIL_PATTERN = /@(digital.){0,1}education.gov.uk$/.freeze
+  DFE_EMAIL_PATTERN = '@(digital.){0,1}education.gov.uk$'.freeze
 
   has_and_belongs_to_many :organisations
   has_many :providers, through: :organisations
@@ -38,6 +38,6 @@ class User < ApplicationRecord
   end
 
   def admin?
-    email.match?(DFE_EMAIL_PATTERN)
+    email.match?(%r{#{DFE_EMAIL_PATTERN}})
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,7 @@ class User < ApplicationRecord
   has_many :access_requests, foreign_key: :requester_id, primary_key: :id
 
   scope :non_admins, -> { where.not('email ~ ?', DFE_EMAIL_PATTERN) }
+  scope :active, -> { where.not(accept_terms_date_utc: nil) }
 
   validates :email, presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,8 @@ class User < ApplicationRecord
   has_many :providers, through: :organisations
   has_many :access_requests, foreign_key: :requester_id, primary_key: :id
 
+  scope :non_admins, -> { where.not('email ~ ?', DFE_EMAIL_PATTERN) }
+
   validates :email, presence: true
 
   audited

--- a/lib/mcb/commands/users/list.rb
+++ b/lib/mcb/commands/users/list.rb
@@ -1,11 +1,14 @@
 summary 'List users in the tb'
 usage 'list [<id1> <id2> <id3>...] where id is either user email, user ID or DfE-Sign-in ID'
+flag :o, 'only-active-non-admins', 'Filter the user list to only active non-admin users for comms purposes'
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
   users = if args.any?
             args.map { |id| MCB.find_user_by_identifier id }
+          elsif opts[:'only-active-non-admins']
+            User.active.non_admins
           else
             User.all
           end

--- a/lib/mcb/commands/users/list.rb
+++ b/lib/mcb/commands/users/list.rb
@@ -1,4 +1,5 @@
 summary 'List users in the tb'
+usage 'list [<id1> <id2> <id3>...] where id is either user email, user ID or DfE-Sign-in ID'
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)

--- a/lib/mcb/commands/users/list.rb
+++ b/lib/mcb/commands/users/list.rb
@@ -1,6 +1,7 @@
 summary 'List users in the tb'
 usage 'list [<id1> <id2> <id3>...] where id is either user email, user ID or DfE-Sign-in ID'
 flag :o, 'only-active-non-admins', 'Filter the user list to only active non-admin users for comms purposes'
+option :c, 'csv-output-filename', 'Write the output to a CVS file at the given path', argument: :required
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
@@ -13,14 +14,23 @@ run do |opts, args, _cmd|
             User.all
           end
 
-  tp.set :capitalize_headers, false
+  if opts[:'csv-output-filename']
+    require 'csv'
+    headers = %w[id email sign_in_user_id first_name last_name last_login_date_utc]
+    results = CSV.open(opts[:'csv-output-filename'], "wb") do |csv|
+      csv << headers
+      users.pluck(*headers).each { |user| csv << user }
+    end
+  else
+    tp.set :capitalize_headers, false
 
-  puts "\nUsers:"
-  puts Tabulo::Table.new(users,
-                         :id,
-                         :email,
-                         :sign_in_user_id,
-                         :first_name,
-                         :last_name,
-                         :last_login_date_utc).pack(max_table_width: nil)
+    puts "\nUsers:"
+    puts Tabulo::Table.new(users,
+                           :id,
+                           :email,
+                           :sign_in_user_id,
+                           :first_name,
+                           :last_name,
+                           :last_login_date_utc).pack(max_table_width: nil)
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -34,5 +34,9 @@ FactoryBot.define do
     trait :with_provider do
       organisations { [create(:organisation, providers: [create(:provider)])] }
     end
+
+    trait :inactive do
+      accept_terms_date_utc { nil }
+    end
   end
 end

--- a/spec/lib/mcb/commands/users/list_spec.rb
+++ b/spec/lib/mcb/commands/users/list_spec.rb
@@ -60,4 +60,18 @@ describe 'mcb users list' do
     expect(output).to have_text_table_row(user1.id)
     expect(output).not_to have_text_table_row(user2.id)
   end
+
+  it 'lists active, non-admin users with the -o option' do
+    user1 = create(:user, :admin)
+    user2 = create(:user, :inactive)
+    user3 = create(:user, accept_terms_date_utc: Date.yesterday)
+
+    output = with_stubbed_stdout do
+      cmd.run(['-o'])
+    end
+
+    expect(output).not_to have_text_table_row(user1.id)
+    expect(output).not_to have_text_table_row(user2.id)
+    expect(output).to     have_text_table_row(user3.id)
+  end
 end

--- a/spec/lib/mcb/commands/users/list_spec.rb
+++ b/spec/lib/mcb/commands/users/list_spec.rb
@@ -1,4 +1,5 @@
 require 'mcb_helper'
+require 'csv'
 
 describe 'mcb users list' do
   let(:lib_dir) { "#{Rails.root}/lib" }
@@ -73,5 +74,22 @@ describe 'mcb users list' do
     expect(output).not_to have_text_table_row(user1.id)
     expect(output).not_to have_text_table_row(user2.id)
     expect(output).to     have_text_table_row(user3.id)
+  end
+
+  it 'exports the results to a CSV file' do
+    tmpfile = Tempfile.new
+    tmpfile.close
+
+    user1 = create(:user)
+    user2 = create(:user)
+
+    with_stubbed_stdout do
+      cmd.run(['-c', tmpfile.path])
+    end
+    table = CSV.read(tmpfile.path, headers: true)
+
+    expect(table.size).to eq(2)
+    expect(table[0]["email"]).to eq(user1.email)
+    expect(table[1]["email"]).to eq(user2.email)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,21 +47,33 @@ describe User, type: :model do
 
   describe '#admin?' do
     context 'user has an education.gov.uk email' do
-      subject { create(:user, email: 'test@education.gov.uk') }
+      subject! { create(:user, email: 'test@education.gov.uk') }
 
       its(:admin?) { should be_truthy }
+
+      it "doesn't show up in User.non_admins" do
+        expect(User.non_admins).to be_empty
+      end
     end
 
     context 'user has a digital.education.gov.uk email' do
-      subject { create(:user, email: 'test@digital.education.gov.uk') }
+      subject! { create(:user, email: 'test@digital.education.gov.uk') }
 
       its(:admin?) { should be_truthy }
+
+      it "doesn't show up in User.non_admins" do
+        expect(User.non_admins).to be_empty
+      end
     end
 
     context 'user does not have a digital.education or education.gov.uk email' do
       subject { create(:user, email: 'test@hrmc.gov.uk') }
 
       its(:admin?) { should be_falsey }
+
+      it "does shows up in User.non_admins" do
+        expect(User.non_admins).to eq([subject])
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -76,4 +76,13 @@ describe User, type: :model do
       end
     end
   end
+
+  describe '.active' do
+    let!(:inactive_user) { create(:user, :inactive) }
+    let!(:active_user) { create(:user, accept_terms_date_utc: Date.yesterday) }
+
+    it "includes active users and excludes inactive users" do
+      expect(User.active).to eq([active_user])
+    end
+  end
 end


### PR DESCRIPTION
### Context
We need a list of active, non-admin users when we send out service comms via Notify.

### Changes proposed in this pull request
Extend the `mcb users list` command to:

- return specifically active, non-admin users
- write the output to a CSV (we can't pipe to `$stdout` since that's used for the `-E` environment confirmation)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
