### PR TITLE
[1513] Add has_many :sites to deserializable course

### DIFF
--- a/app/deserializers/api/v2/deserializable_course.rb
+++ b/app/deserializers/api/v2/deserializable_course.rb
@@ -17,6 +17,8 @@ module API
                  :name,
                  :study_mode
 
+      has_many :sites
+
       attribute :required_qualifications do |value|
         { qualifications: value }
       end


### PR DESCRIPTION
### Context

This is needed to receive course sites on the update endpoint, to allow users to edit locations.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally