### PR TITLE
[1538] Expose about accrediting body on courses

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -101,9 +101,8 @@ class Course < ApplicationRecord
     return nil if provider_enrichment&.accrediting_provider_enrichments.blank?
 
     accrediting_provider_enrichment = provider_enrichment.accrediting_provider_enrichments
-      .find do |p|
-        # 'UcasInstitutionCode' is legacy named used
-      p['UcasInstitutionCode'] == accrediting_provider.provider_code
+      .find do |provider|
+      provider['UcasProviderCode'] == accrediting_provider.provider_code
     end
 
     accrediting_provider_enrichment['Description'] unless accrediting_provider_enrichment.blank?

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -29,6 +29,10 @@ module API
         @object.dfe_subjects.map(&:to_s)
       end
 
+      attribute :about_accrediting_body do
+        @object.accrediting_provider_description
+      end
+
       belongs_to :provider
       belongs_to :accrediting_provider
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -531,7 +531,7 @@ RSpec.describe Course, type: :model do
             let(:accrediting_provider_enrichment_description) { Faker::Lorem.sentence.to_s }
             let(:accrediting_provider_enrichment) do
               {
-                'UcasInstitutionCode' => accrediting_provider.provider_code,
+                'UcasProviderCode' => accrediting_provider.provider_code,
                 'Description' => accrediting_provider_enrichment_description
               }
             end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -124,6 +124,7 @@ describe 'Courses API v2', type: :request do
               "has_early_career_payments?" => false,
               "bursary_amount" => nil,
               "scholarship_amount" => nil,
+              "about_accrediting_body" => nil,
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },
@@ -246,6 +247,7 @@ describe 'Courses API v2', type: :request do
               "has_early_career_payments?" => false,
               "bursary_amount" => nil,
               "scholarship_amount" => nil,
+              "about_accrediting_body" => nil,
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },


### PR DESCRIPTION
### Context
Follow up to https://github.com/DFE-Digital/manage-courses-backend/pull/423

### Changes proposed in this pull request
Expose a provider's accrediting body description from provider enrichment

### Guidance to review
Example - `/api/v2/providers/153/courses`

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
