### PR TITLE
Add asp ip to pg sql firewall whitelist

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -110,16 +110,16 @@
       }
     },
     "settingsAuthenticationSecret": {
-        "type": "string",
-        "metadata": {
-            "description": "Auth secret for manage back-end."
-        }
+      "type": "string",
+      "metadata": {
+        "description": "Auth secret for manage back-end."
+      }
     },
     "settingsManageApiSecret": {
-        "type": "string",
-        "metadata": {
-            "description": "The secret shared between manage courses backend and manage courses API to authorize requests."
-        }
+      "type": "string",
+      "metadata": {
+        "description": "The secret shared between manage courses backend and manage courses API to authorize requests."
+      }
     },
     "databaseServiceName": {
       "type": "string",
@@ -248,12 +248,12 @@
                 "value": "[parameters('sentryDSN')]"
               },
               {
-                  "name": "SETTINGS__AUTHENTICATION__SECRET",
-                  "value": "[parameters('settingsAuthenticationSecret')]"
+                "name": "SETTINGS__AUTHENTICATION__SECRET",
+                "value": "[parameters('settingsAuthenticationSecret')]"
               },
               {
-                  "name": "SETTINGS__MANAGE_API__SECRET",
-                  "value": "[parameters('settingsManageApiSecret')]"
+                "name": "SETTINGS__MANAGE_API__SECRET",
+                "value": "[parameters('settingsManageApiSecret')]"
               }
             ]
           },
@@ -276,25 +276,25 @@
       "type": "Microsoft.Resources/deployments",
       "resourceGroup": "[variables('databaseResourceGroup')]",
       "properties": {
-          "mode": "Incremental",
-          "templateLink": {
-              "uri": "[concat(variables('deploymentUrlBase'),'postgresql-server-firewall-rules.json')]",
-              "contentVersion": "1.0.0.0"
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'),'postgresql-server-firewall-rules.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "firewallRuleNamePrefix": {
+            "value": "[concat(variables('appServicePlanName'),'-AZURE_IP-')]"
           },
-          "parameters": {
-              "firewallRuleNamePrefix": {
-                  "value": "[concat(variables('appServicePlanName'),'-AZURE_IP-')]"
-              },
-              "ipAddresses": {
-                  "value": "[reference('app-service').outputs.possibleOutboundIpAddresses.value]"
-              },
-              "serverName": {
-                  "value": "[variables('databaseServerName')]"
-              }
+          "ipAddresses": {
+            "value": "[reference('app-service').outputs.possibleOutboundIpAddresses.value]"
+          },
+          "serverName": {
+            "value": "[variables('databaseServerName')]"
           }
+        }
       },
       "dependsOn": []
-  },
+    },
     {
       "apiVersion": "2017-05-10",
       "name": "app-insights",

--- a/azure/template.json
+++ b/azure/template.json
@@ -120,6 +120,13 @@
         "metadata": {
             "description": "The secret shared between manage courses backend and manage courses API to authorize requests."
         }
+    },
+    "databaseServiceName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The abbriviation of the database service name to be used when naming a resource."
+      }
     }
   },
   "variables": {
@@ -128,7 +135,10 @@
     "keyvaultCertificateName": "[if(greater(length(parameters('certificateName')),0), parameters('certificateName'), replace(parameters('customHostName'), '.', '-'))]",
     "appServiceName": "[concat(variables('resourceNamePrefix'), '-as')]",
     "appServicePlanName": "[concat(variables('resourceNamePrefix'), '-asp')]",
-    "appServiceRuntimeStack": "[concat('DOCKER|', parameters('dockerHubUsername'), '/', parameters('containerImageReference'))]"
+    "appServiceRuntimeStack": "[concat('DOCKER|', parameters('dockerHubUsername'), '/', parameters('containerImageReference'))]",
+    "databaseResourceNamePrefix": "[toLower(concat('bat-', parameters('resourceEnvironmentName'),'-', parameters('databaseServiceName')))]",
+    "databaseServerName": "[concat(variables('databaseResourceNamePrefix'), '-psql')]",
+    "databaseResourceGroup": "[concat(variables('databaseResourceNamePrefix'), '-rg')]"
   },
   "resources": [
     {
@@ -259,6 +269,32 @@
         "app-service-plan"
       ]
     },
+    {
+      "condition": "[parameters('databaseServiceName')]",
+      "apiVersion": "2017-05-10",
+      "name": "postgresql-server-firewall-rules",
+      "type": "Microsoft.Resources/deployments",
+      "resourceGroup": "[variables('databaseResourceGroup')]",
+      "properties": {
+          "mode": "Incremental",
+          "templateLink": {
+              "uri": "[concat(variables('deploymentUrlBase'),'postgresql-server-firewall-rules.json')]",
+              "contentVersion": "1.0.0.0"
+          },
+          "parameters": {
+              "firewallRuleNamePrefix": {
+                  "value": "[concat(variables('appServicePlanName'),'-AZURE_IP-')]"
+              },
+              "ipAddresses": {
+                  "value": "[reference('app-service').outputs.possibleOutboundIpAddresses.value]"
+              },
+              "serverName": {
+                  "value": "[variables('databaseServerName')]"
+              }
+          }
+      },
+      "dependsOn": []
+  },
     {
       "apiVersion": "2017-05-10",
       "name": "app-insights",

--- a/azure/template.json
+++ b/azure/template.json
@@ -11,7 +11,7 @@
     "serviceName": {
       "type": "string",
       "metadata": {
-        "description": "The abbriviation of the service name to be used when naming a resource."
+        "description": "The abbreviation of the service name to be used when naming a resource."
       }
     },
     "keyVaultName": {
@@ -125,7 +125,7 @@
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "The abbriviation of the database service name to be used when naming a resource."
+        "description": "The abbreviation of the service that contains the database used by this application."
       }
     }
   },

--- a/azure/template.json
+++ b/azure/template.json
@@ -272,7 +272,7 @@
     {
       "condition": "[greater(length(parameters('databaseServiceName')),0)]",
       "apiVersion": "2017-05-10",
-      "name": "postgresql-server-firewall-rules",
+      "name": "mcbe-postgresql-server-firewall-rules",
       "type": "Microsoft.Resources/deployments",
       "resourceGroup": "[variables('databaseResourceGroup')]",
       "properties": {

--- a/azure/template.json
+++ b/azure/template.json
@@ -270,7 +270,7 @@
       ]
     },
     {
-      "condition": "[parameters('databaseServiceName')]",
+      "condition": "[greater(length(parameters('databaseServiceName')),0)]",
       "apiVersion": "2017-05-10",
       "name": "postgresql-server-firewall-rules",
       "type": "Microsoft.Resources/deployments",


### PR DESCRIPTION
### Context

Add resource deployment to ensure ASP outbound IP's are added to the relevant PostgreSQL firewall rules

### Changes proposed in this pull request

- Add firewall rule resource deployment
- Add databaseServiceName name parameter and related variables
- Formatted document so styling is consistent

### Guidance to review

Change enables ability to add ASP outbound IP's to PostgreSQL firewall rules. New parameter is optional.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
