### PR TITLE
[1585] fix use of max-pages and page reporting in apiv1 mcb commands

### DIFF
--- a/lib/mcb/commands/apiv1.rb
+++ b/lib/mcb/commands/apiv1.rb
@@ -7,8 +7,4 @@ option :u, 'url', 'set the base url to connect to',
 option :t, 'token', 'set the authorization token',
        argument: :required,
        default: 'bats'
-option :P, 'max-pages', 'maximum number of pages to request',
-       default: 200,
-       argument: :optional,
-       transform: method(:Integer)
 instance_eval(&MCB.remote_connect_options)

--- a/lib/mcb/commands/apiv1/courses/find.rb
+++ b/lib/mcb/commands/apiv1/courses/find.rb
@@ -23,10 +23,15 @@ run do |opts, args, _cmd|
 
   verbose "looking for provider '#{provider_code}' course '#{course_code}'"
 
-  (course, _last_context) = find_course(provider_code, course_code, opts)
+  (course, last_context) = find_course(provider_code, course_code, opts)
 
   if course.nil?
     error "Provider '#{provider_code}' course '#{course_code}' not found"
+
+    MCB::display_pages_received(page: last_context[:page],
+                                max_pages: opts[:'max-pages'],
+                                next_url: last_context[:next_url])
+
     next
   end
 
@@ -38,10 +43,12 @@ run do |opts, args, _cmd|
 end
 
 def find_course(provider_code, course_code, opts)
-  MCB.each_v1_course(opts).detect do |course, _context|
+  last_context = nil
+  MCB.each_v1_course(opts).detect do |course, context|
+    last_context = context
     course['provider']['institution_code'] == provider_code &&
       course['course_code'] == course_code
-  end
+  end || [nil, last_context]
 end
 
 def print_course_info(course)

--- a/lib/mcb/commands/apiv1/courses/list.rb
+++ b/lib/mcb/commands/apiv1/courses/list.rb
@@ -1,5 +1,10 @@
 summary 'List courses'
 
+option :P, 'max-pages', 'maximum number of pages to request',
+       default: 1,
+       argument: :required,
+       transform: method(:Integer)
+
 run do |opts, _args, _cmd|
   opts = MCB.apiv1_opts(opts)
   last_context = nil
@@ -15,16 +20,7 @@ run do |opts, _args, _cmd|
 
   puts table
 
-  if last_context
-    if opts[:all]
-      puts 'All pages retrieved.'
-    else
-      puts 'Only first page of results retrieved (use -a to retrieve all).'
-    end
-    next_changed_since = last_context[:next_url].sub(/.*changed_since=(.*)(&.*)|$/, '\1')
-    puts(
-      "To continue retrieving results use the changed-since: " +
-      CGI.unescape(next_changed_since)
-    )
-  end
+  MCB::display_pages_received(page: last_context[:page],
+                              max_pages: opts[:'max-pages'],
+                              next_url: last_context[:next_url])
 end

--- a/lib/mcb/commands/apiv1/providers/list.rb
+++ b/lib/mcb/commands/apiv1/providers/list.rb
@@ -1,6 +1,11 @@
 name 'list'
 summary 'List providers'
 
+option :P, 'max-pages', 'maximum number of pages to request',
+       default: 1,
+       argument: :required,
+       transform: method(:Integer)
+
 run do |opts, _args, _cmd|
   opts = MCB.apiv1_opts(opts)
   last_context = nil
@@ -14,16 +19,7 @@ run do |opts, _args, _cmd|
 
   puts table
 
-  if last_context
-    if opts[:all]
-      puts 'All pages retrieved.'
-    else
-      puts 'Only first page of results retrieved (use -a to retrieve all).'
-    end
-    next_changed_since = last_context[:next_url].sub(/.*changed_since=(.*)(&.*)|$/, '\1')
-    puts(
-      "To continue retrieving results use the changed-since: " +
-      CGI.unescape(next_changed_since)
-    )
-  end
+  MCB::display_pages_received(page: last_context[:page],
+                              max_pages: opts[:'max-pages'],
+                              next_url: last_context[:next_url])
 end


### PR DESCRIPTION
### Background

In many of the mcb commands that query the apiv1, the max-pages isn't respected and hard-set to 1.

### What is being changed

Fix this. This was fixed in 1542 for the `mcb apiv1 course find` command, the same approach needs to be copied to the other apiv1 commands.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
