### PR TITLE
[1460] Removed subjects from course factory

### DIFF
--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -35,8 +35,6 @@ FactoryBot.define do
     resulting_in_pgce_with_qts
 
     transient do
-      subject_count      { 1 }
-      subjects           { build_list(:subject, subject_count) }
       with_site_statuses { [] }
       with_enrichments   { [] }
       age                { nil }
@@ -52,10 +50,6 @@ FactoryBot.define do
     end
 
     after(:create) do |course, evaluator|
-      course.subjects << evaluator.subjects.map { |subject|
-        subject.is_a?(Subject) ? subject : create(*subject)
-      }
-
       evaluator.with_site_statuses.each do |traits|
         attrs = { course: course }
         if traits == [:default]

--- a/spec/lib/mcb/commands/apiv1/courses/find_spec.rb
+++ b/spec/lib/mcb/commands/apiv1/courses/find_spec.rb
@@ -2,13 +2,13 @@ require 'mcb_helper'
 
 describe '"mcb apiv1 courses find"' do
   it 'displays the info for the given course' do
-    # The site_status factory is an easy way to create a course and it's site
-    site_status1 = create(:site_status)
-    course1 = site_status1.course
+    course1 = create(:course)
 
-    site_status2 = create(:site_status)
-    course2 = site_status2.course
-    subject2 = course2.subjects.first
+    subject2 = build(:subject)
+    site_status2 = build(:site_status)
+
+    course2 = create(:course, subjects: [subject2], site_statuses: [site_status2])
+
 
     url = 'http://localhost:3001/api/v1/2019/courses'
     next_url = url + '&' + {

--- a/spec/lib/mcb/commands/apiv1/courses/find_spec.rb
+++ b/spec/lib/mcb/commands/apiv1/courses/find_spec.rb
@@ -4,10 +4,10 @@ describe '"mcb apiv1 courses find"' do
   it 'displays the info for the given course' do
     course1 = create(:course)
 
-    subject2 = build(:subject)
-    site_status2 = build(:site_status)
+    subject = build(:subject)
+    site_status = build(:site_status)
 
-    course2 = create(:course, subjects: [subject2], site_statuses: [site_status2])
+    course2 = create(:course, subjects: [subject], site_statuses: [site_status])
 
 
     url = 'http://localhost:3001/api/v1/2019/courses'
@@ -49,15 +49,15 @@ describe '"mcb apiv1 courses find"' do
 
     expect(output).to have_text_table_row('course_code',
                                           course2.course_code)
-    expect(output).to have_text_table_row(subject2.subject_code,
-                                          subject2.subject_name)
+    expect(output).to have_text_table_row(subject.subject_code,
+                                          subject.subject_name)
     expect(output).to(have_text_table_row(
-                        site_status2.site.code,
-                        site_status2.site.location_name,
-                        site_status2.vac_status_before_type_cast,
-                        site_status2.status_before_type_cast,
-                        site_status2.publish_before_type_cast,
-                        site_status2.applications_accepted_from.strftime('%Y-%m-%d')
+                        site_status.site.code,
+                        site_status.site.location_name,
+                        site_status.vac_status_before_type_cast,
+                        site_status.status_before_type_cast,
+                        site_status.publish_before_type_cast,
+                        site_status.applications_accepted_from.strftime('%Y-%m-%d')
                       ))
   end
 end

--- a/spec/lib/mcb/commands/courses/show_spec.rb
+++ b/spec/lib/mcb/commands/courses/show_spec.rb
@@ -9,11 +9,10 @@ describe '"mcb courses show"' do
   end
 
   it 'displays the course info' do
-    _site_status1 = create(:site_status)
+    subject2 = build(:subject)
+    site_status2 = build(:site_status)
 
-    site_status2 = create(:site_status)
-    course2      = site_status2.course
-    subjects2    = course2.subjects
+    course2 = create(:course, subjects: [subject2], site_statuses: [site_status2])
 
     output = with_stubbed_stdout do
       cmd.run([course2.provider.provider_code, course2.course_code])
@@ -22,8 +21,8 @@ describe '"mcb courses show"' do
     expect(output).to have_text_table_row('course_code',
                                           course2.course_code)
 
-    expect(output).to have_text_table_row(subjects2.first.subject_code,
-                                          subjects2.first.subject_name)
+    expect(output).to have_text_table_row(subject2.subject_code,
+                                          subject2.subject_name)
 
     expect(output).to(
       have_text_table_row(

--- a/spec/lib/mcb/commands/courses/show_spec.rb
+++ b/spec/lib/mcb/commands/courses/show_spec.rb
@@ -9,30 +9,30 @@ describe '"mcb courses show"' do
   end
 
   it 'displays the course info' do
-    subject2 = build(:subject)
-    site_status2 = build(:site_status)
+    subject = build(:subject)
+    site_status = build(:site_status)
 
-    course2 = create(:course, subjects: [subject2], site_statuses: [site_status2])
+    course = create(:course, subjects: [subject], site_statuses: [site_status])
 
     output = with_stubbed_stdout do
-      cmd.run([course2.provider.provider_code, course2.course_code])
+      cmd.run([course.provider.provider_code, course.course_code])
     end
 
     expect(output).to have_text_table_row('course_code',
-                                          course2.course_code)
+                                          course.course_code)
 
-    expect(output).to have_text_table_row(subject2.subject_code,
-                                          subject2.subject_name)
+    expect(output).to have_text_table_row(subject.subject_code,
+                                          subject.subject_name)
 
     expect(output).to(
       have_text_table_row(
-        site_status2.id,
-        site_status2.site.code,
-        site_status2.site.location_name,
-        site_status2.vac_status,
-        site_status2.status,
-        site_status2.publish,
-        site_status2.applications_accepted_from.strftime('%Y-%m-%d')
+        site_status.id,
+        site_status.site.code,
+        site_status.site.location_name,
+        site_status.vac_status,
+        site_status.status,
+        site_status.publish,
+        site_status.applications_accepted_from.strftime('%Y-%m-%d')
       )
     )
   end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -394,35 +394,35 @@ RSpec.describe Course, type: :model do
 
   context "subjects & level" do
     context 'with no subjects' do
-      subject { create(:course, subject_count: 0) }
+      subject { create(:course) }
       its(:level) { should eq(:secondary) }
       its(:dfe_subjects) { should be_empty }
     end
 
     context 'with primary subjects' do
-      subject { create(:course, subject_count: 0, subjects: [create(:subject, subject_name: "primary")]) }
+      subject { create(:course, subjects: [create(:subject, subject_name: "primary")]) }
       its(:level) { should eq(:primary) }
       its(:dfe_subjects) { should eq([DFESubject.new("Primary")]) }
     end
 
     context 'with secondary subjects' do
-      subject { create(:course, subject_count: 0, subjects: [create(:subject, subject_name: "physical education")]) }
+      subject { create(:course, subjects: [create(:subject, subject_name: "physical education")]) }
       its(:level) { should eq(:secondary) }
       its(:dfe_subjects) { should eq([DFESubject.new("Physical education")]) }
     end
 
     context 'with further education subjects' do
-      subject { create(:course, subject_count: 0, subjects: [create(:further_education_subject)]) }
+      subject { create(:course, subjects: [create(:further_education_subject)]) }
       its(:level) { should eq(:further_education) }
       its(:dfe_subjects) { should eq([DFESubject.new("Further education")]) }
     end
 
     describe "#is_send?" do
-      subject { create(:course, subject_count: 0) }
+      subject { create(:course) }
       its(:is_send?) { should be_falsey }
 
       context "with a SEND subject" do
-        subject { create(:course, subject_count: 0, subjects: [create(:send_subject)]) }
+        subject { create(:course, subjects: [create(:send_subject)]) }
         its(:is_send?) { should be_truthy }
       end
     end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -19,7 +19,6 @@ describe 'Courses API v2', type: :request do
            provider: provider,
            start_date: Time.now.utc,
            study_mode: :full_time,
-           subject_count: 0,
            subjects: [course_subject_primary, course_subject_mathematics, course_subject_send],
            with_site_statuses: [%i[findable with_any_vacancy applications_being_accepted_from_2019]],
            enrichments: [enrichment],

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -127,17 +127,17 @@ describe API::V2::SerializableCourse do
   end
 
   describe "#is_send?" do
-    let(:course) { create(:course, subject_count: 0) }
+    let(:course) { create(:course) }
     it { expect(subject["attributes"]).to include("is_send?" => false) }
 
     context "with a SEND subject" do
-      let(:course) { create(:course, subject_count: 0, subjects: [create(:send_subject)]) }
+      let(:course) { create(:course, subjects: [create(:send_subject)]) }
       it { expect(subject["attributes"]).to include("is_send?" => true) }
     end
   end
 
   context "subjects & level" do
-    let(:course) { create(:course, subject_count: 0, subjects: subjects) }
+    let(:course) { create(:course, subjects: subjects) }
 
     describe 'are taken from the course' do
       let(:subjects) { [create(:subject, subject_name: "primary")] }

--- a/spec/serializers/search_and_compare/course_serializer_spec.rb
+++ b/spec/serializers/search_and_compare/course_serializer_spec.rb
@@ -26,7 +26,6 @@ describe SearchAndCompare::CourseSerializer do
                name: 'Primary (Special Educational Needs)',
                course_code: '2KXB',
                start_date: '2019-08-01T00:00:00',
-               subject_count: 0,
                program_type: :school_direct_salaried_training_programme,
                qualification: :pgce_with_qts,
                study_mode:  :full_time,


### PR DESCRIPTION
### Context

Subject creation in course factory

### Changes proposed in this pull request
Removed unneeded chaos of having subject_count and its related usage in course factory 

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
