### PR TITLE
[1598] use callbacks to add or remote sites to course

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -74,7 +74,8 @@ class Course < ApplicationRecord
   has_many :site_statuses
   has_many :sites,
            -> { merge(SiteStatus.where(status: %i[new_status running])) },
-           through: :site_statuses
+           through: :site_statuses,
+           dependent: :destroy
 
   has_many :enrichments,
            ->(course) { where(provider_code: course.provider.provider_code) },
@@ -237,30 +238,6 @@ class Course < ApplicationRecord
     enrichments.draft.each do |enrichment|
       enrichment.publish(current_user)
     end
-  end
-
-  def add_site!(site:)
-    is_course_new = ucas_status == :new # persist this before we change anything
-    site_status = site_statuses.find_or_initialize_by(site: site)
-    site_status.start! unless is_course_new
-    site_status.save! if persisted?
-  end
-
-  def remove_site!(site:)
-    site_status = site_statuses.find_by!(site: site)
-    ucas_status == :new ? site_status.destroy! : site_status.suspend!
-  end
-
-  def sites=(desired_sites)
-    existing_sites = sites
-
-    to_add = desired_sites - existing_sites
-    to_add.each { |site| add_site!(site: site) }
-
-    to_remove = existing_sites - desired_sites
-    to_remove.each { |site| remove_site!(site: site) }
-
-    sites.reload
   end
 
   def has_bursary?

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -19,6 +19,21 @@ class SiteStatus < ApplicationRecord
 
   after_initialize :set_defaults
   before_validation :set_vac_status
+  before_create :set_new_status
+
+  def set_new_status
+    if !course.site_statuses.empty? && !course.site_statuses.all?(&:status_new_status?)
+      self.status = :running
+    end
+  end
+
+  def destroy
+    if course.site_statuses.any?(&:status_new_status?)
+      self.delete
+    else
+      self.status_suspended!
+    end
+  end
 
   audited associated_with: :course
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -205,7 +205,15 @@ RSpec.describe Course, type: :model do
                  ])
         }
 
-        its(:has_vacancies?) { should be false }
+        before do
+          SiteStatus.skip_callback(:create, :before, :set_new_status)
+        end
+
+        after do
+          SiteStatus.set_callback(:create, :before, :set_new_status)
+        end
+
+        its(:has_vacancies?) { should be(false) }
       end
     end
 
@@ -499,96 +507,6 @@ RSpec.describe Course, type: :model do
       expect { subject.applications_open_from = Date.new(2018, 10, 23) }.
         to change { subject.reload.site_statuses.pluck(:applications_accepted_from).uniq }.
         from([Date.new(2018, 10, 9)]).to([Date.new(2018, 10, 23)])
-    end
-  end
-
-  describe "adding and removing sites on a course" do
-    let(:provider) { build(:provider) }
-      #this code will be removed and fixed properly in the next pr
-    let(:new_site) { create(:site, provider: provider, code: 'A') }
-     #this code will be removed and fixed properly in the next pr
-    let(:existing_site) { create(:site, provider: provider, code: 'B') }
-    let(:new_site_status) { subject.site_statuses.find_by!(site: new_site) }
-    subject { create(:course, site_statuses: [existing_site_status]) }
-
-    context "for running courses" do
-      let(:existing_site_status) { create(:site_status, :running, :published, site: existing_site) }
-
-      it "suspends the site when an existing site is removed" do
-        expect { subject.remove_site!(site: existing_site) }.
-          to change { existing_site_status.reload.status }.from("running").to("suspended")
-      end
-
-      it "adds a new site status and sets it to running when a new site is added" do
-        expect { subject.add_site!(site: new_site) }.to change { subject.reload.site_statuses.size }.
-          from(1).to(2)
-        expect(new_site_status.status).to eq("running")
-      end
-    end
-
-    context "for new courses" do
-      let(:existing_site_status) { create(:site_status, :new, site: existing_site) }
-
-      it "sets the site to new when a new site is added" do
-        expect { subject.add_site!(site: new_site) }.to change { subject.reload.site_statuses.size }.
-          from(1).to(2)
-        expect(new_site_status.status).to eq("new_status")
-      end
-
-      it "keeps the site status as new when an existing site is added" do
-        expect { subject.add_site!(site: existing_site) }.
-          to_not change { existing_site_status.reload.status }.from("new_status")
-      end
-
-      it "removes the site status when an existing site is removed" do
-        expect { subject.remove_site!(site: existing_site) }.to change { subject.reload.site_statuses.size }.
-          from(1).to(0)
-      end
-    end
-
-    context "for suspended courses" do
-      let(:existing_site_status) { create(:site_status, :suspended, site: existing_site) }
-
-      it "sets the site to running when a new site is added" do
-        expect { subject.add_site!(site: new_site) }.to change { subject.reload.site_statuses.size }.
-          from(1).to(2)
-        expect(new_site_status.status).to eq("running")
-      end
-
-      it "sets the site to running when an existing site is added" do
-        expect { subject.add_site!(site: existing_site) }.
-          to change { existing_site_status.reload.status }.from("suspended").to("running")
-      end
-    end
-
-    context "for courses without any training locations" do
-      subject { create(:course, site_statuses: []) }
-
-      it "sets the site to new when a new site is added" do
-        expect { subject.add_site!(site: new_site) }.to change { subject.reload.site_statuses.size }.
-          from(0).to(1)
-        expect(new_site_status.status).to eq("new_status")
-      end
-    end
-
-    context "for mixed courses with new and running locations" do
-      let(:existing_site_status) { create(:site_status, :running, :published, site: existing_site) }
-      #this code will be removed and fixed properly in the next pr
-      let(:another_existing_site) { create(:site, code: 'C', provider: provider) }
-      let(:existing_new_site_status) { create(:site_status, :new, site: another_existing_site) }
-
-      subject { create(:course, site_statuses: [existing_site_status, existing_new_site_status]) }
-
-      it "adds a new site status and sets it to running when a new site is added" do
-        expect { subject.add_site!(site: new_site) }.to change { subject.reload.site_statuses.size }.
-          from(2).to(3)
-        expect(new_site_status.status).to eq("running")
-      end
-
-      it "suspends the site when an existing site is removed" do
-        expect { subject.remove_site!(site: existing_site) }.
-          to change { existing_site_status.reload.status }.from("running").to("suspended")
-      end
     end
   end
 

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -72,10 +72,11 @@ RSpec.describe SiteStatus, type: :model do
     end
 
     context 'when course has a new site' do
-      let(:site1)       { create(:site) }
-      let(:course)      { create(:course) }
-      let(:site_status) { create(:site_status, :new, site: site1, course: course) }
-      let(:site2)       { create(:site) }
+      let(:provider)    { build(:provider) }
+      let(:site1)       { build(:site, provider: provider) }
+      let(:course)      { create(:course, provider: provider) }
+      let(:site_status) { build(:site_status, :new, site: site1, course: course) }
+      let(:site2)       { build(:site, provider: provider) }
 
       before do
         site_status
@@ -127,12 +128,13 @@ RSpec.describe SiteStatus, type: :model do
     end
 
     context "when course has new and running sites" do
-      let(:site1) { create(:site) }
-      let(:site2) { create(:site) }
+      let(:provider) { build(:provider) }
+      let(:site1) { build(:site, provider: provider) }
+      let(:site2) { build(:site, provider: provider) }
       let!(:site_status1) { create(:site_status, :running, :published, site: site1, course: course) }
       let!(:site_status2) { create(:site_status, :new, site: site2, course: course) }
-      let(:course) { create(:course) }
-      let(:site3) { create(:site) }
+      let(:course) { create(:course, provider: provider) }
+      let(:site3) { build(:site, provider: provider) }
 
       before do
         expect(course.reload.ucas_status).to be(:running)
@@ -149,9 +151,10 @@ RSpec.describe SiteStatus, type: :model do
   end
 
   describe 'destruction' do
-    let(:site1)        { create(:site) }
-    let(:site2)        { create(:site) }
-    let(:course)       { create(:course) }
+    let(:provider)     { build(:provider) }
+    let(:site1)        { build(:site, provider: provider) }
+    let(:site2)        { build(:site, provider: provider) }
+    let(:course)       { create(:course, provider: provider) }
     let(:site_status1) { create(:site_status, state, site: site1, course: course) }
     let(:site_status2) { create(:site_status, state, site: site2, course: course) }
 

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -38,6 +38,161 @@ RSpec.describe SiteStatus, type: :model do
     it { should be_audited.associated_with(:course) }
   end
 
+  describe 'creation' do
+    context 'when course has a running site' do
+      let(:provider)    { build(:provider) }
+      let(:site1)       { build(:site, provider: provider) }
+      let(:site2)       { build(:site, provider: provider) }
+      let(:site_status) { build(:site_status, :running, site: site1) }
+      let(:course) do
+        create(:course, provider: provider, site_statuses: [site_status])
+      end
+
+      before do
+        site_status
+        expect(course.reload).not_to be_new
+      end
+
+      describe 'the status' do
+        it 'is set to running' do
+          new_site_status = SiteStatus.create course: course, site: site2
+
+          expect(new_site_status).to be_status_running
+        end
+
+        context 'when using the course association' do
+          it 'is set to running' do
+            course.sites << site2
+
+            new_site_status = course.site_statuses.last
+            expect(new_site_status).to be_status_running
+          end
+        end
+      end
+    end
+
+    context 'when course has a new site' do
+      let(:site1)       { create(:site) }
+      let(:course)      { create(:course) }
+      let(:site_status) { create(:site_status, :new, site: site1, course: course) }
+      let(:site2)       { create(:site) }
+
+      before do
+        site_status
+        expect(course.reload).to be_new
+      end
+
+      describe 'the status' do
+        it 'is set to new' do
+          new_site_status = SiteStatus.create course: course, site: site2
+
+          expect(new_site_status).to be_status_new_status
+        end
+
+        describe 'when using the course association' do
+          it 'is set to new' do
+            course.sites << site2
+
+            site_status2 = course.site_statuses.last
+            expect(site_status2).to be_status_new_status
+          end
+        end
+      end
+    end
+
+    context 'when course has no sites' do
+      let(:course) { create(:course) }
+      let(:site2)  { create(:site) }
+
+      before do
+        expect(course).to be_new
+      end
+
+      describe 'the status' do
+        it 'is set to new' do
+          new_site_status = SiteStatus.create course: course, site: site2
+
+          expect(new_site_status).to be_status_new_status
+        end
+
+        describe 'when using the course association' do
+          it 'is set to new' do
+            course.sites << site2
+
+            site_status2 = course.site_statuses.last
+            expect(site_status2).to be_status_new_status
+          end
+        end
+      end
+    end
+  end
+
+  describe 'destruction' do
+    let(:site1)        { create(:site) }
+    let(:site2)        { create(:site) }
+    let(:course)       { create(:course) }
+    let(:site_status1) { create(:site_status, state, site: site1, course: course) }
+    let(:site_status2) { create(:site_status, state, site: site2, course: course) }
+
+    context 'when course has running sites' do
+      let(:state) { :running }
+
+      before do
+        site_status1
+        site_status2
+      end
+
+      describe 'the record' do
+        it 'is set to suspended' do
+          expect(course.reload).not_to be_new
+
+          site_status2.destroy
+
+          expect(site_status2.reload).to be_status_suspended
+        end
+      end
+
+      describe 'using courses association' do
+        it 'it is suspended' do
+          expect(course.reload).not_to be_new
+
+          course.sites = [site1]
+
+          expect(site_status2.reload).to be_status_suspended
+        end
+      end
+    end
+
+    context 'when course has new sites' do
+      let(:state) { :new }
+
+      before do
+        site_status1
+        site_status2
+      end
+
+      describe 'the record' do
+        it 'is destroyed' do
+          expect(course.reload).to be_new
+
+          site_status2.destroy
+
+          expect(SiteStatus.exists?(site_status2.id)).to be_falsey
+        end
+      end
+
+      describe 'using courses association' do
+        it 'it is destroyed' do
+          expect(course.reload).to be_new
+
+          course.sites = [site1]
+
+          expect(SiteStatus.exists?(site_status2.id)).to be_falsey
+        end
+      end
+    end
+  end
+
   describe 'associations' do
     subject { build(:site_status) }
 

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -125,6 +125,27 @@ RSpec.describe SiteStatus, type: :model do
         end
       end
     end
