### PR TITLE
[1586] mcb courses edit: part 2

### DIFF
--- a/lib/mcb/courses_editor.rb
+++ b/lib/mcb/courses_editor.rb
@@ -16,7 +16,7 @@ module MCB
       until finished
         choice = @cli.choose do |menu|
           menu.choice(:exit) { finished = true }
-          menu.choices("edit title", "edit maths")
+          menu.choices("edit title", "edit maths", "edit english", "edit science")
         end
 
         if choice.is_a?(String) && choice.start_with?("edit")
@@ -40,6 +40,16 @@ module MCB
     def edit_maths
       print_existing(:maths)
       update(maths: ask_gcse_subject(:maths))
+    end
+
+    def edit_english
+      print_existing(:english)
+      update(english: ask_gcse_subject(:english))
+    end
+
+    def edit_science
+      print_existing(:science)
+      update(science: ask_gcse_subject(:science))
     end
 
     def ask_gcse_subject(subject)

--- a/lib/mcb/courses_editor.rb
+++ b/lib/mcb/courses_editor.rb
@@ -16,7 +16,7 @@ module MCB
       until finished
         choice = @cli.choose do |menu|
           menu.choice(:exit) { finished = true }
-          menu.choices("edit title", "edit maths", "edit english", "edit science")
+          menu.choices("edit title", "edit maths", "edit english", "edit science", "edit route")
         end
 
         if choice.is_a?(String) && choice.start_with?("edit")
@@ -56,6 +56,18 @@ module MCB
       @cli.choose do |menu|
         menu.prompt = "What's the #{subject} entry requirements?  "
         menu.choices(*Course::ENTRY_REQUIREMENT_OPTIONS.keys)
+      end
+    end
+
+    def edit_route
+      print_existing(:program_type)
+      update(program_type: ask_route)
+    end
+
+    def ask_route
+      @cli.choose do |menu|
+        menu.prompt = "What's the route?  "
+        menu.choices(*Course.program_types.keys)
       end
     end
 

--- a/lib/mcb/courses_editor.rb
+++ b/lib/mcb/courses_editor.rb
@@ -16,12 +16,12 @@ module MCB
       until finished
         choice = @cli.choose do |menu|
           menu.choice(:exit) { finished = true }
-          menu.choice("edit title")
+          menu.choices("edit title", "edit maths")
         end
 
-        case choice
-        when "edit title"
-          edit_title
+        if choice.is_a?(String) && choice.start_with?("edit")
+          edit_method_name = choice.gsub(" ", "_").to_sym
+          send(edit_method_name)
         end
       end
     end
@@ -35,6 +35,18 @@ module MCB
 
     def ask_title
       @cli.ask("New course title?  ")
+    end
+
+    def edit_maths
+      print_existing(:maths)
+      update(maths: ask_gcse_subject(:maths))
+    end
+
+    def ask_gcse_subject(subject)
+      @cli.choose do |menu|
+        menu.prompt = "What's the #{subject} entry requirements?  "
+        menu.choices(*Course::ENTRY_REQUIREMENT_OPTIONS.keys)
+      end
     end
 
     def check_authorisation

--- a/spec/lib/mcb/courses_editor_spec.rb
+++ b/spec/lib/mcb/courses_editor_spec.rb
@@ -21,7 +21,8 @@ describe MCB::CoursesEditor do
            name: 'Original name',
            maths: 'must_have_qualification_at_application_time',
            english: 'equivalence_test',
-           science: 'not_required')
+           science: 'not_required',
+           program_type: 'higher_education_programme')
   }
   subject { described_class.new(provider: provider, course_codes: course_codes, requester: requester) }
 
@@ -47,6 +48,11 @@ describe MCB::CoursesEditor do
       it 'updates the science setting when that is valid' do
         expect { run_editor("edit science", "equivalence_test", "exit") }.to change { course.reload.science }.
           from("not_required").to("equivalence_test")
+      end
+
+      it 'updates the route/program type setting when that is valid' do
+        expect { run_editor("edit route", "scitt_programme", "exit") }.to change { course.reload.program_type }.
+          from("higher_education_programme").to("scitt_programme")
       end
 
       it 'does nothing upon an immediate exit' do

--- a/spec/lib/mcb/courses_editor_spec.rb
+++ b/spec/lib/mcb/courses_editor_spec.rb
@@ -19,7 +19,9 @@ describe MCB::CoursesEditor do
            provider: provider,
            course_code: course_code,
            name: 'Original name',
-           maths: 'must_have_qualification_at_application_time')
+           maths: 'must_have_qualification_at_application_time',
+           english: 'equivalence_test',
+           science: 'not_required')
   }
   subject { described_class.new(provider: provider, course_codes: course_codes, requester: requester) }
 
@@ -35,6 +37,16 @@ describe MCB::CoursesEditor do
       it 'updates the maths setting when that is valid' do
         expect { run_editor("edit maths", "equivalence_test", "exit") }.to change { course.reload.maths }.
           from("must_have_qualification_at_application_time").to("equivalence_test")
+      end
+
+      it 'updates the english setting when that is valid' do
+        expect { run_editor("edit english", "must_have_qualification_at_application_time", "exit") }.to change { course.reload.english }.
+          from("equivalence_test").to("must_have_qualification_at_application_time")
+      end
+
+      it 'updates the science setting when that is valid' do
+        expect { run_editor("edit science", "equivalence_test", "exit") }.to change { course.reload.science }.
+          from("not_required").to("equivalence_test")
       end
 
       it 'does nothing upon an immediate exit' do

--- a/spec/lib/mcb/courses_editor_spec.rb
+++ b/spec/lib/mcb/courses_editor_spec.rb
@@ -18,7 +18,8 @@ describe MCB::CoursesEditor do
     create(:course,
            provider: provider,
            course_code: course_code,
-           name: 'Original name')
+           name: 'Original name',
+           maths: 'must_have_qualification_at_application_time')
   }
   subject { described_class.new(provider: provider, course_codes: course_codes, requester: requester) }
 
@@ -29,6 +30,11 @@ describe MCB::CoursesEditor do
       it 'updates the course title' do
         expect { run_editor("edit title", "Mathematics", "exit") }.to change { course.reload.name }.
           from("Original name").to("Mathematics")
+      end
+
+      it 'updates the maths setting when that is valid' do
+        expect { run_editor("edit maths", "equivalence_test", "exit") }.to change { course.reload.maths }.
+          from("must_have_qualification_at_application_time").to("equivalence_test")
       end
 
       it 'does nothing upon an immediate exit' do


### PR DESCRIPTION
### Context
Follow-up to #446.

Until we've built all course editing features for publishers to self-serve, we need support tooling to be able to action support requests for changes.

### Changes proposed in this pull request

- edit equivalency settings (maths, english, science)
- edit route

### Guidance to review
More PRs to follow.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
