### PR TITLE
[1517] Add/remove/suspend course sites

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -56,6 +56,9 @@ module API
         enrichment.assign_attributes(update_params)
         enrichment.save
 
+        site_ids = params[:course][:sites_ids]
+        @course.sites = @provider.sites.where(id: site_ids) if site_ids.present?
+
         if @course.valid?
           render jsonapi: @course.reload
         else
@@ -78,7 +81,7 @@ module API
       def update_params
         params
           .require(:course)
-          .except(:id, :type)
+          .except(:id, :type, :sites_ids, :sites_types)
           .permit(
             :about_course,
             :course_length,

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -260,10 +260,6 @@ class Course < ApplicationRecord
     new? ? site_status.destroy! : site_status.suspend!
   end
 
-  def sites_not_associated_with_course
-    provider.sites - sites
-  end
-
   def has_bursary?
     dfe_subjects.any?(&:has_bursary?)
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -251,13 +251,26 @@ class Course < ApplicationRecord
 
   def add_site!(site:)
     is_course_new = new? # persist this before we change anything
-    site_status = site_statuses.find_or_create_by!(site: site)
+    site_status = site_statuses.find_or_initialize_by(site: site)
     site_status.start! unless is_course_new
+    site_status.save! if persisted?
   end
 
   def remove_site!(site:)
     site_status = site_statuses.find_by!(site: site)
     new? ? site_status.destroy! : site_status.suspend!
+  end
+
+  def sites=(desired_sites)
+    existing_sites = sites
+
+    to_add = desired_sites - existing_sites
+    to_add.each { |site| add_site!(site: site) }
+
+    to_remove = existing_sites - desired_sites
+    to_remove.each { |site| remove_site!(site: site) }
+
+    sites.reload
   end
 
   def has_bursary?

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -68,16 +68,33 @@ RSpec.describe Course, type: :model do
     its(:has_vacancies?) { should be false }
   end
 
-  describe "#sites" do
+  context "with sites" do
     let(:first_site) { create(:site) }
     let(:first_site_status) { create(:site_status, :running, site: first_site) }
     let(:second_site) { create(:site) }
     let(:second_site_status) { create(:site_status, :suspended, site: second_site) }
+    let(:new_site) { create(:site) }
 
     subject { create(:course, site_statuses: [first_site_status, second_site_status]) }
 
-    it "should only return new and running sites" do
-      expect(subject.sites.to_a).to eq([first_site])
+    describe "#sites" do
+      it "should only return new and running sites" do
+        expect(subject.sites.to_a).to eq([first_site])
+      end
+    end
+
+    describe "sites=" do
+      before do
+        subject.sites = [second_site, new_site]
+      end
+
+      it "should assign new sites" do
+        expect(subject.sites.to_a).to eq([second_site, new_site])
+      end
+
+      it "should set old site_status to suspended" do
+        expect(first_site_status.reload.status).to eq("suspended")
+      end
     end
   end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -438,16 +438,6 @@ RSpec.describe Course, type: :model do
     end
   end
 
-  describe "#sites_not_associated_with_course" do
-    let(:first_site) { create(:site) }
-    let(:second_site) { create(:site) }
-    let(:provider) { create(:provider, sites: [first_site, second_site]) }
-
-    subject { create(:course, provider: provider, sites: [first_site]) }
-
-    its(:sites_not_associated_with_course) { should eq([second_site]) }
-  end
-
   describe "adding and removing sites on a course" do
     let(:provider) { create(:provider) }
     let(:new_site) { create(:site, provider: provider) }

--- a/spec/requests/api/v2/providers/courses/update_sites_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_sites_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+describe 'PATCH /providers/:provider_code/courses/:course_code with sites' do
+  let(:organisation) { create :organisation }
+  let(:provider)     { create :provider, organisations: [organisation] }
+  let(:user)         { create :user, organisations: [organisation] }
+  let(:payload)      { { email: user.email } }
+  let(:token)        { build_jwt :apiv2, payload: payload }
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+
+  let(:course) { create :course, provider: provider }
+  let(:site_to_add) { create :site, provider: provider }
+  let(:unwanted_site) { create :site, provider: provider }
+  let(:existing_site) { create :site, provider: provider }
+
+  before do
+    course.add_site!(site: existing_site)
+    course.add_site!(site: unwanted_site)
+  end
+
+  let(:jsonapi_data) do
+    {
+      "_jsonapi" => {
+        "data" => {
+          "id" => course.id.to_s,
+          "type" => "courses",
+          "relationships" => {
+            "sites" => {
+              "data" => [
+                { "type" => "sites", "id" => existing_site.id.to_s },
+                { "type" => "sites", "id" => site_to_add.id.to_s }
+              ]
+            }
+          }
+        }
+      }
+    }
+  end
+
+  def perform_request
+    patch "/api/v2/providers/#{course.provider.provider_code}" \
+            "/courses/#{course.course_code}",
+          headers: { 'HTTP_AUTHORIZATION' => credentials },
+          params: jsonapi_data
+  end
+
+  context "course has some sites" do
+    context "course is new" do
+      before do
+        perform_request
+      end
+
+      it "returns http success" do
+        expect(response).to have_http_status(:success)
+      end
+
+      it "adds a new site" do
+        expect(course.reload.sites.exists?(site_to_add.id)).to be(true)
+      end
+
+      it "leaves existing site in place" do
+        expect(course.reload.sites.exists?(existing_site.id)).to be(true)
+      end
+
+      it "removes an unwanted site" do
+        expect(course.reload.sites.exists?(unwanted_site.id)).to be(false)
+      end
+    end
+
+    context "course is running" do
+      before do
+        course.publish_sites
+        perform_request
+      end
+
+      it "suspends an unwanted site" do
+        expect(
+          course.reload.site_statuses.find_by(site_id: unwanted_site.id).status
+        ).to eq("suspended")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Pairing @davidgisbey & @timabell & @tvararu 

### Changes proposed in this pull request

* Extend the `course#update` endpoint to support supplying a list of sites.
* Remove some dead code that was in the way after discussing with @benilovj 
* Hide more of the exposed `site_status` inside `sites` in the API surface.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
