### PR TITLE
Ensure that course and provider code params are upcased

### DIFF
--- a/app/models/concerns/with_qualifications.rb
+++ b/app/models/concerns/with_qualifications.rb
@@ -69,5 +69,10 @@ module WithQualifications
     def qualifications_description
       qualifications.map(&:upcase).sort.join(" with ")
     end
+
+    def qualification=(value)
+      super(value)
+      self.profpost_flag = qts? ? :recommendation_for_qts : :postgraduate
+    end
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -239,6 +239,10 @@ class Course < ApplicationRecord
     new? ? site_status.destroy! : site_status.suspend!
   end
 
+  def applications_accepted_from=(new_date)
+    site_statuses.each { |ss| ss.update(applications_accepted_from: new_date) }
+  end
+
   def sites_not_associated_with_course
     provider.sites - sites
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -26,6 +26,8 @@ class Course < ApplicationRecord
   include WithQualifications
   include ChangedAt
 
+  after_initialize :set_defaults
+
   has_associated_audits
   audited except: :changed_at
   validates :course_code, uniqueness: { scope: :provider_id }
@@ -253,5 +255,14 @@ class Course < ApplicationRecord
 
   def has_scholarship_and_bursary?
     dfe_subjects.any?(&:has_scholarship_and_bursary?)
+  end
+
+private
+
+  def set_defaults
+    self.modular ||= ''
+    self.start_date ||= Date.new(2019, 9, 1)
+    self.study_mode ||= :full_time
+    self.qualification ||= :pgce_with_qts
   end
 end

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -89,6 +89,10 @@ class SiteStatus < ApplicationRecord
     end
   end
 
+  def self.applications_accepted_from_default
+    Date.today
+  end
+
   def description
     "#{site.description} – #{status}/#{publish}"
   end
@@ -97,7 +101,7 @@ private
 
   def set_defaults
     self.status ||= :new_status
-    self.applications_accepted_from ||= Date.today
+    self.applications_accepted_from ||= self.class.applications_accepted_from_default
     self.publish ||= :unpublished
   end
 

--- a/lib/mcb/commands/apiv1/providers/find.rb
+++ b/lib/mcb/commands/apiv1/providers/find.rb
@@ -5,7 +5,7 @@ description <<~EODESCRIPTION
   record.
 EODESCRIPTION
 usage 'find [options] <code>'
-param :code
+param :code, transform: ->(code) { code.upcase }
 option :j, 'json', 'show the returned JSON response'
 
 

--- a/lib/mcb/commands/courses/create.rb
+++ b/lib/mcb/commands/courses/create.rb
@@ -1,7 +1,7 @@
 name 'create'
 summary 'Create a new course in db'
 usage 'create <provider_code>'
-param :provider_code
+param :provider_code, transform: ->(code) { code.upcase }
 
 class CourseEditor
   def initialize(cli:, course:)

--- a/lib/mcb/commands/courses/create.rb
+++ b/lib/mcb/commands/courses/create.rb
@@ -1,0 +1,169 @@
+name 'create'
+summary 'Create a new course in db'
+usage 'create <provider_code>'
+param :provider_code
+
+class CourseEditor
+  def initialize(cli:, course:)
+    @cli = cli
+    @course = course
+  end
+
+  def new_course_wizard
+    ask_name
+    ask_course_code
+    ask_qualification
+    ask_study_mode
+    ask_age_range
+    ask_accredited_body
+    ask_start_date
+    ask_program_type
+    ask_maths
+    ask_english
+    ask_science
+    ask_ucas_subjects
+
+    if confirm_creation?
+      try_saving_course
+      ask_sites
+      ask_applications_accepted_from
+      print_summary
+    else
+      puts "Aborting"
+    end
+  end
+
+  def ask_name
+    @course.name = @cli.ask("Course name?  ")
+  end
+
+  def ask_qualification
+    @course.qualification = @cli.choose do |menu|
+      menu.prompt = "What's the course outcome? (#{@course.qualification} if blank)  "
+      menu.choices(*Course.qualifications.keys)
+      menu.default = @course.qualification
+    end
+  end
+
+  def ask_study_mode
+    @course.study_mode = @cli.choose do |menu|
+      menu.prompt = "Full time or part time? (#{@course.study_mode} if blank)  "
+      menu.choices(*Course.study_modes.keys)
+      menu.default = @course.study_mode
+    end
+  end
+
+  def ask_age_range
+    @course.age_range = @cli.choose do |menu|
+      menu.prompt = "What's the level of the course?  "
+      menu.choices(*Course.age_ranges.keys)
+    end
+  end
+
+  def ask_accredited_body
+    code = @cli.ask("Provider code of accredited body (leave blank if self-accredited)  ")
+    @course.accrediting_provider = code.present? ? Provider.find_by(provider_code: code) : @course.provider
+  end
+
+  def ask_start_date
+    @course.start_date = Date.parse(@cli.ask("Start date?  ") { |q| q.default = @course.start_date.strftime("%b %Y") })
+  end
+
+  def ask_course_code
+    @course.course_code = @cli.ask("Course code?  ")
+  end
+
+  def ask_program_type
+    @course.program_type = @cli.choose do |menu|
+      menu.prompt = "What's the route?  "
+      menu.choices(*Course.program_types.keys)
+    end
+  end
+
+  [:maths, :english, :science].each do |subject|
+    define_method("ask_#{subject}") do
+      answer = @cli.choose do |menu|
+        menu.prompt = "What's the #{subject} entry requirements?  "
+        menu.choices(*Course::ENTRY_REQUIREMENT_OPTIONS.keys)
+      end
+      @course.send("#{subject}=".to_sym, answer)
+    end
+  end
+
+  def ask_ucas_subjects
+    puts "Original subjects: #{@course.subjects.pluck(:subject_name).join(', ')}"
+
+    finished = false
+    cancel = false
+    subjects = []
+    until finished
+      @cli.choose do |menu|
+        subject_list = !subjects.empty? ? "(#{subjects.map(&:subject_name).join(', ')} so far)" : ""
+        menu.prompt = "UCAS subjects to assign?#{subject_list}  "
+
+        menu.choice("No more subjects") { finished = true }
+        menu.choice("Cancel without saving") { finished = true; cancel = true }
+        Subject.all.order(:subject_name).each do |subject|
+          menu.choice(subject.subject_name) { |cmd| subjects << subject }
+        end
+      end
+    end
+    @course.subjects = subjects unless cancel
+  end
+
+  def ask_sites
+    finished = false
+    until finished
+      @cli.choose do |menu|
+        sites_list = !@course.sites.empty? ? "(#{@course.sites.map(&:location_name).join(', ')} so far)" : ""
+        menu.prompt = "Which training locations to assign? #{sites_list}  "
+
+        menu.choice("No more training locations") { finished = true }
+        @course.provider.sites.each do |site|
+          menu.choice(site.location_name) { |cmd| @course.add_site!(site: site) }
+        end
+      end
+    end
+  end
+
+  def ask_applications_accepted_from
+    response = @cli.ask("Date that applications accepted from? (#{::SiteStatus.applications_accepted_from_default.strftime("%d %b %Y")} if blank)  ")
+    @course.applications_accepted_from = Date.parse(response) unless response.empty?
+  end
+
+  def confirm_creation?
+    puts "\nAbout to create the following course:"
+    print_course
+    @cli.agree("Continue? ")
+  end
+
+  def print_summary
+    puts "\nHere's the final course that's been created:"
+    print_course
+    @cli.ask("Press Enter to continue")
+  end
+
+  def print_course
+    puts Terminal::Table.new rows: MCB::CourseShow.new(@course).to_h
+  end
+
+  def try_saving_course
+    if @course.valid?
+      puts "Saving the course"
+      @course.save!
+    else
+      puts "Course isn't valid:"
+      @course.errors.full_messages.each { |error| puts " - #{error}" }
+    end
+  end
+end
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
+  Course.connection.transaction do
+    provider = Provider.find_by!(provider_code: args[:provider_code])
+    course = provider.courses.build
+    CourseEditor.new(cli: HighLine.new, course: course).new_course_wizard
+  end
+end

--- a/lib/mcb/commands/courses/edit_accredited_body.rb
+++ b/lib/mcb/commands/courses/edit_accredited_body.rb
@@ -1,7 +1,7 @@
 name 'edit_accredited_body'
 summary 'Edit accredited bodies on courses directly in the DB'
 usage 'edit_accredited_body <provider_code>'
-param :provider_code
+param :provider_code, transform: ->(code) { code.upcase }
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)

--- a/lib/mcb/commands/courses/edit_accredited_body.rb
+++ b/lib/mcb/commands/courses/edit_accredited_body.rb
@@ -1,0 +1,56 @@
+name 'edit_accredited_body'
+summary 'Edit accredited bodies on courses directly in the DB'
+usage 'edit_accredited_body <provider_code>'
+param :provider_code
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
+  provider = Provider.find_by!(provider_code: args[:provider_code])
+  cli = HighLine.new
+
+  finished = false
+  until finished
+    chosen_body = nil
+    accredited_bodies = provider.courses.collect(&:accrediting_provider).uniq.sort_by { |p| p&.provider_name || "" }
+
+    cli.choose do |menu|
+      menu.prompt = "Change the accredited body on courses for #{provider.provider_code}"
+      menu.choice(:exit) { finished = true }
+
+      accredited_bodies.each do |body|
+        if body.present?
+          menu.choice("Replace #{body.provider_name} (#{body.provider_code})") { chosen_body = body }
+        else
+          menu.choice("Make self-accredited courses consistent") { chosen_body = :fix_nulls }
+        end
+      end
+    end
+
+    case chosen_body
+    when Provider
+      new_accredited_body_code = cli.ask("What's the provider code of the new accredited provider?  ") {|a| a.default = provider.provider_code }
+      new_accredited_body = Provider.find_by!(provider_code: new_accredited_body_code.strip)
+      affected_courses = provider.courses.where(accrediting_provider: chosen_body)
+
+      puts "Changing accredited body from #{chosen_body.provider_code} to #{new_accredited_body_code} on the following courses:"
+      puts affected_courses.pluck(:course_code).join(", ")
+
+      if cli.agree("Continue? ")
+        provider.courses.where(accrediting_provider: chosen_body).each {|c| c.update(accrediting_provider: new_accredited_body) }
+      end
+    when Symbol
+      affected_courses = provider.courses.where(accrediting_provider: nil)
+
+      puts "Changing accredited body from nil to #{provider.provider_code} on the following courses:"
+      puts affected_courses.pluck(:course_code).join(", ")
+
+      if cli.agree("Continue? ")
+        provider.courses.where(accrediting_provider: nil).each {|c| c.update(accrediting_provider: provider) }
+      end
+    end
+
+    chosen_body = nil
+    provider.reload
+  end
+end

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -65,6 +65,7 @@ run do |opts, args, _cmd|
         menu.choice(:exit) { exit }
         menu.choice(:toggle_sites) { flow = :toggle_sites }
         menu.choice(:edit_route) { flow = :edit_route }
+        menu.choice(:edit_qualifications) { flow = :edit_qualifications }
       when :toggle_sites
         menu.prompt = "Toggling course sites"
         menu.choice(:done) { flow = :root }
@@ -77,6 +78,15 @@ run do |opts, args, _cmd|
         menu.choices(*Course.program_types.keys) do |value|
           course.program_type = value
           course.save!
+          flow = :root
+        end
+      when :edit_qualifications
+        menu.prompt = "Editing course qualifications"
+        menu.choice(:done) { flow = :root }
+        menu.choices(*Course.qualifications.keys) do |value|
+          course.qualification = value
+          course.save!
+          flow = :root
         end
       end
     end

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -6,13 +6,13 @@ run do |opts, args, _cmd|
 
   cli = HighLine.new
 
-  provider = Provider.find_by!(provider_code: args[0])
+  provider = Provider.find_by!(provider_code: args[0].upcase)
 
   all_courses_mode = args.size == 1
   courses = if all_courses_mode
               provider.courses
             else
-              provider.courses.where(course_code: args.to_a)
+              provider.courses.where(course_code: args.to_a.map(&:upcase))
             end
 
   multi_course_mode = courses.size > 1

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -31,7 +31,9 @@ def site_choices(course, provider)
   site_status_choices + new_site_choices
 end
 
-def toggle_site(course, site_str)
+def toggle_site(course, provider, site_str)
+  existing_sites = course.site_statuses.map(&:site)
+  new_sites_to_add = provider.sites - existing_sites
   site_code = site_str.match(/\(code: (.*)\)/)[1]
   if site_status = course.site_statuses.detect { |ss| ss.site.code == site_code }
     puts "Toggling #{site_status}"
@@ -81,7 +83,7 @@ run do |opts, args, _cmd|
         menu.prompt = "Toggling course sites"
         menu.choice(:done) { flow = :root }
         menu.choices(*(site_choices(course, provider))) do |site_str|
-          toggle_site(course, site_str)
+          toggle_site(course, provider, site_str)
         end
       when :edit_route
         menu.prompt = "Editing course route"

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -33,7 +33,7 @@ run do |opts, args, _cmd|
         end
         menu.choice(:exit) { finished = true }
         menu.choice(:toggle_sites) { flow = :toggle_sites } unless multi_course_mode
-        %i[route qualification study_mode english maths science start_date title].each do |attr|
+        %i[route qualifications study_mode english maths science start_date title].each do |attr|
           menu.choice("Edit #{attr}") { flow = attr }
         end
         menu.choice('Publish training locations (not enrichment)') { flow = :publish_sites }
@@ -115,6 +115,9 @@ run do |opts, args, _cmd|
         puts "Setting the training locations to running on #{course.provider.provider_code}/#{course.course_code}"
         course.publish_sites
       end
+      flow = :root
+    else
+      puts "Unexpected option: #{flow}"
       flow = :root
     end
     courses.each(&:save!)

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -36,6 +36,7 @@ run do |opts, args, _cmd|
         %i[route qualification study_mode english maths science start_date title].each do |attr|
           menu.choice("Edit #{attr}") { flow = attr }
         end
+        menu.choice('Sync courses to Find') { flow = :sync_to_find }
       end
     when :toggle_sites
       course = courses.first
@@ -103,6 +104,10 @@ run do |opts, args, _cmd|
       current_course_names = courses.map(&:name).uniq
       name = cli.ask("Course title? (current titles: #{current_course_names.join(', ')})  ").strip
       courses.each { |c| c.name = name }
+      flow = :root
+    when :sync_to_find
+      command_params = ['courses', 'sync_to_find', provider.provider_code, *courses.map(&:course_code)] + (opts[:env].present? ? ['-E', opts[:env]] : [])
+      $mcb.run(command_params)
       flow = :root
     end
     courses.each(&:save!)

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -1,7 +1,5 @@
 name 'edit_published'
 summary 'Edit publisheds course directly in the DB'
-param :provider_code
-param :course_code
 
 ENTRY_REQUIREMENT_OPTIONS = {
   must_have_qualification_at_application_time: 1,
@@ -16,8 +14,14 @@ run do |opts, args, _cmd|
 
   cli = HighLine.new
 
-  provider = Provider.find_by!(provider_code: args[:provider_code])
-  course = provider.courses.find_by!(course_code: args[:course_code])
+  multi_course_mode = args.size > 2
+  if multi_course_mode
+    provider = Provider.find_by!(provider_code: args[0])
+    courses = provider.courses.filter{ |course| args.include?(course.course_code) }
+  else
+    provider = Provider.find_by!(provider_code: args[0])
+    courses = [provider.courses.find_by!(course_code: args[1])]
+  end
 
   flow = :root
   finished = false
@@ -25,12 +29,15 @@ run do |opts, args, _cmd|
     cli.choose do |menu|
       case flow
       when :root
-        puts Terminal::Table.new rows: MCB::CourseShow.new(course).to_h
-        puts "Course status: #{course.ucas_status}"
+        courses.each { |c| puts Terminal::Table.new rows: MCB::CourseShow.new(c).to_h }
 
-        menu.prompt = "Editing course"
+        if multi_course_mode
+          menu.prompt = "Editing multiple courses"
+        else
+          menu.prompt = "Editing course"
+        end
         menu.choice(:exit) { finished = true }
-        menu.choice(:toggle_sites) { flow = :toggle_sites }
+        menu.choice(:toggle_sites) { flow = :toggle_sites } unless multi_course_mode
         menu.choice(:edit_route) { flow = :edit_route }
         menu.choice(:edit_qualifications) { flow = :edit_qualifications }
         menu.choice(:edit_english) { flow = :edit_english }
@@ -39,34 +46,34 @@ run do |opts, args, _cmd|
       when :toggle_sites
         menu.prompt = "Toggling course sites"
         menu.choice(:done) { flow = :root }
-        menu.choices(*(course.actual_and_potential_site_statuses.map(&:description))) do |site_str|
+        menu.choices(*(courses.first.actual_and_potential_site_statuses.map(&:description))) do |site_str|
           site_code = site_str.match(/\(code: (.*)\)/)[1]
-          course.toggle_site(provider.sites.find_by!(code: site_code))
+          courses.first.toggle_site(provider.sites.find_by!(code: site_code))
         end
       when :edit_route
         menu.prompt = "Editing course route"
-        menu.choices(*Course.program_types.keys) { |value| course.program_type = value }
+        menu.choices(*Course.program_types.keys) { |value| courses.each{ |c| c.program_type = value } }
         flow = :root
       when :edit_qualifications
         menu.prompt = "Editing course qualifications"
-        menu.choices(*Course.qualifications.keys) { |value| course.qualification = value }
+        menu.choices(*Course.qualifications.keys) { |value| courses.each{ |c| c.qualification = value } }
         flow = :root
       when :edit_english
         menu.prompt = "Editing course english"
-        menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) { |value| course.english = value }
+        menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) { |value| courses.each{ |c| c.english = value } }
         flow = :root
       when :edit_maths
         menu.prompt = "Editing course maths"
-        menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) { |value| course.maths = value }
+        menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) { |value| courses.each{ |c| c.maths = value } }
         flow = :root
       when :edit_science
         menu.prompt = "Editing course science"
-        menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) { |value| course.science = value }
+        menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) { |value| courses.each{ |c| c.science = value } }
         flow = :root
       end
     end
-    course.save!
-    course.reload
-    course.site_statuses.reload
+    courses.each(&:save!)
+    courses.each(&:reload)
+    courses.first.site_statuses.reload unless multi_course_mode
   end
 end

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -11,49 +11,6 @@ ENTRY_REQUIREMENT_OPTIONS = {
   not_set: nil,
 }.freeze
 
-def vacancy_status(course)
-  case course.study_mode
-  when "full_time"
-    :full_time_vacancies
-  when "part_time"
-    :part_time_vacancies
-  when "full_time_or_part_time"
-    :both_full_time_and_part_time_vacancies
-  else
-    raise "Unexpected study mode #{course.study_mode}"
-  end
-end
-
-def site_choices(course, provider)
-  existing_sites = course.site_statuses.map(&:site)
-  new_sites_to_add = provider.sites - existing_sites
-  site_status_choices = course.site_statuses.map {|ss| "#{ss.site.location_name} (code: #{ss.site.code}) – #{ss.status}/#{ss.publish}" }
-  new_site_choices = new_sites_to_add.map {|s| "#{s.location_name} (code: #{s.code})" }
-
-  site_status_choices + new_site_choices
-end
-
-def toggle_site(course, provider, site_str)
-  existing_sites = course.site_statuses.map(&:site)
-  new_sites_to_add = provider.sites - existing_sites
-  site_code = site_str.match(/\(code: (.*)\)/)[1]
-  if site_status = course.site_statuses.detect { |ss| ss.site.code == site_code }
-    puts "Toggling #{site_status}"
-    site_status.toggle!
-  else
-    is_course_new = course.new? # persist this before we create the site status
-    site_status = SiteStatus.create!(
-      course: course,
-      site: new_sites_to_add.detect { |s| s.code == site_code },
-      vac_status: vacancy_status(course),
-      status: :new_status,
-      applications_accepted_from: Date.today,
-      publish: :unpublished,
-    )
-    site_status.start! unless is_course_new
-  end
-end
-
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
@@ -82,8 +39,9 @@ run do |opts, args, _cmd|
       when :toggle_sites
         menu.prompt = "Toggling course sites"
         menu.choice(:done) { flow = :root }
-        menu.choices(*(site_choices(course, provider))) do |site_str|
-          toggle_site(course, provider, site_str)
+        menu.choices(*(course.actual_and_potential_site_statuses.map(&:description))) do |site_str|
+          site_code = site_str.match(/\(code: (.*)\)/)[1]
+          course.toggle_site(provider.sites.find_by!(code: site_code))
         end
       when :edit_route
         menu.prompt = "Editing course route"

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -35,6 +35,7 @@ run do |opts, args, _cmd|
         menu.choice(:toggle_sites) { flow = :toggle_sites } unless multi_course_mode
         menu.choice(:edit_route) { flow = :edit_route }
         menu.choice(:edit_qualifications) { flow = :edit_qualifications }
+        menu.choice(:edit_study_mode) { flow = :edit_study_mode }
         menu.choice(:edit_english) { flow = :edit_english }
         menu.choice(:edit_maths) { flow = :edit_maths }
         menu.choice(:edit_science) { flow = :edit_science }
@@ -52,6 +53,10 @@ run do |opts, args, _cmd|
       when :edit_qualifications
         menu.prompt = "Editing course qualifications"
         menu.choices(*Course.qualifications.keys) { |value| courses.each{ |c| c.qualification = value } }
+        flow = :root
+      when :edit_study_mode
+        menu.prompt = "Editing course study mode"
+        menu.choices(*Course.study_modes.keys) { |value| courses.each{ |c| c.study_mode = value } }
         flow = :root
       when :edit_english
         menu.prompt = "Editing course english"

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -120,8 +120,11 @@ run do |opts, args, _cmd|
       puts "Unexpected option: #{flow}"
       flow = :root
     end
-    courses.each(&:save!)
-    courses.each(&:reload)
-    courses.first.site_statuses.reload unless multi_course_mode
+    unless finished
+      courses.each(&:save!)
+      provider.reload
+      courses.reload
+      courses.first.site_statuses.reload unless multi_course_mode
+    end
   end
 end

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -1,6 +1,14 @@
 name 'edit_published'
 summary 'Edit publisheds course directly in the DB'
 
+ENTRY_REQUIREMENT_OPTIONS = {
+  must_have_qualification_at_application_time: 1,
+  expect_to_achieve_before_training_begins: 2,
+  equivalence_test: 3,
+  not_required: 9,
+  not_set: nil,
+}.freeze
+
 def vacancy_status(course)
   case course.study_mode
   when "full_time"
