### PR TITLE
[1619] mcb console with environmental config

### DIFF
--- a/config/initializers/mcb_audit.rb
+++ b/config/initializers/mcb_audit.rb
@@ -1,0 +1,10 @@
+if ENV['MCB_SETUP_AUDIT_USER'].present?
+  require 'mcb'
+  require 'mcb/config'
+
+  def verbose(msg)
+    Rails.logger.info msg
+  end
+
+  MCB.configure_audited_user if MCB.connecting_to_remote_db?
+end

--- a/lib/mcb/commands/console.rb
+++ b/lib/mcb/commands/console.rb
@@ -1,0 +1,8 @@
+name 'console'
+summary 'Launch a rails console (useful for remote environments)'
+
+instance_eval(&MCB.remote_connect_options)
+
+run do |opts, _args, _cmd|
+  MCB.rails_console(opts)
+end


### PR DESCRIPTION
### Context

Part of supporting the live product involves making data changes on production. In order to allow making safe, audited changes we need to be able to connect the Rails console to production environments.

### Changes proposed in this pull request

Add an `mcb` command for launching the Rails console:

```ruby
$ bundle exec mcb console -E qa -v
As a safety measure, please enter the expected RAILS_ENV for bat-qa-mcbe-as: qa
Loading qa environment (Rails 5.2.3)
irb(main):001:0>
```

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
