### PR TITLE
1489 sink it

### DIFF
--- a/app/services/search_and_compare_api_service.rb
+++ b/app/services/search_and_compare_api_service.rb
@@ -1,0 +1,44 @@
+module SearchAndCompareAPIService
+  class Connection
+    class << self
+      def api
+        Faraday.new(url: Settings.search_api.base_url) do |faraday|
+          faraday.response :logger unless Rails.env.test?
+          faraday.adapter Faraday.default_adapter
+          faraday.headers['Content-Type'] = 'application/json; charset=utf-8;'
+          faraday.headers['Authorization'] = "Bearer #{Settings.search_api.secret}"
+        end
+      end
+    end
+  end
+
+  class Request
+    class << self
+      # NOTE:
+      #   HTTP PUT "/api/courses" accepts a list of courses
+      #   It will only add or update, no DELETION.
+      def sync(course)
+        response = api.put(
+          "/api/courses/",
+          serialize(course)
+        )
+
+        response.success?
+      end
+
+      def api
+        Connection.api
+      end
+
+    private
+
+      def serialize(payload)
+        ActiveModel::Serializer::CollectionSerializer.new(
+          payload,
+          serializer: SearchAndCompare::CourseSerializer,
+          adapter: ActiveModel::Serializer::Adapter::JsonApi
+        ).to_json
+      end
+    end
+  end
+end

--- a/spec/services/search_and_compare_api_service_spec.rb
+++ b/spec/services/search_and_compare_api_service_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+describe SearchAndCompareAPIService do
+  describe "Connection.api" do
+    subject { described_class::Connection.api }
+
+    it "exposes an Faraday connection" do
+      should be_instance_of(Faraday::Connection)
+    end
+
+    it "uses the configured URL as the base" do
+      expect(subject.url_prefix.to_s).to eq(Settings.search_api.base_url + "/")
+    end
+
+    it "uses the configured secret for the bearer token" do
+      expect(subject.headers["Authorization"]).to eq("Bearer #{Settings.search_api.secret}")
+    end
+  end
+
+  describe "Request" do
+    let(:request) { described_class::Request }
+    let(:body) do
+      ActiveModel::Serializer::CollectionSerializer.new(
+        [course],
+        serializer: SearchAndCompare::CourseSerializer,
+        adapter: :attributes
+      )
+    end
+
+    let(:published_enrichment) do
+      build :course_enrichment, :published,
+            created_at: 5.days.ago
+    end
+
+    let(:course) { create :course, enrichments: [published_enrichment] }
+
+    let(:course_code) { course.course_code }
+    let(:provider_code) { course.provider.provider_code }
+
+    let(:status) { 200 }
+
+    before do
+      stub_request(:put, "#{Settings.search_api.base_url}/api/courses/")
+        .with { |req| req.body == body.to_json }
+        .to_return(
+          status: status
+        )
+    end
+
+    describe 'sync' do
+      subject {
+        request.sync(
+          [course]
+        )
+      }
+      describe "with a normal response" do
+        it { should eq true }
+      end
+
+      describe "with a bad response" do
+        let(:status) { 400 }
+        it { should eq false }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Publishing to Search and Compare api

### Changes proposed in this pull request
Syncing via Pub

### Guidance to review
app/serializers/search_and_compare/course_serializer.rb
Changes made was flushed out using proper data that is available

`provider_enrichment&` are optional data.
`attribute(:StartDate)` &   `attribute(:ApplicationsAcceptedFrom)` seems to be optional data.
`course_enrichment.xxx.to_i,` needs to be int not float/decimal

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
