### PR TITLE
[1610] Expose provider_code in course endpoint

### DIFF
--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -34,6 +34,10 @@ module API
         @object.accrediting_provider_description
       end
 
+      attribute :provider_code do
+        @object.provider.provider_code
+      end
+
       belongs_to :provider
       belongs_to :accrediting_provider
 

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -130,7 +130,8 @@ describe 'Courses API v2', type: :request do
               "about_accrediting_body" => nil,
               "english" => 'must_have_qualification_at_application_time',
               "maths" => 'must_have_qualification_at_application_time',
-              "science" => 'must_have_qualification_at_application_time'
+              "science" => 'must_have_qualification_at_application_time',
+              "provider_code" => provider.provider_code
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },
@@ -257,7 +258,8 @@ describe 'Courses API v2', type: :request do
               "about_accrediting_body" => nil,
               "english" => 'must_have_qualification_at_application_time',
               "maths" => 'must_have_qualification_at_application_time',
-              "science" => 'must_have_qualification_at_application_time'
+              "science" => 'must_have_qualification_at_application_time',
+              "provider_code" => provider.provider_code
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -21,7 +21,8 @@ describe API::V2::SerializableCourse do
   it { should have_type('courses') }
   it {
     should have_attributes(:start_date, :content_status, :ucas_status,
-                           :funding, :subjects, :applications_open_from, :is_send?, :level)
+                           :funding, :subjects, :applications_open_from,
+                           :is_send?, :level, :provider_code)
   }
 
   context 'with a provider' do


### PR DESCRIPTION
### Context

Having to manually set this on the frontend as a workaround every time is
annoying. The course endpoint in APIv2 should show the provider_code of the
course to make the relationship between provider and course work smoothly.

### Changes proposed in this pull request

Expose `provider_code` in the APIv2 course endpoint.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally