### PR TITLE
Revert [1180] Don't use enrichments to generate provider admin contacts

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -63,18 +63,12 @@ class Provider < ApplicationRecord
 
   scope :in_order, -> { order(:provider_name) }
 
-  # Currently Provider#contact_info isn't used but will likely be needed when
-  # we need to expose the candidate-facing contact info.
-  #
-  # When the time comes:
-  # - rename this method to reflect that it's the candidate-facing contact
-  # - resurrect the tests which were stripped from models/provider_spec.rb
-  #
-  # def contact_info
-  #   self
-  #     .attributes_before_type_cast
-  #     .slice('address1', 'address2', 'address3', 'address4', 'postcode', 'region_code', 'telephone', 'email')
-  # end
+  # TODO: filter to published enrichments, maybe rename to published_address_info
+  def contact_info
+    (enrichments.latest_created_at.with_contact_info.first || self)
+      .attributes_before_type_cast
+      .slice('address1', 'address2', 'address3', 'address4', 'postcode', 'region_code', 'telephone', 'email')
+  end
 
   def update_changed_at(timestamp: Time.now.utc)
     # Changed_at represents changes to related records as well as provider

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -59,8 +59,36 @@ class ProviderSerializer < ActiveModel::Serializer
     object.provider_type_before_type_cast
   end
 
+  def address1
+    object.contact_info['address1']
+  end
+
+  def address2
+    object.contact_info['address2']
+  end
+
+  def address3
+    object.contact_info['address3']
+  end
+
+  def address4
+    object.contact_info['address4']
+  end
+
+  def postcode
+    object.contact_info['postcode']
+  end
+
+  def email
+    object.contact_info['email']
+  end
+
+  def telephone
+    object.contact_info['telephone']
+  end
+
   def region_code
-    "%02d" % object.region_code_before_type_cast if object.region_code.present?
+    "%02d" % object.contact_info['region_code'] if object.contact_info['region_code'].present?
   end
 
   def utt_application_alerts

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -60,6 +60,190 @@ describe Provider, type: :model do
     end
   end
 
+  describe '#contact_info' do
+    context 'empty enrichments' do
+      it 'returns address of the provider' do
+        provider = create(:provider, enrichments: [])
+
+        expect(provider.contact_info).to eq(
+          'address1' => provider.address1,
+          'address2' => provider.address2,
+          'address3' => provider.address3,
+          'address4' => provider.address4,
+          'postcode' => provider.postcode,
+          'region_code' => provider.region_code_before_type_cast,
+          'email' => provider.email,
+          'telephone' => provider.telephone
+        )
+      end
+
+      context 'provider has enrichments' do
+        context 'enrichment has nothing set for contact_info' do
+          context 'via absent json_data fields' do
+            it 'returns address of the provider' do
+              enrichment = build(:provider_enrichment)
+              provider = create(:provider, enrichments: [enrichment])
+
+              # forcing all fields to be absent in json_data altogether
+              ProviderEnrichment.connection.update(<<~EOSQL)
+                UPDATE provider_enrichment
+                      SET json_data=json_data-'Address1'-'Address2'-'Address3'-'Address4'-'Postcode'-'RegionCode'-'Email'-'Telephone'
+                      WHERE provider_code='#{enrichment.provider_code}'
+              EOSQL
+
+              expect(provider.contact_info).to eq(
+                'address1' => provider.address1,
+                'address2' => provider.address2,
+                'address3' => provider.address3,
+                'address4' => provider.address4,
+                'postcode' => provider.postcode,
+                'region_code' => provider.region_code_before_type_cast,
+                'email' => provider.email,
+                'telephone' => provider.telephone
+              )
+            end
+          end
+          context 'via nil fields' do
+            it 'returns address of the provider' do
+              enrichment = build(:provider_enrichment,
+                  address1: nil,
+                  address2: nil,
+                  address3: nil,
+                  address4: nil,
+                  postcode: nil,
+                  region_code: nil,
+                  email: nil,
+                  telephone: nil)
+              provider = create(:provider, enrichments: [enrichment])
+
+              expect(provider.contact_info).to eq(
+                'address1' => provider.address1,
+                'address2' => provider.address2,
+                'address3' => provider.address3,
+                'address4' => provider.address4,
+                'postcode' => provider.postcode,
+                'region_code' => provider.region_code_before_type_cast,
+                'email' => provider.email,
+                'telephone' => provider.telephone
+              )
+            end
+          end
+        end
+
+        context 'enrichment is valid' do
+          it 'returns json_data from the first enrichment' do
+            enrichment = build(:provider_enrichment)
+            provider = create(:provider, enrichments: [enrichment])
+
+            expect(provider.contact_info).to eq(
+              'address1' => enrichment.address1,
+              'address2' => enrichment.address2,
+              'address3' => enrichment.address3,
+              'address4' => enrichment.address4,
+              'postcode' => enrichment.postcode,
+              'region_code' => enrichment.region_code_before_type_cast,
+              'email' => enrichment.email,
+              'telephone' => enrichment.telephone
+            )
+          end
+
+          it 'returns json_data from the newest enrichment' do
+            enrichment = build(:provider_enrichment)
+            newest_enrichment = build(:provider_enrichment, created_at: Date.today)
+            provider = create(:provider, enrichments: [enrichment, newest_enrichment])
+
+            expect(provider.contact_info).to eq(
+              'address1' => newest_enrichment.address1,
+              'address2' => newest_enrichment.address2,
+              'address3' => newest_enrichment.address3,
+              'address4' => newest_enrichment.address4,
+              'postcode' => newest_enrichment.postcode,
+              'region_code' => newest_enrichment.region_code_before_type_cast,
+              'email' => newest_enrichment.email,
+              'telephone' => newest_enrichment.telephone
+            )
+          end
+        end
+        context 'enrichment has partial set for contact_info' do
+          it 'returns address of the enrichment' do
+            enrichment = build(:provider_enrichment,
+              address2: nil,
+              address3: nil,
+              address4: nil,
+              postcode: nil,
+              email: nil,
+              telephone: nil)
+            provider = create(:provider, enrichments: [enrichment])
+
+            expect(provider.contact_info).to eq(
+              'address1' => enrichment.address1,
+              'address2' => enrichment.address2,
+              'address3' => enrichment.address3,
+              'address4' => enrichment.address4,
+              'postcode' => enrichment.postcode,
+              'region_code' => enrichment.region_code_before_type_cast,
+              'email' => enrichment.email,
+              'telephone' => enrichment.telephone
+            )
+          end
+
+          context 'enrichment has only region code set for contact_info' do
+            london = ProviderEnrichment.region_codes['London']
+            no_region = ProviderEnrichment.region_codes['No region']
+            context 'via absent json_data fields' do
+              it 'returns address of the provider' do
+                enrichment = build(:provider_enrichment, region_code: no_region,)
+                provider = create(:provider, region_code: london, enrichments: [enrichment])
+
+                # forcing all fields apart region_code to be absent in json_data altogether
+                ProviderEnrichment.connection.update(<<~EOSQL)
+                  UPDATE provider_enrichment
+                        SET json_data=json_data-'Address1'-'Address2'-'Address3'-'Address4'-'Postcode'-'RegionCode'-'Email'-'Telephone'
+                        WHERE provider_code='#{enrichment.provider_code}'
+                EOSQL
+
+                expect(provider.contact_info).to eq(
+                  'address1' => provider.address1,
+                  'address2' => provider.address2,
+                  'address3' => provider.address3,
+                  'address4' => provider.address4,
+                  'postcode' => provider.postcode,
+                  'region_code' => provider.region_code_before_type_cast,
+                  'email' => provider.email,
+                  'telephone' => provider.telephone
+                )
+              end
+            end
+            context 'via nil fields' do
+              it 'returns address of the provider' do
+                enrichment = build(:provider_enrichment, region_code: no_region,
+                address1: nil,
+                address2: nil,
+                address3: nil,
+                address4: nil,
+                postcode: nil,
+                email: nil,
+                telephone: nil)
+                provider = create(:provider, region_code: london, enrichments: [enrichment])
+
+                expect(provider.contact_info).to eq(
+                  'address1' => provider.address1,
+                  'address2' => provider.address2,
+                  'address3' => provider.address3,
+                  'address4' => provider.address4,
+                  'postcode' => provider.postcode,
+                  'region_code' => provider.region_code_before_type_cast,
+                  'email' => provider.email,
+                  'telephone' => provider.telephone
+                )
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
   describe '#changed_since' do
     context 'with a provider that has been changed after the given timestamp' do
       let(:provider) { create(:provider, changed_at: 5.minutes.ago) }

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -35,6 +35,7 @@ describe ProviderSerializer do
 
   it { should include(institution_code: provider.provider_code) }
   it { should include(institution_name: provider.provider_name) }
+<<<<<<< HEAD
   it { should include(address1: provider.address1) }
   it { should include(address2: provider.address2) }
   it { should include(address3: provider.address3) }
@@ -43,6 +44,44 @@ describe ProviderSerializer do
   it { should include(region_code: "%02d" % provider.region_code_before_type_cast) }
   it { should include(institution_type: provider.provider_type) }
   it { should include(accrediting_provider: provider.accrediting_provider) }
+=======
+  it { should include(address1: provider.enrichments.last.address1) }
+  it { should include(address2: provider.enrichments.last.address2) }
+  it { should include(address3: provider.enrichments.last.address3) }
+  it { should include(address4: provider.enrichments.last.address4) }
+  it { should include(postcode: provider.enrichments.last.postcode) }
+  it { should include(institution_type: provider.provider_type) }
+  it { should include(accrediting_provider: provider.accrediting_provider) }
+  it { should include(contact_name: provider.contact_name) }
+  it { should include(email: provider.enrichments.last.email) }
+  it { should include(telephone: provider.enrichments.last.telephone) }
+
+  describe 'ProviderSerializer#region_code' do
+    subject do
+      serialize(provider)["region_code"]
+    end
+
+    describe "provider region code 'London' can be overriden by enrichment region code 'Scotland'" do
+      let(:enrichment) do
+        build(:provider_enrichment, region_code: :scotland)
+      end
+
+      let(:provider) { create :provider, region_code: :london, enrichments: [enrichment] }
+      it { is_expected.not_to eql("%02d" % 1) }
+      it { is_expected.to eql("%02d" % 11) }
+    end
+
+    describe "provider region code 00 is overriden with enrichment region code" do
+      let(:enrichment) do
+        build(:provider_enrichment, region_code: region_code)
+      end
+      let(:region_code) { 1 }
+      let(:provider) { create :provider, region_code: 0, enrichments: [enrichment] }
+      it { is_expected.to eql("%02d" % region_code) }
+      it { is_expected.not_to eql("%02d" % 0) }
+    end
+  end
+>>>>>>> parent of 3e87469... Merge pull request #226 from DFE-Digital/1180-ignore-enrichments-for-admin-contacts
 
   describe 'type_of_gt12' do
     subject { serialize(provider)['type_of_gt12'] }


### PR DESCRIPTION
### Context
We need provider contact data for `course#preview` (and eventually editing for provider enrichments)

### Changes proposed in this pull request
Add provider contact data

### Guidance to review
Example - `/api/v2/providers/1CS`

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
