### PR TITLE
[1541] add mcb course show

### DIFF
--- a/bin/mcb
+++ b/bin/mcb
@@ -24,6 +24,8 @@ require 'mcb/config'
 require 'mcb/course_show'
 require 'mcb/grant_access_wizard'
 require 'mcb/render'
+require 'mcb/render/active_record'
+require 'mcb/render/apiv1'
 
 tp.set :capitalize_headers, false
 

--- a/lib/mcb/commands/apiv1/courses/find.rb
+++ b/lib/mcb/commands/apiv1/courses/find.rb
@@ -49,11 +49,11 @@ def print_course_info(course)
   subjects        = course.delete('subjects')
   provider        = course.delete('provider')
 
-  puts MCB::Render.course_record course
+  puts MCB::Render::APIV1.course_record course
   puts "\n"
-  puts MCB::Render.provider_record provider
+  puts MCB::Render::APIV1.provider_record provider
   puts "\n"
-  puts MCB::Render.subjects_table subjects
+  puts MCB::Render::APIV1.subjects_table subjects
   puts "\n"
-  puts MCB::Render.site_statuses_table campus_statuses
+  puts MCB::Render::APIV1.site_statuses_table campus_statuses
 end

--- a/lib/mcb/commands/apiv1/courses/find.rb
+++ b/lib/mcb/commands/apiv1/courses/find.rb
@@ -33,7 +33,7 @@ run do |opts, args, _cmd|
   if opts[:json]
     puts JSON.pretty_generate(JSON.parse(course.to_json))
   else
-    print_course_info(course)
+    puts MCB::Render::APIV1.course course
   end
 end
 
@@ -42,18 +42,4 @@ def find_course(provider_code, course_code, opts)
     course['provider']['institution_code'] == provider_code &&
       course['course_code'] == course_code
   end
-end
-
-def print_course_info(course)
-  campus_statuses = course.delete('campus_statuses')
-  subjects        = course.delete('subjects')
-  provider        = course.delete('provider')
-
-  puts MCB::Render::APIV1.course_record course
-  puts "\n"
-  puts MCB::Render::APIV1.provider_record provider
-  puts "\n"
-  puts MCB::Render::APIV1.subjects_table subjects
-  puts "\n"
-  puts MCB::Render::APIV1.site_statuses_table campus_statuses
 end

--- a/lib/mcb/commands/apiv1/providers/find.rb
+++ b/lib/mcb/commands/apiv1/providers/find.rb
@@ -46,9 +46,9 @@ def print_provider_info(provider)
   campuses = provider.delete('campuses')
   contacts = provider.delete('contacts')
 
-  puts MCB::Render.provider_record provider
+  puts MCB::Render::APIV1.provider_record provider
   puts "\n"
-  puts MCB::Render.campuses_table campuses
+  puts MCB::Render::APIV1.campuses_table campuses
   puts "\n"
-  puts MCB::Render.contacts_table contacts
+  puts MCB::Render::APIV1.contacts_table contacts
 end

--- a/lib/mcb/commands/courses/show.rb
+++ b/lib/mcb/commands/courses/show.rb
@@ -1,0 +1,15 @@
+# coding: utf-8
+
+summary 'Show course info from the db'
+usage 'show <provider_code> <course_code>'
+param :provider_code, transform: ->(code) { code.upcase }
+param :course_code, transform: ->(code) { code.upcase }
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
+  provider = Provider.find_by!(provider_code: args[:provider_code])
+  course = provider.courses.find_by!(course_code: args[:course_code])
+
+  puts MCB::Render::ActiveRecord.course(course)
+end

--- a/lib/mcb/commands/providers/show.rb
+++ b/lib/mcb/commands/providers/show.rb
@@ -1,7 +1,8 @@
 name 'show'
 summary 'Show information about provider'
-param :code
-option :p, :'preview-courses', 'Show courses as a mini-preview of Find, instead of a database view.',
+param :code, transform: ->(code) { code.upcase }
+option :p, :'preview-courses',
+       'Show courses as a mini-preview of Find, instead of a database view.',
        default: false
 
 run do |opts, args, _cmd|

