### PR TITLE
[1502] make 'rake lint' return error of rubocop fails

### DIFF
--- a/lib/tasks/govuk_lint.rake
+++ b/lib/tasks/govuk_lint.rake
@@ -2,6 +2,8 @@ desc "Lint ruby code"
 namespace :lint do
   task :ruby do
     puts 'Linting...'
-    system 'bundle exec rubocop app config db lib spec Gemfile --format clang -a'
+    unless system 'bundle exec rubocop app config db lib spec Gemfile --format clang -a'
+      exit $?
+    end
   end
 end


### PR DESCRIPTION
### Context

`rake lint` does not return an error code when `rubocop` fails.

### Changes proposed in this pull request

Make `rake lint` return an error code when `rubocop` fails.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
