### PR TITLE
[1571] Remove rspec-json_matchers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,7 +112,6 @@ group :development, :test do
   gem 'rspec-its'
 
   # Test framework
-  gem 'rspec-json_matchers'
   gem 'rspec-rails'
 
   # A Ruby static code analyzer and formatter

--- a/spec/serializers/api/v2/serializable_provider_spec.rb
+++ b/spec/serializers/api/v2/serializable_provider_spec.rb
@@ -8,13 +8,13 @@ describe API::V2::SerializableProvider do
     expect(resource.jsonapi_type).to eq :providers
   end
 
-  subject { resource.as_jsonapi.to_json }
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
 
-  it { should be_json.with_content(type: 'providers') }
+  it { should have_type 'providers' }
   it {
-    should be_json.with_content(attributes: { provider_code: provider.provider_code,
-                                              provider_name: provider.provider_name,
-                                              accredited_body?: true,
-                                              can_add_more_sites?: true })
+    should have_attribute(:provider_code).with_value(provider.provider_code)
+    should have_attribute(:provider_name).with_value(provider.provider_name)
+    should have_attribute(:accredited_body?).with_value(true)
+    should have_attribute(:can_add_more_sites?).with_value(true)
   }
 end

--- a/spec/serializers/api/v2/serializable_site_spec.rb
+++ b/spec/serializers/api/v2/serializable_site_spec.rb
@@ -8,16 +8,16 @@ describe API::V2::SerializableSite do
     expect(resource.jsonapi_type).to eq :sites
   end
 
-  subject { resource.as_jsonapi.to_json }
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
 
-  it { should be_json.with_content(type: 'sites') }
+  it { should have_type 'sites' }
   it {
-    should be_json.with_content(attributes: { location_name: site.location_name,
-                                              address1: site.address1,
-                                              address2: site.address2,
-                                              address3: site.address3,
-                                              address4: site.address4,
-                                              postcode: site.postcode,
-                                              region_code: site.region_code })
+    should have_attribute(:location_name).with_value(site.location_name)
+    should have_attribute(:address1).with_value(site.address1)
+    should have_attribute(:address2).with_value(site.address2)
+    should have_attribute(:address3).with_value(site.address3)
+    should have_attribute(:address4).with_value(site.address4)
+    should have_attribute(:postcode).with_value(site.postcode)
+    should have_attribute(:region_code).with_value(site.region_code)
   }
 end

--- a/spec/serializers/api/v2/serializable_site_status_spec.rb
+++ b/spec/serializers/api/v2/serializable_site_status_spec.rb
@@ -8,7 +8,7 @@ describe API::V2::SerializableSiteStatus do
     expect(resource.jsonapi_type).to eq :site_statuses
   end
 
-  subject { resource.as_jsonapi.to_json }
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
 
-  it { should be_json.with_content(type: 'site_statuses') }
+  it { should have_type 'site_statuses' }
 end

--- a/spec/serializers/api/v2/serializable_user_spec.rb
+++ b/spec/serializers/api/v2/serializable_user_spec.rb
@@ -8,8 +8,8 @@ describe API::V2::SerializableUser do
     expect(resource.jsonapi_type).to eq :users
   end
 
-  subject { resource.as_jsonapi.to_json }
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
 
-  it { should be_json.with_content(type: 'users') }
-  it { should be_json.with_content(attributes: { state: user.state }) }
+  it { should have_type 'users' }
+  it { should have_attribute(:state).with_value(user.state.to_s) }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'rspec-json_matchers'
 require 'pundit/rspec'
 require 'jsonapi/rspec'
 require "super_diff/rspec"
@@ -64,8 +63,6 @@ RSpec.configure do |config|
 
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
-
-  config.include RSpec::JsonMatchers::Matchers
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.


### PR DESCRIPTION
### Context

It's not necessary for checking types and attributes on jsonapi hashes. `jsonapi-rspec` has better matchers which we already bundle.

### Changes proposed in this pull request

Replace calls to the library matchers and remove the library.

### Guidance to review

SHIP IT

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally