### PR TITLE
1429 snc serializer part 3

### DIFF
--- a/app/serializers/search_and_compare/course_serializer.rb
+++ b/app/serializers/search_and_compare/course_serializer.rb
@@ -33,5 +33,35 @@ module SearchAndCompare
         Maximum: nil,
       }
     end
+
+    # Subjects_related_Mapping
+    attribute(:IsSen)                                 { object.is_send? }
+    attribute(:CourseSubjects)                        { get_subjects }
+
+    def get_subjects
+      # CourseSubject_Mapping
+      object.dfe_subjects.map do |subject_name|
+        {
+          # CourseSubject_default_value_mapping
+          CourseId: 0,
+          Course: nil,
+          SubjectId: 0,
+          # CourseSubject_complex
+          Subject:
+            {
+              # Subject_default_value_Mapping
+              Id: 0,
+              SubjectArea: nil,
+              FundingId: nil,
+              Funding: nil,
+              IsSubjectKnowledgeEnhancementAvailable: false,
+              CourseSubjects: nil,
+
+              # Subject_direct_Mapping
+              Name: subject_name,
+            }
+        }
+      end
+    end
   end
 end

--- a/spec/serializers/search_and_compare/mappings.yaml
+++ b/spec/serializers/search_and_compare/mappings.yaml
@@ -41,6 +41,39 @@ Salary_nested_default_value_Mapping: &Salary
   Minimum:
   Maximum:
 
+Subject_default_value_Mapping: &Subject_default_value
+  Id: 0
+  SubjectArea:
+  FundingId:
+  Funding:
+  IsSubjectKnowledgeEnhancementAvailable: false
+  CourseSubjects:
+
+Subject_direct_Mapping: &Subject_direct
+  Name: 'subject_name'
+
+Subject_Mapping: &Subject
+  <<: &Subject_default_value
+  <<: &Subject_direct
+
+CourseSubject_default_value_Mapping: &CourseSubject_default_value
+  CourseId: 0
+  Course:
+  SubjectId: 0
+
+CourseSubject_complex_Mapping: &CourseSubject_complex
+  Subject:
+    <<: *Subject
+
+CourseSubject_Mapping: &CourseSubject
+  <<: &CourseSubject_default_value
+  <<: &CourseSubject_complex
+
+Subjects_related_Mapping: &Subjects_related
+  IsSen: is_send?
+  CourseSubjects:
+  - <<: *CourseSubject
+
 # Actual course
 Course_Full_Mapping:
   <<: *Provider_serializer
@@ -48,3 +81,4 @@ Course_Full_Mapping:
   <<: *Course_direct_simple
   Salary:
     <<: *Salary
+  <<: *Subjects_related


### PR DESCRIPTION
### Context
search and compare serialiizer part 3
subject matters

### Changes proposed in this pull request
Added course subject serializing using dfe subjects (calculated subset of `course's subject`)
Added is sen for course as its part of the `course's subject`

### Guidance to review
part 3 ot x

Refer to the almost complete
https://github.com/DFE-Digital/manage-courses-backend/pull/377

For the full whack

FYI 

Part 1
https://github.com/DFE-Digital/manage-courses-backend/pull/381

Part 2
https://github.com/DFE-Digital/manage-courses-backend/pull/387

Probably easier to follow the commits

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
