### PR TITLE
[1527] Training locations without vacancies should be suspended

### DIFF
--- a/app/serializers/site_status_serializer.rb
+++ b/app/serializers/site_status_serializer.rb
@@ -23,7 +23,11 @@ class SiteStatusSerializer < ActiveModel::Serializer
   end
 
   def status
-    object.status_before_type_cast
+    if object.no_vacancies?
+      SiteStatus.statuses["suspended"]
+    else
+      object.status_before_type_cast
+    end
   end
 
   def publish

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -284,5 +284,21 @@ describe "Courses API", type: :request do
         end
       end
     end
+
+    describe "site status" do
+      context "when there are no vacancies" do
+        before do
+          create(:site_status, :running, :with_no_vacancies)
+        end
+
+        it 'presents the site status as suspended (so that the UTT Apply system hides the site altogether)' do
+          get "/api/v1/2019/courses", headers: { 'HTTP_AUTHORIZATION' => credentials }
+
+          json = JSON.parse(response.body)
+
+          expect(json[0]["campus_statuses"][0]["status"]). to eq(SiteStatus.statuses["suspended"])
+        end
+      end
+    end
   end
 end

--- a/spec/serializers/site_status_serializer_spec.rb
+++ b/spec/serializers/site_status_serializer_spec.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: course_site
+#
+#  id                         :integer          not null, primary key
+#  applications_accepted_from :date
+#  course_id                  :integer
+#  publish                    :text
+#  site_id                    :integer
+#  status                     :text
+#  vac_status                 :text
+#
+
+require "rails_helper"
+
+RSpec.describe SiteStatusSerializer do
+  subject { serialize(site_status) }
+
+  context "when the site status has some vacancies" do
+    let(:site_status) { create :site_status, :full_time_vacancies }
+    its([:status]) { should eq(site_status.status_before_type_cast) }
+  end
+
+  context "when the site status has no vacancies" do
+    let(:site_status) { create :site_status, :with_no_vacancies }
+    its([:status]) { should eq(SiteStatus.statuses["suspended"]) }
+  end
+end


### PR DESCRIPTION
### Context
If a training location has no vacancies, it's still selectable on UCAS Apply
but the candidate is informed several steps into their application journey
that it's full.

### Changes proposed in this pull request
This change makes the training location suspended in the V1 API. The end effect
of this change is that the location is no longer listed on UCAS Apply, so candidates
don't inadvertently select them anymore.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
