### PR TITLE
[1580] Add validations to edit locations

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -53,8 +53,13 @@ module API
 
         site_ids = params[:course][:sites_ids]
         @course.sites = @provider.sites.where(id: site_ids) if site_ids.present?
+        # This validation is done at the controller level instead of the model.
+        # This is because sites = [] is something that we can validate against,
+        # but we can't actually revert easily from what I can tell because of the
+        # remove_site! side effects that occur when it's called.
+        @course.errors[:sites] << "^You must choose at least one location" if site_ids == []
 
-        if @course.valid?
+        if @course.errors.empty? && @course.valid?
           render jsonapi: @course.reload
         else
           render jsonapi_errors: @course.errors, status: :unprocessable_entity

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -47,12 +47,7 @@ module API
       end
 
       def update
-        enrichment = if @course.enrichments.draft.any?
-                       @course.enrichments.draft.first
-                     else
-                       @course.enrichments.new(status: 'draft')
-                     end
-
+        enrichment = first_draft_or_new_enrichment
         enrichment.assign_attributes(update_params)
         enrichment.save
 
@@ -67,6 +62,14 @@ module API
       end
 
     private
+
+      def first_draft_or_new_enrichment
+        if @course.enrichments.draft.any?
+          @course.enrichments.draft.first
+        else
+          @course.enrichments.new(status: 'draft')
+        end
+      end
 
       def build_provider
         @provider = Provider.find_by!(provider_code: params[:provider_code].upcase)


### PR DESCRIPTION
### Context

This will allow us to display an appropriate error message on the frontend when the user submits an empty array of sites.

### Changes proposed in this pull request

Pushes a validation message to `@course.errors` and checks for its presence before rendering the response.

### Guidance to review

The validation is done at the controller level instead of the model. This is because `sites = []` is something that we can validate against, but we can't actually revert easily from what I can tell because of the `remove_site!` side effects that occur when it's called.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally