### PR TITLE
[1606] raise error when sync to sac fails

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 module API
   module V2
     class CoursesController < API::V2::ApplicationController
@@ -26,7 +28,13 @@ module API
           @course.course_code
         )
 
-        head response ? :ok : :internal_server_error
+        if response
+          head :ok
+        else
+          raise RuntimeError.new(
+            'error received when syncing with search and compare'
+          )
+        end
       end
 
       def publish
@@ -40,7 +48,13 @@ module API
             @course.course_code
           )
 
-          head response ? :ok : :internal_server_error
+          if response
+            head :ok
+          else
+            raise RuntimeError.new(
+              'error received when syncing with search and compare'
+            )
+          end
         else
           render jsonapi_errors: @course.errors, status: :unprocessable_entity
         end

--- a/app/services/manage_courses_api_service.rb
+++ b/app/services/manage_courses_api_service.rb
@@ -29,8 +29,9 @@ module ManageCoursesAPIService
           "/api/Publish/internal/courses/#{provider_code}",
           { email: email }.to_json
         )
+
         if response.success?
-          JSON.parse(response.body)["result"]
+          JSON.parse(response.body).fetch('result')
         else
           false
         end

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -91,14 +91,24 @@ describe 'Publish API v2', type: :request do
     context 'when the api responds with result: false' do
       let(:manage_api_response) { '{ "result": false }' }
 
-      it { should have_http_status(:internal_server_error) }
+      it 'raises an error' do
+        expect {
+          subject
+        }.to raise_error RuntimeError,
+                         'error received when syncing with search and compare'
+      end
     end
 
     context 'when the api sets http status to 500' do
       let(:manage_api_status) { 500 }
       let(:manage_api_response) { '{ "result": true }' }
 
-      it { should have_http_status(:internal_server_error) }
+      it 'raises an error' do
+        expect {
+          subject
+        }.to raise_error RuntimeError,
+                         'error received when syncing with search and compare'
+      end
     end
 
     describe 'failed validation' do

--- a/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
+++ b/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
@@ -71,13 +71,24 @@ describe 'Courses API v2', type: :request do
     context 'when the api responds with result: false' do
       let(:manage_api_response) { '{ "result": false }' }
 
-      it { should have_http_status(:internal_server_error) }
+      it 'raises an error' do
+        expect {
+          subject
+        }.to raise_error RuntimeError,
+                         'error received when syncing with search and compare'
+      end
     end
 
     context 'when the api sets http status to 500' do
       let(:manage_api_status) { 500 }
       let(:manage_api_response) { '{ "result": true }' }
-      it { should have_http_status(:internal_server_error) }
+
+      it 'raises an error' do
+        expect {
+          subject
+        }.to raise_error RuntimeError,
+                         'error received when syncing with search and compare'
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

We're getting errors when we try to sync a course with search and compare.

### Changes proposed in this pull request

Ensure an error is raised when we try to sync a course so we have a better understanding of what's gone wrong.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
