### PR TITLE
[1586] mcb courses edit: edit title

### DIFF
--- a/bin/mcb
+++ b/bin/mcb
@@ -22,6 +22,7 @@ require 'mcb'
 require 'mcb/azure'
 require 'mcb/config'
 require 'mcb/course_show'
+require 'mcb/courses_editor'
 require 'mcb/grant_access_wizard'
 require 'mcb/render'
 

--- a/lib/mcb/commands/courses/edit.rb
+++ b/lib/mcb/commands/courses/edit.rb
@@ -1,0 +1,16 @@
+name 'edit'
+summary 'Edit one or more courses directly in the DB'
+usage 'edit <provider_code> <course code 1> [<course code 2> ...]'
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
+  provider_code = args[0].upcase
+  course_codes = args.to_a[1..-1].map(&:upcase)
+
+  MCB::CoursesEditor.new(
+    requester: User.find_by!(email: MCB.config[:email]),
+    provider: Provider.find_by!(provider_code: provider_code),
+    course_codes: course_codes
+  ).run
+end

--- a/lib/mcb/courses_editor.rb
+++ b/lib/mcb/courses_editor.rb
@@ -11,8 +11,19 @@ module MCB
     end
 
     def run
+      finished = false
       puts "Editing #{course_codes.join(', ')}"
-      edit_title
+      until finished
+        choice = @cli.choose do |menu|
+          menu.choice(:exit) { finished = true }
+          menu.choice("edit title")
+        end
+
+        case choice
+        when "edit title"
+          edit_title
+        end
+      end
     end
 
   private

--- a/lib/mcb/courses_editor.rb
+++ b/lib/mcb/courses_editor.rb
@@ -11,21 +11,32 @@ module MCB
     end
 
     def run
+      puts "Editing #{course_codes.join(', ')}"
       edit_title
     end
 
   private
 
     def edit_title
+      print_existing(:name)
       update(name: ask_title)
     end
 
     def ask_title
-      @cli.ask("Course title?  ")
+      @cli.ask("New course title?  ")
     end
 
     def check_authorisation
       @courses.each { |course| raise Pundit::NotAuthorizedError unless can_update?(course) }
+    end
+
+    def print_existing(attribute_name)
+      puts "Existing values for course #{attribute_name}:"
+      table = Tabulo::Table.new @courses.order(:course_code) do |t|
+        t.add_column(:course_code, header: "course\ncode", width: 4)
+        t.add_column(attribute_name)
+      end
+      puts table.pack(max_table_width: nil), table.horizontal_rule
     end
 
     def update(attrs)
@@ -34,6 +45,10 @@ module MCB
 
     def can_update?(course)
       CoursePolicy.new(@requester, course).update?
+    end
+
+    def course_codes
+      @courses.order(:course_code).pluck(:course_code)
     end
 
     def find_courses(course_codes)

--- a/lib/mcb/courses_editor.rb
+++ b/lib/mcb/courses_editor.rb
@@ -1,0 +1,47 @@
+module MCB
+  class CoursesEditor
+    def initialize(provider:, requester:, course_codes: [])
+      @cli = HighLine.new
+
+      @provider = provider
+      @requester = requester
+      @courses = course_codes.present? ? find_courses(course_codes) : provider.courses
+
+      check_authorisation
+    end
+
+    def run
+      edit_title
+    end
+
+  private
+
+    def edit_title
+      update(name: ask_title)
+    end
+
+    def ask_title
+      @cli.ask("Course title?  ")
+    end
+
+    def check_authorisation
+      @courses.each { |course| raise Pundit::NotAuthorizedError unless can_update?(course) }
+    end
+
+    def update(attrs)
+      @courses.each { |course| course.update(attrs) }
+    end
+
+    def can_update?(course)
+      CoursePolicy.new(@requester, course).update?
+    end
+
+    def find_courses(course_codes)
+      courses = Course.where(course_code: course_codes)
+      missing_course_codes = course_codes - courses.pluck(:course_code)
+      raise ArgumentError, "Couldn't find course " + missing_course_codes.join(", ") unless missing_course_codes.empty?
+
+      courses
+    end
+  end
+end

--- a/spec/lib/mcb/commands/courses/edit_spec.rb
+++ b/spec/lib/mcb/commands/courses/edit_spec.rb
@@ -1,0 +1,70 @@
+require 'mcb_helper'
+
+describe 'mcb courses edit' do
+  def edit(provider_code, course_codes, *input_cmds)
+    stderr = nil
+    output = with_stubbed_stdout(stdin: input_cmds.join("\n"), stderr: stderr) do
+      cmd.run([provider_code] + course_codes)
+    end
+    [output, stderr]
+  end
+
+  let(:lib_dir) { "#{Rails.root}/lib" }
+  let(:cmd) do
+    Cri::Command.load_file("#{lib_dir}/mcb/commands/courses/edit.rb")
+  end
+  let(:provider_code) { 'X12' }
+  let(:course_code) { '3FC4' }
+  let(:email) { 'user@education.gov.uk' }
+  let(:provider) { create(:provider, provider_code: provider_code) }
+  let!(:course) {
+    create(:course,
+           provider: provider,
+           course_code: course_code,
+           name: 'Original name')
+  }
+
+  before do
+    allow(MCB).to receive(:config).and_return(email: email)
+  end
+
+  context 'for an authorised user' do
+    let!(:requester) { create(:user, email: email, organisations: provider.organisations) }
+
+    describe 'edits the course name for a single course' do
+      it 'updates the course' do
+        expect { edit(provider_code, [course_code], "Mathematics") }.to change { course.reload.name }.
+          from("Original name").to("Mathematics")
+      end
+    end
+
+    describe 'trying to edit a course on a nonexistent provider' do
+      it 'raises an error' do
+        expect { edit("ABC", [course_code]) }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find Provider/)
+      end
+    end
+
+    describe 'not specifying any course codes' do
+      let!(:another_course) {
+        create(:course,
+               provider: provider,
+               course_code: "A123",
+               name: 'Another name')
+      }
+
+      it 'edits all the courses on the provider' do
+        expect { edit(provider_code, [], "Mathematics") }.
+          to change { provider.reload.courses.order(:name).pluck(:name) }.
+          from(["Another name", "Original name"]).to(%w[Mathematics Mathematics])
+      end
+    end
+  end
+
+  context 'when a non-existent user tries to edit a course' do
+    let!(:requester) { create(:user, email: 'someother@email.com') }
+
+    it 'raises an error' do
+      expect { edit(provider_code, [course_code]) }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find User/)
+    end
+  end
+end

