### PR TITLE
[1580] use callbacks to add or remote sites to course

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -47,12 +47,7 @@ module API
       end
 
       def update
-        enrichment = if @course.enrichments.draft.any?
-                       @course.enrichments.draft.first
-                     else
-                       @course.enrichments.new(status: 'draft')
-                     end
-
+        enrichment = first_draft_or_new_enrichment
         enrichment.assign_attributes(update_params)
         enrichment.save
 
@@ -68,6 +63,14 @@ module API
       end
 
     private
+
+      def first_draft_or_new_enrichment
+        if @course.enrichments.draft.any?
+          @course.enrichments.draft.first
+        else
+          @course.enrichments.new(status: 'draft')
+        end
+      end
 
       def build_provider
         @provider = Provider.find_by!(provider_code: params[:provider_code].upcase)

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -58,8 +58,9 @@ module API
 
         site_ids = params[:course][:sites_ids]
         @course.sites = @provider.sites.where(id: site_ids) if site_ids.present?
+        @course.errors[:sites] << "^You must choose at least one location" if site_ids == []
 
-        if @course.valid?
+        if @course.errors.empty? && @course.valid?
           render jsonapi: @course.reload
         else
           render jsonapi_errors: @course.errors, status: :unprocessable_entity

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -72,7 +72,8 @@ class Course < ApplicationRecord
   has_many :site_statuses
   has_many :sites,
            -> { merge(SiteStatus.where(status: %i[new_status running])) },
-           through: :site_statuses
+           through: :site_statuses,
+           dependent: :destroy
 
   has_many :enrichments,
            ->(course) { where(provider_code: course.provider.provider_code) },
@@ -261,17 +262,17 @@ class Course < ApplicationRecord
     new? ? site_status.destroy! : site_status.suspend!
   end
 
-  def sites=(desired_sites)
-    existing_sites = sites
+  # def sites=(desired_sites)
+  #   existing_sites = sites
 
-    to_add = desired_sites - existing_sites
-    to_add.each { |site| add_site!(site: site) }
+  #   to_add = desired_sites - existing_sites
+  #   to_add.each { |site| add_site!(site: site) }
 
-    to_remove = existing_sites - desired_sites
-    to_remove.each { |site| remove_site!(site: site) }
+  #   to_remove = existing_sites - desired_sites
+  #   to_remove.each { |site| remove_site!(site: site) }
 
-    sites.reload
-  end
+  #   sites.reload
+  # end
 
   def has_bursary?
     dfe_subjects.any?(&:has_bursary?)

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # == Schema Information
 #
 # Table name: course_site
@@ -19,6 +20,21 @@ class SiteStatus < ApplicationRecord
 
   after_initialize :set_defaults
   before_validation :set_vac_status
+  before_create :set_new_status
+
+  def set_new_status
+    if !course.site_statuses.empty? && !course.site_statuses.all?(&:status_new_status?)
+      self.status = 'R'
+    end
+  end
+
+  def destroy
+    if course.site_statuses.any?(&:status_new_status?)
+      self.delete
+    else
+      self.status_suspended!
+    end
+  end
 
   audited associated_with: :course
 

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -24,7 +24,7 @@ class SiteStatus < ApplicationRecord
 
   def set_new_status
     if !course.site_statuses.empty? && !course.site_statuses.all?(&:status_new_status?)
-      self.status = 'R'
+      self.status = :running
     end
   end
 


### PR DESCRIPTION
- this replaces the functionality of add_site! and remove_site!

### Context

We should be able to add or remove sites to a course without having to resort to custom methods like `add_site!` or `remove_site!`.

### Changes proposed in this pull request

Replace the functionality in those methods with callbacks in `SiteStatus`.

### Guidance to review

This code was done as a proof of concept and, on account of it being pretty late and me not being able to see straight, could probably use a little tidying up. It also doesn't remove the mentioned methods, that might be slightly more work.

This change could probably happen independent of `1580-edit-locations-validations`, if we think it's a good idea.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
