### PR TITLE
[1460] Remove course_count from provider factory

### DIFF
--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -50,7 +50,6 @@ FactoryBot.define do
     transient do
       changed_at           { nil }
       skip_associated_data { false }
-      course_count         { 0 }
       enrichments          { [build(:provider_enrichment)] }
     end
 

--- a/spec/policies/course_policy_spec.rb
+++ b/spec/policies/course_policy_spec.rb
@@ -16,7 +16,6 @@ describe CoursePolicy do
     let(:course) { create(:course) }
     let!(:provider) {
       create(:provider,
-             course_count: 0,
              courses: [course],
              organisations: [organisation])
     }

--- a/spec/policies/site_policy_spec.rb
+++ b/spec/policies/site_policy_spec.rb
@@ -16,7 +16,6 @@ describe SitePolicy do
     let(:site) { create(:site) }
     let!(:provider) {
       create(:provider,
-             course_count: 0,
              sites: [site],
              organisations: [organisation])
     }

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -13,7 +13,6 @@ describe 'Sites API v2', type: :request do
   let(:site2) { create :site, location_name: 'Main site 2', provider: provider }
   let!(:provider) {
     create(:provider,
-           course_count: 0,
            organisations: [organisation])
   }
 

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -16,7 +16,6 @@ describe 'Providers API v2', type: :request do
 
     let!(:provider) {
       create(:provider,
-             course_count: 0,
              organisations: [organisation],
              enrichments: [enrichment])
     }
@@ -144,7 +143,7 @@ describe 'Providers API v2', type: :request do
       ActionController::HttpAuthentication::Token.encode_credentials(token)
     end
     let(:site) { build(:site) }
-    let!(:provider) { create(:provider, course_count: 0, sites: [site], organisations: [organisation]) }
+    let!(:provider) { create(:provider, sites: [site], organisations: [organisation]) }
     let(:enrichment) { provider.enrichments.first }
 
     subject { response }
@@ -248,7 +247,7 @@ describe 'Providers API v2', type: :request do
 
     context "with the maximum number of sites" do
       let(:sites) { (('A'..'Z').to_a + %w[0 -] + ('1'..'9').to_a).map { |code| build(:site, code: code) } }
-      let(:provider) { create(:provider, course_count: 0, sites: sites, organisations: [organisation]) }
+      let(:provider) { create(:provider, sites: sites, organisations: [organisation]) }
 
 
       before do


### PR DESCRIPTION
### Context

**This has been rebased onto the previous pr removing site_count do not merge until that PR has been approved and merged**
We've decided to remove dependencies from the factories where possible. This PR removes site_count from the provider factory.

### Changes proposed in this pull request
- Removes course_count from the provider factory.

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
