### PR TITLE
[1587] Create enrichment in courses#update only when necessary

### DIFF
--- a/spec/requests/api/v2/providers/courses/update_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_spec.rb
@@ -137,6 +137,31 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
         .to include(update_attributes.stringify_keys)
     end
 
+    context "with no attributes to update" do
+      let(:update_attributes) do
+        {
+          about_course: nil,
+          course_length: nil,
+          fee_details: nil,
+          fee_international: nil,
+          fee_uk_eu: nil,
+          financial_support: nil,
+          how_school_placements_work: nil,
+          interview_process: nil,
+          other_requirements: nil,
+          personal_qualities: nil,
+          qualifications: nil,
+          salary_details: nil
+        }
+      end
+
+      it "doesn't create a draft enrichment" do
+        expect {
+          perform_request update_course
+        }.to_not(change { course.reload.enrichments.count })
+      end
+    end
+
     it 'returns ok' do
       perform_request update_course
 


### PR DESCRIPTION
### Context

Currently the courses#update action always creates an enrichment when called. This leads to two bugs:

- When updating the sites, the course is set to draft
- When the user opens the enrichment pages but makes no changes and
  hits "Save", the course changes state

### Changes proposed in this pull request

This wraps the enrichment logic in a guard so that it isn't run unnecessarily.

The enrichment and site update logic are both wrapped in private methods to make the update action a bit easier to parse.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally