### PR TITLE
[1540] include site_status sites when generating api v1 courses

### DIFF
--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -17,8 +17,11 @@ module API
         ActiveRecord::Base.transaction do
           ActiveRecord::Base.connection.execute('LOCK provider, provider_enrichment, site IN SHARE UPDATE EXCLUSIVE MODE')
           @courses = Course
-                       .includes(:provider, :site_statuses,
-                                 :accrediting_provider, :subjects)
+                       .includes(:provider,
+                                 :site_statuses,
+                                 :accrediting_provider,
+                                 :subjects,
+                                 site_statuses: [:site])
                        .changed_since(changed_since)
                        .limit(per_page)
         end


### PR DESCRIPTION
### What

Change the query used to generate the results for `/api/v1/2019/courses` to include the `sites` that belong to the `site_statuses`.

### Why

This speeds up the generation of these results by about 33%.

### Background

This is an N+1 query that can be fixed by simply including the data being used when making the original SQL request.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
