### PR TITLE
[1542] add mcb apiv1 course find command

### DIFF
--- a/bin/mcb
+++ b/bin/mcb
@@ -23,6 +23,7 @@ require 'mcb/azure'
 require 'mcb/config'
 require 'mcb/course_show'
 require 'mcb/grant_access_wizard'
+require 'mcb/render'
 
 tp.set :capitalize_headers, false
 

--- a/bin/mcb
+++ b/bin/mcb
@@ -13,6 +13,7 @@ require 'rainbow'
 require 'pry'
 require 'table_print'
 require 'terminal-table'
+require 'tabulo'
 
 lib_dir = File.expand_path 'lib'
 

--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -167,10 +167,12 @@ module MCB
 
       endpoint_url = process_opt_changed_since(opts, URI.join(url, endpoint))
       token = opts.fetch(:token) { apiv1_token(opts.slice(:webapp, :rgroup)) }
-      max_pages = opts.fetch('max-pages', 1)
+
+      # Safeguard to ensure we don't go off the deep end.
+      max_pages = opts.fetch(:'max-pages')
 
       Enumerator.new do |y|
-        max_pages.times do |page_count|
+        pages = max_pages.times do |page_count|
           verbose "Requesting page #{page_count + 1}: #{endpoint_url}"
           response = HTTParty.get(
             endpoint_url.to_s,
@@ -196,7 +198,7 @@ module MCB
           end
         end
 
-        puts "max page count of #{max_pages} reached" if page_count == max_pages
+        puts "max page count of #{max_pages} reached" if pages == max_pages
       end
     end
 

--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -108,14 +108,15 @@ module MCB
 
     process_opt_changed_since(opts, url)
     page_count = 0
-    max_pages = 30
+    max_pages = opts.fetch(:'max-pages', '30').to_i
     all_pages = opts.fetch(:all, false)
 
     Enumerator.new do |y|
       loop do
         if page_count > max_pages
           raise "too many page requests, stopping at #{page_count}" \
-                " as a safeguard. Increase max page_count if necessary."
+                " as a safeguard. Use --max-pages to increase max page count" \
+                " if necessary."
         end
 
         verbose "Requesting page #{page_count + 1}: #{url}"
@@ -155,14 +156,15 @@ module MCB
 
     process_opt_changed_since(opts, url)
     page_count = 0
-    max_pages = 30
+    max_pages = opts.fetch(:'max-pages', '30').to_i
     all_pages = opts.fetch(:all, false)
 
     Enumerator.new do |y|
       loop do
         if page_count > max_pages
           raise "too many page requests, stopping at #{page_count}" \
-                " as a safeguard. Increase max page_count if necessary."
+                " as a safeguard. Use --max-pages to increase max page count" \
+                " if necessary."
         end
 
         verbose "Requesting page #{page_count + 1}: #{url}"

--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -80,7 +80,7 @@ module MCB
   def self.apiv1_token(webapp: nil, rgroup: nil)
     if webapp
       verbose "getting config for webapp: #{webapp} rgroup: #{rgroup}"
-      MCB::Azure.get_config(webapp, rgroup: rgroup).fetch('AUTHENTICATION_TOKEN')
+      MCB::Azure.get_config(webapp: webapp, rgroup: rgroup).fetch('AUTHENTICATION_TOKEN')
     else
       Rails.application.config.authentication_token
     end

--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -99,12 +99,12 @@ module MCB
   end
 
   def self.each_v1_course(opts)
-    # This methods can actually be entirely driven by the args provided it. auto-configure!
+    # This method can actually be entirely driven by the args provided, it is auto-configure!
     iterate_v1_endpoint(**opts)
   end
 
   def self.each_v1_provider(opts)
-    # This methods can actually be entirely driven by the args provided it. auto-configure!
+    # This method can actually be entirely driven by the args provided, it is auto-configure!
     iterate_v1_endpoint(**opts)
   end
 

--- a/lib/mcb/azure.rb
+++ b/lib/mcb/azure.rb
@@ -21,9 +21,9 @@ module MCB
                         "is this the right subscription?")
     end
 
