### PR TITLE
[1520] Financial incentives

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -242,4 +242,12 @@ class Course < ApplicationRecord
   def sites_not_associated_with_course
     provider.sites - sites
   end
+
+  def has_bursary?
+    dfe_subjects.any?(&:has_bursary?)
+  end
+
+  def has_scholarship_and_bursary?
+    dfe_subjects.any?(&:has_scholarship_and_bursary?)
+  end
 end

--- a/app/models/dfe_subject.rb
+++ b/app/models/dfe_subject.rb
@@ -1,6 +1,28 @@
 class DFESubject
+  FINANCIAL_SUPPORT_FOR_2019_20_RECRUITMENT_CYCLE = [
+    { subjects: %w[Mathematics], bursary_amount: 20000, early_career_payments: 10000, scholarship: 22000 },
+    { subjects: %w[French Chemistry Computing Spanish Geography Physics German], bursary_amount: 26000, early_career_payments: nil, scholarship: 28000 },
+    { subjects: ["Modern languages (other)", "Classics", "Italian", "Japanese", "Mandarin", "Russian", "Biology"], bursary_amount: 26000, early_career_payments: nil, scholarship: nil },
+    { subjects: %w[English], bursary_amount: 15000, early_career_payments: nil, scholarship: nil },
+    { subjects: ["Design and technology", "History"], bursary_amount: 12000, early_career_payments: nil, scholarship: nil },
+    { subjects: %w[Music], bursary_amount: 9000, early_career_payments: nil, scholarship: nil },
+    { subjects: ["Primary with mathematics"], bursary_amount: 6000, early_career_payments: nil, scholarship: nil },
+  ].freeze
+
   def initialize(subject_name)
     @subject_name = subject_name
+  end
+
+  def has_bursary?
+    financial_support&.fetch(:bursary_amount).present?
+  end
+
+  def has_scholarship?
+    financial_support&.fetch(:scholarship).present?
+  end
+
+  def has_scholarship_and_bursary?
+    has_bursary? && has_scholarship?
   end
 
   def to_s
@@ -9,5 +31,11 @@ class DFESubject
 
   def ==(other)
     to_s == other.to_s
+  end
+
+private
+
+  def financial_support
+    FINANCIAL_SUPPORT_FOR_2019_20_RECRUITMENT_CYCLE.detect { |entry| @subject_name.in?(entry[:subjects]) }
   end
 end

--- a/app/models/dfe_subject.rb
+++ b/app/models/dfe_subject.rb
@@ -1,0 +1,13 @@
+class DFESubject
+  def initialize(subject_name)
+    @subject_name = subject_name
+  end
+
+  def to_s
+    @subject_name
+  end
+
+  def ==(other)
+    to_s == other.to_s
+  end
+end

--- a/app/models/subjects/ucas_to_dfe_subject_mapping.rb
+++ b/app/models/subjects/ucas_to_dfe_subject_mapping.rb
@@ -20,7 +20,7 @@ module Subjects
     end
 
     def to_dfe_subject
-      @resulting_dfe_subject
+      DFESubject.new(@resulting_dfe_subject)
     end
 
   private

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -14,7 +14,7 @@ module API
       attributes :findable?, :open_for_applications?, :has_vacancies?,
                  :course_code, :name, :study_mode, :qualifications, :description,
                  :content_status, :ucas_status, :funding, :applications_open_from,
-                 :level, :is_send?
+                 :level, :is_send?, :has_bursary?, :has_scholarship_and_bursary?
 
       attribute :start_date do
         @object.start_date&.iso8601

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -25,7 +25,7 @@ module API
       end
 
       attribute :subjects do
-        @object.dfe_subjects
+        @object.dfe_subjects.map(&:to_s)
       end
 
       belongs_to :provider

--- a/app/serializers/search_and_compare/course_serializer.rb
+++ b/app/serializers/search_and_compare/course_serializer.rb
@@ -40,7 +40,7 @@ module SearchAndCompare
 
     def get_subjects
       # CourseSubject_Mapping
