### PR TITLE
[1538] Added accrediting body description on course model using provider enrichment

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -50,6 +50,7 @@ module API
 
       def build_course
         @course = @provider.courses.find_by!(course_code: params[:code].upcase)
+
         authorize @course
       end
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -90,24 +90,23 @@ class Course < ApplicationRecord
   validate :validate_enrichment, on: :publish
 
   def accrediting_provider_description
-    if accrediting_provider.present?
-      provider_enrichment = provider
-                              .enrichments
-                              .published
-                              .latest_published_at
-                              .first
+    return nil if accrediting_provider.blank?
 
-      if provider_enrichment.present? && provider_enrichment.accrediting_provider_enrichments.present?
+    provider_enrichment = provider
+                            .enrichments
+                            .published
+                            .latest_published_at
+                            .first
 
-        accrediting_provider_enrichment = provider_enrichment.accrediting_provider_enrichments
-          .find do |p|
-            # 'UcasInstitutionCode' is legacy named used
-          p['UcasInstitutionCode'] == accrediting_provider.provider_code
-        end
+    return nil if provider_enrichment&.accrediting_provider_enrichments.blank?
 
-        accrediting_provider_enrichment['Description'] unless accrediting_provider_enrichment.nil?
-      end
+    accrediting_provider_enrichment = provider_enrichment.accrediting_provider_enrichments
+      .find do |p|
+        # 'UcasInstitutionCode' is legacy named used
+      p['UcasInstitutionCode'] == accrediting_provider.provider_code
     end
+
+    accrediting_provider_enrichment['Description'] unless accrediting_provider_enrichment.blank?
   end
 
   def publishable?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -89,6 +89,27 @@ class Course < ApplicationRecord
   validates :enrichments, presence: true, on: :publish
   validate :validate_enrichment, on: :publish
 
+  def accrediting_provider_description
+    if accrediting_provider.present?
+      provider_enrichment = provider
+                              .enrichments
+                              .published
+                              .latest_published_at
+                              .first
+
+      if provider_enrichment.present? && provider_enrichment.accrediting_provider_enrichments.present?
+
+        accrediting_provider_enrichment = provider_enrichment.accrediting_provider_enrichments
+          .find do |p|
+            # 'UcasInstitutionCode' is legacy named used
+          p['UcasInstitutionCode'] == accrediting_provider.provider_code
+        end
+
+        accrediting_provider_enrichment['Description'] unless accrediting_provider_enrichment.nil?
+      end
+    end
+  end
+
   def publishable?
     valid? :publish
   end

--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -37,5 +37,7 @@ class ProviderEnrichment < ApplicationRecord
                  telephone: [:string, store_key: 'Telephone'],
                  train_with_us: [:string, store_key: 'TrainWithUs'],
                  train_with_disability: [:string,
-                                         store_key: 'TrainWithDisability']
+                                         store_key: 'TrainWithDisability'],
+                 accrediting_provider_enrichments: [:json,
+                                                    store_key: 'AccreditingProviderEnrichments']
 end

--- a/spec/factories/provider_enrichments.rb
+++ b/spec/factories/provider_enrichments.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
     region_code { 'eastern' }
     train_with_us { Faker::Lorem.sentence.to_s }
     train_with_disability { Faker::Lorem.sentence.to_s }
+    accrediting_provider_enrichments { nil }
     created_at { Faker::Date.between 2.days.ago, 1.days.ago }
 
     after(:build) do |enrichment, evaluator|


### PR DESCRIPTION
### Context
A course may have an accrediting provider
An accrediting provider description may be enriched via provider enrichment

### Changes proposed in this pull request
Expose the accrediting provider description if the course has accrediting provider and it has been enriched

### Guidance to review


### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
