### PR TITLE
Allow exiting requirements selection

### DIFF
--- a/lib/mcb/courses_editor.rb
+++ b/lib/mcb/courses_editor.rb
@@ -47,7 +47,7 @@ module MCB
       database_attribute = LOGICAL_NAME_TO_DATABASE_NAME_MAPPING[logical_attribute]
       print_existing(database_attribute)
       user_response_from_cli = @cli.send("ask_#{logical_attribute}".to_sym)
-      if user_response_from_cli != "exit"
+      unless user_response_from_cli.nil?
         update(database_attribute => user_response_from_cli)
       end
     end

--- a/lib/mcb/courses_editor.rb
+++ b/lib/mcb/courses_editor.rb
@@ -47,7 +47,9 @@ module MCB
       database_attribute = LOGICAL_NAME_TO_DATABASE_NAME_MAPPING[logical_attribute]
       print_existing(database_attribute)
       user_response_from_cli = @cli.send("ask_#{logical_attribute}".to_sym)
-      update(database_attribute => user_response_from_cli)
+      if user_response_from_cli != "exit"
+        update(database_attribute => user_response_from_cli)
+      end
     end
 
     def check_authorisation

--- a/lib/mcb/courses_editor_cli.rb
+++ b/lib/mcb/courses_editor_cli.rb
@@ -37,7 +37,7 @@ module MCB
     def ask_gcse_subject(subject)
       @cli.choose do |menu|
         menu.prompt = "What's the #{subject} entry requirements?  "
-        menu.choice("exit")
+        menu.choice("exit") { nil }
         menu.choices(*Course::ENTRY_REQUIREMENT_OPTIONS.keys)
       end
     end
@@ -45,7 +45,7 @@ module MCB
     def ask_route
       @cli.choose do |menu|
         menu.prompt = "What's the route?  "
-        menu.choice("exit")
+        menu.choice("exit") { nil }
         menu.choices(*Course.program_types.keys)
       end
     end

--- a/lib/mcb/courses_editor_cli.rb
+++ b/lib/mcb/courses_editor_cli.rb
@@ -37,6 +37,7 @@ module MCB
     def ask_gcse_subject(subject)
       @cli.choose do |menu|
         menu.prompt = "What's the #{subject} entry requirements?  "
+        menu.choice("exit")
         menu.choices(*Course::ENTRY_REQUIREMENT_OPTIONS.keys)
       end
     end
@@ -44,6 +45,7 @@ module MCB
     def ask_route
       @cli.choose do |menu|
         menu.prompt = "What's the route?  "
+        menu.choice("exit")
         menu.choices(*Course.program_types.keys)
       end
     end

--- a/spec/lib/mcb/courses_editor_spec.rb
+++ b/spec/lib/mcb/courses_editor_spec.rb
@@ -41,24 +41,52 @@ describe MCB::CoursesEditor do
           from("Original name").to("Mathematics")
       end
 
-      it 'updates the maths setting when that is valid' do
-        expect { run_editor("edit maths", "equivalence_test", "exit") }.to change { course.reload.maths }.
-          from("must_have_qualification_at_application_time").to("equivalence_test")
+      describe "(maths)" do
+        it 'updates the maths setting when that is valid' do
+          expect { run_editor("edit maths", "equivalence_test", "exit") }.to change { course.reload.maths }.
+            from("must_have_qualification_at_application_time").to("equivalence_test")
+        end
+
+        it "doesn't change the setting if the user exits" do
+          expect { run_editor("edit maths", "exit", "exit") }.to_not change { course.reload.maths }.
+            from("must_have_qualification_at_application_time")
+        end
       end
 
-      it 'updates the english setting when that is valid' do
-        expect { run_editor("edit english", "must_have_qualification_at_application_time", "exit") }.to change { course.reload.english }.
-          from("equivalence_test").to("must_have_qualification_at_application_time")
+      describe "(english)" do
+        it 'updates the english setting when that is valid' do
+          expect { run_editor("edit english", "must_have_qualification_at_application_time", "exit") }.to change { course.reload.english }.
+            from("equivalence_test").to("must_have_qualification_at_application_time")
+        end
+
+        it "doesn't change the setting if the user exits" do
+          expect { run_editor("edit english", "exit", "exit") }.to_not change { course.reload.english }.
+            from("equivalence_test")
+        end
       end
 
-      it 'updates the science setting when that is valid' do
-        expect { run_editor("edit science", "equivalence_test", "exit") }.to change { course.reload.science }.
-          from("not_required").to("equivalence_test")
+      describe "(science)" do
+        it 'updates the science setting when that is valid' do
+          expect { run_editor("edit science", "equivalence_test", "exit") }.to change { course.reload.science }.
+            from("not_required").to("equivalence_test")
+        end
+
+        it "doesn't change the setting if the user exits" do
+          expect { run_editor("edit science", "exit", "exit") }.to_not change { course.reload.science }.
+            from("not_required")
+        end
       end
 
-      it 'updates the route/program type setting when that is valid' do
-        expect { run_editor("edit route", "scitt_programme", "exit") }.to change { course.reload.program_type }.
-          from("higher_education_programme").to("scitt_programme")
+      describe "(route)" do
+        it 'updates the route/program type setting when that is valid' do
+          expect { run_editor("edit route", "scitt_programme", "exit") }.to change { course.reload.program_type }.
+            from("higher_education_programme").to("scitt_programme")
+        end
+
+        it "doesn't change the setting if the user exits" do
+          expect { run_editor("edit route", "exit", "exit") }.to_not change { course.reload.program_type }.
+            from("higher_education_programme")
+        end
       end
 
       describe "(qualifications)" do


### PR DESCRIPTION
### Context

Accidentally set a requirement because 1 is usually exit.
Not spending too long on this.


### Changes proposed in this pull request

Make exit an option

### Guidance to review

Suggestions for why exit isn't a symbol would be nice, also how to apply it to the other editing bits of course (route etc) as they don't follow the same pattern.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
