### PR TITLE
[1608] Sync courses when updating courses and site_statuses

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -20,11 +20,7 @@ module API
       end
 
       def sync_with_search_and_compare
-        response = ManageCoursesAPIService::Request.sync_course_with_search_and_compare(
-          @current_user.email,
-          @provider.provider_code,
-          @course.course_code
-        )
+        response = sync_courses
 
         head response ? :ok : :internal_server_error
       end
@@ -59,6 +55,14 @@ module API
 
     private
 
+      def sync_courses
+        ManageCoursesAPIService::Request.sync_course_with_search_and_compare(
+          @current_user.email,
+          @provider.provider_code,
+          @course.course_code
+        )
+      end
+
       def update_enrichment
         return unless enrichment_params.values.any?
 
@@ -76,6 +80,8 @@ module API
         # but we can't actually revert easily from what I can tell because of the
         # remove_site! side effects that occur when it's called.
         @course.errors[:sites] << "^You must choose at least one location" if site_ids.empty?
+
+        sync_courses if site_ids.any?
       end
 
       def first_draft_or_new_enrichment

--- a/spec/requests/api/v2/providers/courses/update_sites_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_sites_spec.rb
@@ -43,6 +43,14 @@ describe 'PATCH /providers/:provider_code/courses/:course_code with sites' do
     }
   end
 
+  let!(:sync_courses_request_stub) do
+    stub_request(:post, %r{#{Settings.manage_api.base_url}/api/Publish/internal/course/})
+      .to_return(
+        status: 200,
+        body: '{ "result": true }'
+      )
+  end
+
   def perform_request
     patch "/api/v2/providers/#{course.provider.provider_code}" \
             "/courses/#{course.course_code}",
@@ -73,6 +81,10 @@ describe 'PATCH /providers/:provider_code/courses/:course_code with sites' do
 
       it "removes an unwanted site" do
         expect(course.reload.sites.exists?(unwanted_site.id)).to be(false)
+      end
+
+      it "syncs the course" do
+        expect(sync_courses_request_stub).to have_been_requested
       end
     end
 
@@ -107,6 +119,10 @@ describe 'PATCH /providers/:provider_code/courses/:course_code with sites' do
 
       it "returns validation error" do
         expect(response.body).to include("You must choose at least one location")
+      end
+
+      it "doesn't sync the course" do
+        expect(sync_courses_request_stub).to_not have_been_requested
       end
     end
   end


### PR DESCRIPTION
### Context

The frontend doesn't necessarily know when a course is due to be synced with search-and-compare, the concern for that knowledge should be in the backend.

### Changes proposed in this pull request

Call `ManageCoursesAPIService` in courses update.

### Guidance to review

🚢 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally