### PR TITLE
[1506] Grant user access to provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,8 +51,9 @@ gem 'jwt'
 # Formalise config settings with support for env vars
 gem 'config'
 
-# For building cmdline apps (mcb)
+# For building interactive cmdline apps (mcb)
 gem 'cri'
+gem 'highline'
 gem 'rainbow'
 
 # Build pretty tables in the terminal

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,7 @@ GEM
       guard (~> 2.0)
       rubocop (~> 0.20)
     hashdiff (0.3.8)
+    highline (2.0.2)
     httparty (0.17.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
@@ -411,6 +412,7 @@ DEPENDENCIES
   guard
   guard-rspec
   guard-rubocop
+  highline
   httparty
   jsonapi-rails
   jsonapi-rb

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,8 @@ class User < ApplicationRecord
   scope :non_admins, -> { where.not('email ~ ?', DFE_EMAIL_PATTERN) }
   scope :active, -> { where.not(accept_terms_date_utc: nil) }
 
-  validates :email, presence: true
+  validates :email, presence: true, format: { with: /@/, message: "must contain @" }
+  validate :email_is_lowercase
 
   audited
 
@@ -46,5 +47,13 @@ class User < ApplicationRecord
 
   def to_s
     "#{first_name} #{last_name} <#{email}>"
+  end
+
+private
+
+  def email_is_lowercase
+    if email.present? && email.downcase != email
+      errors.add(:email, "must be lowercase")
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,4 +43,8 @@ class User < ApplicationRecord
   def admin?
     email.match?(%r{#{DFE_EMAIL_PATTERN}})
   end
+
+  def to_s
+    "#{first_name} #{last_name} <#{email}>"
+  end
 end

--- a/bin/mcb
+++ b/bin/mcb
@@ -21,6 +21,7 @@ require 'mcb'
 require 'mcb/azure'
 require 'mcb/config'
 require 'mcb/course_show'
+require 'mcb/grant_access_wizard'
 
 tp.set :capitalize_headers, false
 

--- a/lib/mcb/commands/users/grant_access_to_provider.rb
+++ b/lib/mcb/commands/users/grant_access_to_provider.rb
@@ -1,0 +1,11 @@
+summary 'Attach a user to an organisation/provider in the DB'
+param :provider_code
+usage 'grant_access_to_provider <provider_code>'
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
+  cli = HighLine.new
+  provider = Provider.find_by!(provider_code: args[:provider_code])
+  MCB::GrantAccessWizard.new(cli, provider).run
+end

--- a/lib/mcb/grant_access_wizard.rb
+++ b/lib/mcb/grant_access_wizard.rb
@@ -1,0 +1,64 @@
+module MCB
+  class GrantAccessWizard
+    def initialize(cli, provider)
+      @cli = cli
+      @provider = provider
+    end
+
+    def run
+      fetch_organisation
+      ask_email
+      find_or_init_user
+      should_continue = persist_user_if_new
+      confirm_and_add_user_to_organisation if should_continue
+    end
+
+  private
+
+    def fetch_organisation
+      @organisation = @provider.organisations.first # a provider should only ever be associated with one organisation
+    end
+
+    def ask_email
+      @email = @cli.ask("Email address of user?  ").strip.downcase
+    end
+
+    def find_or_init_user
+      @user = User.find_or_initialize_by(email: @email) do |u|
+        puts "#{@email} appears to be a new user"
+        u.first_name = @cli.ask("First name?  ").strip
+        u.last_name = @cli.ask("Last name?  ").strip
+      end
+    end
+
+    def persist_user_if_new
+      if @user.new_record?
+        if !@user.valid?
+          puts "Cannot create this user:"
+          @user.errors.full_messages.each do |message|
+            puts "- #{message}"
+          end
+          return false
+        elsif @cli.agree("About to create #{@user}. Continue? ")
+          @user.save!
+          true
+        else
+          return false
+        end
+      end
+      true
+    end
+
+    def confirm_and_add_user_to_organisation
+      if @user.in?(@organisation.users)
+        puts "#{@user} already belongs to #{@organisation.name}"
+      else
+        puts "You're about to give #{@user} access to #{@organisation.name}. They will manage:"
+        @organisation.providers.each do |p|
+          puts " - #{p.provider_name} (#{p.provider_code})"
+        end
+        @organisation.users << @user if @cli.agree("Agree?  ")
+      end
+    end
+  end
+end

--- a/spec/lib/mcb/commands/users/grant_access_to_provider_spec.rb
+++ b/spec/lib/mcb/commands/users/grant_access_to_provider_spec.rb
@@ -1,0 +1,85 @@
+require 'mcb_helper'
+
+describe 'mcb users grant_access_to_provider' do
+  def grant_access_to_provider(provider_code, commands)
+    stderr = ""
+    output = with_stubbed_stdout(stdin: commands, stderr: stderr) do
+      cmd.run([provider_code])
+    end
+    [output, stderr]
+  end
+
+  let(:lib_dir) { "#{Rails.root}/lib" }
+  let(:cmd) do
+    Cri::Command.load_file(
+      "#{lib_dir}/mcb/commands/users/grant_access_to_provider.rb"
+    )
+  end
+  let(:organisation) { create(:organisation) }
+  let(:provider) { create(:provider, organisations: [organisation]) }
+  let(:output) { grant_access_to_provider(provider.provider_code, input_commands.join("\n") + "\n").first }
+
+  context 'when the user exists and already has access to the provider' do
+    let(:input_commands) { [user.email] }
+    let(:user) { create(:user, organisations: [organisation]) }
+
+    it 'informs the support agen that it is not going to do anything' do
+      expect(output).to include("#{user} already belongs to #{organisation.name}")
+    end
+  end
+
+  context 'when the user does not exist' do
+    let(:input_commands) { %w[jsmith@acme.org Jane Smith y y] }
+
+    before do
+      output
+    end
+
+    it 'creates the user' do
+      expect(User.find_by(first_name: 'Jane', last_name: 'Smith', email: 'jsmith@acme.org')).to be_present
+    end
+
+    it 'grants organisation membership to that user' do
+      user = User.find_by!(first_name: 'Jane', last_name: 'Smith', email: 'jsmith@acme.org')
+      expect(user.organisations).to eq([organisation])
+    end
+
+    it 'confirms user creation and organisation membership' do
+      expect(output).to include("jsmith@acme.org appears to be a new user")
+      expect(output).to include("You're about to give Jane Smith <jsmith@acme.org> access to #{organisation.name}.")
+    end
+  end
+
+  context 'when the user details are invalid' do
+    let(:input_commands) { %w[jsmith Jane Smith] }
+
+    before do
+      output
+    end
+
+    it 'does not create the user' do
+      expect(User.count).to eq(0)
+    end
+
+    it 'displays the validation errors' do
+      expect(output).to include("Email must contain @")
+    end
+  end
+
+  context 'when the user exists but is not a member of the org' do
+    let(:user) { create(:user, organisations: []) }
+    let(:input_commands) { [user.email, 'y'] }
+
+    before do
+      output
+    end
+
+    it 'grants organisation membership to that user' do
+      expect(user.reload.organisations).to eq([organisation])
+    end
+
+    it 'confirms user creation and organisation membership' do
+      expect(output).to include("You're about to give #{user} access to #{organisation.name}.")
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,7 +18,7 @@
 require 'rails_helper'
 
 describe User, type: :model do
-  subject { create(:user) }
+  subject { create(:user, first_name: 'Jane', last_name: 'Smith', email: 'jsmith@scitt.org') }
 
   describe 'associations' do
     it { should have_and_belong_to_many(:organisations) }
@@ -26,6 +26,7 @@ describe User, type: :model do
   end
 
   it { is_expected.to validate_presence_of(:email) }
+  its(:to_s) { should eq("Jane Smith <jsmith@scitt.org>") }
 
   describe 'auditing' do
     it { should be_audited }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,8 +25,11 @@ describe User, type: :model do
     it { should have_many(:providers).through(:organisations) }
   end
 
-  it { is_expected.to validate_presence_of(:email) }
+  it { is_expected.to validate_presence_of(:email).with_message("must contain @") }
   its(:to_s) { should eq("Jane Smith <jsmith@scitt.org>") }
+
+  it { should_not allow_value('CAPS_IN_EMAIL@ACME.ORG').for(:email) }
+  it { should_not allow_value('email_without_at').for(:email) }
 
   describe 'auditing' do
     it { should be_audited }


### PR DESCRIPTION
### Context
We need to be able to add new users to organisations. It's possible to use access requests for this, but only as long as there is an existing user in the organisation.

### Changes proposed in this pull request
- Add an `mcb` command which adds new users to an organisation, or gives existing users access to that organisation.
- Add some validations on `User` to help catch any mistakes while using `mcb`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
