### PR TITLE
[1529] Include only course counts on provider index

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -5,7 +5,7 @@ module API
 
       def index
         authorize Provider
-        providers = policy_scope(Provider).includes(:courses)
+        providers = policy_scope(Provider).include_courses_counts
         providers = providers.where(id: @user.providers) if @user.present?
 
         render jsonapi: providers.in_order, fields: { providers: %i[provider_code provider_name courses] }

--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -57,7 +57,7 @@ module API
 
       has_many :courses do
         meta do
-          { count: @object.courses.size }
+          { count: @object.courses_count }
         end
       end
     end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -201,4 +201,39 @@ describe Provider, type: :model do
       its(:can_add_more_sites?) { should be_falsey }
     end
   end
+
+  describe "courses" do
+    let!(:provider) { create(:provider) }
+    let!(:course) { create(:course, provider: provider) }
+
+    describe "#courses_count" do
+      it 'returns course count using courses.size' do
+        allow(provider.courses).to receive(:size).and_return(1)
+
+        expect(provider.courses_count).to eq(1)
+        expect(provider.courses).to have_received(:size)
+      end
+
+      context "with .include_courses_counts" do
+        let(:provider_with_included) { Provider.include_courses_counts.first }
+
+        it "return course count using included_courses_count" do
+          allow(provider_with_included).to receive(:included_courses_count).and_return(1)
+          allow(provider_with_included.courses).to receive(:size)
+
+          expect(provider_with_included.courses_count).to eq(1)
+          expect(provider_with_included).to have_received(:included_courses_count)
+          expect(provider_with_included.courses).to_not have_received(:size)
+        end
+      end
+    end
+
+    describe ".include_courses_counts" do
+      let(:first_provider) { Provider.include_courses_counts.first }
+
+      it 'includes course counts' do
+        expect(first_provider.courses_count).to eq(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

Improving our performance by optimising out N+1 and slow db queries.

### Changes proposed in this pull request

Uses a bit of raw SQL on the provider model to only include the course counts.

This vastly improves response times, two-fold:

- Cuts the database/ActiveRecord time 2.5x, by not fetching the entire course information as part of the call, only the count
- Cuts the view/json rendering time 5x, because `JSONAPI::Serializable::Resource` seems to do unnecessary work when the entire course information is fetched in

Before:

```
Completed 200 OK in 519ms (Views: 481.4ms | ActiveRecord: 36.4ms)
Completed 200 OK in 649ms (Views: 608.0ms | ActiveRecord: 38.9ms)
Completed 200 OK in 513ms (Views: 473.4ms | ActiveRecord: 38.4ms)
Completed 200 OK in 636ms (Views: 594.4ms | ActiveRecord: 39.6ms)
Completed 200 OK in 535ms (Views: 492.8ms | ActiveRecord: 40.0ms)
```

After:

```
Completed 200 OK in 96ms (Views: 76.9ms | ActiveRecord: 17.0ms)
Completed 200 OK in 97ms (Views: 79.2ms | ActiveRecord: 16.6ms)
Completed 200 OK in 136ms (Views: 118.1ms | ActiveRecord: 16.3ms)
Completed 200 OK in 97ms (Views: 78.8ms | ActiveRecord: 16.3ms)
Completed 200 OK in 98ms (Views: 79.3ms | ActiveRecord: 16.8ms)
```

### Guidance to review

More tests forthcoming.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally