### PR TITLE
[1508] add Provider#external_contact_info

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -100,7 +100,7 @@ class Provider < ApplicationRecord
   end
 
   def external_contact_info
-    enrichments.published.order(created_at: :desc).first
+    enrichments.published.order(last_published_at: :desc).first
       .attributes
       .slice(
         'address1',
@@ -111,6 +111,7 @@ class Provider < ApplicationRecord
         'region_code',
         'telephone',
         'email',
+        'website'
       )
   end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -98,4 +98,19 @@ class Provider < ApplicationRecord
   def can_add_more_sites?
     sites.size < Site::POSSIBLE_CODES.size
   end
+
+  def external_contact_info
+    enrichments.published.order(created_at: :desc).first
+      .attributes
+      .slice(
+        'address1',
+        'address2',
+        'address3',
+        'address4',
+        'postcode',
+        'region_code',
+        'telephone',
+        'email',
+      )
+  end
 end

--- a/spec/factories/provider_enrichments.rb
+++ b/spec/factories/provider_enrichments.rb
@@ -20,6 +20,7 @@ FactoryBot.define do
       age { nil }
     end
 
+    status { :draft }
     sequence(:provider_code) { |n| "A#{n}" }
     email { Faker::Internet.email }
     website { Faker::Internet.url }
@@ -38,6 +39,11 @@ FactoryBot.define do
         enrichment.created_at = evaluator.age
         enrichment.updated_at = evaluator.age
       end
+    end
+
+    trait :published do
+      status { :published }
+      last_published_at { 5.days.ago }
     end
   end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -96,6 +96,35 @@ describe Provider, type: :model do
     end
   end
 
+  describe '#external_contact_info' do
+    context 'provider has draft and multiple published enrichments' do
+      it 'returns contact info from the provider enrichment' do
+        published_enrichment = build(:provider_enrichment, :published,
+                                     last_published_at: 5.days.ago)
+        latest_published_enrichment = build(:provider_enrichment, :published,
+                                            last_published_at: 1.day.ago)
+        enrichment = build(:provider_enrichment)
+
+        provider = create(:provider, enrichments: [published_enrichment,
+                                                   latest_published_enrichment,
+                                                   enrichment])
+
+        expect(provider.external_contact_info).to(
+          eq(
+            'address1'    => latest_published_enrichment.address1,
+            'address2'    => latest_published_enrichment.address2,
+            'address3'    => latest_published_enrichment.address3,
+            'address4'    => latest_published_enrichment.address4,
+            'postcode'    => latest_published_enrichment.postcode,
+            'region_code' => latest_published_enrichment.region_code,
+            'email'       => latest_published_enrichment.email,
+            'telephone'   => latest_published_enrichment.telephone
+          )
+        )
+      end
+    end
+  end
+
   describe '.in_order' do
     let!(:second_alphabetical_provider) { create(:provider, provider_name: "Zork") }
     let!(:first_alphabetical_provider) { create(:provider, provider_name: "Acme") }

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -117,8 +117,9 @@ describe Provider, type: :model do
             'address4'    => latest_published_enrichment.address4,
             'postcode'    => latest_published_enrichment.postcode,
             'region_code' => latest_published_enrichment.region_code,
+            'telephone'   => latest_published_enrichment.telephone,
             'email'       => latest_published_enrichment.email,
-            'telephone'   => latest_published_enrichment.telephone
+            'website'     => latest_published_enrichment.website
           )
         )
       end


### PR DESCRIPTION
### Context

The contact info on the provider record is for internal/UCAS use. We need to expose the contact info from the enrichment if it's there.

### Changes proposed in this pull request

Expose the contact info from the latest published provider enrichment as "external_contact_info", if exists.

### Guidance to review

Although this method should do more (fall-back to the contact info in the provider for example), this is a temporary measure to just get it in there for course syncing and preview generation. Another PR will be created for the rest of the work.

Also, ignore the wrong card number in the branch name. Doh!

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