@@ -66,6 +74,9 @@ run do |opts, args, _cmd|
         menu.choice(:toggle_sites) { flow = :toggle_sites }
         menu.choice(:edit_route) { flow = :edit_route }
         menu.choice(:edit_qualifications) { flow = :edit_qualifications }
+        menu.choice(:edit_english) { flow = :edit_english }
+        menu.choice(:edit_maths) { flow = :edit_maths }
+        menu.choice(:edit_science) { flow = :edit_science }
       when :toggle_sites
         menu.prompt = "Toggling course sites"
         menu.choice(:done) { flow = :root }
@@ -85,6 +96,30 @@ run do |opts, args, _cmd|
         menu.choice(:done) { flow = :root }
         menu.choices(*Course.qualifications.keys) do |value|
           course.qualification = value
+          course.save!
+          flow = :root
+        end
+      when :edit_english
+        menu.prompt = "Editing course english"
+        menu.choice(:done) { flow = :root }
+        menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) do |value|
+          course.english = value
+          course.save!
+          flow = :root
+        end
+      when :edit_maths
+        menu.prompt = "Editing course maths"
+        menu.choice(:done) { flow = :root }
+        menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) do |value|
+          course.maths = value
+          course.save!
+          flow = :root
+        end
+      when :edit_science
+        menu.prompt = "Editing course science"
+        menu.choice(:done) { flow = :root }
+        menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) do |value|
+          course.science = value
           course.save!
           flow = :root
         end

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -37,6 +37,7 @@ run do |opts, args, _cmd|
           menu.choice("Edit #{attr}") { flow = attr }
         end
         menu.choice('Sync courses to Find') { flow = :sync_to_find }
+        menu.choice('Publish training locations (not enrichment)') { flow = :publish_sites }
       end
     when :toggle_sites
       course = courses.first
@@ -108,6 +109,12 @@ run do |opts, args, _cmd|
     when :sync_to_find
       command_params = ['courses', 'sync_to_find', provider.provider_code, *courses.map(&:course_code)] + (opts[:env].present? ? ['-E', opts[:env]] : [])
       $mcb.run(command_params)
+      flow = :root
+    when :publish_sites
+      courses.each do |course|
+        puts "Setting the training locations to running on #{course.provider.provider_code}/#{course.course_code}"
+        course.publish_sites
+      end
       flow = :root
     end
     courses.each(&:save!)

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -14,6 +14,15 @@ def vacancy_status(course)
   end
 end
 
+def site_choices(course, provider)
+  existing_sites = course.site_statuses.map(&:site)
+  new_sites_to_add = provider.sites - existing_sites
+  site_status_choices = course.site_statuses.map {|ss| "#{ss.site.location_name} (code: #{ss.site.code}) – #{ss.status}/#{ss.publish}" }
+  new_site_choices = new_sites_to_add.map {|s| "#{s.location_name} (code: #{s.code})" }
+
+  site_status_choices + new_site_choices
+end
+
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
@@ -32,11 +41,7 @@ run do |opts, args, _cmd|
   finished = false
   until finished do
     cli.choose do |menu|
-      existing_sites = course.site_statuses.map(&:site)
-      new_sites_to_add = provider.sites - existing_sites
-      site_status_choices = course.site_statuses.map {|ss| "#{ss.site.location_name} (code: #{ss.site.code}) – #{ss.status}/#{ss.publish}" }
-      new_site_choices = new_sites_to_add.map {|s| "#{s.location_name} (code: #{s.code})" }
-      menu.choices(*(site_status_choices + new_site_choices + ['exit'])) do |cmd|
+      menu.choices(*(site_choices(course, provider) + ['exit'])) do |cmd|
         if cmd == 'exit'
           finished = true
         else

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -1,14 +1,6 @@
 name 'edit_published'
 summary 'Edit publisheds course directly in the DB'
 
-ENTRY_REQUIREMENT_OPTIONS = {
-  must_have_qualification_at_application_time: 1,
-  expect_to_achieve_before_training_begins: 2,
-  equivalence_test: 3,
-  not_required: 9,
-  not_set: nil,
-}.freeze
-
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
@@ -63,15 +55,15 @@ run do |opts, args, _cmd|
         flow = :root
       when :edit_english
         menu.prompt = "Editing course english"
-        menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) { |value| courses.each{ |c| c.english = value } }
+        menu.choices(*Course.englishes.keys) { |value| courses.each{ |c| c.english = value } }
         flow = :root
       when :edit_maths
         menu.prompt = "Editing course maths"
-        menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) { |value| courses.each{ |c| c.maths = value } }
+        menu.choices(*Course.maths.keys) { |value| courses.each{ |c| c.maths = value } }
         flow = :root
       when :edit_science
         menu.prompt = "Editing course science"
-        menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) { |value| courses.each{ |c| c.science = value } }
+        menu.choices(*Course.sciences.keys) { |value| courses.each{ |c| c.science = value } }
         flow = :root
       end
     end

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -46,6 +46,7 @@ run do |opts, args, _cmd|
               puts "Toggling #{site_status}"
               site_status.toggle!
             else
+              is_course_new = course.new? # persist this before we create the site status
               site_status = SiteStatus.create!(
                 course: course,
                 site: new_sites_to_add.detect { |s| s.code == site_code },
@@ -54,11 +55,13 @@ run do |opts, args, _cmd|
                 applications_accepted_from: Date.today,
                 publish: :unpublished,
               )
-              site_status.start! unless course.new?
+              site_status.start! unless is_course_new
             end
           end
         end
       end
+      course.reload
+      course.site_statuses.reload
     end
   end
 end

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -17,51 +17,49 @@ end
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
-  Provider.connection.transaction do
-    cli = HighLine.new
+  cli = HighLine.new
 
-    provider_code = cli.ask("Provider code?  ")
-    provider = Provider.find_by!(provider_code: provider_code)
+  provider_code = cli.ask("Provider code?  ")
+  provider = Provider.find_by!(provider_code: provider_code)
 
-    course_code = cli.ask("Course code?  ")
-    course = provider.courses.find_by!(course_code: course_code)
+  course_code = cli.ask("Course code?  ")
+  course = provider.courses.find_by!(course_code: course_code)
 
-    puts Terminal::Table.new rows: MCB::CourseShow.new(course).to_h
+  puts Terminal::Table.new rows: MCB::CourseShow.new(course).to_h
 
-    puts "Course status: #{course.ucas_status}"
+  puts "Course status: #{course.ucas_status}"
 
-    finished = false
-    until finished do
-      cli.choose do |menu|
-        existing_sites = course.site_statuses.map(&:site)
-        new_sites_to_add = provider.sites - existing_sites
-        site_status_choices = course.site_statuses.map {|ss| "#{ss.site.location_name} (code: #{ss.site.code}) – #{ss.status}/#{ss.publish}" }
-        new_site_choices = new_sites_to_add.map {|s| "#{s.location_name} (code: #{s.code})" }
-        menu.choices(*(site_status_choices + new_site_choices + ['exit'])) do |cmd|
-          if cmd == 'exit'
-            finished = true
+  finished = false
+  until finished do
+    cli.choose do |menu|
+      existing_sites = course.site_statuses.map(&:site)
+      new_sites_to_add = provider.sites - existing_sites
+      site_status_choices = course.site_statuses.map {|ss| "#{ss.site.location_name} (code: #{ss.site.code}) – #{ss.status}/#{ss.publish}" }
+      new_site_choices = new_sites_to_add.map {|s| "#{s.location_name} (code: #{s.code})" }
+      menu.choices(*(site_status_choices + new_site_choices + ['exit'])) do |cmd|
+        if cmd == 'exit'
+          finished = true
+        else
+          site_code = cmd.match(/\(code: (.*)\)/)[1]
+          if site_status = course.site_statuses.detect { |ss| ss.site.code == site_code }
+            puts "Toggling #{site_status}"
+            site_status.toggle!
           else