--- a/lib/mcb/render.rb
+++ b/lib/mcb/render.rb
@@ -1,121 +1,164 @@
 module MCB
   module Render
-    class << self
-      def campuses_table(campuses, name: 'Campuses')
-        if campuses.all? { |campuse| campuse.respond_to? :keys }
-          campuses = hashes_to_ostructs campuses
+    def contacts_table(contacts, name: 'Contacts')
+      return if contacts.nil?
+
+      [
+        "#{name}:",
+        render_table_or_none(contacts, contacts_table_columns)
+      ]
+    end
+
+    def contacts_table_columns
+      %i[type name email telephone]
+    end
+
+    def course_enrichments_table(enrichments, name: 'Course Enrichments')
+      return if enrichments.nil?
+
+      [
+        "#{name}:",
+        render_table_or_none(enrichments, course_enrichments_table_columns)
+      ]
+    end
+
+    def course_enrichments_table_columns
+      [
+        :id,
+        :status,
+        [:last_published, ->(ce) { ce.last_published_timestamp_utc }]
+      ]
+    end
+
+    def course_record(course, name: 'Course')
+      course_table = Terminal::Table.new rows: course
+
+      [
+        "#{name}:",
+        *course_table,
+      ]
+    end
+
+    def course_site_statuses_table(site_statuses,
+                                   name: 'Site Statuses',
+                                   add_columns: [])
+      columns = course_site_statuses_table_columns + add_columns
+
+      site_statuses_table = Tabulo::Table.new site_statuses do |t|
+        add_columns_to_table columns, table: t
+      end
+
+      [
+        "#{name}:",
+        *site_statuses_table.pack(max_table_width: nil),
+        site_statuses_table.horizontal_rule
+      ]
+    end
+
+    def course_site_statuses_table_columns
+      [
+        :id,
+        [:code, ->(ss) { ss.site.code }],
+        [:location_name, ->(ss) { ss.site.location_name }],
+        :vac_status,
+        :status,
+        :publish,
+        :applications_accepted_from
+      ]
+    end
+
+    def provider_record(provider, name: 'Provider')
+      provider = provider.attributes if provider.respond_to?(:attributes)
+
+      provider_table = Terminal::Table.new rows: provider
+
+      [
+        "#{name}:",
+        *provider_table,
+      ]
+    end
+
+    def providers_table(providers,
+                        name: 'Providers',
+                        add_columns: [])
+      return if providers.nil?
+
+      [
+        "#{name}:",
+        render_table_or_none(providers, providers_table_columns + add_columns)
+      ]
+    end
+
+    def providers_table_columns
+      [
+        :id,
+        [:provider_name, header: 'name'],
+        [:provider_code, header: 'code']
+      ]
+    end
+
+    def sites_table(sites, name: 'Sites')
+      return if sites.nil?
+
+      [
+        "#{name}:",
+        render_table_or_none(sites, sites_table_columns)
+      ]
+    end
+
+    def sites_table_columns
+      %i[code location_name address1 address2 address3 address4 postcode
+         region_code]
+    end
+
+    def subjects_table(subjects, name: 'Subjects')
+      return if subjects.nil?
+
+      [
+        "#{name}:",
+        render_table_or_none(subjects, subjects_table_columns)
+      ]
+    end
+
+    def subjects_table_columns
+      %i[subject_code subject_name]
+    end
+
+  private
+
+    def add_columns_to_table(columns, table:)
+      columns.each do |column|
+        # An Array will have to be splat-expanded ...
+        #
+        # e.g. [:provider_name, header: 'name']
+        if column.is_a? Array
+          # A Proc will have to be block-annotated.
+          #
+          # e.g. [:code, ->(ss) { ss.site.code }]
+          if column.last.is_a? Proc
+            block = column.pop
+            table.add_column(*column, &block)
+          else
+            table.add_column(*column)
+          end
+        else
+          table.add_column column
+        end
+      end
+    end
+
+    def render_table_or_none(rows, columns)
+      if rows.any?
+        table = Tabulo::Table.new rows do |t|
+          add_columns_to_table columns, table: t
         end
 
-        campuses_table = Tabulo::Table.new campuses,
-                                           :campus_code,
-                                           :name,
-                                           :region_code
-
         [
-          "#{name}:",
-          *campuses_table.pack(max_table_width: nil),
-          campuses_table.horizontal_rule
+          table.pack(max_table_width: nil),
+          table.horizontal_rule
         ]
-      end
-
-      def contacts_table(contacts, name: 'Contacts')
-        if contacts.all? { |contact| contact.respond_to? :keys }
-          contacts = hashes_to_ostructs contacts
-        end
-
-        contacts_table = Tabulo::Table.new contacts,
-                                           :type,
-                                           :name,
-                                           :email,
-                                           :telephone
-
-        [
-          "#{name}:",
-          *contacts_table.pack(max_table_width: nil),
-          contacts_table.horizontal_rule
-        ]
-      end
-
-      def course_record(course, name: 'Course')
-        course_table = Terminal::Table.new rows: course
-
-        [
-          "#{name}:",
-          *course_table,
-        ]
-      end
-
-      def provider_record(provider, name: 'Provider')
-        provider_table = Terminal::Table.new rows: provider
-
-        [
-          "#{name}:",
-          *provider_table,
-        ]
-      end
-
-      def site_statuses_table(site_statuses, name: 'Site Statuses')
-        if site_statuses.all? { |site_status| site_status.respond_to? :keys }
-          site_statuses = hashes_to_ostructs site_statuses
-        end
-
-        site_statuses_table = Tabulo::Table.new site_statuses,
-                                                :campus_code,
-                                                :name,
-                                                :vac_status,
-                                                :publish,
-                                                :status,
-                                                :course_open_date
-
-        [
-          "#{name}:",
-          *site_statuses_table.pack(max_table_width: nil),
-          site_statuses_table.horizontal_rule
-        ]
-      end
-
-      def sites_table(sites, name: 'Sites')
-        if sites.all? { |site| site.respond_to? :keys }
-          sites = hashes_to_ostructs sites
-        end
-
-        sites_table = Tabulo::Table.new sites,
-                                        :code,
-                                        :location_name,
-                                        :address1,
-                                        :address2,
-                                        :address3,
-                                        :address4,
-                                        :postcode,
-                                        :region_code
-
-        [
-          "#{name}:",
-          *sites_table.pack(max_table_width: nil),
-          sites_table.horizontal_rule
-        ]
-      end
-
-      def subjects_table(subjects, name: 'Subjects')
-        if subjects.all? { |subject| subject.respond_to? :keys }
-          subjects = hashes_to_ostructs subjects
-        end
-
-        subjects_table = Tabulo::Table.new subjects,
-                                           :subject_code,
-                                           :subject_name
-
-        [
-          "#{name}:",
-          *subjects_table.pack(max_table_width: nil),
-          subjects_table.horizontal_rule
-        ]
-      end
-
-    private
-
-      def hashes_to_ostructs(hashes)
-        hashes.map { |hash| OpenStruct.new(hash) }
+      else
+        ['-none-']
       end
     end
   end

--- a/lib/mcb/render.rb
+++ b/lib/mcb/render.rb
@@ -13,6 +13,40 @@ module MCB
       %i[type name email telephone]
     end
 
+    # Render a course for output to the terminal.
+    #
+    # Takes care of rendering out all the attributes and related objects in
+    # the correct format. Associations are specified as params to allow the
+    # caller to decide how they are retrieved (ActiveRecord objects will
+    # access attributes and associations differently from JSON API
+    # responses).
+    def course(course,
+               provider:,
+               accrediting_provider:,
+               subjects:,
+               site_statuses:,
+               enrichments:)
+      [
+        course_record(course),
+        "\n",
+        providers_table([provider], name: "Provider"),
+        "\n",
+        providers_table(
+          [accrediting_provider],
+          name: "Accredited body",
+          add_columns: [[:accrediting_provider, header: 'accrediting']]
+        ),
+        "\n",
+        subjects_table(subjects),
+        "\n",
+        course_site_statuses_table(site_statuses),
+        "\n",
+        unless enrichments.nil?
+          course_enrichments_table(enrichments)
+        end
+      ]
+    end
+
     def course_enrichments_table(enrichments, name: 'Course Enrichments')
       return if enrichments.nil?
 

--- a/lib/mcb/render/active_record.rb
+++ b/lib/mcb/render/active_record.rb
@@ -3,6 +3,17 @@ module MCB
     module ActiveRecord
       class << self
         include MCB::Render
+
+        def course(course)
+          super(
+            course.attributes,
+            provider:             course.provider,
+            accrediting_provider: course.accrediting_provider,
+            subjects:             course.subjects,
+            site_statuses:        course.site_statuses,
+            enrichments:          course.enrichments,
+          )
+        end
       end
     end
   end

--- a/lib/mcb/render/active_record.rb
+++ b/lib/mcb/render/active_record.rb
@@ -1,0 +1,9 @@
+module MCB
+  module Render
+    module ActiveRecord
+      class << self
+        include MCB::Render
+      end
+    end
+  end
+end

--- a/lib/mcb/render/apiv1.rb
+++ b/lib/mcb/render/apiv1.rb
@@ -1,0 +1,64 @@
+module MCB
+  module Render
+    module APIV1
+      class << self
+        include MCB::Render
+
+        def contacts_table(contacts, name: 'Contacts')
+          super(hashes_to_ostructs(contacts),
+                name: name)
+        end
+
+        def course_record(course, name: 'Course')
+          course_table = Terminal::Table.new rows: course
+
+          [
+            "#{name}:",
+            *course_table,
+          ]
+        end
+
+        def course_site_statuses_table(site_statuses, name: 'Campuses')
+          super(hashes_to_ostructs(site_statuses),
+                name: name)
+        end
+
+        def course_site_statuses_table_columns
+          %i[campus_code name vac_status status publish course_open_date]
+        end
+
+        def providers_table(providers, name: 'Providers', add_columns: [])
+          super(hashes_to_ostructs(providers),
+                name: name,
+                add_columns: add_columns)
+        end
+
+        def providers_table_columns
+          %i[institution_name institution_code]
+        end
+
+        def sites_table(sites, name: 'Sites')
+          super(hashes_to_ostructs(sites),
+                name: name)
+        end
+
+        def subjects_table(subjects, name: 'Subjects')
+          super(hashes_to_ostructs(subjects),
+                name: name)
+        end
+
+      private
+
+        def hashes_to_ostructs(hashes_or_ostructs)
+          hashes_or_ostructs.map do |hash_or_ostruct|
+            if hash_or_ostruct.is_a? OpenStruct
+              hash_or_ostruct
+            else
+              OpenStruct.new(hash_or_ostruct)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mcb/render/apiv1.rb
+++ b/lib/mcb/render/apiv1.rb
@@ -9,6 +9,21 @@ module MCB
                 name: name)
         end
 
+        def course(course)
+          # duplicate this so we can remove keys we don't want displayed, as
+          # course_record below just outputs all the key-value pairs in course
+          render_course = course.dup
+
+          super(
+            render_course,
+            provider:             render_course.delete('provider'),
+            accrediting_provider: render_course.delete('accrediting_provider'),
+            subjects:             render_course.delete('subjects'),
+            site_statuses:        render_course.delete('campus_statuses'),
+            enrichments:          nil,
+          )
+        end
+
         def course_record(course, name: 'Course')
           course_table = Terminal::Table.new rows: course
 

--- a/spec/lib/mcb/commands/apiv1/courses/find_spec.rb
+++ b/spec/lib/mcb/commands/apiv1/courses/find_spec.rb
@@ -40,7 +40,11 @@ describe '"mcb apiv1 courses find"' do
                  })
 
     output = with_stubbed_stdout do
-      $mcb.run(%W[apiv1 courses find #{course2.provider.provider_code} #{course2.course_code}])
+      $mcb.run(%W[apiv1
+                  courses
+                  find
+                  #{course2.provider.provider_code}
+                  #{course2.course_code}])
     end
 
     expect(output).to have_text_table_row('course_code',
@@ -51,8 +55,8 @@ describe '"mcb apiv1 courses find"' do
                         site_status2.site.code,
                         site_status2.site.location_name,
                         site_status2.vac_status_before_type_cast,
-                        site_status2.publish_before_type_cast,
                         site_status2.status_before_type_cast,
+                        site_status2.publish_before_type_cast,
                         site_status2.applications_accepted_from.strftime('%Y-%m-%d')
                       ))
   end

--- a/spec/lib/mcb/commands/courses/show_spec.rb
+++ b/spec/lib/mcb/commands/courses/show_spec.rb
@@ -1,0 +1,40 @@
+require 'mcb_helper'
+
+describe '"mcb courses show"' do
+  let(:lib_dir) { "#{Rails.root}/lib" }
+  let(:cmd) do
+    Cri::Command.load_file(
+      "#{lib_dir}/mcb/commands/courses/show.rb"
+    )
+  end
+
+  it 'displays the course info' do
+    _site_status1 = create(:site_status)
+
+    site_status2 = create(:site_status)
+    course2      = site_status2.course
+    subjects2    = course2.subjects
+
+    output = with_stubbed_stdout do
+      cmd.run([course2.provider.provider_code, course2.course_code])
+    end
+
+    expect(output).to have_text_table_row('course_code',
+                                          course2.course_code)
+
+    expect(output).to have_text_table_row(subjects2.first.subject_code,
+                                          subjects2.first.subject_name)
+
+    expect(output).to(
+      have_text_table_row(
+        site_status2.id,
+        site_status2.site.code,
+        site_status2.site.location_name,
+        site_status2.vac_status,
+        site_status2.status,
+        site_status2.publish,
+        site_status2.applications_accepted_from.strftime('%Y-%m-%d')
+      )
+    )
+  end
+end

--- a/spec/lib/mcb/commands/users/audit_spec.rb
+++ b/spec/lib/mcb/commands/users/audit_spec.rb
@@ -24,7 +24,7 @@ describe 'mcb users audit' do
                                           'update',
                                           '',
                                           '',
-                                          '{"email"=>\["a@a", "b@b"\]}')
+                                          '{"email"=>["a@a", "b@b"]}')
   end
 
   it 'allows specifying user by email' do
@@ -43,7 +43,7 @@ describe 'mcb users audit' do
                                           'update',
                                           '',
                                           '',
-                                          '{"email"=>\["a@a", "b@b"\]}')
+                                          '{"email"=>["a@a", "b@b"]}')
   end
 
   it 'allows specifying user by sign-in id' do
@@ -62,6 +62,6 @@ describe 'mcb users audit' do
                                           'update',
                                           '',
                                           '',
-                                          '{"email"=>\["a@a", "b@b"\]}')
+                                          '{"email"=>["a@a", "b@b"]}')
   end
 end

--- a/spec/support/matchers/have_text_table_row.rb
+++ b/spec/support/matchers/have_text_table_row.rb
@@ -1,5 +1,23 @@
 RSpec::Matchers.define :have_text_table_row do |*column_values|
   match do |actual|
-    actual.match? '(^\s*|\|\s+)' + column_values.join('\s+\|\s+') + '(\s+\||\s*$)'
+    escaped_column_values = column_values.map do |val|
+      val.is_a?(Regexp) ? val : Regexp.quote(val.to_s)
+    end
+
+    actual.match?('(^\s*|\|\s+)' +
+                  escaped_column_values.join('\s+\|\s+') +
+                  '(\s+\||\s*$)')
+  end
+
+  failure_message do |output|
+    <<~EOMESSAGE
+      expected the columns:
+
+      #{column_values.join(' | ')}
+
+      To be in the output:
+
+      #{output}
+    EOMESSAGE
   end
 end


### PR DESCRIPTION
### Context

When handling support requests it's handy to be able to easily view the state a course is in quickly and through the CLI.

### Changes proposed in this pull request

Add a `mcb course show` command to mcb. Also cleans up the rendering a little bit so that there is more common code between `course show` and `apiv1 course find`.

```
% be bin/mcb course show 2K5 3B55
Course:
+-------------------------+---------------------------------------------+
| id                      | 8252934                                     |
| age_range               | secondary                                   |
| course_code             | 3B55                                        |
| name                    | Chemistry                                   |
| profpost_flag           | recommendation_for_qts                      |
| program_type            | school_direct_training_programme            |
| qualification           | qts                                         |
| start_date              | 2019-09-01 00:00:00 UTC                     |
| study_mode              | full_time                                   |
| accrediting_provider_id | 12610                                       |
| provider_id             | 12204                                       |
| modular                 |                                             |
| english                 | must_have_qualification_at_application_time |
| maths                   | must_have_qualification_at_application_time |
| science                 |                                             |
| created_at              | 2019-02-21 05:20:49 UTC                     |
| updated_at              | 2019-02-21 05:20:49 UTC                     |
| changed_at              | 2019-02-21 05:20:49 UTC                     |
+-------------------------+---------------------------------------------+

Provider:
+-------+----------------------------------+------+
|   id  |               name               | code |
+-------+----------------------------------+------+
| 12204 | Spires Academy Teaching Alliance | 2K5  |
+-------+----------------------------------+------+

Accrediting Provider:
+-------+-------------------------------------+------+-------------+
|   id  |                 name                | code | accrediting |
+-------+-------------------------------------+------+-------------+
| 12610 | Canterbury Christ Church University | C10  | Y           |
+-------+-------------------------------------+------+-------------+

Subjects:
+--------------+--------------+
| subject_code | subject_name |
+--------------+--------------+
| 05           | Secondary    |
| F0           | Science      |
| F1           | Chemistry    |
+--------------+--------------+

Site Statuses:
+----------+------+---------------+---------------------+---------+-----------+----------------------------+
|    id    | code | location_name |      vac_status     |  status |  publish  | applications_accepted_from |
+----------+------+---------------+---------------------+---------+-----------+----------------------------+
| 14175863 | -    | Main Site     | full_time_vacancies | running | published | 2018-10-09                 |
+----------+------+---------------+--------
```

And the apiv1 find results:

```
% be bin/mcb apiv1 course find 2K5 3B55
Course:
+--------------------+----------------------+
| course_code        | 3B55                 |
| start_month        | 2019-09-01T00:00:00Z |
| name               | Chemistry            |
| study_mode         | F                    |
| copy_form_required | Y                    |
| profpost_flag      |                      |
| program_type       | SD                   |
| modular            |                      |
| english            | 1                    |
| maths              | 1                    |
| science            |                      |
| recruitment_cycle  | 2019                 |
| start_month_string | September            |
| age_range          | S                    |
+--------------------+----------------------+

Provider:
+----------------------------------+------------------+
|         institution_name         | institution_code |
+----------------------------------+------------------+
| Spires Academy Teaching Alliance | 2K5              |
+----------------------------------+------------------+

Accrediting Provider:
+-------------------------------------+------------------+-------------+
|           institution_name          | institution_code | accrediting |
+-------------------------------------+------------------+-------------+
| Canterbury Christ Church University | C10              | Y           |
+-------------------------------------+------------------+-------------+

Subjects:
+--------------+--------------+
| subject_code | subject_name |
+--------------+--------------+
| 05           | Secondary    |
| F1           | Chemistry    |
| F0           | Science      |
+--------------+--------------+

Campuses:
+-------------+-----------+------------+--------+---------+------------------+
| campus_code |    name   | vac_status | status | publish | course_open_date |
+-------------+-----------+------------+--------+---------+------------------+
| -           | Main Site | F          | R      | Y       | 2018-10-09       |
+-------------+-----------+------------+--------+---------+------------------+
```

### Review Notes

There's a lot of whitespace change to `lib/mcb/render.rb`, turn off whitespace for a clearer picture.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
