### PR TITLE
[1566] force course to update to ucas

### DIFF
--- a/lib/mcb/commands/courses/touch.rb
+++ b/lib/mcb/commands/courses/touch.rb
@@ -9,4 +9,5 @@ run do |opts, args, _cmd|
   provider = Provider.find_by(provider_code: args[:provider_code].upcase)
   course = provider.courses.find_by(course_code: args[:course_code].upcase)
   course.touch
+  course.update! audit_comment: 'timestamps updated to expose in api v1'
 end

--- a/lib/mcb/commands/courses/touch.rb
+++ b/lib/mcb/commands/courses/touch.rb
@@ -1,0 +1,12 @@
+summary 'Update a course so that it will be at the top of the apiv1 results'
+usage 'touch <provider_code> <course_code>'
+param :provider_code
+param :course_code
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
+  provider = Provider.find_by(provider_code: args[:provider_code].upcase)
+  course = provider.courses.find_by(course_code: args[:course_code].upcase)
+  course.touch
+end

--- a/lib/mcb/commands/courses/touch.rb
+++ b/lib/mcb/commands/courses/touch.rb
@@ -6,8 +6,8 @@ param :course_code
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
-  provider = Provider.find_by(provider_code: args[:provider_code].upcase)
-  course = provider.courses.find_by(course_code: args[:course_code].upcase)
+  provider = Provider.find_by!(provider_code: args[:provider_code].upcase)
+  course = provider.courses.find_by!(course_code: args[:course_code].upcase)
   course.touch
   course.update! audit_comment: 'timestamps updated to expose in api v1'
 end

--- a/lib/mcb/commands/providers/touch.rb
+++ b/lib/mcb/commands/providers/touch.rb
@@ -5,7 +5,7 @@ param :provider_code, transform: ->(code) { code.upcase }
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
-  provider = Provider.find_by(provider_code: args[:provider_code])
+  provider = Provider.find_by!(provider_code: args[:provider_code])
   provider.touch
   provider.update! audit_comment: 'timestamps updated to expose in api v1'
 end

--- a/lib/mcb/commands/providers/touch.rb
+++ b/lib/mcb/commands/providers/touch.rb
@@ -1,0 +1,10 @@
+summary 'Update a provider so that it will be at the top of the apiv1 results'
+usage 'touch <provider_code>'
+param :provider_code, transform: ->(code) { code.upcase }
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
+  provider = Provider.find_by(provider_code: args[:provider_code])
+  provider.touch
+end

--- a/lib/mcb/commands/providers/touch.rb
+++ b/lib/mcb/commands/providers/touch.rb
@@ -7,4 +7,5 @@ run do |opts, args, _cmd|
 
   provider = Provider.find_by(provider_code: args[:provider_code])
   provider.touch
+  provider.update! audit_comment: 'timestamps updated to expose in api v1'
 end

--- a/spec/lib/mcb/commands/courses/touch_spec.rb
+++ b/spec/lib/mcb/commands/courses/touch_spec.rb
@@ -23,4 +23,13 @@ describe '"mcb courses touch"' do
       expect(course.reload.changed_at).to eq Time.now
     end
   end
+
+  it 'adds audit comment' do
+    expect {
+      with_stubbed_stdout do
+        $mcb.run(%W[course touch #{provider.provider_code} #{course.course_code}])
+      end
+    }.to change { course.reload.audits.count }
+           .from(1).to(2)
+  end
 end

--- a/spec/lib/mcb/commands/courses/touch_spec.rb
+++ b/spec/lib/mcb/commands/courses/touch_spec.rb
@@ -1,0 +1,26 @@
+require 'mcb_helper'
+
+describe '"mcb courses touch"' do
+  let(:course)   { create :course, updated_at: 1.day.ago, changed_at: 1.day.ago }
+  let(:provider) { course.provider }
+
+  it 'updates the courses updated_at' do
+    Timecop.freeze do
+      with_stubbed_stdout do
+        $mcb.run(%W[course touch #{provider.provider_code} #{course.course_code}])
+      end
+
+      expect(course.reload.updated_at).to eq Time.now
+    end
+  end
+
+  it 'updates the courses changed_at' do
+    Timecop.freeze do
+      with_stubbed_stdout do
+        $mcb.run(%W[course touch #{provider.provider_code} #{course.course_code}])
+      end
+
+      expect(course.reload.changed_at).to eq Time.now
+    end
+  end
+end

--- a/spec/lib/mcb/commands/courses/touch_spec.rb
+++ b/spec/lib/mcb/commands/courses/touch_spec.rb
@@ -10,7 +10,9 @@ describe '"mcb courses touch"' do
         $mcb.run(%W[course touch #{provider.provider_code} #{course.course_code}])
       end
 
-      expect(course.reload.updated_at).to eq Time.now
+      # Use to_i compare seconds since epoch and side-step sub-second
+      # differences that show up even with Timecop on certain platforms.
+      expect(course.reload.updated_at.to_i).to eq Time.now.to_i
     end
   end
 
@@ -20,7 +22,7 @@ describe '"mcb courses touch"' do
         $mcb.run(%W[course touch #{provider.provider_code} #{course.course_code}])
       end
 
-      expect(course.reload.changed_at).to eq Time.now
+      expect(course.reload.changed_at.to_i).to eq Time.now.to_i
     end
   end
 

--- a/spec/lib/mcb/commands/providers/touch_spec.rb
+++ b/spec/lib/mcb/commands/providers/touch_spec.rb
@@ -1,0 +1,25 @@
+require 'mcb_helper'
+
+describe '"mcb providers touch"' do
+  let(:provider) { create :provider, updated_at: 1.day.ago, changed_at: 1.day.ago }
+
+  it 'updates the providers updated_at' do
+    Timecop.freeze do
+      with_stubbed_stdout do
+        $mcb.run(%W[provider touch #{provider.provider_code}])
+      end
+
+      expect(provider.reload.updated_at).to eq Time.now
+    end
+  end
+
+  it 'updates the providers changed_at' do
+    Timecop.freeze do
+      with_stubbed_stdout do
+        $mcb.run(%W[provider touch #{provider.provider_code}])
+      end
+
+      expect(provider.reload.changed_at).to eq Time.now
+    end
+  end
+end

--- a/spec/lib/mcb/commands/providers/touch_spec.rb
+++ b/spec/lib/mcb/commands/providers/touch_spec.rb
@@ -9,7 +9,9 @@ describe '"mcb providers touch"' do
         $mcb.run(%W[provider touch #{provider.provider_code}])
       end
 
-      expect(provider.reload.updated_at).to eq Time.now
+      # Use to_i compare seconds since epoch and side-step sub-second
+      # differences that show up even with Timecop on certain platforms.
+      expect(provider.reload.updated_at.to_i).to eq Time.now.to_i
     end
   end
 
@@ -19,7 +21,7 @@ describe '"mcb providers touch"' do
         $mcb.run(%W[provider touch #{provider.provider_code}])
       end
 
-      expect(provider.reload.changed_at).to eq Time.now
+      expect(provider.reload.changed_at.to_i).to eq Time.now.to_i
     end
   end
 

--- a/spec/lib/mcb/commands/providers/touch_spec.rb
+++ b/spec/lib/mcb/commands/providers/touch_spec.rb
@@ -22,4 +22,13 @@ describe '"mcb providers touch"' do
       expect(provider.reload.changed_at).to eq Time.now
     end
   end
+
+  it 'adds audit comment' do
+    expect {
+      with_stubbed_stdout do
+        $mcb.run(%W[provider touch #{provider.provider_code}])
+      end
+    }.to change { provider.reload.audits.count }
+           .from(1).to(2)
+  end
 end


### PR DESCRIPTION
### Context

So that we can "push" a course to UCAS to update their records, could be used to address a support issue, for example.

### Changes proposed in this pull request

Add the commands `mcb course touch` and `mcb provider touch`.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
