### PR TITLE
[1483] Add has_vacancies method to site status

### DIFF
--- a/app/controllers/api/v2/site_statuses_controller.rb
+++ b/app/controllers/api/v2/site_statuses_controller.rb
@@ -15,7 +15,7 @@ module API
       def site_status_params
         params
           .require(:site_status)
-          .except(:id, :type, :site_id, :site_type)
+          .except(:id, :type, :site_id, :site_type, :has_vacancies?)
           .permit(
             :applications_accepted_from,
             :publish,

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -93,6 +93,10 @@ class SiteStatus < ApplicationRecord
     "#{site.description} – #{status}/#{publish}"
   end
 
+  def has_vacancies?
+    SiteStatus.findable.with_vacancies.any?
+  end
+
 private
 
   def set_defaults

--- a/app/serializers/api/v2/serializable_site_status.rb
+++ b/app/serializers/api/v2/serializable_site_status.rb
@@ -3,7 +3,7 @@ module API
     class SerializableSiteStatus < JSONAPI::Serializable::Resource
       type 'site_statuses'
 
-      attributes :vac_status, :publish, :status, :applications_accepted_from
+      attributes :vac_status, :publish, :status, :applications_accepted_from, :has_vacancies?
 
       has_one :site
     end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -141,7 +141,8 @@ describe 'Courses API v2', type: :request do
               "vac_status" => site_status.vac_status,
               "publish" => site_status.publish,
               "status" => site_status.status,
-              "applications_accepted_from" => site_status.applications_accepted_from.strftime("%Y-%m-%d")
+              "applications_accepted_from" => site_status.applications_accepted_from.strftime("%Y-%m-%d"),
+              "has_vacancies?" => true
             },
             "relationships" => {
               "site" => {


### PR DESCRIPTION
### Context
Easily expose if a site status has any vacancies 

### Changes proposed in this pull request
Add `has_vacancies?` to site statuses

### Guidance to review
Example - `/api/v2/providers/2AT/courses/3CXL?include=site_statuses.site`

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