--- a/spec/lib/mcb/commands/courses/edit_spec.rb
+++ b/spec/lib/mcb/commands/courses/edit_spec.rb
@@ -33,7 +33,7 @@ describe 'mcb courses edit' do
 
     describe 'edits the course name for a single course' do
       it 'updates the course' do
-        expect { edit(provider_code, [course_code], "Mathematics") }.to change { course.reload.name }.
+        expect { edit(provider_code, [course_code], "edit title", "Mathematics", "exit") }.to change { course.reload.name }.
           from("Original name").to("Mathematics")
       end
     end
@@ -53,7 +53,7 @@ describe 'mcb courses edit' do
       }
 
       it 'edits all the courses on the provider' do
-        expect { edit(provider_code, [], "Mathematics") }.
+        expect { edit(provider_code, [], "edit title", "Mathematics", "exit") }.
           to change { provider.reload.courses.order(:name).pluck(:name) }.
           from(["Another name", "Original name"]).to(%w[Mathematics Mathematics])
       end

--- a/spec/lib/mcb/courses_editor_spec.rb
+++ b/spec/lib/mcb/courses_editor_spec.rb
@@ -27,8 +27,13 @@ describe MCB::CoursesEditor do
 
     describe 'runs the editor' do
       it 'updates the course title' do
-        expect { run_editor("Mathematics") }.to change { course.reload.name }.
+        expect { run_editor("edit title", "Mathematics", "exit") }.to change { course.reload.name }.
           from("Original name").to("Mathematics")
+      end
+
+      it 'does nothing upon an immediate exit' do
+        expect { run_editor("exit") }.to_not change { course.reload.name }.
+          from("Original name")
       end
     end
 
@@ -42,7 +47,7 @@ describe MCB::CoursesEditor do
       let(:course_codes) { [] }
 
       it 'edits all courses on the provider' do
-        expect { run_editor("Mathematics") }.
+        expect { run_editor("edit title", "Mathematics", "exit") }.
           to change { provider.reload.courses.order(:name).pluck(:name) }.
           from(["Another name", "Original name"]).to(%w[Mathematics Mathematics])
       end

--- a/spec/lib/mcb/courses_editor_spec.rb
+++ b/spec/lib/mcb/courses_editor_spec.rb
@@ -1,0 +1,67 @@
+require 'mcb_helper'
+
+describe MCB::CoursesEditor do
+  def run_editor(*input_cmds)
+    stderr = nil
+    output = with_stubbed_stdout(stdin: input_cmds.join("\n"), stderr: stderr) do
+      subject.run
+    end
+    [output, stderr]
+  end
+
+  let(:provider_code) { 'X12' }
+  let(:course_code) { '3FC4' }
+  let(:course_codes) { [course_code] }
+  let(:email) { 'user@education.gov.uk' }
+  let(:provider) { create(:provider, provider_code: provider_code) }
+  let!(:course) {
+    create(:course,
+           provider: provider,
+           course_code: course_code,
+           name: 'Original name')
+  }
+  subject { described_class.new(provider: provider, course_codes: course_codes, requester: requester) }
+
+  context 'when an authorised user' do
+    let!(:requester) { create(:user, email: email, organisations: provider.organisations) }
+
+    describe 'runs the editor' do
+      it 'updates the course title' do
+        expect { run_editor("Mathematics") }.to change { course.reload.name }.
+          from("Original name").to("Mathematics")
+      end
+    end
+
+    describe 'does not specify any course codes' do
+      let!(:another_course) {
+        create(:course,
+               provider: provider,
+               course_code: "A123",
+               name: 'Another name')
+      }
+      let(:course_codes) { [] }
+
+      it 'edits all courses on the provider' do
+        expect { run_editor("Mathematics") }.
+          to change { provider.reload.courses.order(:name).pluck(:name) }.
+          from(["Another name", "Original name"]).to(%w[Mathematics Mathematics])
+      end
+    end
+
+    describe 'tries to edit a non-existent course' do
+      let(:course_codes) { [course_code, "ABCD"] }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(ArgumentError, /Couldn't find course ABCD/)
+      end
+    end
+  end
+
+  context 'for an unauthorised user' do
+    let!(:requester) { create(:user, email: email, organisations: []) }
+
+    it 'raises an error' do
+      expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+    end
+  end
+end


### PR DESCRIPTION
### Context
Until we've built all course editing features for publishers to self-serve, we need support tooling to be able to action support requests for changes.

### Changes proposed in this pull request
- add a new `mcb courses edit` command
- allow editing individual courses or all courses for a provider
- some basic validation on the provider, course codes and the user making the changes
- editing of course title

### Guidance to review

I will add the editing of other aspects of course in subsequent PRs, I wanted to lay the groundwork with this one and get feedback.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