-      object.dfe_subjects.map do |subject_name|
+      object.dfe_subjects.map do |subject|
         {
           # CourseSubject_default_value_mapping
           CourseId: 0,
@@ -58,7 +58,7 @@ module SearchAndCompare
               CourseSubjects: nil,
 
               # Subject_direct_Mapping
-              Name: subject_name,
+              Name: subject.to_s,
             }
         }
       end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -396,6 +396,19 @@ RSpec.describe Course, type: :model do
         its(:is_send?) { should be_truthy }
       end
     end
+
+    describe "bursaries and scholarships" do
+      let(:subjects) {
+        [
+          build(:subject, subject_name: 'mathematics'),
+          build(:subject, subject_name: 'secondary'),
+        ]
+      }
+      subject { create(:course, subjects: subjects) }
+
+      it { should have_bursary }
+      it { should have_scholarship_and_bursary }
+    end
   end
 
   context "entry requirements" do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -372,19 +372,19 @@ RSpec.describe Course, type: :model do
     context 'with primary subjects' do
       subject { create(:course, subject_count: 0, subjects: [create(:subject, subject_name: "primary")]) }
       its(:level) { should eq(:primary) }
-      its(:dfe_subjects) { should eq(%w[Primary]) }
+      its(:dfe_subjects) { should eq([DFESubject.new("Primary")]) }
     end
 
     context 'with secondary subjects' do
       subject { create(:course, subject_count: 0, subjects: [create(:subject, subject_name: "physical education")]) }
       its(:level) { should eq(:secondary) }
-      its(:dfe_subjects) { should eq(["Physical education"]) }
+      its(:dfe_subjects) { should eq([DFESubject.new("Physical education")]) }
     end
 
     context 'with further education subjects' do
       subject { create(:course, subject_count: 0, subjects: [create(:further_education_subject)]) }
       its(:level) { should eq(:further_education) }
-      its(:dfe_subjects) { should eq(["Further education"]) }
+      its(:dfe_subjects) { should eq([DFESubject.new("Further education")]) }
     end
 
     describe "#is_send?" do

--- a/spec/models/dfe_subject_spec.rb
+++ b/spec/models/dfe_subject_spec.rb
@@ -1,0 +1,19 @@
+describe DFESubject do
+  subject { DFESubject.new(subject_name) }
+
+  context "(secondary mathematics)" do
+    let(:subject_name) { "Mathematics" }
+
+    it { should have_bursary }
+    it { should have_scholarship }
+
+    it { should eq(DFESubject.new("Mathematics")) }
+  end
+
+  context "(physical education)" do
+    let(:subject_name) { "Physical education" }
+
+    it { should_not have_bursary }
+    it { should_not have_scholarship }
+  end
+end

--- a/spec/models/subjects/ucas_to_dfe_subject_mapping_collection_spec.rb
+++ b/spec/models/subjects/ucas_to_dfe_subject_mapping_collection_spec.rb
@@ -13,7 +13,7 @@ module Subjects
     subject { described_class.new(config: config) }
 
     it "applies individual mappings to derive the result" do
-      expect(subject.to_dfe_subjects(ucas_subjects: ["UCAS subject A1"], course_title: :anything)).
+      expect(subject.to_dfe_subjects(ucas_subjects: ["UCAS subject A1"], course_title: :anything).map(&:to_s)).
         to eq(["DfE subject A"])
     end
 
@@ -22,7 +22,7 @@ module Subjects
         subject.to_dfe_subjects(
           ucas_subjects: ["UCAS subject A1", "UCAS subject B", "UCAS subject W"],
           course_title: "XY with V"
-        )
+        ).map(&:to_s)
       ).to match_array(["DfE subject A", "DfE subject B", "DfE subject XY"])
     end
 

--- a/spec/models/subjects/ucas_to_dfe_subject_mapping_spec.rb
+++ b/spec/models/subjects/ucas_to_dfe_subject_mapping_spec.rb
@@ -7,7 +7,7 @@ module Subjects
       it { should be_applicable_to(["maths (abridged)", "something else"], :anything) }
       it { should_not be_applicable_to(%w[english], :anything) }
 
-      its(:to_dfe_subject) { should eq("Mathematics") }
+      its(:to_dfe_subject) { should eq(DFESubject.new("Mathematics")) }
     end
 
     context "when passed a lambda that matches on the course title" do
@@ -25,7 +25,7 @@ module Subjects
       it { should_not be_applicable_to(["something else"], "english language") }
       it { should_not be_applicable_to(%w[english], "some other course title") }
 
-      its(:to_dfe_subject) { should eq("English") }
+      its(:to_dfe_subject) { should eq(DFESubject.new("English")) }
     end
 
     context "when passed a lambda that matches on the UCAS subjects list" do
@@ -42,7 +42,7 @@ module Subjects
       it { should_not be_applicable_to(%w[a], :anything) }
       it { should_not be_applicable_to(%[a b c], :anything) }
 
-      its(:to_dfe_subject) { should eq("English") }
+      its(:to_dfe_subject) { should eq(DFESubject.new("English")) }
     end
   end
 end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -119,6 +119,8 @@ describe 'Courses API v2', type: :request do
               "required_qualifications" => enrichment.qualifications,
               "salary_details" => enrichment.salary_details,
               "last_published_at" => enrichment.last_published_timestamp_utc.iso8601,
+              "has_bursary?" => true,
+              "has_scholarship_and_bursary?" => false,
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },
@@ -235,6 +237,8 @@ describe 'Courses API v2', type: :request do
               "required_qualifications" => enrichment.qualifications,
               "salary_details" => enrichment.salary_details,
               "last_published_at" => enrichment.last_published_timestamp_utc.iso8601,
+              "has_bursary?" => true,
+              "has_scholarship_and_bursary?" => false,
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -98,10 +98,18 @@ describe API::V2::SerializableCourse do
   end
 
   context "subjects & level" do
+    let(:course) { create(:course, subject_count: 0, subjects: subjects) }
+
     describe 'are taken from the course' do
-      let(:course) { create(:course, subject_count: 0, subjects: [create(:subject, subject_name: "primary")]) }
+      let(:subjects) { [create(:subject, subject_name: "primary")] }
       it { expect(subject["attributes"]).to include("level" => "primary") }
       it { expect(subject["attributes"]).to include("subjects" => %w[Primary]) }
+    end
+
+    describe 'determine bursary and scholarship info' do
+      let(:subjects) { [create(:subject, subject_name: "Secondary"), create(:subject, subject_name: "Russian")] }
+      it { expect(subject["attributes"]).to include("has_bursary?" => true) }
+      it { expect(subject["attributes"]).to include("has_scholarship_and_bursary?" => false) }
     end
   end
 

--- a/spec/services/subject_mapper_service_spec.rb
+++ b/spec/services/subject_mapper_service_spec.rb
@@ -11,7 +11,7 @@ describe SubjectMapperService do
     end
 
     def mapped_subjects(course_title, ucas_subjects)
-      described_class.get_subject_list(course_title, ucas_subjects)
+      described_class.get_subject_list(course_title, ucas_subjects).map(&:to_s)
     end
 
     chain :at_level do |level|
@@ -144,7 +144,7 @@ describe SubjectMapperService do
                   header_converters: :symbol).with_index do |row, i|
 
         describe "Test case row '#{i}': subjects #{row[:ucas_subjects]}, title: #{row[:course_title]}" do
-          subject { described_class.get_subject_list(row[:course_title], row[:ucas_subjects].split(",")) }
+          subject { described_class.get_subject_list(row[:course_title], row[:ucas_subjects].split(",")).map(&:to_s) }
           it { should match_array row[:expected_subjects]&.split(",") || [] }
         end
       end


### PR DESCRIPTION
### Context
We need financial incentive information for rendering the course details page preview. Currently this information resides only on Find.

### Changes proposed in this pull request
- extract a `DFESubject` plain-old-Ruby-object model
- define financial incentives data as a Ruby structure on `DFESubject` (this would only get updated at most once a year so should be fine being hard-coded)
- expose `has_bursary?` and `has_scholarship_and_bursary?` on `Course` through the Course API V2

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
