### PR TITLE
[1533] Optimise providers show

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -12,7 +12,7 @@ module API
       end
 
       def show
-        provider = Provider.find_by!(provider_code: params[:code].upcase)
+        provider = Provider.includes(:latest_published_enrichment).find_by!(provider_code: params[:code].upcase)
         authorize provider, :show?
 
         render jsonapi: provider, include: params[:include]

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -49,6 +49,11 @@ class Provider < ApplicationRecord
            foreign_key: :provider_code,
            primary_key: :provider_code,
            class_name: "ProviderEnrichment"
+  has_one :latest_published_enrichment,
+          -> { published.latest_published_at },
+          foreign_key: :provider_code,
+          primary_key: :provider_code,
+          class_name: "ProviderEnrichment"
   has_many :courses
   has_one :ucas_preferences, class_name: 'ProviderUCASPreference'
   has_many :contacts
@@ -131,9 +136,8 @@ class Provider < ApplicationRecord
       email
     ]
 
-    enrichment = enrichments.published.latest_published_at.first
-    if enrichment
-      enrichment.attributes.slice(*(attribute_names + %w[website]))
+    if latest_published_enrichment
+      latest_published_enrichment.attributes.slice(*(attribute_names + %w[website]))
     else
       attributes.slice(*attribute_names).merge('website' => url)
     end


### PR DESCRIPTION
### Context

Fixing N+1 queries.

### Changes proposed in this pull request

Creates a new `has_many` relationship which can be independently `included` to fetch the latest enrichment.

### Guidance to review

There should already be adequate test coverage for this.

Before:

```
Started GET "/api/v2/providers/2AT" for ::1 at 2019-05-28 15:28:01 +0100
Processing by API::V2::ProvidersController#show as JSONAPI
  Parameters: {"code"=>"2AT"}
  User Load (0.4ms)  SELECT  "user".* FROM "user" WHERE "user"."sign_in_user_id" = $1 LIMIT $2  [["sign_in_user_id", "135AEC82-DA17-40E8-A280-1B20460475EC"], ["LIMIT", 1]]
  ↳ app/services/authentication_service.rb:53
  Provider Load (0.5ms)  SELECT  "provider".* FROM "provider" WHERE "provider"."provider_code" = $1 LIMIT $2  [["provider_code", "2AT"], ["LIMIT", 1]]
  ↳ app/controllers/api/v2/providers_controller.rb:15
  Provider Exists (0.7ms)  SELECT  1 AS one FROM "provider" INNER JOIN "organisation_provider" ON "provider"."id" = "organisation_provider"."provider_id" INNER JOIN "organisation" ON "organisation_provider"."organisation_id" = "organisation"."id" INNER JOIN "organisation_user" ON "organisation"."id" = "organisation_user"."organisation_id" WHERE "organisation_user"."user_id" = $1 AND "provider"."id" = $2 LIMIT $3  [["user_id", 10333], ["id", 12403], ["LIMIT", 1]]
  ↳ app/policies/provider_policy.rb:27
   (0.2ms)  SELECT COUNT(*) FROM "course" WHERE "course"."provider_id" = $1  [["provider_id", 12403]]
  ↳ app/models/provider.rb:96
   (0.3ms)  SELECT COUNT(*) FROM "site" WHERE "site"."provider_id" = $1  [["provider_id", 12403]]
  ↳ app/models/provider.rb:119
  ProviderEnrichment Load (0.3ms)  SELECT  "provider_enrichment".* FROM "provider_enrichment" WHERE "provider_enrichment"."provider_code" = $1 AND "provider_enrichment"."status" = $2 ORDER BY "provider_enrichment"."last_published_at" DESC LIMIT $3  [["provider_code", "2AT"], ["status", 1], ["LIMIT", 1]]
  ↳ app/models/provider.rb:134
  CACHE ProviderEnrichment Load (0.0ms)  SELECT  "provider_enrichment".* FROM "provider_enrichment" WHERE "provider_enrichment"."provider_code" = $1 AND "provider_enrichment"."status" = $2 ORDER BY "provider_enrichment"."last_published_at" DESC LIMIT $3  [["provider_code", "2AT"], ["status", 1], ["LIMIT", 1]]
  ↳ app/models/provider.rb:134
  CACHE ProviderEnrichment Load (0.0ms)  SELECT  "provider_enrichment".* FROM "provider_enrichment" WHERE "provider_enrichment"."provider_code" = $1 AND "provider_enrichment"."status" = $2 ORDER BY "provider_enrichment"."last_published_at" DESC LIMIT $3  [["provider_code", "2AT"], ["status", 1], ["LIMIT", 1]]
  ↳ app/models/provider.rb:134
  CACHE ProviderEnrichment Load (0.0ms)  SELECT  "provider_enrichment".* FROM "provider_enrichment" WHERE "provider_enrichment"."provider_code" = $1 AND "provider_enrichment"."status" = $2 ORDER BY "provider_enrichment"."last_published_at" DESC LIMIT $3  [["provider_code", "2AT"], ["status", 1], ["LIMIT", 1]]
  ↳ app/models/provider.rb:134
  CACHE ProviderEnrichment Load (0.0ms)  SELECT  "provider_enrichment".* FROM "provider_enrichment" WHERE "provider_enrichment"."provider_code" = $1 AND "provider_enrichment"."status" = $2 ORDER BY "provider_enrichment"."last_published_at" DESC LIMIT $3  [["provider_code", "2AT"], ["status", 1], ["LIMIT", 1]]
  ↳ app/models/provider.rb:134
  CACHE ProviderEnrichment Load (0.0ms)  SELECT  "provider_enrichment".* FROM "provider_enrichment" WHERE "provider_enrichment"."provider_code" = $1 AND "provider_enrichment"."status" = $2 ORDER BY "provider_enrichment"."last_published_at" DESC LIMIT $3  [["provider_code", "2AT"], ["status", 1], ["LIMIT", 1]]
  ↳ app/models/provider.rb:134
  CACHE ProviderEnrichment Load (0.0ms)  SELECT  "provider_enrichment".* FROM "provider_enrichment" WHERE "provider_enrichment"."provider_code" = $1 AND "provider_enrichment"."status" = $2 ORDER BY "provider_enrichment"."last_published_at" DESC LIMIT $3  [["provider_code", "2AT"], ["status", 1], ["LIMIT", 1]]
  ↳ app/models/provider.rb:134
  CACHE ProviderEnrichment Load (0.0ms)  SELECT  "provider_enrichment".* FROM "provider_enrichment" WHERE "provider_enrichment"."provider_code" = $1 AND "provider_enrichment"."status" = $2 ORDER BY "provider_enrichment"."last_published_at" DESC LIMIT $3  [["provider_code", "2AT"], ["status", 1], ["LIMIT", 1]]
  ↳ app/models/provider.rb:134
  CACHE ProviderEnrichment Load (0.0ms)  SELECT  "provider_enrichment".* FROM "provider_enrichment" WHERE "provider_enrichment"."provider_code" = $1 AND "provider_enrichment"."status" = $2 ORDER BY "provider_enrichment"."last_published_at" DESC LIMIT $3  [["provider_code", "2AT"], ["status", 1], ["LIMIT", 1]]
  ↳ app/models/provider.rb:134
  ProviderEnrichment Load (0.5ms)  SELECT  "provider_enrichment".* FROM "provider_enrichment" WHERE "provider_enrichment"."provider_code" = $1 ORDER BY "provider_enrichment"."provider_code" DESC LIMIT $2  [["provider_code", "2AT"], ["LIMIT", 1]]
  ↳ app/serializers/api/v2/serializable_provider.rb:7
  CACHE ProviderEnrichment Load (0.0ms)  SELECT  "provider_enrichment".* FROM "provider_enrichment" WHERE "provider_enrichment"."provider_code" = $1 ORDER BY "provider_enrichment"."provider_code" DESC LIMIT $2  [["provider_code", "2AT"], ["LIMIT", 1]]
  ↳ app/serializers/api/v2/serializable_provider.rb:7
Completed JSON API rendering (44.11ms)
Completed 200 OK in 105ms (Views: 39.4ms | ActiveRecord: 12.9ms)
```

After:

```bash
Started GET "/api/v2/providers/2AT" for ::1 at 2019-05-28 15:30:24 +0100
Processing by API::V2::ProvidersController#show as JSONAPI
  Parameters: {"code"=>"2AT"}
  User Load (0.4ms)  SELECT  "user".* FROM "user" WHERE "user"."sign_in_user_id" = $1 LIMIT $2  [["sign_in_user_id", "135AEC82-DA17-40E8-A280-1B20460475EC"], ["LIMIT", 1]]
  ↳ app/services/authentication_service.rb:53
  Provider Load (0.2ms)  SELECT  "provider".* FROM "provider" WHERE "provider"."provider_code" = $1 LIMIT $2  [["provider_code", "2AT"], ["LIMIT", 1]]
  ↳ app/controllers/api/v2/providers_controller.rb:15
  ProviderEnrichment Load (0.3ms)  SELECT "provider_enrichment".* FROM "provider_enrichment" WHERE "provider_enrichment"."status" = $1 AND "provider_enrichment"."provider_code" = $2 ORDER BY "provider_enrichment"."last_published_at" DESC  [["status", 1], ["provider_code", "2AT"]]
  ↳ app/controllers/api/v2/providers_controller.rb:15
  Provider Exists (0.8ms)  SELECT  1 AS one FROM "provider" INNER JOIN "organisation_provider" ON "provider"."id" = "organisation_provider"."provider_id" INNER JOIN "organisation" ON "organisation_provider"."organisation_id" = "organisation"."id" INNER JOIN "organisation_user" ON "organisation"."id" = "organisation_user"."organisation_id" WHERE "organisation_user"."user_id" = $1 AND "provider"."id" = $2 LIMIT $3  [["user_id", 10333], ["id", 12403], ["LIMIT", 1]]
  ↳ app/policies/provider_policy.rb:27
   (0.3ms)  SELECT COUNT(*) FROM "course" WHERE "course"."provider_id" = $1  [["provider_id", 12403]]
  ↳ app/models/provider.rb:101
   (0.2ms)  SELECT COUNT(*) FROM "site" WHERE "site"."provider_id" = $1  [["provider_id", 12403]]
  ↳ app/models/provider.rb:124
  ProviderEnrichment Load (0.2ms)  SELECT  "provider_enrichment".* FROM "provider_enrichment" WHERE "provider_enrichment"."provider_code" = $1 ORDER BY "provider_enrichment"."provider_code" DESC LIMIT $2  [["provider_code", "2AT"], ["LIMIT", 1]]
  ↳ app/serializers/api/v2/serializable_provider.rb:7
  CACHE ProviderEnrichment Load (0.0ms)  SELECT  "provider_enrichment".* FROM "provider_enrichment" WHERE "provider_enrichment"."provider_code" = $1 ORDER BY "provider_enrichment"."provider_code" DESC LIMIT $2  [["provider_code", "2AT"], ["LIMIT", 1]]
  ↳ app/serializers/api/v2/serializable_provider.rb:7
Completed JSON API rendering (5.52ms)
Completed 200 OK in 13ms (Views: 5.1ms | ActiveRecord: 2.4ms)
```
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally