### PR TITLE
[1571] Split course_enrichment validations

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -60,7 +60,7 @@ module API
         update_enrichment
         update_sites
 
-        if @course.errors.empty? && @course.publishable?
+        if @course.errors.empty? && @course.saveable?
           render jsonapi: @course.reload
         else
           render jsonapi_errors: @course.errors, status: :unprocessable_entity

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -60,7 +60,7 @@ module API
         update_enrichment
         update_sites
 
-        if @course.errors.empty? && @course.valid?
+        if @course.errors.empty? && @course.publishable?
           render jsonapi: @course.reload
         else
           render jsonapi_errors: @course.errors, status: :unprocessable_entity

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -118,18 +118,18 @@ class Course < ApplicationRecord
 
   def validate_enrichment
     latest_enrichment = enrichments.latest_first.first
-    if latest_enrichment.present?
-      latest_enrichment.valid? :publish
-      latest_enrichment.errors.messages.each do |field, _error|
-        # Compute a key of `latest_enrichment__FIELD` to allow the frontend to determine
-        # which field should be linked to from the error title.
-        key = "latest_enrichment__#{field}".to_sym
-        # `full_messages_for` here will remove any `^`s defined in the validator or en.yml.
-        # We still need it for later, so re-add it.
-        # jsonapi_errors will throw if it's given an array, so we call `.first`.
-        message = "^" + latest_enrichment.errors.full_messages_for(field).first.to_s
-        errors.add key, message
-      end
+    return unless latest_enrichment.present?
+
+    latest_enrichment.valid? :publish
+    latest_enrichment.errors.messages.each do |field, _error|
+      # Compute a key of `latest_enrichment__FIELD` to allow the frontend to determine
+      # which field should be linked to from the error title.
+      key = "latest_enrichment__#{field}".to_sym
+      # `full_messages_for` here will remove any `^`s defined in the validator or en.yml.
+      # We still need it for later, so re-add it.
+      # jsonapi_errors will throw if it's given an array, so we call `.first`.
+      message = "^" + latest_enrichment.errors.full_messages_for(field).first.to_s
+      errors.add key, message
     end
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -92,6 +92,7 @@ class Course < ApplicationRecord
 
   validates :enrichments, presence: true, on: :publish
   validate :validate_enrichment_publishable, on: :publish
+  validate :validate_enrichment_saveable, on: :save
 
   def accrediting_provider_description
     return nil if accrediting_provider.blank?
@@ -116,6 +117,10 @@ class Course < ApplicationRecord
     valid? :publish
   end
 
+  def saveable?
+    valid? :save
+  end
+
   def add_enrichment_errors(enrichment)
     enrichment.errors.messages.map do |field, _error|
       # Compute a key of `latest_enrichment__FIELD` to allow the frontend to determine
@@ -134,6 +139,14 @@ class Course < ApplicationRecord
     return unless latest_enrichment.present?
 
     latest_enrichment.valid? :publish
+    add_enrichment_errors(latest_enrichment)
+  end
+
+  def validate_enrichment_saveable
+    latest_enrichment = enrichments.latest_first.first
+    return unless latest_enrichment.present?
+
+    latest_enrichment.valid? :save
     add_enrichment_errors(latest_enrichment)
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -91,7 +91,7 @@ class Course < ApplicationRecord
   end
 
   validates :enrichments, presence: true, on: :publish
-  validate :validate_enrichment, on: :publish
+  validate :validate_enrichment_publishable, on: :publish
 
   def accrediting_provider_description
     return nil if accrediting_provider.blank?
@@ -116,21 +116,25 @@ class Course < ApplicationRecord
     valid? :publish
   end
 
-  def validate_enrichment
-    latest_enrichment = enrichments.latest_first.first
-    return unless latest_enrichment.present?
-
-    latest_enrichment.valid? :publish
-    latest_enrichment.errors.messages.each do |field, _error|
+  def add_enrichment_errors(enrichment)
+    enrichment.errors.messages.map do |field, _error|
       # Compute a key of `latest_enrichment__FIELD` to allow the frontend to determine
       # which field should be linked to from the error title.
       key = "latest_enrichment__#{field}".to_sym
       # `full_messages_for` here will remove any `^`s defined in the validator or en.yml.
       # We still need it for later, so re-add it.
       # jsonapi_errors will throw if it's given an array, so we call `.first`.
-      message = "^" + latest_enrichment.errors.full_messages_for(field).first.to_s
+      message = "^" + enrichment.errors.full_messages_for(field).first.to_s
       errors.add key, message
     end
+  end
+
+  def validate_enrichment_publishable
+    latest_enrichment = enrichments.latest_first.first
+    return unless latest_enrichment.present?
+
+    latest_enrichment.valid? :publish
+    add_enrichment_errors(latest_enrichment)
   end
 
   def recruitment_cycle

--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -42,20 +42,22 @@ class CourseEnrichment < ApplicationRecord
 
   scope :latest_first, -> { order(created_at: :desc) }
 
-  # mandatory validation for any course to be published
-  validates :about_course, presence: true, words_count: { maximum: 400 }, on: :publish
-  validates :interview_process, words_count: { maximum: 250 }, on: :publish
-  validates :how_school_placements_work, presence: true, words_count: { maximum: 350 }, on: :publish
+  validates :about_course, presence: true, on: :publish
+  validates :how_school_placements_work, presence: true, on: :publish
   validates :course_length, presence: true, on: :publish
-  validates :qualifications, presence: true, words_count: { maximum: 100 }, on: :publish
+  validates :qualifications, presence: true, on: :publish
 
