### PR TITLE
[1429] snc serializer part 5

### DIFF
--- a/app/serializers/search_and_compare/course_serializer.rb
+++ b/app/serializers/search_and_compare/course_serializer.rb
@@ -5,6 +5,22 @@ module SearchAndCompare
     has_one :provider, key: :Provider, serializer: SearchAndCompare::ProviderSerializer
     has_one :accrediting_provider, key: :AccreditingProvider, serializer: SearchAndCompare::ProviderSerializer
 
+    # TODO: After completion
+    # TASK: Anything that return (ie. default_xxx_value, or attribute(:xxx))
+    #         (int)             0
+    #         (reference type)  nil
+    #         (bool)            false
+    #         (date)            '0001-01-01T00:00:00'
+    #       applies to SearchAndCompare::ProviderSerializer
+    #
+    #       snc should just hydrate default values when omitted
+    #
+    # TASK: strftime('%Y-%m-%dT%H:%M:%S')
+    #       double check that this can be removed
+    #       as long as its a valid date format it should work in snc
+    # TASK: see attribute(:Route)
+    # TASK: see attribute(:Salary)
+
     # Course_default_value_Mapping
     attribute(:Id)                                    { 0 }
     attribute(:ProviderCodeName)                      { nil }
@@ -25,20 +41,40 @@ module SearchAndCompare
 
 
     # Salary_nested_default_value_Mapping
-    attribute(:Salary)                                { default_salary }
+    # TODO: After completion
+    # TASK: Double check is Salary actual in use in snc else drop it
+    attribute(:Salary)                                { default_salary_value }
 
-    def default_salary
+    # Subjects_related_Mapping
+    attribute(:IsSen)                                 { object.is_send? }
+    attribute(:CourseSubjects)                        { course_subjects }
+
+    # Course_variant_Mapping
+    # TODO: After completion
+    # TASK: Route.Name can be blank, snc needs to relax blank rule
+    #       Route.Name can be dropped, snc don't use it
+    #       Course.Route.IsSalaried should become Course.IsSalaried
+    #       Then Route
+    #       Route can be dropped altogether in snc
+    attribute(:Route)                                 { route }
+
+    attribute(:IsSalaried)                            { is_salaried? }
+    attribute(:Mod)                                   { object.description }
+    attribute(:IncludesPgce)                          { include_pgce }
+
+    attribute(:FullTime)                              { object.part_time? ? 3 : 1 }
+    attribute(:PartTime)                              { object.full_time? ? 3 : 1 }
+
+  private
+
+    def default_salary_value
       {
         Minimum: nil,
         Maximum: nil,
       }
     end
 
-    # Subjects_related_Mapping
-    attribute(:IsSen)                                 { object.is_send? }
-    attribute(:CourseSubjects)                        { get_subjects }
-
-    def get_subjects
+    def course_subjects
       # CourseSubject_Mapping
       object.dfe_subjects.map do |subject_name|
         {
@@ -64,15 +100,7 @@ module SearchAndCompare
       end
     end
 
-    attribute(:Route)                                 { get_route }
-    attribute(:IsSalaried)                            { is_salaried? }
-    attribute(:Mod)                                   { object.description }
-    attribute(:IncludesPgce)                          { get_include_pgce }
-
-    attribute(:FullTime)                              { object.part_time? ? 3 : 1 }
-    attribute(:PartTime)                              { object.full_time? ? 3 : 1 }
-
-    def get_route
+    def route
       route_names = {
         higher_education_programme: "Higher education programme",
         school_direct_training_programme: "School Direct training programme",
@@ -95,7 +123,7 @@ module SearchAndCompare
       !object.is_fee_based?
     end
 
-    def get_include_pgce
+    def include_pgce
       include_pgces = {
         qts: 0,
         pgce_with_qts: 1,

--- a/app/serializers/search_and_compare/course_serializer.rb
+++ b/app/serializers/search_and_compare/course_serializer.rb
@@ -63,5 +63,48 @@ module SearchAndCompare
         }
       end
     end
+
+    attribute(:Route)                                 { get_route }
+    attribute(:IsSalaried)                            { is_salaried? }
+    attribute(:Mod)                                   { object.description }
+    attribute(:IncludesPgce)                          { get_include_pgce }
+
+    attribute(:FullTime)                              { object.part_time? ? 3 : 1 }
+    attribute(:PartTime)                              { object.full_time? ? 3 : 1 }
+
+    def get_route
+      route_names = {
+        higher_education_programme: "Higher education programme",
+        school_direct_training_programme: "School Direct training programme",
+        school_direct_salaried_training_programme: "School Direct (salaried) training programme",
+        scitt_programme: "SCITT programme",
+        pg_teaching_apprenticeship: "PG Teaching Apprenticeship",
+      }
+
+      {
+        # Route_default_value_Mapping
+        Id: 0,
+        Courses: nil,
+        # Route_Complex_value_Mapping
+        Name: route_names[object.program_type.to_sym],
+        IsSalaried: is_salaried?
+      }
+    end
+
+    def is_salaried?
+      !object.is_fee_based?
+    end
+
+    def get_include_pgce
+      include_pgces = {
+        qts: 0,
+        pgce_with_qts: 1,
+        pgde_with_qts: 3,
+        pgce: 5,
+        pgde: 6,
+      }
+
+      include_pgces[object.qualification.to_sym]
+    end
   end
 end

--- a/spec/serializers/search_and_compare/course_serializer_spec.rb
+++ b/spec/serializers/search_and_compare/course_serializer_spec.rb
@@ -18,6 +18,11 @@ describe SearchAndCompare::CourseSerializer do
         { subjects: subjects }
       end
 
+      let(:course_variant) do
+        { program_type: :school_direct_salaried_training_programme,
+          qualification: :pgce_with_qts,
+          study_mode:  :full_time, }
+      end
       let(:course_factory_args) do
         {
           provider: provider,
@@ -26,7 +31,8 @@ describe SearchAndCompare::CourseSerializer do
           course_code: '2KXB',
           start_date: '2019-08-01T00:00:00',
           subject_count: 0,
-          **course_subjects
+          **course_subjects,
+          **course_variant,
         }
       end
 
@@ -135,6 +141,40 @@ describe SearchAndCompare::CourseSerializer do
             end
           end
           it { should match_array expected_course_subjects }
+        end
+      end
+
+      describe 'Course_variant_Mapping' do
+        # related to the course's qualification + program_type + study_mode
+        it { should include(Mod: 'PGCE with QTS full time with salary') }
+
+        # related to the course's program_type
+        it { should include(IsSalaried: !course.is_fee_based?) }
+
+        # related to the course's qualification
+        it { should include(IncludesPgce: 1) }
+
+        # related to the course's study_mode
+        it { should include(FullTime: 1) }
+        it { should include(PartTime: 3) }
+
+        describe 'Route' do
+          subject { resource[:Route] }
+
+          describe 'Route_default_value_Mapping' do
+            it { should include(Id: 0) }
+            it { should include(Courses: nil) }
+          end
+          describe 'Route_Complex_value_Mapping'do
+            # related to the course's program_type
+            it { should include(Name: 'School Direct (salaried) training programme') }
+            # related to the course's program_type
+            it { should include(IsSalaried: !course.is_fee_based?) }
+          end
+
+          describe 'json' do
+            it { should eq expected_json[:Route] }
+          end
         end
       end
 

--- a/spec/serializers/search_and_compare/mappings.yaml
+++ b/spec/serializers/search_and_compare/mappings.yaml
@@ -74,6 +74,54 @@ Subjects_related_Mapping: &Subjects_related
   CourseSubjects:
   - <<: *CourseSubject
 
+IsSalaried_Mapping: &IsSalaried
+  IsSalaried: '!course.is_fee_based?'
+
+Route_default_value_Mapping: &Route_default_value
+  Id: 0
+  Courses:
+
+Route_Complex_value_Mapping: &Route_Complex_value
+  <<: *IsSalaried
+  Name: course.program_type
+
+Route_Mapping: &Route
+  <<: *Route_default_value
+  <<: *Route_Complex_value
+
+Mod_Mapping: &Mod
+  Mod: course.description
+
+IncludesPgce_Mapping: &IncludesPgce
+  IncludesPgce: course.description
+  # {CourseQualification.Qts, IncludesPgce.No} 0,
+  # {CourseQualification.QtsWithPgce, IncludesPgce.Yes} 1,
+  # {CourseQualification.QtsWithPgde, IncludesPgce.QtsWithPgde} 3,
+  # {CourseQualification.QtlsWithPgce, IncludesPgce.QtlsWithPgce} 5,
+  # {CourseQualification.QtlsWithPgde, IncludesPgce.QtlsWithPgde} 6
+
+  # No = 0,
+  # Yes = 1,
+  # QtsWithOptionalPgce = 2,
+  # QtsWithPgde = 3,
+  # QtlsOnly = 4,
+  # QtlsWithPgce = 5,
+  # QtlsWithPgde = 6
+FullTime_mapping: &FullTime
+  FullTime: 'object.part_time? ? 3 : 1'
+  # FullTime = ucasCourseData.StudyMode == "P" ? VacancyStatus.NA : VacancyStatus.Vacancies,
+
+PartTime_mapping: &PartTime
+  PartTime: 'object.full_time? ? 3 : 1'
+  # PartTime = ucasCourseData.StudyMode == "F" ? VacancyStatus.NA : VacancyStatus.Vacancies,
+Course_variant_Mapping: &Course_variant
+  <<: *IsSalaried
+  <<: *Route
+  <<: *Mod
+  <<: *IncludesPgce
+  <<: *FullTime
+  <<: *PartTime
+
 # Actual course
 Course_Full_Mapping:
   <<: *Provider_serializer
@@ -82,3 +130,4 @@ Course_Full_Mapping:
   Salary:
     <<: *Salary
   <<: *Subjects_related
+  <<: *Course_variant


### PR DESCRIPTION
### Context
search and compare serializer part 5
course variant interplay of `program_type`, `study_mode` & `qualification`

### Changes proposed in this pull request
Added serialization of related course variant touch points

### Guidance to review
Its going to get mess from henceforth, PR to make it better is welcome

part 5 ot x

Refer to the almost complete
https://github.com/DFE-Digital/manage-courses-backend/pull/377

For the full whack

FYI 

Part 1
https://github.com/DFE-Digital/manage-courses-backend/pull/381

Part 2
https://github.com/DFE-Digital/manage-courses-backend/pull/387

Part 3
https://github.com/DFE-Digital/manage-courses-backend/pull/390

Part 4
https://github.com/DFE-Digital/manage-courses-backend/pull/401

Probably easier to follow the commits

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
