### PR TITLE
[1508] fallback to provider info for external contact info

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -100,18 +100,22 @@ class Provider < ApplicationRecord
   end
 
   def external_contact_info
-    (enrichments.published.latest_published_at.first || self)
-      .attributes
-      .slice(
-        'address1',
-        'address2',
-        'address3',
-        'address4',
-        'postcode',
-        'region_code',
-        'telephone',
-        'email',
-        'website'
-      )
+    attribute_names = %w[
+      address1
+      address2
+      address3
+      address4
+      postcode
+      region_code
+      telephone
+      email
+    ]
+
+    enrichment = enrichments.published.latest_published_at.first
+    if enrichment
+      enrichment.attributes.slice(*(attribute_names + %w[website]))
+    else
+      attributes.slice(*attribute_names).merge('website' => url)
+    end
   end
 end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -38,6 +38,7 @@ FactoryBot.define do
     contact_name { Faker::Name.name }
     email { Faker::Internet.email }
     telephone { Faker::PhoneNumber.phone_number }
+    url { Faker::Internet.url }
     accrediting_provider { 'N' }
     region_code { 'london' }
     organisations { build_list :organisation, 1 }

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -124,6 +124,25 @@ describe Provider, type: :model do
         )
       end
     end
+
+    context 'provider has no published enrichments' do
+      it 'returns the info from the provider record' do
+        provider = create(:provider)
+        expect(provider.external_contact_info).to(
+          eq(
+            'address1'    => provider.address1,
+            'address2'    => provider.address2,
+            'address3'    => provider.address3,
+            'address4'    => provider.address4,
+            'postcode'    => provider.postcode,
+            'region_code' => provider.region_code,
+            'telephone'   => provider.telephone,
+            'email'       => provider.email,
+            'website'     => provider.url
+          )
+        )
+      end
+    end
   end
 
   describe '.in_order' do


### PR DESCRIPTION
### Changes proposed in this pull request

When a provider doesn't have any enrichments we default to using their "internal" contact info for the "external" contact info.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
