### PR TITLE
1460 Remove with site status from course factory

### DIFF
--- a/spec/factories/course_enrichments.rb
+++ b/spec/factories/course_enrichments.rb
@@ -16,7 +16,7 @@
 
 FactoryBot.define do
   factory :course_enrichment do
-    provider
+    provider { course.provider }
     course
     status { :draft }
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -36,7 +36,6 @@ FactoryBot.define do
 
     transient do
       with_site_statuses { [] }
-      with_enrichments   { [] }
       age                { nil }
       enrichments        { [] }
     end
@@ -59,22 +58,12 @@ FactoryBot.define do
         end
       end
 
-      evaluator.with_enrichments.each do |trait, attributes = {}|
-        defaults = {
-          ucas_course_code: course.course_code,
-          provider_code: course.provider.provider_code,
-        }
-        if evaluator.age.present?
-          defaults = defaults.merge(
-            created_at: evaluator.age,
-            updated_at: evaluator.age,
-          )
-        end
-        create(:course_enrichment, trait, attributes.merge(defaults))
-      end
-
+      # This is important to retain the relationship behaviour between
+      # course and it's enrichment
       course.enrichments += evaluator.enrichments.map do |enrichment|
-        enrichment.tap { |e| e.provider_code = course.provider.provider_code }
+        enrichment.tap do |e|
+          e.provider_code = course.provider.provider_code
+        end
       end
 
       if evaluator.age.present?

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -35,7 +35,7 @@ FactoryBot.define do
     resulting_in_pgce_with_qts
 
     transient do
-      with_site_statuses { [] }
+      # with_site_statuses { [] }
       age                { nil }
       enrichments        { [] }
     end
@@ -49,15 +49,6 @@ FactoryBot.define do
     end
 
     after(:create) do |course, evaluator|
-      evaluator.with_site_statuses.each do |traits|
-        attrs = { course: course }
-        if traits == [:default]
-          create(:site_status, attrs)
-        else
-          create(:site_status, *traits, attrs)
-        end
-      end
-
       # This is important to retain the relationship behaviour between
       # course and it's enrichment
       course.enrichments += evaluator.enrichments.map do |enrichment|

--- a/spec/factories/site_statuses.rb
+++ b/spec/factories/site_statuses.rb
@@ -13,7 +13,7 @@
 
 FactoryBot.define do
   factory :site_status do
-    association :course, study_mode: :full_time_or_part_time
+    association :course, study_mode: :full_time
     association(:site)
     publish { 'N' }
     vac_status { :full_time_vacancies }

--- a/spec/factory_specs/course_spec.rb
+++ b/spec/factory_specs/course_spec.rb
@@ -12,12 +12,12 @@ describe "Course factory" do
   end
 
   context "with_course_enrichments" do
+    let(:first_enrichment) { build(:course_enrichment, :published, created_at: 3.days.ago) }
+    let(:second_enrichment) { build(:course_enrichment, :published, created_at: 5.days.ago) }
+    let(:third_enrichment) { build(:course_enrichment, :subsequent_draft, created_at: 1.day.ago) }
+
     subject {
-      create(:course, with_enrichments: [
-               [:published, created_at: 5.days.ago],
-               [:published, created_at: 3.days.ago],
-               [:subsequent_draft, created_at: 1.day.ago],
-             ])
+      create(:course, enrichments: [first_enrichment, second_enrichment, third_enrichment])
     }
 
     it "has enrichments" do

--- a/spec/models/course/publishable_spec.rb
+++ b/spec/models/course/publishable_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe Course, type: :model do
     its(:publishable?) { should be_falsey }
 
     context 'with enrichment' do
+      let(:enrichment) { build(:course_enrichment, :subsequent_draft, created_at: 1.day.ago) }
       let(:course) {
-        create(:course, with_enrichments: [[:subsequent_draft, created_at: 1.day.ago]])
+        create(:course, enrichments: [enrichment])
       }
 
       its(:publishable?) { should be_truthy }
@@ -16,7 +17,7 @@ RSpec.describe Course, type: :model do
 
     context 'with no enrichment' do
       let(:course) {
-        create(:course, with_enrichments: [])
+        create(:course)
       }
 
       its(:publishable?) { should be_falsey }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -126,12 +126,16 @@ RSpec.describe Course, type: :model do
   end
 
   context 'with site statuses' do
+    let(:findable) { build(:site_status, :findable) }
+    let(:with_any_vacancy) { build(:site_status, :with_any_vacancy) }
+    let(:default) { build(:site_status) }
+    let(:applications_being_accepted_now) { build(:site_status, :applications_being_accepted_now) }
+    let(:applications_being_accepted_in_future) { build(:site_status, :applications_being_accepted_in_future) }
+    let(:site_status_with_no_vacancies) { build(:site_status, :with_no_vacancies) }
     describe 'findable?' do
       context 'with at least one site status as findable' do
         context 'single site status as findable' do
-          let(:subject) { create(:course, site_statuses: course_site_statuses) }
-
-          let(:course_site_statuses) { [create(:site_status, :findable)] }
+          let(:subject) { create(:course, site_statuses: [findable]) }
 
           its(:site_statuses) { should_not be_empty }
           its(:findable?) { should be true }
@@ -139,13 +143,11 @@ RSpec.describe Course, type: :model do
 
         context 'single site status as findable and mix site status as non findable' do
           let(:subject) {
-            create(:course, with_site_statuses: [
-                     [:findable],
-                     [:with_any_vacancy],
-                     [:default],
-                     [:applications_being_accepted_now],
-                     [:applications_being_accepted_in_future]
-                   ])
+            create(:course, site_statuses: [findable,
+                                            with_any_vacancy,
+                                            default,
+                                            applications_being_accepted_now,
+                                            applications_being_accepted_in_future])
           }
 
           its(:site_statuses) { should_not be_empty }
@@ -155,21 +157,19 @@ RSpec.describe Course, type: :model do
     end
 
     describe '#has_vacancies?' do
+    let(:findable_without_vacancies) { build(:site_status, :findable, :with_no_vacancies) }
       context 'for a single site status that has vacancies' do
         let(:subject) {
-          create(:course, with_site_statuses: [%i[findable applications_being_accepted_now with_any_vacancy]])
+          create(:course, site_statuses: [findable, applications_being_accepted_now, with_any_vacancy])
         }
 
         its(:has_vacancies?) { should be true }
       end
 
       context 'for a site status with vacancies and others without' do
+        let(:findable_with_vacancies) { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_now) }
         let(:subject) {
-          create(:course, with_site_statuses: [
-                   %i[findable applications_being_accepted_now with_any_vacancy],
-                   %i[findable with_no_vacancies],
-                   %i[findable with_no_vacancies],
-                 ])
+          create(:course, site_statuses: [findable_with_vacancies, findable_without_vacancies])
         }
 
         its(:has_vacancies?) { should be true }
@@ -177,32 +177,27 @@ RSpec.describe Course, type: :model do
 
       context 'when none of the sites have vacancies' do
         let(:subject) {
-          create(:course, with_site_statuses: [
-                   %i[findable with_no_vacancies],
-                   %i[findable with_no_vacancies],
-                 ])
+          create(:course, site_statuses: [findable_without_vacancies, findable_without_vacancies])
         }
 
         its(:has_vacancies?) { should be false }
       end
 
       context 'when the site is findable but only opens in the future' do
+        let(:findable_with_vacancies) { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_in_future) }
         let(:subject) {
-          create(:course, with_site_statuses: [
-                   %i[findable with_any_vacancy applications_being_accepted_in_future],
-                 ])
+          create(:course, site_statuses: [findable_with_vacancies])
         }
-
         its(:has_vacancies?) { should be true }
       end
 
       context 'when only discontinued and suspended site statuses have vacancies' do
+        let(:findable_with_no_vacancies) { build(:site_status, :findable, :with_no_vacancies) }
+        let(:published_suspended_with_any_vacancy) { build(:site_status, :published, :discontinued, :with_any_vacancy) }
+        let(:published_discontinued_with_any_vacancy) { build(:site_status, :published, :suspended, :with_any_vacancy) }
+
         let(:subject) {
-          create(:course, with_site_statuses: [
-                   %i[published suspended with_any_vacancy],
-                   %i[published discontinued with_any_vacancy],
-                   %i[findable with_no_vacancies],
-                 ])
+          create(:course, site_statuses: [findable_with_no_vacancies, published_suspended_with_any_vacancy, published_discontinued_with_any_vacancy])
         }
 
         before do
@@ -220,8 +215,9 @@ RSpec.describe Course, type: :model do
     describe 'open_for_applications?' do
       context 'with at least one site status applications_being_accepted_now' do
         context 'single site status applications_being_accepted_now as it open now' do
+          let(:findable_with_vacancies) { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_now) }
           let(:subject) {
-            create(:course, with_site_statuses: [%i[findable applications_being_accepted_now with_any_vacancy]])
+            create(:course, site_statuses: [findable_with_vacancies])
           }
 
           its(:site_statuses) { should_not be_empty }
@@ -230,7 +226,7 @@ RSpec.describe Course, type: :model do
 
         context 'single site status applications_being_accepted_now as it open future' do
           let(:subject) {
-            create(:course, with_site_statuses: [:applications_being_accepted_in_future])
+            create(:course, site_statuses: [applications_being_accepted_in_future])
           }
 
           its(:site_statuses) { should_not be_empty }
@@ -238,11 +234,10 @@ RSpec.describe Course, type: :model do
         end
 
         context 'site statuses applications_being_accepted_now as it open now & future' do
+          let(:findable_with_vacancies_now) { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_now) }
+          let(:findable_with_vacancies_in_future) { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_in_future) }
           let(:subject) {
-            create(:course, with_site_statuses: [
-                     %i[findable applications_being_accepted_now with_any_vacancy],
-                     %i[applications_being_accepted_in_future with_any_vacancy]
-                   ])
+            create(:course, site_statuses: [findable_with_vacancies_now, findable_with_vacancies_in_future])
           }
 
           its(:site_statuses) { should_not be_empty }
@@ -253,25 +248,27 @@ RSpec.describe Course, type: :model do
 
     describe 'ucas_status' do
       context 'without any site statuses' do
-        let(:subject) { create(:course, with_site_statuses: []) }
+        let(:subject) { create(:course) }
 
         its(:ucas_status) { should eq :new }
       end
 
       context 'with a running site_status' do
-        let(:subject) { create(:course, with_site_statuses: [%i[findable]]) }
+        let(:subject) { create(:course, site_statuses: [findable]) }
 
         its(:ucas_status) { should eq :running }
       end
 
       context 'with a new site_status' do
-        let(:subject) { create(:course, with_site_statuses: [%i[new]]) }
+        let(:new) { build(:site_status, :new) }
+        let(:subject) { create(:course, site_statuses: [new]) }
 
         its(:ucas_status) { should eq :new }
       end
 
       context 'with a not running site_status' do
-        let(:subject) { create(:course, with_site_statuses: [%i[suspended]]) }
+        let(:suspended) { build(:site_status, :suspended) }
+        let(:subject) { create(:course, site_statuses: [suspended]) }
 
         its(:ucas_status) { should eq :not_running }
       end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Course, type: :model do
     end
 
     describe '#has_vacancies?' do
-    let(:findable_without_vacancies) { build(:site_status, :findable, :with_no_vacancies) }
+      let(:findable_without_vacancies) { build(:site_status, :findable, :with_no_vacancies) }
       context 'for a single site status that has vacancies' do
         let(:subject) {
           create(:course, site_statuses: [findable, applications_being_accepted_now, with_any_vacancy])

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -258,12 +258,14 @@ RSpec.describe SiteStatus, type: :model do
     end
 
     describe 'if on find, application date open and has part-time vacancies' do
-      subject { create(:site_status, :findable, :applications_being_accepted_now, :part_time_vacancies) }
+      let(:course) { build(:course, study_mode: :part_time) }
+      subject { create(:site_status, :findable, :applications_being_accepted_now, :part_time_vacancies, course: course) }
       it { should be_open_for_applications }
     end
 
     describe 'if on find, application date open and has both full-time and part-time vacancies' do
-      subject { create(:site_status, :findable, :applications_being_accepted_now, :both_full_time_and_part_time_vacancies) }
+      let(:course) { build(:course, study_mode: :full_time_or_part_time) }
+      subject { create(:site_status, :findable, :applications_being_accepted_now, :both_full_time_and_part_time_vacancies, course: course) }
       it { should be_open_for_applications }
     end
 
@@ -285,7 +287,8 @@ RSpec.describe SiteStatus, type: :model do
 
   describe "has vacancies?" do
     describe 'if has part-time vacancies' do
-      subject { create(:site_status, :part_time_vacancies) }
+      let(:course) { build(:course, study_mode: :part_time) }
+      subject { create(:site_status, :part_time_vacancies, course: course) }
       it { should have_vacancies }
     end
 
@@ -295,7 +298,8 @@ RSpec.describe SiteStatus, type: :model do
     end
 
     describe 'if has both full-time and part-time vacancies' do
-      subject { create(:site_status, :both_full_time_and_part_time_vacancies) }
+      let(:course) { build(:course, study_mode: :full_time_or_part_time) }
+      subject { create(:site_status, :both_full_time_and_part_time_vacancies, course: course) }
       it { should have_vacancies }
     end
 

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -27,10 +27,11 @@ describe 'Publish API v2', type: :request do
         )
     end
     let(:enrichment) { build(:course_enrichment, :initial_draft) }
+    let(:site_status) { build(:site_status, :new) }
     let(:course) {
       create(:course,
              provider: provider,
-             with_site_statuses: [:new],
+             site_statuses: [site_status],
              enrichments: [enrichment])
     }
 
@@ -69,11 +70,12 @@ describe 'Publish API v2', type: :request do
 
     context 'unpublished course with draft enrichment' do\
       let(:enrichment) { build(:course_enrichment, :initial_draft) }
+      let(:site_status) { build(:site_status, :new) }
       let!(:course) {
         create(:course,
                provider: provider,
-               with_site_statuses: [:new],
-              enrichments: [enrichment],
+               site_statuses: [site_status],
+               enrichments: [enrichment],
                age: 17.days.ago)
       }
       it 'publishes a course' do

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -26,11 +26,12 @@ describe 'Publish API v2', type: :request do
           body: manage_api_response
         )
     end
+    let(:enrichment) { build(:course_enrichment, :initial_draft) }
     let(:course) {
       create(:course,
              provider: provider,
              with_site_statuses: [:new],
-             with_enrichments: [:initial_draft])
+             enrichments: [enrichment])
     }
 
     subject do
@@ -66,12 +67,13 @@ describe 'Publish API v2', type: :request do
       it { should have_http_status(:not_found) }
     end
 
-    context 'unpublished course with draft enrichment' do
+    context 'unpublished course with draft enrichment' do\
+      let(:enrichment) { build(:course_enrichment, :initial_draft) }
       let!(:course) {
         create(:course,
                provider: provider,
                with_site_statuses: [:new],
-               with_enrichments: [:initial_draft],
+              enrichments: [enrichment],
                age: 17.days.ago)
       }
       it 'publishes a course' do
@@ -115,7 +117,7 @@ describe 'Publish API v2', type: :request do
       let(:json_data) { JSON.parse(subject.body)['errors'] }
 
       context 'no enrichments' do
-        let(:course) { create(:course, provider: provider, with_enrichments: []) }
+        let(:course) { create(:course, provider: provider) }
         it { should have_http_status(:unprocessable_entity) }
         it 'has validation errors' do
           expect(json_data.count).to eq 1

--- a/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
+++ b/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
@@ -18,7 +18,7 @@ describe 'Courses API v2', type: :request do
         "/courses/#{course.course_code}/sync_with_search_and_compare"
     end
 
-    let(:course) { create(:course, provider: provider, with_enrichments: [:initial_draft]) }
+    let(:course) { create(:course, provider: provider, enrichments: [build(:course_enrichment, :initial_draft)]) }
 
     before do
       stub_request(:post, %r{#{Settings.manage_api.base_url}/api/Publish/internal/course/})

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -19,13 +19,14 @@ describe 'Courses API v2', type: :request do
            start_date: Time.now.utc,
            study_mode: :full_time,
            subjects: [course_subject_primary, course_subject_mathematics, course_subject_send],
-           with_site_statuses: [%i[findable with_any_vacancy applications_being_accepted_from_2019]],
+           site_statuses: [courses_site_status],
            enrichments: [enrichment],
            maths: :must_have_qualification_at_application_time,
            english: :must_have_qualification_at_application_time,
            science: :must_have_qualification_at_application_time)
   }
 
+  let(:courses_site_status)    { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_from_2019) }
   let(:enrichment)     { build :course_enrichment, :published }
   let(:provider)       { create :provider, organisations: [organisation] }
   let(:course_subject) { course.subjects.first }

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -8,7 +8,6 @@ describe 'Courses API v2', type: :request do
   let(:credentials) do
     ActionController::HttpAuthentication::Token.encode_credentials(token)
   end
-
   let(:course_subject_primary) { find_or_create(:subject, subject_name: 'Primary', subject_code: 'P') }
   let(:course_subject_mathematics) { find_or_create(:subject, subject_name: 'Mathematics', subject_code: 'M') }
   let(:course_subject_send) { find_or_create(:send_subject) }


### PR DESCRIPTION
### Context
**Do not merge until #477 has been merged. This is branched off from it**

Pull request No. 6 to clean up the associations in our factories. This PR removes with_site_statuses from the course factory.

### Changes proposed in this pull request

- Remove with_site_statuses from the course factory

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