-            site_code = cmd.match(/\(code: (.*)\)/)[1]
-            if site_status = course.site_statuses.detect { |ss| ss.site.code == site_code }
-              puts "Toggling #{site_status}"
-              site_status.toggle!
-            else
-              is_course_new = course.new? # persist this before we create the site status
-              site_status = SiteStatus.create!(
-                course: course,
-                site: new_sites_to_add.detect { |s| s.code == site_code },
-                vac_status: vacancy_status(course),
-                status: :new_status,
-                applications_accepted_from: Date.today,
-                publish: :unpublished,
-              )
-              site_status.start! unless is_course_new
-            end
+            is_course_new = course.new? # persist this before we create the site status
+            site_status = SiteStatus.create!(
+              course: course,
+              site: new_sites_to_add.detect { |s| s.code == site_code },
+              vac_status: vacancy_status(course),
+              status: :new_status,
+              applications_accepted_from: Date.today,
+              publish: :unpublished,
+            )
+            site_status.start! unless is_course_new
           end
         end
       end
-      course.reload
-      course.site_statuses.reload
     end
+    course.reload
+    course.site_statuses.reload
   end
 end

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -63,7 +63,8 @@ run do |opts, args, _cmd|
   course = provider.courses.find_by!(course_code: args[:course_code])
 
   flow = :root
-  loop do
+  finished = false
+  until finished do
     cli.choose do |menu|
       case flow
       when :root
@@ -71,7 +72,7 @@ run do |opts, args, _cmd|
         puts "Course status: #{course.ucas_status}"
 
         menu.prompt = "Editing course"
-        menu.choice(:exit) { exit }
+        menu.choice(:exit) { finished = true }
         menu.choice(:toggle_sites) { flow = :toggle_sites }
         menu.choice(:edit_route) { flow = :edit_route }
         menu.choice(:edit_qualifications) { flow = :edit_qualifications }

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -39,6 +39,7 @@ run do |opts, args, _cmd|
         menu.choice(:edit_english) { flow = :edit_english }
         menu.choice(:edit_maths) { flow = :edit_maths }
         menu.choice(:edit_science) { flow = :edit_science }
+        menu.choice(:edit_start_date) { flow = :edit_start_date }
       end
     when :toggle_sites
       cli.choose do |menu|
@@ -85,6 +86,12 @@ run do |opts, args, _cmd|
         menu.choices(*Course.sciences.keys) { |value| courses.each{ |c| c.science = value } }
         flow = :root
       end
+    when :edit_start_date
+      start_date = Date.parse(cli.ask("What's the new start date?  "))
+      if cli.agree("Start date will be set to #{start_date.strftime('%d %b %Y')}. Continue? ")
+        courses.each { |c| c.start_date = start_date }
+      end
+      flow = :root
     end
     courses.each(&:save!)
     courses.each(&:reload)

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -1,5 +1,7 @@
 name 'edit_published'
 summary 'Edit publisheds course directly in the DB'
+param :provider_code
+param :course_code
 
 ENTRY_REQUIREMENT_OPTIONS = {
   must_have_qualification_at_application_time: 1,
@@ -57,11 +59,8 @@ run do |opts, args, _cmd|
 
   cli = HighLine.new
 
-  provider_code = cli.ask("Provider code?  ")
-  provider = Provider.find_by!(provider_code: provider_code)
-
-  course_code = cli.ask("Course code?  ")
-  course = provider.courses.find_by!(course_code: course_code)
+  provider = Provider.find_by!(provider_code: args[:provider_code])
+  course = provider.courses.find_by!(course_code: args[:course_code])
 
   flow = :root
   loop do

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -88,7 +88,6 @@ run do |opts, args, _cmd|
         menu.choice(:done) { flow = :root }
         menu.choices(*Course.program_types.keys) do |value|
           course.program_type = value
-          course.save!
           flow = :root
         end
       when :edit_qualifications
@@ -96,7 +95,6 @@ run do |opts, args, _cmd|
         menu.choice(:done) { flow = :root }
         menu.choices(*Course.qualifications.keys) do |value|
           course.qualification = value
-          course.save!
           flow = :root
         end
       when :edit_english
@@ -104,7 +102,6 @@ run do |opts, args, _cmd|
         menu.choice(:done) { flow = :root }
         menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) do |value|
           course.english = value
-          course.save!
           flow = :root
         end
       when :edit_maths
@@ -112,7 +109,6 @@ run do |opts, args, _cmd|
         menu.choice(:done) { flow = :root }
         menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) do |value|
           course.maths = value
-          course.save!
           flow = :root
         end
       when :edit_science
@@ -120,11 +116,11 @@ run do |opts, args, _cmd|
         menu.choice(:done) { flow = :root }
         menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) do |value|
           course.science = value
-          course.save!
           flow = :root
         end
       end
     end
+    course.save!
     course.reload
     course.site_statuses.reload
   end

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -29,7 +29,8 @@ run do |opts, args, _cmd|
     cli.choose do |menu|
       case flow
       when :root
-        courses.each { |c| puts Terminal::Table.new rows: MCB::CourseShow.new(c).to_h }
+        courses[0..2].each { |c| puts Terminal::Table.new rows: MCB::CourseShow.new(c).to_h }
+        puts "Only showing first 2 courses of #{courses.size}." if courses.size > 2
 
         if multi_course_mode
           menu.prompt = "Editing multiple courses"

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -20,9 +20,9 @@ run do |opts, args, _cmd|
   flow = :root
   finished = false
   until finished do
-    cli.choose do |menu|
-      case flow
-      when :root
+    case flow
+    when :root
+      cli.choose do |menu|
         courses[0..1].each { |c| puts Terminal::Table.new rows: MCB::CourseShow.new(c).to_h }
         puts "Only showing first 2 courses of #{courses.size}." if courses.size > 2
 
@@ -39,34 +39,48 @@ run do |opts, args, _cmd|
         menu.choice(:edit_english) { flow = :edit_english }
         menu.choice(:edit_maths) { flow = :edit_maths }
         menu.choice(:edit_science) { flow = :edit_science }
-      when :toggle_sites
+      end
+    when :toggle_sites
+      cli.choose do |menu|
         menu.prompt = "Toggling course sites"
         menu.choice(:done) { flow = :root }
         menu.choices(*(courses.first.actual_and_potential_site_statuses.map(&:description))) do |site_str|
           site_code = site_str.match(/\(code: (.*)\)/)[1]
           courses.first.toggle_site(provider.sites.find_by!(code: site_code))
         end
-      when :edit_route
+      end
+    when :edit_route
+      cli.choose do |menu|
         menu.prompt = "Editing course route"
         menu.choices(*Course.program_types.keys) { |value| courses.each{ |c| c.program_type = value } }
         flow = :root
-      when :edit_qualifications
+      end
+    when :edit_qualifications
+      cli.choose do |menu|
         menu.prompt = "Editing course qualifications"
         menu.choices(*Course.qualifications.keys) { |value| courses.each{ |c| c.qualification = value } }
         flow = :root
-      when :edit_study_mode
+      end
+    when :edit_study_mode
+      cli.choose do |menu|
         menu.prompt = "Editing course study mode"
         menu.choices(*Course.study_modes.keys) { |value| courses.each{ |c| c.study_mode = value } }
         flow = :root
-      when :edit_english
+      end
+    when :edit_english
+      cli.choose do |menu|
         menu.prompt = "Editing course english"
         menu.choices(*Course.englishes.keys) { |value| courses.each{ |c| c.english = value } }
         flow = :root
-      when :edit_maths
+      end
+    when :edit_maths
+      cli.choose do |menu|
         menu.prompt = "Editing course maths"
         menu.choices(*Course.maths.keys) { |value| courses.each{ |c| c.maths = value } }
         flow = :root
-      when :edit_science
+      end
+    when :edit_science
+      cli.choose do |menu|
         menu.prompt = "Editing course science"
         menu.choices(*Course.sciences.keys) { |value| courses.each{ |c| c.science = value } }
         flow = :root

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -50,7 +50,7 @@ run do |opts, args, _cmd|
           else
             site_status = course.site_statuses.detect { |ss| ss.site == site }
             menu.choice(site_status.description) do
-              if site_status.status_running?
+              if site_status.status_running? || site_status.status_new_status?
                 course.remove_site!(site: site)
               else
                 course.add_site!(site: site)

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -14,14 +14,16 @@ run do |opts, args, _cmd|
 
   cli = HighLine.new
 
-  multi_course_mode = args.size > 2
-  if multi_course_mode
-    provider = Provider.find_by!(provider_code: args[0])
-    courses = provider.courses.filter{ |course| args.include?(course.course_code) }
-  else
-    provider = Provider.find_by!(provider_code: args[0])
-    courses = [provider.courses.find_by!(course_code: args[1])]
-  end
+  provider = Provider.find_by!(provider_code: args[0])
+
+  all_courses_mode = args.size == 1
+  courses = if all_courses_mode
+              provider.courses
+            else
+              provider.courses.filter{ |course| args.include?(course.course_code) }
+            end
+
+  multi_course_mode = courses.size > 1
 
   flow = :root
   finished = false

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -33,7 +33,7 @@ run do |opts, args, _cmd|
         end
         menu.choice(:exit) { finished = true }
         menu.choice(:toggle_sites) { flow = :toggle_sites } unless multi_course_mode
-        %i[route qualifications study_mode english maths science start_date title].each do |attr|
+        %i[route qualifications study_mode accredited_body english maths science start_date title].each do |attr|
           menu.choice("Edit #{attr}") { flow = attr }
         end
         menu.choice('Publish training locations (not enrichment)') { flow = :publish_sites }
@@ -77,6 +77,11 @@ run do |opts, args, _cmd|
         menu.choices(*Course.study_modes.keys) { |value| courses.each{ |c| c.study_mode = value } }
         flow = :root
       end
+    when :accredited_body
+      accredited_body_provider_code = cli.ask("What's the provider code of the new accredited body? (can't be blank)  ")
+      accredited_body = Provider.find_by!(provider_code: accredited_body_provider_code)
+      courses.each { |c| c.accrediting_provider = accredited_body }
+      flow = :root
     when :english
       cli.choose do |menu|
         menu.prompt = "Editing course english"

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -1,0 +1,42 @@
+name 'edit_published'
+summary 'Edit publisheds course directly in the DB'
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
+  Provider.connection.transaction do
+    cli = HighLine.new
+
+    provider_code = cli.ask("Provider code?  ")
+    provider = Provider.find_by!(provider_code: provider_code)
+
+    course_code = cli.ask("Course code?  ")
+    course = provider.courses.find_by!(course_code: course_code)
+
+    puts Terminal::Table.new rows: MCB::CourseShow.new(course).to_h
+
+    if course.new?
+      puts "This course is new, meaning the provider can edit them directly"
+      break
+    end
+
+    puts "Course status: #{course.ucas_status}"
+
+    finished = false
+    until finished do
+      cli.choose do |menu|
+        existing_sites = course.site_statuses.map(&:site)
+        new_sites_to_add = provider.sites - existing_sites
+        site_status_choices = course.site_statuses.map {|ss| "#{ss.site.location_name} (code: #{ss.site.code}) – #{ss.status}/#{ss.publish}" }
+        new_site_choices = new_sites_to_add.map {|s| "#{s.location_name} (code: #{s.code})" }
+        menu.choices(*(site_status_choices + new_site_choices + ['exit'])) do |cmd|
+          if cmd == 'exit'
+            finished = true
+          else
+            # either tweak the site status or add new site here
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -31,7 +31,7 @@ run do |opts, args, _cmd|
     cli.choose do |menu|
       case flow
       when :root
-        courses[0..2].each { |c| puts Terminal::Table.new rows: MCB::CourseShow.new(c).to_h }
+        courses[0..1].each { |c| puts Terminal::Table.new rows: MCB::CourseShow.new(c).to_h }
         puts "Only showing first 2 courses of #{courses.size}." if courses.size > 2
 
         if multi_course_mode

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -28,11 +28,6 @@ run do |opts, args, _cmd|
 
     puts Terminal::Table.new rows: MCB::CourseShow.new(course).to_h
 
-    if course.new?
-      puts "This course is new, meaning the provider can edit them directly"
-      break
-    end
-
     puts "Course status: #{course.ucas_status}"
 
     finished = false
@@ -59,7 +54,7 @@ run do |opts, args, _cmd|
                 applications_accepted_from: Date.today,
                 publish: :unpublished,
               )
-              site_status.start!
+              site_status.start! unless course.new?
             end
           end
         end

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -85,39 +85,24 @@ run do |opts, args, _cmd|
         end
       when :edit_route
         menu.prompt = "Editing course route"
-        menu.choice(:done) { flow = :root }
-        menu.choices(*Course.program_types.keys) do |value|
-          course.program_type = value
-          flow = :root
-        end
+        menu.choices(*Course.program_types.keys) { |value| course.program_type = value }
+        flow = :root
       when :edit_qualifications
         menu.prompt = "Editing course qualifications"
-        menu.choice(:done) { flow = :root }
-        menu.choices(*Course.qualifications.keys) do |value|
-          course.qualification = value
-          flow = :root
-        end
+        menu.choices(*Course.qualifications.keys) { |value| course.qualification = value }
+        flow = :root
       when :edit_english
         menu.prompt = "Editing course english"
-        menu.choice(:done) { flow = :root }
-        menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) do |value|
-          course.english = value
-          flow = :root
-        end
+        menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) { |value| course.english = value }
+        flow = :root
       when :edit_maths
         menu.prompt = "Editing course maths"
-        menu.choice(:done) { flow = :root }
-        menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) do |value|
-          course.maths = value
-          flow = :root
-        end
+        menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) { |value| course.maths = value }
+        flow = :root
       when :edit_science
         menu.prompt = "Editing course science"
-        menu.choice(:done) { flow = :root }
-        menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) do |value|
-          course.science = value
-          flow = :root
-        end
+        menu.choices(*ENTRY_REQUIREMENT_OPTIONS.keys) { |value| course.science = value }
+        flow = :root
       end
     end
     course.save!

--- a/lib/mcb/commands/courses/edit_published.rb
+++ b/lib/mcb/commands/courses/edit_published.rb
@@ -36,8 +36,8 @@ run do |opts, args, _cmd|
         %i[route qualification study_mode english maths science start_date title].each do |attr|
           menu.choice("Edit #{attr}") { flow = attr }
         end
-        menu.choice('Sync courses to Find') { flow = :sync_to_find }
         menu.choice('Publish training locations (not enrichment)') { flow = :publish_sites }
+        menu.choice('Sync courses to Find') { flow = :sync_to_find }
       end
     when :toggle_sites
       course = courses.first

--- a/lib/mcb/commands/providers/audit.rb
+++ b/lib/mcb/commands/providers/audit.rb
@@ -1,5 +1,5 @@
 summary 'Show changes made to a user record'
-param :code
+param :code, transform: ->(code) { code.upcase }
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)

--- a/lib/mcb/commands/providers/edit.rb
+++ b/lib/mcb/commands/providers/edit.rb
@@ -43,12 +43,6 @@ run do |opts, args, _cmd|
         chosen_course_codes = []
       end
 
-      menu.choice("Add a new location") do
-        command_params = ['sites', 'create', args[:code]] + (opts[:env].present? ? ['-E', opts[:env]] : [])
-        $mcb.run(command_params)
-        chosen_course_codes = []
-      end
-
       menu.choice("Clone a course") do
         provider_code = cli.ask("Provider code of course you want to clone? (#{provider.provider_code} if blank)  ") { |q| q.default = provider.provider_code }
         course_code = cli.ask("Code of course you want to clone?  ")
@@ -59,6 +53,12 @@ run do |opts, args, _cmd|
         new_course.course_code = cli.ask("New course code?  ")
         new_course.subjects = original_course.subjects
         new_course.save!
+      end
+
+      menu.choice("Add a new location") do
+        command_params = ['sites', 'create', args[:code]] + (opts[:env].present? ? ['-E', opts[:env]] : [])
+        $mcb.run(command_params)
+        chosen_course_codes = []
       end
     end
     provider.reload

--- a/lib/mcb/commands/providers/edit.rb
+++ b/lib/mcb/commands/providers/edit.rb
@@ -8,12 +8,12 @@ run do |opts, args, _cmd|
   cli = HighLine.new
 
   provider = Provider.find_by!(provider_code: args[:code])
-  courses = provider.courses
 
   finished = false
   chosen_course_codes = []
   until finished do
     cli.choose do |menu|
+      courses = provider.courses
       if chosen_course_codes.empty?
         menu.prompt = "Choose one or multiple courses to edit."
       else
@@ -49,6 +49,6 @@ run do |opts, args, _cmd|
         chosen_course_codes = []
       end
     end
-    courses.each(&:reload)
+    provider.reload
   end
 end

--- a/lib/mcb/commands/providers/edit.rb
+++ b/lib/mcb/commands/providers/edit.rb
@@ -20,19 +20,15 @@ run do |opts, args, _cmd|
         menu.prompt = "Chosen courses: #{chosen_course_codes.join(", ")}"
       end
 
+      unchosen_course_codes = (courses.map(&:course_code) - chosen_course_codes)
+
       menu.choice(:exit) { finished = true }
 
-      unchosen_course_codes = (courses.map(&:course_code) - chosen_course_codes)
-      unless unchosen_course_codes.empty?
-        menu.choices(:all_courses) { chosen_course_codes = courses.map(&:course_code) }
-      end
-
-      unless chosen_course_codes.empty?
-        menu.choice(:edit_selected_courses) do
-          command_params = ['courses', 'edit_published', args[:code], *chosen_course_codes] + (opts[:env].present? ? ['-E', opts[:env]] : [])
-          $mcb.run(command_params)
-          chosen_course_codes = []
-        end
+      all_courses_or_just_selected = chosen_course_codes.empty? ? :all_courses : :edit_selected_courses
+      menu.choice(all_courses_or_just_selected) do
+        command_params = ['courses', 'edit_published', args[:code], *chosen_course_codes] + (opts[:env].present? ? ['-E', opts[:env]] : [])
+        $mcb.run(command_params)
+        chosen_course_codes = []
       end
 
       unless unchosen_course_codes.empty?
@@ -40,7 +36,6 @@ run do |opts, args, _cmd|
           chosen_course_codes.push(course_code)
         end
       end
-
     end
   end
 end

--- a/lib/mcb/commands/providers/edit.rb
+++ b/lib/mcb/commands/providers/edit.rb
@@ -60,6 +60,13 @@ run do |opts, args, _cmd|
         $mcb.run(command_params)
         chosen_course_codes = []
       end
+
+      menu.choice("Edit provider name") do
+        puts "Current name: #{provider.provider_name}"
+        new_name = cli.ask("Enter new name").strip
+        provider.provider_name = new_name
+        provider.save!
+      end
     end
     provider.reload
   end

--- a/lib/mcb/commands/providers/edit.rb
+++ b/lib/mcb/commands/providers/edit.rb
@@ -1,6 +1,6 @@
 name 'show'
 summary 'Edit information about provider'
-param :code
+param :code, transform: ->(code) { code.upcase }
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
@@ -46,7 +46,9 @@ run do |opts, args, _cmd|
       menu.choice("Clone a course") do
         provider_code = cli.ask("Provider code of course you want to clone? (#{provider.provider_code} if blank)  ") { |q| q.default = provider.provider_code }
         course_code = cli.ask("Code of course you want to clone?  ")
-        original_course = Provider.find_by!(provider_code: provider_code).courses.find_by!(course_code: course_code)
+        original_course = Provider
+                            .find_by!(provider_code: provider_code.upcase)
+                            .courses.find_by!(course_code: course_code.upcase)
 
         new_course = original_course.dup
         new_course.provider = provider

--- a/lib/mcb/commands/providers/edit.rb
+++ b/lib/mcb/commands/providers/edit.rb
@@ -1,0 +1,23 @@
+name 'show'
+summary 'Edit information about provider'
+param :code
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
+  cli = HighLine.new
+
+  provider = Provider.find_by!(provider_code: args[:code])
+  courses = provider.courses
+
+  finished = false
+  until finished do
+    cli.choose do |menu|
+      menu.prompt = "Choose a course"
+      menu.choice(:exit) { finished = true }
+      menu.choices(*courses.map(&:course_code)) do |course_code|
+        $mcb.run(['courses', 'edit_published', args[:code], course_code, '-E', opts[:env]])
+      end
+    end
+  end
+end

--- a/lib/mcb/commands/providers/edit.rb
+++ b/lib/mcb/commands/providers/edit.rb
@@ -36,6 +36,19 @@ run do |opts, args, _cmd|
           chosen_course_codes.push(course_code)
         end
       end
+
+      menu.choice("Create new course") do
+        command_params = ['courses', 'create', args[:code]] + (opts[:env].present? ? ['-E', opts[:env]] : [])
+        $mcb.run(command_params)
+        chosen_course_codes = []
+      end
+
+      menu.choice("Add a new location") do
+        command_params = ['sites', 'create', args[:code]] + (opts[:env].present? ? ['-E', opts[:env]] : [])
+        $mcb.run(command_params)
+        chosen_course_codes = []
+      end
     end
+    courses.each(&:reload)
   end
 end

--- a/lib/mcb/commands/providers/edit.rb
+++ b/lib/mcb/commands/providers/edit.rb
@@ -11,13 +11,27 @@ run do |opts, args, _cmd|
   courses = provider.courses
 
   finished = false
+  chosen_course_codes = []
   until finished do
     cli.choose do |menu|
-      menu.prompt = "Choose a course"
+      if chosen_course_codes.empty?
+        menu.prompt = "Choose one or multiple courses to edit."
+      else
+        menu.prompt = "Chosen courses: #{chosen_course_codes.join(", ")}"
+      end
+
       menu.choice(:exit) { finished = true }
+
+      unless chosen_course_codes.empty?
+        menu.choice(:edit_selected_courses) do
+          command_params = ['courses', 'edit_published', args[:code], *chosen_course_codes] + (opts[:env].present? ? ['-E', opts[:env]] : [])
+          $mcb.run(command_params)
+          chosen_course_codes = []
+        end
+      end
+
       menu.choices(*courses.map(&:course_code)) do |course_code|
-        command_params = ['courses', 'edit_published', args[:code], course_code] + (opts[:env].present? ? ['-E', opts[:env]] : [])
-        $mcb.run(command_params)
+        chosen_course_codes.push(course_code)
       end
     end
   end

--- a/lib/mcb/commands/providers/edit.rb
+++ b/lib/mcb/commands/providers/edit.rb
@@ -55,12 +55,6 @@ run do |opts, args, _cmd|
         new_course.save!
       end
 
-      menu.choice("Add a new location") do
-        command_params = ['sites', 'create', args[:code]] + (opts[:env].present? ? ['-E', opts[:env]] : [])
-        $mcb.run(command_params)
-        chosen_course_codes = []
-      end
-
       menu.choice("Edit provider name") do
         puts "Current name: #{provider.provider_name}"
         new_name = cli.ask("Enter new name").strip

--- a/lib/mcb/commands/providers/edit.rb
+++ b/lib/mcb/commands/providers/edit.rb
@@ -16,7 +16,8 @@ run do |opts, args, _cmd|
       menu.prompt = "Choose a course"
       menu.choice(:exit) { finished = true }
       menu.choices(*courses.map(&:course_code)) do |course_code|
-        $mcb.run(['courses', 'edit_published', args[:code], course_code, '-E', opts[:env]])
+        command_params = ['courses', 'edit_published', args[:code], course_code] + (opts[:env].present? ? ['-E', opts[:env]] : [])
+        $mcb.run(command_params)
       end
     end
   end

--- a/lib/mcb/commands/providers/edit.rb
+++ b/lib/mcb/commands/providers/edit.rb
@@ -48,6 +48,18 @@ run do |opts, args, _cmd|
         $mcb.run(command_params)
         chosen_course_codes = []
       end
+
+      menu.choice("Clone a course") do
+        provider_code = cli.ask("Provider code of course you want to clone? (#{provider.provider_code} if blank)  ") { |q| q.default = provider.provider_code }
+        course_code = cli.ask("Code of course you want to clone?  ")
+        original_course = Provider.find_by!(provider_code: provider_code).courses.find_by!(course_code: course_code)
+
+        new_course = original_course.dup
+        new_course.provider = provider
+        new_course.course_code = cli.ask("New course code?  ")
+        new_course.subjects = original_course.subjects
+        new_course.save!
+      end
     end
     provider.reload
   end

--- a/lib/mcb/commands/providers/edit.rb
+++ b/lib/mcb/commands/providers/edit.rb
@@ -22,6 +22,11 @@ run do |opts, args, _cmd|
 
       menu.choice(:exit) { finished = true }
 
+      unchosen_course_codes = (courses.map(&:course_code) - chosen_course_codes)
+      unless unchosen_course_codes.empty?
+        menu.choices(:all_courses) { chosen_course_codes = courses.map(&:course_code) }
+      end
+
       unless chosen_course_codes.empty?
         menu.choice(:edit_selected_courses) do
           command_params = ['courses', 'edit_published', args[:code], *chosen_course_codes] + (opts[:env].present? ? ['-E', opts[:env]] : [])
@@ -30,9 +35,12 @@ run do |opts, args, _cmd|
         end
       end
 
-      menu.choices(*courses.map(&:course_code)) do |course_code|
-        chosen_course_codes.push(course_code)
+      unless unchosen_course_codes.empty?
+        menu.choices(*unchosen_course_codes) do |course_code|
+          chosen_course_codes.push(course_code)
+        end
       end
+
     end
   end
 end

--- a/lib/mcb/commands/providers/list.rb
+++ b/lib/mcb/commands/providers/list.rb
@@ -5,7 +5,7 @@ run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
   providers = if args.any?
-                Provider.where(provider_code: args.to_a)
+                Provider.where(provider_code: args.to_a.map(&:upcase))
               else
                 Provider.all
               end

--- a/lib/mcb/commands/providers/show.rb
+++ b/lib/mcb/commands/providers/show.rb
@@ -1,6 +1,6 @@
 name 'show'
 summary 'Show information about provider'
-param :code
+param :code, transform: ->(code) { code.upcase }
 option :p, :'preview-courses', 'Show courses as a mini-preview of Find, instead of a database view.',
        default: false
 

--- a/lib/mcb/commands/providers/sync_to_find.rb
+++ b/lib/mcb/commands/providers/sync_to_find.rb
@@ -1,7 +1,7 @@
 name 'sync_to_find'
 summary 'Send all courses for a particular provider to Find'
 usage 'sync_to_find <provider_code>'
-param :provider_code
+param :provider_code, transform: ->(code) { code.upcase }
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)

--- a/lib/mcb/commands/providers/ucas_preferences/show.rb
+++ b/lib/mcb/commands/providers/ucas_preferences/show.rb
@@ -1,5 +1,5 @@
 summary 'Show UCAS preferences for provider with given code'
-param :code
+param :code, transform: ->(code) { code.upcase }
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)

--- a/lib/mcb/commands/sites.rb
+++ b/lib/mcb/commands/sites.rb
@@ -1,0 +1,4 @@
+name 'sites'
+summary 'Operate on sites directly in db'
+
+instance_eval(&MCB.remote_connect_options)

--- a/lib/mcb/commands/sites/assign_to_courses.rb
+++ b/lib/mcb/commands/sites/assign_to_courses.rb
@@ -1,0 +1,22 @@
+name 'assign_to_courses'
+summary 'Assign a new site to multiple courses in db'
+usage 'assign_to_courses <provider_code> <site_code<'
+param :provider_code
+param :site_code
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
+  provider = Provider.find_by!(provider_code: args[:provider_code])
+  site = provider.sites.find_by!(code: args[:site_code])
+
+  cli = HighLine.new
+  course_codes_string = cli.ask("Which courses do you wish to add #{site.location_name} to? (Enter comma-separated course codes)")
+  course_codes = course_codes_string.split(",").map(&:strip)
+
+  courses = provider.courses.where(course_code: course_codes)
+  courses.each do |course|
+    puts "Adding #{site.location_name} to course #{course.course_code}"
+    course.add_site!(site: site)
+  end
+end

--- a/lib/mcb/commands/sites/assign_to_courses.rb
+++ b/lib/mcb/commands/sites/assign_to_courses.rb
@@ -1,8 +1,8 @@
 name 'assign_to_courses'
 summary 'Assign a new site to multiple courses in db'
 usage 'assign_to_courses <provider_code> <site_code<'
-param :provider_code
-param :site_code
+param :provider_code, transform: ->(code) { code.upcase }
+param :site_code, transform: ->(code) { code.upcase }
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)

--- a/lib/mcb/commands/users/grant_access_to_provider.rb
+++ b/lib/mcb/commands/users/grant_access_to_provider.rb
@@ -1,5 +1,5 @@
 summary 'Attach a user to an organisation/provider in the DB'
-param :provider_code
+param :provider_code, transform: ->(code) { code.upcase }
 usage 'grant_access_to_provider <provider_code>'
 
 run do |opts, args, _cmd|

--- a/lib/mcb/course_show.rb
+++ b/lib/mcb/course_show.rb
@@ -7,6 +7,7 @@ module MCB
     def to_h
       {
         "Course code" => @course.course_code,
+        "Title" => @course.name,
         "Description" => @course.description,
         "Provider" => @course.provider.provider_code,
         "Accredited body" => @course.accrediting_provider&.provider_code || "Self-accrediting",


### PR DESCRIPTION
### Changes proposed in this pull request

Just make sure that when taking course and providers as params, they are upcased automatically.

This just makes cmdline use more convenient ... helps to avoid pinky-syndrome. :)

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
