### PR TITLE
[1503] Expose provider enrichments

### DIFF
--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -1,9 +1,20 @@
 module API
   module V2
     class SerializableProvider < JSONAPI::Serializable::Resource
+      class << self
+        def enrichment_attribute(name, enrichment_name = name)
+          attribute name do
+            @object.enrichments.last&.__send__(enrichment_name)
+          end
+        end
+      end
+
       type 'providers'
 
       attributes :provider_code, :provider_name, :accredited_body?, :can_add_more_sites?
+
+      enrichment_attribute :train_with_us
+      enrichment_attribute :train_with_disability
 
       has_many :sites
 

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -15,6 +15,7 @@ describe 'Providers API v2', type: :request do
     end
 
     let!(:provider) { create(:provider, course_count: 0, site_count: 0, organisations: [organisation]) }
+    let(:enrichment) { provider.enrichments.first }
 
     subject { response }
 
@@ -45,7 +46,9 @@ describe 'Providers API v2', type: :request do
               "provider_code" => provider.provider_code,
               "provider_name" => provider.provider_name,
               "accredited_body?" => false,
-              "can_add_more_sites?" => true
+              "can_add_more_sites?" => true,
+              "train_with_us" => enrichment.train_with_us,
+              "train_with_disability" => enrichment.train_with_disability,
             },
             "relationships" => {
               "sites" => {
@@ -82,7 +85,9 @@ describe 'Providers API v2', type: :request do
               "provider_code" => provider.provider_code,
               "provider_name" => provider.provider_name,
               "accredited_body?" => false,
-              "can_add_more_sites?" => true
+              "can_add_more_sites?" => true,
+              "train_with_us" => enrichment.train_with_us,
+              "train_with_disability" => enrichment.train_with_disability,
             },
             "relationships" => {
               "sites" => {
@@ -153,6 +158,7 @@ describe 'Providers API v2', type: :request do
     end
 
     let!(:provider) { create(:provider, course_count: 0, site_count: 1, organisations: [organisation]) }
+    let(:enrichment) { provider.enrichments.first }
 
     subject { response }
 
@@ -165,7 +171,9 @@ describe 'Providers API v2', type: :request do
             "provider_code" => provider.provider_code,
             "provider_name" => provider.provider_name,
             "accredited_body?" => false,
-            "can_add_more_sites?" => true
+            "can_add_more_sites?" => true,
+            "train_with_us" => enrichment.train_with_us,
+            "train_with_disability" => enrichment.train_with_disability,
           },
           "relationships" => {
             "sites" => {
@@ -204,7 +212,9 @@ describe 'Providers API v2', type: :request do
                 "provider_code" => provider.provider_code,
                 "provider_name" => provider.provider_name,
                 "accredited_body?" => false,
-                "can_add_more_sites?" => true
+                "can_add_more_sites?" => true,
+                "train_with_us" => enrichment.train_with_us,
+                "train_with_disability" => enrichment.train_with_disability,
               },
               "relationships" => {
                 "sites" => {


### PR DESCRIPTION
### Context
Course#preview

### Changes proposed in this pull request
Add `train_with_us` and `train_with_disability` to the V2 provider endpoint

### Guidance to review
Example - `/api/v2/providers/12K`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