+
+    context "when course has new and running sites" do
+      let(:site1) { create(:site) }
+      let(:site2) { create(:site) }
+      let!(:site_status1) { create(:site_status, :running, :published, site: site1, course: course) }
+      let!(:site_status2) { create(:site_status, :new, site: site2, course: course) }
+      let(:course) { create(:course) }
+      let(:site3) { create(:site) }
+
+      before do
+        expect(course.reload.ucas_status).to be(:running)
+      end
+
+      describe "the status" do
+        it "is set to running" do
+          new_site_status = SiteStatus.create course: course, site: site3
+
+          expect(new_site_status).to be_status_running
+        end
+      end
+    end
   end
 
   describe 'destruction' do

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe SiteStatus, type: :model do
 
       before do
         site_status
-        expect(course.reload).not_to be_new
+        expect(course.reload.ucas_status).not_to be(:new)
       end
 
       describe 'the status' do
@@ -79,7 +79,7 @@ RSpec.describe SiteStatus, type: :model do
 
       before do
         site_status
-        expect(course.reload).to be_new
+        expect(course.reload.ucas_status).to be(:new)
       end
 
       describe 'the status' do
@@ -105,7 +105,7 @@ RSpec.describe SiteStatus, type: :model do
       let(:site2)  { create(:site) }
 
       before do
-        expect(course).to be_new
+        expect(course.reload.ucas_status).to be(:new)
       end
 
       describe 'the status' do
@@ -144,7 +144,7 @@ RSpec.describe SiteStatus, type: :model do
 
       describe 'the record' do
         it 'is set to suspended' do
-          expect(course.reload).not_to be_new
+          expect(course.reload.ucas_status).not_to be(:new)
 
           site_status2.destroy
 
@@ -154,7 +154,7 @@ RSpec.describe SiteStatus, type: :model do
 
       describe 'using courses association' do
         it 'it is suspended' do
-          expect(course.reload).not_to be_new
+          expect(course.reload.ucas_status).not_to be(:new)
 
           course.sites = [site1]
 
@@ -173,7 +173,7 @@ RSpec.describe SiteStatus, type: :model do
 
       describe 'the record' do
         it 'is destroyed' do
-          expect(course.reload).to be_new
+          expect(course.reload.ucas_status).to be(:new)
 
           site_status2.destroy
 
@@ -183,7 +183,7 @@ RSpec.describe SiteStatus, type: :model do
 
       describe 'using courses association' do
         it 'it is destroyed' do
-          expect(course.reload).to be_new
+          expect(course.reload.ucas_status).to be(:new)
 
           course.sites = [site1]
 

--- a/spec/requests/api/v2/providers/courses/update_sites_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_sites_spec.rb
@@ -16,8 +16,8 @@ describe 'PATCH /providers/:provider_code/courses/:course_code with sites' do
   let(:existing_site) { create :site, provider: provider }
 
   before do
-    course.add_site!(site: existing_site)
-    course.add_site!(site: unwanted_site)
+    course.sites << existing_site
+    course.sites << unwanted_site
   end
 
   let(:sites_payload) {


### PR DESCRIPTION
### Context

We should be able to add or remove sites to a course without having to resort to custom methods like add_site! or remove_site!.

### Changes proposed in this pull request

Replace the functionality in those methods with callbacks in SiteStatus.

### Guidance to review

This code was done as a proof of concept and, on account of it being pretty late and me not being able to see straight, could probably use a little tidying up. It also doesn't remove the mentioned methods, that might be slightly more work.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