-    def self.get_config(app, rgroup: nil, subscription: nil)
-      rgroup ||= rgroup_for_app(app)
-      cmd = "az webapp config appsettings list -g \"#{rgroup}\" -n \"#{app}\""
+    def self.get_config(webapp:, rgroup: nil, subscription: nil)
+      rgroup ||= rgroup_for_app(webapp)
+      cmd = "az webapp config appsettings list -g \"#{rgroup}\" -n \"#{webapp}\""
       cmd += " --subscription \"#{subscription}\"" if subscription
       raw_json = MCB::run_command(cmd)
       config = JSON.parse(raw_json)
@@ -56,7 +56,7 @@ module MCB
     def self.configure_for_webapp(webapp:, rgroup: nil, subscription: nil, **_opts)
       # switch_to_subscription(opts[:subscription])
       rgroup ||= rgroup_for_app(webapp)
-      app_config = MCB::Azure.get_config(webapp,
+      app_config = MCB::Azure.get_config(webapp: webapp,
                                          rgroup: rgroup,
                                          subscription: subscription)
 

--- a/lib/mcb/commands/apiv1.rb
+++ b/lib/mcb/commands/apiv1.rb
@@ -8,7 +8,7 @@ option :t, 'token', 'set the authorization token',
        argument: :required,
        default: 'bats'
 option :P, 'max-pages', 'maximum number of pages to request',
-       argument: :required,
-       default: '200',
+       default: 200,
+       argument: :optional,
        transform: method(:Integer)
 instance_eval(&MCB.remote_connect_options)

--- a/lib/mcb/commands/apiv1.rb
+++ b/lib/mcb/commands/apiv1.rb
@@ -7,3 +7,7 @@ option :u, 'url', 'set the base url to connect to',
 option :t, 'token', 'set the authorization token',
        argument: :required,
        default: 'bats'
+option :P, 'max-pages', 'maximum number of pages to request',
+       argument: :required,
+       default: '200',
+       transform: method(:Integer)

--- a/lib/mcb/commands/apiv1.rb
+++ b/lib/mcb/commands/apiv1.rb
@@ -11,3 +11,4 @@ option :P, 'max-pages', 'maximum number of pages to request',
        argument: :required,
        default: '200',
        transform: method(:Integer)
+instance_eval(&MCB.remote_connect_options)

--- a/lib/mcb/commands/apiv1/courses/find.rb
+++ b/lib/mcb/commands/apiv1/courses/find.rb
@@ -1,0 +1,82 @@
+summary 'Find a particular provider course entry'
+description <<~EODESCRIPTION
+  Searches for a course with the given provider and course code by iterating
+  through all the pages of results provided from the course endpoint, outputing
+  the found record.
+EODESCRIPTION
+usage 'find [options] <provider_code> <course_code>'
+param :provider_code
+param :course_code
+option :j, 'json', 'show the returned JSON response'
+
+
+run do |opts, args, _cmd|
+  opts[:all] ||= true
+
+  provider_code = args[:provider_code].upcase
+  course_code = args[:course_code].upcase
+
+  verbose "looking for provider '#{provider_code}' course '#{course_code}'"
+
+  (course, last_context) = find_course(provider_code, course_code, opts)
+
+  if course.nil?
+    error "Provider '#{provider_code}' course '#{course_code}' not found"
+    next
+  end
+
+  if opts[:json]
+    puts JSON.pretty_generate(JSON.parse(course.to_json))
+  else
+    print_course_info(course)
+  end
+
+  if opts[:all]
+    puts 'All pages searched.'
+  else
+    puts 'Only first page of results searched (use -a to retrieve all).'
+  end
+  puts "To continue searching use the url: #{last_context[:next_url]}"
+end
+
+def find_course(provider_code, course_code, opts)
+  MCB.each_v1_course(opts).detect do |course, _context|
+    course['provider']['institution_code'] == provider_code &&
+      course['course_code'] == course_code
+  end
+end
+
+def hashes_to_ostructs(hashes)
+  hashes.map { |hash| OpenStruct.new(hash) }
+end
+
+def print_course_info(course)
+  campus_statuses = hashes_to_ostructs course.delete('campus_statuses')
+  subjects        = hashes_to_ostructs course.delete('subjects')
+  provider        = course.delete('provider')
+
+  puts Terminal::Table.new rows: course
+  puts "\n"
+  puts "Provider:"
+  puts Terminal::Table.new rows: provider
+  puts "\n"
+  puts "Subjects:"
+
+  subjects_table = Tabulo::Table.new(subjects,
+                                     :subject_code,
+                                     :subject_name).pack(max_table_width: nil)
+  puts subjects_table
+  puts subjects_table.horizontal_rule
+
+  puts "\n"
+  puts "Campus Statuses:"
+  campus_statuses_table = Tabulo::Table.new(campus_statuses,
+                                            :campus_code,
+                                            :name,
+                                            :vac_status,
+                                            :publish,
+                                            :status,
+                                            :course_open_date).pack(max_table_width: nil)
+  puts campus_statuses_table
+  puts campus_statuses_table.horizontal_rule
+end

--- a/lib/mcb/commands/apiv1/courses/find.rb
+++ b/lib/mcb/commands/apiv1/courses/find.rb
@@ -2,7 +2,7 @@ summary 'Find a particular provider course entry'
 description <<~EODESCRIPTION
   Searches for a course with the given provider and course code by iterating
   through all the pages of results provided from the course endpoint, outputting
-  the found records.
+  the found record.
 EODESCRIPTION
 usage 'find [options] <provider_code> <course_code>'
 param :provider_code

--- a/lib/mcb/commands/apiv1/courses/find.rb
+++ b/lib/mcb/commands/apiv1/courses/find.rb
@@ -8,6 +8,10 @@ usage 'find [options] <provider_code> <course_code>'
 param :provider_code
 param :course_code
 option :j, 'json', 'show the returned JSON response'
+option :P, 'max-pages', 'maximum number of pages to request',
+       default: 250,
+       argument: :required,
+       transform: method(:Integer)
 
 
 run do |opts, args, _cmd|
@@ -19,7 +23,7 @@ run do |opts, args, _cmd|
 
   verbose "looking for provider '#{provider_code}' course '#{course_code}'"
 
-  (course, last_context) = find_course(provider_code, course_code, opts)
+  (course, _last_context) = find_course(provider_code, course_code, opts)
 
   if course.nil?
     error "Provider '#{provider_code}' course '#{course_code}' not found"
@@ -31,13 +35,6 @@ run do |opts, args, _cmd|
   else
     print_course_info(course)
   end
-
-  if opts[:all]
-    puts 'All pages searched.'
-  else
-    puts 'Only first page of results searched (use -a to retrieve all).'
-  end
-  puts "To continue searching use the url: #{last_context[:next_url]}"
 end
 
 def find_course(provider_code, course_code, opts)

--- a/lib/mcb/commands/apiv1/courses/find.rb
+++ b/lib/mcb/commands/apiv1/courses/find.rb
@@ -46,37 +46,16 @@ def find_course(provider_code, course_code, opts)
   end
 end
 
-def hashes_to_ostructs(hashes)
-  hashes.map { |hash| OpenStruct.new(hash) }
-end
-
 def print_course_info(course)
-  campus_statuses = hashes_to_ostructs course.delete('campus_statuses')
-  subjects        = hashes_to_ostructs course.delete('subjects')
+  campus_statuses = course.delete('campus_statuses')
+  subjects        = course.delete('subjects')
   provider        = course.delete('provider')
 
-  puts Terminal::Table.new rows: course
+  puts MCB::Render.course_record course
   puts "\n"
-  puts "Provider:"
-  puts Terminal::Table.new rows: provider
+  puts MCB::Render.provider_record provider
   puts "\n"
-  puts "Subjects:"
-
-  subjects_table = Tabulo::Table.new(subjects,
-                                     :subject_code,
-                                     :subject_name).pack(max_table_width: nil)
-  puts subjects_table
-  puts subjects_table.horizontal_rule
-
+  puts MCB::Render.subjects_table subjects
   puts "\n"
-  puts "Campus Statuses:"
-  campus_statuses_table = Tabulo::Table.new(campus_statuses,
-                                            :campus_code,
-                                            :name,
-                                            :vac_status,
-                                            :publish,
-                                            :status,
-                                            :course_open_date).pack(max_table_width: nil)
-  puts campus_statuses_table
-  puts campus_statuses_table.horizontal_rule
+  puts MCB::Render.site_statuses_table campus_statuses
 end

--- a/lib/mcb/commands/apiv1/courses/find.rb
+++ b/lib/mcb/commands/apiv1/courses/find.rb
@@ -1,8 +1,8 @@
 summary 'Find a particular provider course entry'
 description <<~EODESCRIPTION
   Searches for a course with the given provider and course code by iterating
-  through all the pages of results provided from the course endpoint, outputing
-  the found record.
+  through all the pages of results provided from the course endpoint, outputting
+  the found records.
 EODESCRIPTION
 usage 'find [options] <provider_code> <course_code>'
 param :provider_code

--- a/lib/mcb/commands/apiv1/courses/find.rb
+++ b/lib/mcb/commands/apiv1/courses/find.rb
@@ -11,6 +11,7 @@ option :j, 'json', 'show the returned JSON response'
 
 
 run do |opts, args, _cmd|
+  opts = MCB.apiv1_opts(opts)
   opts[:all] ||= true
 
   provider_code = args[:provider_code].upcase

--- a/lib/mcb/commands/apiv1/courses/list.rb
+++ b/lib/mcb/commands/apiv1/courses/list.rb
@@ -1,6 +1,7 @@
 summary 'List courses'
 
 run do |opts, _args, _cmd|
+  opts = MCB.apiv1_opts(opts)
   last_context = nil
 
   table = Terminal::Table.new headings: %w[Code Name Provider\ Code Provider\ Name] do |t|

--- a/lib/mcb/commands/apiv1/providers/find.rb
+++ b/lib/mcb/commands/apiv1/providers/find.rb
@@ -34,7 +34,6 @@ run do |opts, args, _cmd|
     puts 'Only first page of results searched (use -a to retrieve all).'
   end
   puts "To continue searching use the url: #{last_context[:next_url]}"
-
 end
 
 def find_provider(code, opts)

--- a/lib/mcb/commands/apiv1/providers/find.rb
+++ b/lib/mcb/commands/apiv1/providers/find.rb
@@ -14,7 +14,7 @@ run do |opts, args, _cmd|
 
   verbose "looking for provider #{args[:code]}"
 
-  find_provider(args[:code], opts)
+  (provider, last_context) = find_provider(args[:code], opts)
 
   if provider.nil?
     error "Provider with code '#{args[:code]}' not found"
@@ -32,23 +32,23 @@ run do |opts, args, _cmd|
   else
     puts 'Only first page of results searched (use -a to retrieve all).'
   end
-  puts "To continue searching use the url: #{next_url}"
+  puts "To continue searching use the url: #{last_context[:next_url]}"
+
 end
 
 def find_provider(code, opts)
-  MCB.each_v1_provider(opts).detect do |p|
-    p['institution_code'] == code
+  MCB.each_v1_provider(opts).detect do |provider, _context|
+    provider['institution_code'] == code
   end
 end
 
 def print_provider_info(provider)
   campuses = provider.delete('campuses')
   contacts = provider.delete('contacts')
-  puts Terminal::Table.new rows: provider
-  puts ''
-  puts "Campuses:"
-  tp campuses
-  puts ''
-  puts "Contacts:"
-  tp contacts
+
+  puts MCB::Render.provider_record provider
+  puts "\n"
+  puts MCB::Render.campuses_table campuses
+  puts "\n"
+  puts MCB::Render.contacts_table contacts
 end

--- a/lib/mcb/commands/apiv1/providers/find.rb
+++ b/lib/mcb/commands/apiv1/providers/find.rb
@@ -10,6 +10,7 @@ option :j, 'json', 'show the returned JSON response'
 
 
 run do |opts, args, _cmd|
+  opts = MCB.apiv1_opts(opts)
   opts[:all] ||= true
 
   verbose "looking for provider #{args[:code]}"

--- a/lib/mcb/commands/apiv1/providers/list.rb
+++ b/lib/mcb/commands/apiv1/providers/list.rb
@@ -2,6 +2,7 @@ name 'list'
 summary 'List providers'
 
 run do |opts, _args, _cmd|
+  opts = MCB.apiv1_opts(opts)
   last_context = nil
 
   table = Terminal::Table.new headings: %w[Code Name] do |t|

--- a/lib/mcb/commands/az/apps/config.rb
+++ b/lib/mcb/commands/az/apps/config.rb
@@ -8,5 +8,5 @@ param :rgroup
 run do |_opts, args, _cmd|
   app = args[:app]
   rgroup = args[:rgroup]
-  puts MCB::Azure.get_config(app, rgroup: rgroup)
+  puts MCB::Azure.get_config(webapp: app, rgroup: rgroup)
 end

--- a/lib/mcb/render.rb
+++ b/lib/mcb/render.rb
@@ -1,6 +1,41 @@
 module MCB
   module Render
     class << self
+      def campuses_table(campuses, name: 'Campuses')
+        if campuses.all? { |campuses| campuses.respond_to? :keys }
+          campuses = hashes_to_ostructs campuses
+        end
+
+        campuses_table = Tabulo::Table.new campuses,
+                                           :campus_code,
+                                           :name,
+                                           :region_code
+
+        [
+          "#{name}:",
+          *campuses_table.pack(max_table_width: nil),
+          campuses_table.horizontal_rule
+        ]
+      end
+
+      def contacts_table(contacts, name: 'Contacts')
+        if contacts.all? { |contact| contact.respond_to? :keys }
+          contacts = hashes_to_ostructs contacts
+        end
+
+        contacts_table = Tabulo::Table.new contacts,
+                                           :type,
+                                           :name,
+                                           :email,
+                                           :telephone
+
+        [
+          "#{name}:",
+          *contacts_table.pack(max_table_width: nil),
+          contacts_table.horizontal_rule
+        ]
+      end
+
       def course_record(course, name: 'Course')
         course_table = Terminal::Table.new rows: course
 
@@ -36,6 +71,28 @@ module MCB
           "#{name}:",
           *site_statuses_table.pack(max_table_width: nil),
           site_statuses_table.horizontal_rule
+        ]
+      end
+
+      def sites_table(sites, name: 'Sites')
+        if sites.all? { |site| site.respond_to? :keys }
+          sites = hashes_to_ostructs sites
+        end
+
+        sites_table = Tabulo::Table.new sites,
+                                        :code,
+                                        :location_name,
+                                        :address1,
+                                        :address2,
+                                        :address3,
+                                        :address4,
+                                        :postcode,
+                                        :region_code
+
+        [
+          "#{name}:",
+          *sites_table.pack(max_table_width: nil),
+          sites_table.horizontal_rule
         ]
       end
 

--- a/lib/mcb/render.rb
+++ b/lib/mcb/render.rb
@@ -1,0 +1,65 @@
+module MCB
+  module Render
+    class << self
+      def course_record(course, name: 'Course')
+        course_table = Terminal::Table.new rows: course
+
+        [
+          "#{name}:",
+          *course_table,
+        ]
+      end
+
+      def provider_record(provider, name: 'Provider')
+        provider_table = Terminal::Table.new rows: provider
+
+        [
+          "#{name}:",
+          *provider_table,
+        ]
+      end
+
+      def site_statuses_table(site_statuses, name: 'Site Statuses')
+        if site_statuses.all? { |site_status| site_status.respond_to? :keys }
+          site_statuses = hashes_to_ostructs site_statuses
+        end
+
+        site_statuses_table = Tabulo::Table.new site_statuses,
+                                                :campus_code,
+                                                :name,
+                                                :vac_status,
+                                                :publish,
+                                                :status,
+                                                :course_open_date
+
+        [
+          "#{name}:",
+          *site_statuses_table.pack(max_table_width: nil),
+          site_statuses_table.horizontal_rule
+        ]
+      end
+
+      def subjects_table(subjects, name: 'Subjects')
+        if subjects.all? { |subject| subject.respond_to? :keys }
+          subjects = hashes_to_ostructs subjects
+        end
+
+        subjects_table = Tabulo::Table.new subjects,
+                                           :subject_code,
+                                           :subject_name
+
+        [
+          "#{name}:",
+          *subjects_table.pack(max_table_width: nil),
+          subjects_table.horizontal_rule
+        ]
+      end
+
+      private
+
+      def hashes_to_ostructs(hashes)
+        hashes.map { |hash| OpenStruct.new(hash) }
+      end
+    end
+  end
+end

--- a/lib/mcb/render.rb
+++ b/lib/mcb/render.rb
@@ -2,7 +2,7 @@ module MCB
   module Render
     class << self
       def campuses_table(campuses, name: 'Campuses')
-        if campuses.all? { |campuses| campuses.respond_to? :keys }
+        if campuses.all? { |campuse| campuse.respond_to? :keys }
           campuses = hashes_to_ostructs campuses
         end
 
@@ -112,7 +112,7 @@ module MCB
         ]
       end
 
-      private
+    private
 
       def hashes_to_ostructs(hashes)
         hashes.map { |hash| OpenStruct.new(hash) }

--- a/spec/lib/mcb/azure_spec.rb
+++ b/spec/lib/mcb/azure_spec.rb
@@ -83,7 +83,7 @@ describe MCB::Azure do
       EOCONFIG
     end
 
-    subject { MCB::Azure.get_config('some-app', rgroup: 'some-rgroup') }
+    subject { MCB::Azure.get_config(webapp: 'some-app', rgroup: 'some-rgroup') }
 
     before :each do
       allow(MCB).to receive(:run_command).and_return(config_json)

--- a/spec/lib/mcb/commands/apiv1/courses/find_spec.rb
+++ b/spec/lib/mcb/commands/apiv1/courses/find_spec.rb
@@ -1,0 +1,59 @@
+require 'mcb_helper'
+
+describe '"mcb apiv1 courses find"' do
+  it 'displays the info for the given course' do
+    # The site_status factory is an easy way to create a course and it's site
+    site_status1 = create(:site_status)
+    course1 = site_status1.course
+
+    site_status2 = create(:site_status)
+    course2 = site_status2.course
+    subject2 = course2.subjects.first
+
+    url = 'http://localhost:3001/api/v1/2019/courses'
+    next_url = url + '&' + {
+        changed_since: course2.created_at.utc.strftime('%FT%T.%6NZ'),
+        per_page: 100
+      }.to_query
+    json = ActiveModel::Serializer::CollectionSerializer.new(
+      [
+        course1,
+        course2
+      ],
+      serializer: CourseSerializer
+    )
+
+    stub_request(:get, url)
+      .with(headers: {
+              'Authorization' => 'Bearer bats'
+            })
+      .to_return(status: 200,
+                 body: json.to_json,
+                 headers: {
+                   link: next_url + '; rel="next"'
+                 })
+    stub_request(:get, next_url)
+      .to_return(status: 200,
+                 body: [].to_json,
+                 headers: {
+                   link: next_url + '; rel="next"'
+                 })
+
+    output = with_stubbed_stdout do
+      $mcb.run(%W[apiv1 courses find #{course2.provider.provider_code} #{course2.course_code}])
+    end
+
+    expect(output).to have_text_table_row('course_code',
+                                          course2.course_code)
+    expect(output).to have_text_table_row(subject2.subject_code,
+                                          subject2.subject_name)
+    expect(output).to(have_text_table_row(
+                        site_status2.site.code,
+                        site_status2.site.location_name,
+                        site_status2.vac_status_before_type_cast,
+                        site_status2.publish_before_type_cast,
+                        site_status2.status_before_type_cast,
+                        site_status2.applications_accepted_from.strftime('%Y-%m-%d')
+                      ))
+  end
+end

--- a/spec/lib/mcb_spec.rb
+++ b/spec/lib/mcb_spec.rb
@@ -131,4 +131,36 @@ describe 'mcb command' do
         .to have_received(:new).with(config_file: MCB.config_file)
     end
   end
+
+  describe '.apiv1_opts' do
+    context 'with the -E flag' do
+      let(:opts) { { env: 'low-cal' } }
+      let(:opts_with_webapp) do
+        opts.merge(
+          webapp: 'weebapp',
+          rgroup: 'rezgrp',
+          subscription: 'sub6'
+        )
+      end
+      let(:urls) { %w[http://web.local https://webs.local] }
+      let(:config) { { "AUTHENTICATION_TOKEN" => 'jrr' } }
+
+      before do
+        allow(MCB).to(receive(:azure_env_settings_for_opts)
+                        .with(opts) { |o| o.merge opts_with_webapp })
+        allow(MCB).to(receive(:requesting_remote_connection?).and_return(true))
+
+        allow(MCB::Azure).to receive(:get_urls).and_return(urls)
+        allow(MCB::Azure).to receive(:get_config).and_return(config)
+      end
+
+      subject { MCB.apiv1_opts(opts) }
+
+      it { should include url: 'http://web.local' }
+      it { should include webapp: 'weebapp' }
+      it { should include rgroup: 'rezgrp' }
+      it { should include subscription: 'sub6' }
+      it { should include token: 'jrr' }
+    end
+  end
 end

--- a/spec/lib/mcb_spec.rb
+++ b/spec/lib/mcb_spec.rb
@@ -83,7 +83,7 @@ describe 'mcb command' do
 
       it 'uses get_config to retrieve the app config' do
         expect(MCB.apiv1_token(webapp: 'az-app')).to eq 'bar'
-        expect(MCB::Azure).to have_received(:get_config).with('az-app',
+        expect(MCB::Azure).to have_received(:get_config).with(webapp: 'az-app',
                                                               rgroup: nil)
       end
     end

--- a/spec/serializers/api/v2/serializable_access_request_spec.rb
+++ b/spec/serializers/api/v2/serializable_access_request_spec.rb
@@ -46,7 +46,11 @@ describe API::V2::SerializableAccessRequest do
           .and(have_id(requester.id.to_s))))
     end
   end
+
   describe 'has the correct attributes' do
+    before { Timecop.freeze }
+    after  { Timecop.return }
+
     it { should have_attribute(:email_address).with_value(access_request.email_address) }
     it { should have_attribute(:first_name).with_value(access_request.first_name) }
     it { should have_attribute(:last_name).with_value(access_request.last_name) }


### PR DESCRIPTION
###Why are we doing this?

To allow admins to view what a course looks like as it's being sent to UCAS.

###What are we adding or changing?

A command to`mcb` to find a course in the output generated by the api v1.

###Background

Useful for investigating issues with the system.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
