### PR TITLE
[1681] Fix course enrichment qualifications attribute

### DIFF
--- a/app/deserializers/api/v2/deserializable_course.rb
+++ b/app/deserializers/api/v2/deserializable_course.rb
@@ -11,7 +11,6 @@ module API
                  :interview_process,
                  :other_requirements,
                  :personal_qualities,
-                 :qualifications,
                  :salary_details,
                  :course_code,
                  :name,
@@ -20,7 +19,11 @@ module API
       has_many :sites
 
       attribute :required_qualifications do |value|
-        { qualifications: value }
+        if value
+          { qualifications: value }
+        else
+          {}
+        end
       end
     end
   end

--- a/spec/desieralizers/api/v2/deserializable_course_spec.rb
+++ b/spec/desieralizers/api/v2/deserializable_course_spec.rb
@@ -1,0 +1,25 @@
+describe API::V2::DeserializableCourse do
+  let(:course) { build(:course) }
+  let(:course_jsonapi) do
+    JSON.parse(jsonapi_renderer.render(
+      course,
+      class: {
+        Course: API::V2::SerializableCourse
+      }
+    ).to_json)['data']
+  end
+  let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+
+  subject { described_class.new(course_jsonapi).to_h }
+
+  describe 'required_qualifications' do
+    before do
+      course_jsonapi['attributes'].delete('qualifications')
+      course_jsonapi['attributes']['required_qualifications'] = 'test'
+    end
+
+    it 'maps to qualifications' do
+      expect(subject[:qualifications]).to eq('test')
+    end
+  end
+end


### PR DESCRIPTION
### Context
`qualifications` vs `required_qualifications`

### Changes proposed in this pull request
😑 

### Guidance to review
n/a

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally