### PR TITLE
1460 Remove course count from provider factory

### DIFF
--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -50,8 +50,6 @@ FactoryBot.define do
     transient do
       changed_at           { nil }
       skip_associated_data { false }
-      site_count           { 1 }
-      sites                { build_list :site, site_count, provider: nil }
       course_count         { 0 }
       enrichments          { [build(:provider_enrichment)] }
     end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -50,7 +50,6 @@ FactoryBot.define do
     transient do
       changed_at           { nil }
       skip_associated_data { false }
-      course_count         { 0 }
       enrichments          { [build(:provider_enrichment)] }
     end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -200,12 +200,11 @@ describe Provider, type: :model do
 
     context "when provider has the max sites allowed" do
       let(:all_site_codes) { ('A'..'Z').to_a + %w[0 -] + ('1'..'9').to_a }
-
-      subject { create(:provider) }
-
-      before do
-        all_site_codes.each { |code| subject.sites << build(:site, code: code) }
+      let(:sites) do
+        all_site_codes.map { |code| build(:site, code: code) }
       end
+
+      subject { create(:provider, sites: sites) }
 
       its(:can_add_more_sites?) { should be_falsey }
     end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -182,11 +182,11 @@ describe Provider, type: :model do
   end
 
   describe '#unassigned_site_codes' do
-    subject { create(:provider, site_count: 0) }
-
+    subject { create(:provider) }
     before do
       %w[A B C D 1 2 3 -].each { |code| subject.sites << build(:site, code: code) }
     end
+
     let(:expected_unassigned_codes) { ('E'..'Z').to_a + %w[0] + ('4'..'9').to_a }
 
     its(:unassigned_site_codes) { should eq(expected_unassigned_codes) }
@@ -194,12 +194,19 @@ describe Provider, type: :model do
 
   describe "#can_add_more_sites?" do
     context "when provider has less sites than max allowed" do
-      subject { create(:provider, site_count: 0) }
+      subject { create(:provider) }
       its(:can_add_more_sites?) { should be_truthy }
     end
 
     context "when provider has the max sites allowed" do
-      subject { create(:provider, site_count: Site::POSSIBLE_CODES.size) }
+      let(:all_site_codes) { ('A'..'Z').to_a + %w[0 -] + ('1'..'9').to_a }
+
+      subject { create(:provider) }
+
+      before do
+        all_site_codes.each { |code| subject.sites << build(:site, code: code) }
+      end
+
       its(:can_add_more_sites?) { should be_falsey }
     end
   end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -57,8 +57,9 @@ describe Provider, type: :model do
   end
 
   describe 'after running validation' do
-    let(:provider) { create(:provider) }
-    subject { build(:site, provider: provider) }
+    let(:site) { build(:site, provider: provider) }
+    let(:provider) { build(:provider) }
+    subject { site }
 
     it 'is assigned a valid code by default' do
       expect { subject.valid? }.to change { subject.code.blank? }.from(true).to(false)
@@ -67,7 +68,6 @@ describe Provider, type: :model do
 
     it 'is assigned easily-confused codes only when all others have been used up' do
       (Site::DESIRABLE_CODES - %w[A]).each { |code| create(:site, code: code, provider: provider) }
-      provider.reload
       subject.validate
       expect(subject.code).to eq('A')
     end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -57,7 +57,7 @@ describe Provider, type: :model do
   end
 
   describe 'after running validation' do
-    let(:provider) { create(:provider, site_count: 0) }
+    let(:provider) { create(:provider) }
     subject { build(:site, provider: provider) }
 
     it 'is assigned a valid code by default' do
@@ -67,6 +67,7 @@ describe Provider, type: :model do
 
     it 'is assigned easily-confused codes only when all others have been used up' do
       (Site::DESIRABLE_CODES - %w[A]).each { |code| create(:site, code: code, provider: provider) }
+      provider.reload
       subject.validate
       expect(subject.code).to eq('A')
     end

--- a/spec/policies/course_policy_spec.rb
+++ b/spec/policies/course_policy_spec.rb
@@ -16,7 +16,6 @@ describe CoursePolicy do
     let(:course) { create(:course) }
     let!(:provider) {
       create(:provider,
-             course_count: 0,
              courses: [course],
              organisations: [organisation])
     }

--- a/spec/policies/site_policy_spec.rb
+++ b/spec/policies/site_policy_spec.rb
@@ -16,7 +16,6 @@ describe SitePolicy do
     let(:site) { create(:site) }
     let!(:provider) {
       create(:provider,
-             course_count: 0,
              sites: [site],
              organisations: [organisation])
     }

--- a/spec/policies/site_policy_spec.rb
+++ b/spec/policies/site_policy_spec.rb
@@ -17,7 +17,6 @@ describe SitePolicy do
     let!(:provider) {
       create(:provider,
              course_count: 0,
-             site_count: 0,
              sites: [site],
              organisations: [organisation])
     }

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -21,7 +21,6 @@ describe "Courses API", type: :request do
                         provider_name: "ACME SCITT",
                         provider_code: "2LD",
                         provider_type: :scitt,
-                        site_count: 0,
                         scheme_member: 'Y',
                         enrichments: [])
     end

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -52,7 +52,6 @@ describe 'Providers API', type: :request do
                provider_name: 'ACME SCITT',
                provider_code: 'A123',
                provider_type: :scitt,
-               site_count: 0,
                address1: 'Shoreditch Park Primary School',
                address2: '313 Bridport Pl',
                address3: nil,
@@ -124,7 +123,6 @@ describe 'Providers API', type: :request do
                scheme_member: 'N',
                last_published_at: DateTime.now.utc,
                enrichments: [],
-               site_count: 0,
                ucas_preferences: ucas_preferences2,
                contacts: contacts2)
       end

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -11,11 +11,9 @@ describe 'Sites API v2', type: :request do
 
   let(:site1) { create :site, location_name: 'Main site 1', provider: provider }
   let(:site2) { create :site, location_name: 'Main site 2', provider: provider }
-  let!(:sites) { [site1, site2] }
   let!(:provider) {
     create(:provider,
            course_count: 0,
-           site_count: 0,
            organisations: [organisation])
   }
 
@@ -80,6 +78,7 @@ describe 'Sites API v2', type: :request do
     end
 
     describe 'JSON generated for sites' do
+      let!(:sites) { [site1, site2] }
       before do
         get "/api/v2/providers/#{provider.provider_code}/sites",
             headers: { 'HTTP_AUTHORIZATION' => credentials }
@@ -406,7 +405,7 @@ describe 'Sites API v2', type: :request do
       let(:postcode)      { 'SW1A 1AA' }
       let(:region_code)   { 'west_midlands' }
 
-      let(:site) { provider.sites.last }
+      let(:site) { provider.reload.sites.last }
 
       describe 'permitted parameters' do
         before do

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -13,7 +13,6 @@ describe 'Sites API v2', type: :request do
   let(:site2) { create :site, location_name: 'Main site 2', provider: provider }
   let!(:provider) {
     create(:provider,
-           course_count: 0,
            organisations: [organisation])
   }
 

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -16,7 +16,6 @@ describe 'Providers API v2', type: :request do
 
     let!(:provider) {
       create(:provider,
-             course_count: 0,
              organisations: [organisation],
              enrichments: [enrichment])
     }
@@ -144,7 +143,7 @@ describe 'Providers API v2', type: :request do
       ActionController::HttpAuthentication::Token.encode_credentials(token)
     end
     let(:site) { build(:site) }
-    let!(:provider) { create(:provider, course_count: 0, sites: [site], organisations: [organisation]) }
+    let!(:provider) { create(:provider, sites: [site], organisations: [organisation]) }
     let(:enrichment) { provider.enrichments.first }
 
     subject { response }
@@ -248,7 +247,7 @@ describe 'Providers API v2', type: :request do
 
     context "with the maximum number of sites" do
       let(:sites) { (('A'..'Z').to_a + %w[0 -] + ('1'..'9').to_a).map { |code| build(:site, code: code) } }
-      let(:provider) { create(:provider, course_count: 0, sites: sites, organisations: [organisation]) }
+      let(:provider) { create(:provider, sites: sites, organisations: [organisation]) }
 
 
       before do

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -17,7 +17,6 @@ describe 'Providers API v2', type: :request do
     let!(:provider) {
       create(:provider,
              course_count: 0,
-             site_count: 0,
              organisations: [organisation],
              enrichments: [enrichment])
     }
@@ -144,8 +143,8 @@ describe 'Providers API v2', type: :request do
     let(:credentials) do
       ActionController::HttpAuthentication::Token.encode_credentials(token)
     end
-
-    let!(:provider) { create(:provider, course_count: 0, site_count: 1, organisations: [organisation]) }
+    let(:site) { create(:site) }
+    let!(:provider) { create(:provider, course_count: 0, sites: [site], organisations: [organisation]) }
     let(:enrichment) { provider.enrichments.first }
 
     subject { response }
@@ -248,9 +247,13 @@ describe 'Providers API v2', type: :request do
     end
 
     context "with the maximum number of sites" do
-      let(:provider) { create(:provider, course_count: 0, site_count: Site::POSSIBLE_CODES.size, organisations: [organisation]) }
+      let(:all_site_codes) { ('A'..'Z').to_a + %w[0 -] + ('1'..'9').to_a }
+      let(:provider) { create(:provider, course_count: 0, organisations: [organisation]) }
+
 
       before do
+        all_site_codes.each { |code| provider.sites << create(:site, code: code) }
+
         get "/api/v2/providers/#{provider.provider_code}",
             headers: { 'HTTP_AUTHORIZATION' => credentials }
       end

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -143,7 +143,7 @@ describe 'Providers API v2', type: :request do
     let(:credentials) do
       ActionController::HttpAuthentication::Token.encode_credentials(token)
     end
-    let(:site) { create(:site) }
+    let(:site) { build(:site) }
     let!(:provider) { create(:provider, course_count: 0, sites: [site], organisations: [organisation]) }
     let(:enrichment) { provider.enrichments.first }
 
@@ -247,13 +247,11 @@ describe 'Providers API v2', type: :request do
     end
 
     context "with the maximum number of sites" do
-      let(:all_site_codes) { ('A'..'Z').to_a + %w[0 -] + ('1'..'9').to_a }
-      let(:provider) { create(:provider, course_count: 0, organisations: [organisation]) }
+      let(:sites) { (('A'..'Z').to_a + %w[0 -] + ('1'..'9').to_a).map { |code| build(:site, code: code) } }
+      let(:provider) { create(:provider, course_count: 0, sites: sites, organisations: [organisation]) }
 
 
       before do
-        all_site_codes.each { |code| provider.sites << create(:site, code: code) }
-
         get "/api/v2/providers/#{provider.provider_code}",
             headers: { 'HTTP_AUTHORIZATION' => credentials }
       end

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -72,7 +72,7 @@ describe ProviderSerializer do
     end
 
     context 'if nil' do
-      let(:ucas_preferences) { create :ucas_preferences, application_alert_email: nil }
+      let(:ucas_preferences) { build :ucas_preferences, application_alert_email: nil }
       let(:provider) { create :provider, ucas_preferences: ucas_preferences }
       let(:contacts) do
         serialize(provider)['contacts'].map { |contact| contact[:type] }

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -29,7 +29,7 @@
 require "rails_helper"
 
 describe ProviderSerializer do
-  let(:provider) { create :provider, site_count: 0 }
+  let(:provider) { create :provider }
 
   subject { serialize(provider) }
 
@@ -73,7 +73,7 @@ describe ProviderSerializer do
 
     context 'if nil' do
       let(:ucas_preferences) { create :ucas_preferences, application_alert_email: nil }
-      let(:provider) { create :provider, ucas_preferences: ucas_preferences, site_count: 0 }
+      let(:provider) { create :provider, ucas_preferences: ucas_preferences }
       let(:contacts) do
         serialize(provider)['contacts'].map { |contact| contact[:type] }
       end
@@ -101,7 +101,7 @@ describe ProviderSerializer do
   describe 'contacts' do
     describe 'generate provider object returns the providers contacts' do
       let(:contact)  { create :contact }
-      let(:provider) { create :provider, contacts: [contact], site_count: 0 }
+      let(:provider) { create :provider, contacts: [contact] }
 
       subject { serialize(provider)['contacts'].first }
 
@@ -121,7 +121,7 @@ describe ProviderSerializer do
 
       context 'exists in contacts table' do
         let(:contact)  { create :contact, type: 'admin' }
-        let(:provider) { create :provider, contacts: [contact], site_count: 0 }
+        let(:provider) { create :provider, contacts: [contact] }
 
         subject { serialize(provider)['contacts'].find { |c| c[:type] == 'admin' } }
 


### PR DESCRIPTION
### Context
 **This has been rebased onto the previous pr removing site_count do not merge until that PR has been approved and merged**
We've decided to remove dependencies from the factories where possible. This PR removes site_count from the provider factory.

### Changes proposed in this pull request
- Removes course_count from the provider factory.

### Checklist

- [ x] Make sure all information from the Trello card is in here
- [ x] Attach to Trello card
- [x ] Rebased master
- [ x] Cleaned commit history
- [ ] Tested by running locally
