### PR TITLE
[1599] fix apiv1 provider find campuses rendering

### DIFF
--- a/lib/mcb/render/apiv1.rb
+++ b/lib/mcb/render/apiv1.rb
@@ -4,6 +4,20 @@ module MCB
       class << self
         include MCB::Render
 
+        def campuses_table(campuses, name: 'Campuses')
+          return if campuses.nil?
+
+          [
+            "#{name}:",
+            render_table_or_none(hashes_to_ostructs(campuses),
+                                 campuses_table_columns)
+          ]
+        end
+
+        def campuses_table_columns
+          %i[campus_code name region_code]
+        end
+
         def contacts_table(contacts, name: 'Contacts')
           super(hashes_to_ostructs(contacts),
                 name: name)

--- a/spec/lib/mcb/commands/apiv1/providers/find_spec.rb
+++ b/spec/lib/mcb/commands/apiv1/providers/find_spec.rb
@@ -7,10 +7,8 @@ describe '"mcb apiv1 providers find"' do
   let(:contact2)  { build(:contact, :admin_type) }
   let(:provider1) { create(:provider, sites: [site1], contacts: [contact1]) }
   let(:provider2) { create(:provider, sites: [site2], contacts: [contact2]) }
-  let(:course1)   { create(:course, provider: provider1)}
-  let(:course2)   { create(:course, provider: provider2)}
 
-  it 'displays the info for the given course' do
+  it 'displays the info for the given provider' do
     url = 'http://localhost:3001/api/v1/2019/providers'
     next_url = url + '&' + {
         changed_since: provider2.created_at.utc.strftime('%FT%T.%16NZ'),
@@ -56,11 +54,11 @@ describe '"mcb apiv1 providers find"' do
 
     expect(output).to have_text_table_row('institution_code',
                                           provider2.provider_code)
-    expect(output).to have_text_table_row(
+    expect(output).to(have_text_table_row(
                         site2.code,
                         site2.location_name,
                         '%02d' % site2.region_code_before_type_cast
-                      )
+                      ))
     expect(output).to(have_text_table_row(
                         contact2.type,
                         contact2.name,

--- a/spec/lib/mcb/commands/apiv1/providers/find_spec.rb
+++ b/spec/lib/mcb/commands/apiv1/providers/find_spec.rb
@@ -1,0 +1,71 @@
+require 'mcb_helper'
+
+describe '"mcb apiv1 providers find"' do
+  let(:site1)     { build(:site) }
+  let(:site2)     { build(:site) }
+  let(:contact1)  { build(:contact, :utt_type) }
+  let(:contact2)  { build(:contact, :admin_type) }
+  let(:provider1) { create(:provider, sites: [site1], contacts: [contact1]) }
+  let(:provider2) { create(:provider, sites: [site2], contacts: [contact2]) }
+  let(:course1)   { create(:course, provider: provider1)}
+  let(:course2)   { create(:course, provider: provider2)}
+
+  it 'displays the info for the given course' do
+    url = 'http://localhost:3001/api/v1/2019/providers'
+    next_url = url + '&' + {
+        changed_since: provider2.created_at.utc.strftime('%FT%T.%16NZ'),
+        per_page: 100
+      }.to_query
+    json = ActiveModel::Serializer::CollectionSerializer.new(
+      [
+        provider1,
+        provider2
+      ],
+      serializer: ProviderSerializer
+    )
+
+    # For some reason provider1.sites.first.region_code_before_type_cast is
+    # site to "london" here, in memory. In the DB, however, this value is
+    # correct. This sounds likely related to how FactorBot does the build on an
+    # object, but a reload here seems to fix it.
+    provider1.sites.reload
+    provider2.sites.reload
+
+    stub_request(:get, url)
+      .with(headers: {
+              'Authorization' => 'Bearer bats'
+            })
+      .to_return(status: 200,
+                 body: json.to_json,
+                 headers: {
+                   link: next_url + '; rel="next"'
+                 })
+    stub_request(:get, next_url)
+      .to_return(status: 200,
+                 body: [].to_json,
+                 headers: {
+                   link: next_url + '; rel="next"'
+                 })
+
+    output = with_stubbed_stdout do
+      $mcb.run(%W[apiv1
+                  providers
+                  find
+                  #{provider2.provider_code}])
+    end
+
+    expect(output).to have_text_table_row('institution_code',
+                                          provider2.provider_code)
+    expect(output).to have_text_table_row(
+                        site2.code,
+                        site2.location_name,
+                        '%02d' % site2.region_code_before_type_cast
+                      )
+    expect(output).to(have_text_table_row(
+                        contact2.type,
+                        contact2.name,
+                        contact2.email,
+                        contact2.telephone
+                      ))
+  end
+end

--- a/spec/mcb_helper.rb
+++ b/spec/mcb_helper.rb
@@ -24,6 +24,7 @@ RSpec.configure do |config|
       # loaded.
       allow(MCB).to receive(:init_rails)
     end
+
     # "run_command" is used to run "az" and maybe more. Any test relying on
     # this must stub for it specifically.
     allow(MCB).to receive(:run_command)
@@ -32,6 +33,15 @@ RSpec.configure do |config|
   # Ensure that if the config file that is read is not the user's real data,
   # and if saved for any reason it does not over-write the user's.
   config.around(:each, mcb_cli: true) do |example|
+    # Re-initialize $mcb and everything else. If we don't, then certain cmdline
+    # options might persist between commands, e.g. when testing
+    # lib/mcb/commands/apiv1/courses/find_spec.rb' and
+    # lib/mcb/commands/apiv1/providers/find_spec.rb the 'endpoint' option used
+    # by the two commands being tested gets set by the first test to the
+    # default value defined in courses/find_spec.rb and then persists to the
+    # providers/find_spec.rb
+    load 'bin/mcb'
+
     @temp_config_file = Tempfile.new ['mcb_cli_config', '.yml']
     @temp_config_file.close
     MCB.config_file = @temp_config_file.path


### PR DESCRIPTION
### Context

The previous commit to add `mcb courses show` tweaked and broke rendering for `mcb apiv1 provider find`.

### Changes proposed in this pull request

Re-add campus table rendering.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
