### PR TITLE
[1528] Fix manual access requests

### DIFF
--- a/app/controllers/api/v2/access_requests_controller.rb
+++ b/app/controllers/api/v2/access_requests_controller.rb
@@ -25,11 +25,13 @@ module API
       end
 
       def create
-        authorize AccessRequest # todo, generalise admin auth
         access_request = AccessRequest.new(access_request_params)
-        access_request.update(requester: @current_user,
-                              request_date_utc: Time.now.utc,
-                              status: :requested)
+        authorize access_request
+
+        access_request.requester        = User.find_by(email: access_request.requester_email)
+        access_request.request_date_utc = Time.now.utc
+        access_request.status           = :requested
+        access_request.save!
 
         render jsonapi: access_request
       end
@@ -41,7 +43,14 @@ module API
       end
 
       def access_request_params
-        params.require(:access_request).permit(:email_address, :first_name, :last_name, :organisation, :reason)
+        params.require(:access_request).permit(
+          :email_address,
+          :first_name,
+          :last_name,
+          :organisation,
+          :reason,
+          :requester_email
+        )
       end
     end
   end

--- a/spec/requests/api/v2/access_request_spec.rb
+++ b/spec/requests/api/v2/access_request_spec.rb
@@ -311,6 +311,7 @@ describe 'Access Request API V2', type: :request do
              last_name: "monkhouse",
              organisation: "bbc",
              reason: "star qualities",
+             requester_email: requesting_user.email
            } }.as_json
     end
     context 'when unauthenticated' do
@@ -369,7 +370,7 @@ describe 'Access Request API V2', type: :request do
           expect(access_request.organisation).to eq("bbc")
           expect(access_request.reason).to eq("star qualities")
           expect(access_request.request_date_utc).to be_within(1.second).of Time.now.utc # https://github.com/travisjeffery/timecop/issues/97
-          expect(access_request.requester.email).to eq("super.admin@digital.education.gov.uk")
+          expect(access_request.requester.email).to eq(requesting_user.email)
         end
       end
     end


### PR DESCRIPTION
### Context

Manual access requests give users God access.

### Changes proposed in this pull request

Read the `requester_email` from the params, and pass it into the update. Do not use the super admin. Oops.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally