### PR TITLE
[1531] Expose entry requirement options to course

### DIFF
--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -15,7 +15,8 @@ module API
                  :course_code, :name, :study_mode, :qualifications, :description,
                  :content_status, :ucas_status, :funding, :applications_open_from,
                  :level, :is_send?, :has_bursary?, :has_scholarship_and_bursary?,
-                 :has_early_career_payments?, :bursary_amount, :scholarship_amount
+                 :has_early_career_payments?, :bursary_amount, :scholarship_amount,
+                 :english, :maths, :science
 
       attribute :start_date do
         @object.start_date&.iso8601

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -22,7 +22,10 @@ describe 'Courses API v2', type: :request do
            subject_count: 0,
            subjects: [course_subject_primary, course_subject_mathematics, course_subject_send],
            with_site_statuses: [%i[findable with_any_vacancy applications_being_accepted_from_2019]],
-           enrichments: [enrichment])
+           enrichments: [enrichment],
+           maths: :must_have_qualification_at_application_time,
+           english: :must_have_qualification_at_application_time,
+           science: :must_have_qualification_at_application_time)
   }
 
   let(:enrichment)     { build :course_enrichment, :published }
@@ -125,6 +128,9 @@ describe 'Courses API v2', type: :request do
               "bursary_amount" => nil,
               "scholarship_amount" => nil,
               "about_accrediting_body" => nil,
+              "english" => 'must_have_qualification_at_application_time',
+              "maths" => 'must_have_qualification_at_application_time',
+              "science" => 'must_have_qualification_at_application_time'
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },
@@ -248,6 +254,9 @@ describe 'Courses API v2', type: :request do
               "bursary_amount" => nil,
               "scholarship_amount" => nil,
               "about_accrediting_body" => nil,
+              "english" => 'must_have_qualification_at_application_time',
+              "maths" => 'must_have_qualification_at_application_time',
+              "science" => 'must_have_qualification_at_application_time'
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },


### PR DESCRIPTION
### Context
Entry requirement options i.e. English, maths and science

### Changes proposed in this pull request
Expose the options as they already live in our course model

### Guidance to review
Example endpoint `/api/v2/providers/13E/courses/386H`

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
