### PR TITLE
mcb help - show subcommands in full

### DIFF
--- a/bin/mcb
+++ b/bin/mcb
@@ -40,7 +40,11 @@ $mcb = Cri::Command.define do
     puts cmd.help
     puts
     puts Rainbow("SUBCOMMANDS").red.bright
-    show_all_commands(cmd, "")
+    prefix = "    "
+    cmd.commands.each do |c|
+      show_all_commands(c, prefix + c.name + " ")
+      puts
+    end
     exit 0
   end
 
@@ -50,12 +54,12 @@ $mcb = Cri::Command.define do
   end
 end
 
-def show_all_commands(cmd, indent)
+def show_all_commands(cmd, prefix)
   cmd.commands.each do |c|
-    aligned_cmd_name = (indent + c.name).ljust(20, ' ')
+    aligned_cmd_name = (prefix + c.name).ljust(37, ' ')
     coloured_name = Rainbow(aligned_cmd_name).green
-    puts "    #{coloured_name} #{c.summary}"
-    show_all_commands(c, indent + "  ")
+    puts "#{coloured_name} #{c.summary}"
+    show_all_commands(c, prefix + c.name + " ")
   end
 end
 


### PR DESCRIPTION
So that you can more easily copy-paste a deep sub-command.
Also omitted repeated help for top commands and added spacing.

### Context

small iteration - I needed to generate a token for local testing and wanted to copy-paste the full command

### Changes proposed in this pull request

#### after
![Selection_622](https://user-images.githubusercontent.com/19378/58489403-255b5a00-8163-11e9-87b0-145e3e0d709a.png)

#### before

![Selection_623](https://user-images.githubusercontent.com/19378/58489401-23919680-8163-11e9-8ad9-92ed0aaedc82.png)


### Guidance to review

:ship: 

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
