### PR TITLE
[1503] Add website to provider

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -24,6 +24,7 @@
 #  accrediting_provider :text
 #  last_published_at    :datetime
 #  changed_at           :datetime         not null
+#  website              :text
 #
 
 class Provider < ApplicationRecord

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -24,6 +24,7 @@
 #  accrediting_provider :text
 #  last_published_at    :datetime
 #  changed_at           :datetime         not null
+#  website              :text
 #
 
 class ProviderSerializer < ActiveModel::Serializer

--- a/db/data/20190522061744_initialise_provider_website.rb
+++ b/db/data/20190522061744_initialise_provider_website.rb
@@ -1,0 +1,6 @@
+class InitialiseProviderWebsite < ActiveRecord::Migration[5.2]
+  def change
+    # Initialize website with the same data as url
+    Provider.update_all("website = url")
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,3 +1,3 @@
 # encoding: UTF-8
 
-DataMigrate::Data.define(version: 20190424094003)
+DataMigrate::Data.define(version: 20190522061744)

--- a/db/migrate/20190521214615_add_website_to_provider.rb
+++ b/db/migrate/20190521214615_add_website_to_provider.rb
@@ -1,0 +1,5 @@
+class AddWebsiteToProvider < ActiveRecord::Migration[5.2]
+  def change
+    add_column :provider, :website, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_07_150812) do
+ActiveRecord::Schema.define(version: 2019_05_21_214615) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -179,6 +179,7 @@ ActiveRecord::Schema.define(version: 2019_05_07_150812) do
     t.text "accrediting_provider"
     t.datetime "last_published_at"
     t.datetime "changed_at", default: -> { "timezone('utc'::text, now())" }, null: false
+    t.text "website"
     t.index ["changed_at"], name: "index_provider_on_changed_at", unique: true
     t.index ["last_published_at"], name: "IX_provider_last_published_at"
     t.index ["provider_code"], name: "IX_provider_provider_code", unique: true

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -24,6 +24,7 @@
 #  accrediting_provider :text
 #  last_published_at    :datetime
 #  changed_at           :datetime         not null
+#  website              :text
 #
 
 FactoryBot.define do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -24,6 +24,7 @@
 #  accrediting_provider :text
 #  last_published_at    :datetime
 #  changed_at           :datetime         not null
+#  website              :text
 #
 
 require 'rails_helper'

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -24,6 +24,7 @@
 #  accrediting_provider :text
 #  last_published_at    :datetime
 #  changed_at           :datetime         not null
+#  website              :text
 #
 
 require "rails_helper"


### PR DESCRIPTION
### Context
All of our provider enrichment attributes match our provider attributes names so falling back when data is missing is straight forward except for `url` / `website`

### Changes proposed in this pull request

- Add provider `website` and copy all data from `url`
- Once our c# app is decommisioned then the `url` column can  be removed

### Guidance to review
Note: The V1 API doesn’t use it so this shouldn't have any upstream issues

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