-  # mandatory validation for fee based course to be published
+  validates :about_course, words_count: { maximum: 400 }, on: %i[save publish]
+  validates :interview_process, words_count: { maximum: 250 }, on: %i[save publish]
+  validates :how_school_placements_work, words_count: { maximum: 350 }, on: %i[save publish]
+  validates :qualifications, words_count: { maximum: 100 }, on: %i[save publish]
+
   validates :fee_uk_eu, presence: true, on: :publish, if: :is_fee_based?
-  validates :fee_details, words_count: { maximum: 250 }, on: :publish, if: :is_fee_based?
-  validates :financial_support, words_count: { maximum: 250 }, on: :publish, if: :is_fee_based?
+  validates :fee_details, words_count: { maximum: 250 }, on: %i[save publish], if: :is_fee_based?
+  validates :financial_support, words_count: { maximum: 250 }, on: %i[save publish], if: :is_fee_based?
 
-  # mandatory validation for salary based course to be published
-  validates :salary_details, presence: true, words_count: { maximum: 250 }, on: :publish, unless: :is_fee_based?
+  validates :salary_details, presence: true, on: :publish, unless: :is_fee_based?
+  validates :salary_details, words_count: { maximum: 250 }, on: %i[save publish], unless: :is_fee_based?
 
   def is_fee_based?
     course.is_fee_based?

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -25,7 +25,8 @@
 require 'rails_helper'
 
 RSpec.describe Course, type: :model do
-  let(:subject) { create(:course) }
+  let(:course) { create(:course) }
+  let(:subject) { course }
 
   describe 'auditing' do
     it { should be_audited.except(:changed_at) }
@@ -42,6 +43,32 @@ RSpec.describe Course, type: :model do
 
   describe 'validations' do
     it { should validate_uniqueness_of(:course_code).scoped_to(:provider_id) }
+
+    describe 'saveable?' do
+      let(:course) { create(:course, enrichments: [invalid_enrichment]) }
+      let(:invalid_enrichment) { create(:course_enrichment, about_course: Faker::Lorem.sentence(1000)) }
+
+      before do
+        subject.saveable?
+      end
+
+      it 'should add enrichment errors' do
+        expect(subject.errors.full_messages).to_not be_empty
+      end
+    end
+
+    describe 'publishable?' do
+      let(:course) { create(:course, enrichments: [invalid_enrichment]) }
+      let(:invalid_enrichment) { create(:course_enrichment, about_course: '') }
+
+      before do
+        subject.publishable?
+      end
+
+      it 'should add enrichment errors' do
+        expect(subject.errors.full_messages).to_not be_empty
+      end
+    end
   end
 
   describe 'changed_at' do

--- a/spec/requests/api/v2/providers/courses/update_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_spec.rb
@@ -250,6 +250,30 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
         expect("#{prefix}financial_support".in?(subject)).to eq(true)
       end
     end
+
+    context "with nil data" do
+      let(:update_attributes) do
+        {
+          about_course: "",
+          fee_details: "",
+          fee_international: "",
+          fee_uk_eu: "",
+          financial_support: "",
+          how_school_placements_work: "",
+          interview_process: "",
+          other_requirements: "",
+          personal_qualities: "",
+          qualifications: "",
+          salary_details: ""
+        }
+      end
+
+      it "returns ok" do
+        perform_request update_course
+
+        expect(response).to be_ok
+      end
+    end
   end
 
   context 'course has only a published enrichment' do

--- a/spec/requests/api/v2/providers/courses/update_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_spec.rb
@@ -218,6 +218,38 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
       expect(draft_enrichment.attributes.slice(*update_attributes.keys.map(&:to_s)))
         .to include(update_attributes.stringify_keys)
     end
+
+    context "with invalid data" do
+      let(:update_attributes) do
+        {
+          about_course: Faker::Lorem.sentence(1000),
+          fee_details: Faker::Lorem.sentence(1000),
+          fee_international: 200_000,
+          fee_uk_eu: 200_000,
+          financial_support: Faker::Lorem.sentence(1000),
+          how_school_placements_work: Faker::Lorem.sentence(1000),
+          interview_process: Faker::Lorem.sentence(1000),
+          other_requirements: Faker::Lorem.sentence(1000),
+          personal_qualities: Faker::Lorem.sentence(1000),
+          qualifications: Faker::Lorem.sentence(1000),
+          salary_details: Faker::Lorem.sentence(1000)
+        }
+      end
+
+      subject { JSON.parse(response.body)["errors"].map { |e| e["title"] } }
+
+      it "returns validation errors" do
+        perform_request update_course
+
+        prefix = "Invalid latest_enrichment__"
+        expect("#{prefix}about_course".in?(subject)).to eq(true)
+        expect("#{prefix}interview_process".in?(subject)).to eq(true)
+        expect("#{prefix}how_school_placements_work".in?(subject)).to eq(true)
+        expect("#{prefix}qualifications".in?(subject)).to eq(true)
+        expect("#{prefix}fee_details".in?(subject)).to eq(true)
+        expect("#{prefix}financial_support".in?(subject)).to eq(true)
+      end
+    end
   end
 
   context 'course has only a published enrichment' do


### PR DESCRIPTION
### Context

We need to add validations for saving enrichments and for publishing them.

First PR of a few.

### Changes proposed in this pull request

Splits up the `course_enrichment` validations into two scopes: `:publish` which is same as before, and `:save` which skips the presence validations.

Also some miscellaneous refactors.

### Guidance to review

Best reviewed commit by commit.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally