### PR TITLE
1460 remove with site status from course factory

### DIFF
--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -35,7 +35,6 @@ FactoryBot.define do
     resulting_in_pgce_with_qts
 
     transient do
-      # with_site_statuses { [] }
       age                { nil }
       enrichments        { [] }
     end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -35,7 +35,7 @@ FactoryBot.define do
     resulting_in_pgce_with_qts
 
     transient do
-      with_site_statuses { [] }
+      # with_site_statuses { [] }
       age                { nil }
       enrichments        { [] }
     end
@@ -49,15 +49,6 @@ FactoryBot.define do
     end
 
     after(:create) do |course, evaluator|
-      evaluator.with_site_statuses.each do |traits|
-        attrs = { course: course }
-        if traits == [:default]
-          create(:site_status, attrs)
-        else
-          create(:site_status, *traits, attrs)
-        end
-      end
-
       # This is important to retain the relationship behaviour between
       # course and it's enrichment
       course.enrichments += evaluator.enrichments.map do |enrichment|

--- a/spec/factories/site_statuses.rb
+++ b/spec/factories/site_statuses.rb
@@ -13,7 +13,7 @@
 
 FactoryBot.define do
   factory :site_status do
-    association :course, study_mode: :full_time_or_part_time
+    association :course, study_mode: :full_time
     association(:site)
     publish { 'N' }
     vac_status { :full_time_vacancies }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -126,12 +126,16 @@ RSpec.describe Course, type: :model do
   end
 
   context 'with site statuses' do
+    let(:findable) { build(:site_status, :findable) }
+    let(:with_any_vacancy) { build(:site_status, :with_any_vacancy) }
+    let(:default) { build(:site_status) }
+    let(:applications_being_accepted_now) { build(:site_status, :applications_being_accepted_now) }
+    let(:applications_being_accepted_in_future) { build(:site_status, :applications_being_accepted_in_future) }
+    let(:site_status_with_no_vacancies) { build(:site_status, :with_no_vacancies) }
     describe 'findable?' do
       context 'with at least one site status as findable' do
         context 'single site status as findable' do
-          let(:subject) { create(:course, site_statuses: course_site_statuses) }
-
-          let(:course_site_statuses) { [create(:site_status, :findable)] }
+          let(:subject) { create(:course, site_statuses: [findable]) }
 
           its(:site_statuses) { should_not be_empty }
           its(:findable?) { should be true }
@@ -139,13 +143,11 @@ RSpec.describe Course, type: :model do
 
         context 'single site status as findable and mix site status as non findable' do
           let(:subject) {
-            create(:course, with_site_statuses: [
-                     [:findable],
-                     [:with_any_vacancy],
-                     [:default],
-                     [:applications_being_accepted_now],
-                     [:applications_being_accepted_in_future]
-                   ])
+            create(:course, site_statuses: [findable,
+                                            with_any_vacancy,
+                                            default,
+                                            applications_being_accepted_now,
+                                            applications_being_accepted_in_future])
           }
 
           its(:site_statuses) { should_not be_empty }
@@ -155,21 +157,19 @@ RSpec.describe Course, type: :model do
     end
 
     describe '#has_vacancies?' do
+    let(:findable_without_vacancies) { build(:site_status, :findable, :with_no_vacancies) }
       context 'for a single site status that has vacancies' do
         let(:subject) {
-          create(:course, with_site_statuses: [%i[findable applications_being_accepted_now with_any_vacancy]])
+          create(:course, site_statuses: [findable, applications_being_accepted_now, with_any_vacancy])
         }
 
         its(:has_vacancies?) { should be true }
       end
 
       context 'for a site status with vacancies and others without' do
+        let(:findable_with_vacancies) { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_now) }
         let(:subject) {
-          create(:course, with_site_statuses: [
-                   %i[findable applications_being_accepted_now with_any_vacancy],
-                   %i[findable with_no_vacancies],
-                   %i[findable with_no_vacancies],
-                 ])
+          create(:course, site_statuses: [findable_with_vacancies, findable_without_vacancies])
         }
 
         its(:has_vacancies?) { should be true }
@@ -177,32 +177,27 @@ RSpec.describe Course, type: :model do
 
       context 'when none of the sites have vacancies' do
         let(:subject) {
-          create(:course, with_site_statuses: [
-                   %i[findable with_no_vacancies],
-                   %i[findable with_no_vacancies],
-                 ])
+          create(:course, site_statuses: [findable_without_vacancies, findable_without_vacancies])
         }
 
         its(:has_vacancies?) { should be false }
       end
 
       context 'when the site is findable but only opens in the future' do
+        let(:findable_with_vacancies) { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_in_future) }
         let(:subject) {
-          create(:course, with_site_statuses: [
-                   %i[findable with_any_vacancy applications_being_accepted_in_future],
-                 ])
+          create(:course, site_statuses: [findable_with_vacancies])
         }
-
         its(:has_vacancies?) { should be true }
       end
 
       context 'when only discontinued and suspended site statuses have vacancies' do
+        let(:findable_with_no_vacancies) { build(:site_status, :findable, :with_no_vacancies) }
+        let(:published_suspended_with_any_vacancy) { build(:site_status, :published, :discontinued, :with_any_vacancy) }
+        let(:published_discontinued_with_any_vacancy) { build(:site_status, :published, :suspended, :with_any_vacancy) }
+
         let(:subject) {
-          create(:course, with_site_statuses: [
-                   %i[published suspended with_any_vacancy],
-                   %i[published discontinued with_any_vacancy],
-                   %i[findable with_no_vacancies],
-                 ])
+          create(:course, site_statuses: [findable_with_no_vacancies, published_suspended_with_any_vacancy, published_discontinued_with_any_vacancy])
         }
 
         before do
@@ -220,8 +215,9 @@ RSpec.describe Course, type: :model do
     describe 'open_for_applications?' do
       context 'with at least one site status applications_being_accepted_now' do
         context 'single site status applications_being_accepted_now as it open now' do
+          let(:findable_with_vacancies) { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_now) }
           let(:subject) {
-            create(:course, with_site_statuses: [%i[findable applications_being_accepted_now with_any_vacancy]])
+            create(:course, site_statuses: [findable_with_vacancies])
           }
 
           its(:site_statuses) { should_not be_empty }
@@ -230,7 +226,7 @@ RSpec.describe Course, type: :model do
 
         context 'single site status applications_being_accepted_now as it open future' do
           let(:subject) {
-            create(:course, with_site_statuses: [:applications_being_accepted_in_future])
+            create(:course, site_statuses: [applications_being_accepted_in_future])
           }
 
           its(:site_statuses) { should_not be_empty }
@@ -238,11 +234,10 @@ RSpec.describe Course, type: :model do
         end
 
         context 'site statuses applications_being_accepted_now as it open now & future' do
+          let(:findable_with_vacancies_now) { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_now) }
+          let(:findable_with_vacancies_in_future) { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_in_future) }
           let(:subject) {
-            create(:course, with_site_statuses: [
-                     %i[findable applications_being_accepted_now with_any_vacancy],
-                     %i[applications_being_accepted_in_future with_any_vacancy]
-                   ])
+            create(:course, site_statuses: [findable_with_vacancies_now, findable_with_vacancies_in_future])
           }
 
           its(:site_statuses) { should_not be_empty }
@@ -253,25 +248,27 @@ RSpec.describe Course, type: :model do
 
     describe 'ucas_status' do
       context 'without any site statuses' do
-        let(:subject) { create(:course, with_site_statuses: []) }
+        let(:subject) { create(:course) }
 
         its(:ucas_status) { should eq :new }
       end
 
       context 'with a running site_status' do
-        let(:subject) { create(:course, with_site_statuses: [%i[findable]]) }
+        let(:subject) { create(:course, site_statuses: [findable]) }
 
         its(:ucas_status) { should eq :running }
       end
 
       context 'with a new site_status' do
-        let(:subject) { create(:course, with_site_statuses: [%i[new]]) }
+        let(:new) { build(:site_status, :new) }
+        let(:subject) { create(:course, site_statuses: [new]) }
 
         its(:ucas_status) { should eq :new }
       end
 
       context 'with a not running site_status' do
-        let(:subject) { create(:course, with_site_statuses: [%i[suspended]]) }
+        let(:suspended) { build(:site_status, :suspended) }
+        let(:subject) { create(:course, site_statuses: [suspended]) }
 
         its(:ucas_status) { should eq :not_running }
       end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Course, type: :model do
     end
 
     describe '#has_vacancies?' do
-    let(:findable_without_vacancies) { build(:site_status, :findable, :with_no_vacancies) }
+      let(:findable_without_vacancies) { build(:site_status, :findable, :with_no_vacancies) }
       context 'for a single site status that has vacancies' do
         let(:subject) {
           create(:course, site_statuses: [findable, applications_being_accepted_now, with_any_vacancy])

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -258,12 +258,14 @@ RSpec.describe SiteStatus, type: :model do
     end
 
     describe 'if on find, application date open and has part-time vacancies' do
-      subject { create(:site_status, :findable, :applications_being_accepted_now, :part_time_vacancies) }
+      let(:course) { build(:course, study_mode: :part_time) }
+      subject { create(:site_status, :findable, :applications_being_accepted_now, :part_time_vacancies, course: course) }
       it { should be_open_for_applications }
     end
 
     describe 'if on find, application date open and has both full-time and part-time vacancies' do
-      subject { create(:site_status, :findable, :applications_being_accepted_now, :both_full_time_and_part_time_vacancies) }
+      let(:course) { build(:course, study_mode: :full_time_or_part_time) }
+      subject { create(:site_status, :findable, :applications_being_accepted_now, :both_full_time_and_part_time_vacancies, course: course) }
       it { should be_open_for_applications }
     end
 
@@ -285,7 +287,8 @@ RSpec.describe SiteStatus, type: :model do
 
   describe "has vacancies?" do
     describe 'if has part-time vacancies' do
-      subject { create(:site_status, :part_time_vacancies) }
+      let(:course) { build(:course, study_mode: :part_time) }
+      subject { create(:site_status, :part_time_vacancies, course: course) }
       it { should have_vacancies }
     end
 
@@ -295,7 +298,8 @@ RSpec.describe SiteStatus, type: :model do
     end
 
     describe 'if has both full-time and part-time vacancies' do
-      subject { create(:site_status, :both_full_time_and_part_time_vacancies) }
+      let(:course) { build(:course, study_mode: :full_time_or_part_time) }
+      subject { create(:site_status, :both_full_time_and_part_time_vacancies, course: course) }
       it { should have_vacancies }
     end
 

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -27,10 +27,11 @@ describe 'Publish API v2', type: :request do
         )
     end
     let(:enrichment) { build(:course_enrichment, :initial_draft) }
+    let(:site_status) { build(:site_status, :new) }
     let(:course) {
       create(:course,
              provider: provider,
-             with_site_statuses: [:new],
+             site_statuses: [site_status],
              enrichments: [enrichment])
     }
 
@@ -69,11 +70,12 @@ describe 'Publish API v2', type: :request do
 
     context 'unpublished course with draft enrichment' do\
       let(:enrichment) { build(:course_enrichment, :initial_draft) }
+      let(:site_status) { build(:site_status, :new) }
       let!(:course) {
         create(:course,
                provider: provider,
-               with_site_statuses: [:new],
-              enrichments: [enrichment],
+               site_statuses: [site_status],
+               enrichments: [enrichment],
                age: 17.days.ago)
       }
       it 'publishes a course' do

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -19,13 +19,14 @@ describe 'Courses API v2', type: :request do
            start_date: Time.now.utc,
            study_mode: :full_time,
            subjects: [course_subject_primary, course_subject_mathematics, course_subject_send],
-           with_site_statuses: [%i[findable with_any_vacancy applications_being_accepted_from_2019]],
+           site_statuses: [courses_site_status],
            enrichments: [enrichment],
            maths: :must_have_qualification_at_application_time,
            english: :must_have_qualification_at_application_time,
            science: :must_have_qualification_at_application_time)
   }
 
+  let(:courses_site_status)    { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_from_2019) }
   let(:enrichment)     { build :course_enrichment, :published }
   let(:provider)       { create :provider, organisations: [organisation] }
   let(:course_subject) { course.subjects.first }

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -9,12 +9,13 @@ describe 'Sites API v2', type: :request do
     ActionController::HttpAuthentication::Token.encode_credentials(token)
   end
 
-  let(:site1) { build :site, location_name: 'Main site 1' }
-  let(:site2) { build :site, location_name: 'Main site 2' }
-  let!(:provider) {
-    create(:provider,
-           organisations: [organisation],
-           sites: [site1, site2])
+  let(:site1) { create :site, location_name: 'Main site 1', provider: provider }
+  let(:site2) { create :site, location_name: 'Main site 2', provider: provider }
+  let!(:sites) { [site1, site2] }
+
+  let(:provider) {
+    build(:provider,
+          organisations: [organisation],)
   }
 
   subject { response }
@@ -78,7 +79,6 @@ describe 'Sites API v2', type: :request do
     end
 
     describe 'JSON generated for sites' do
-      let!(:sites) { [site1, site2] }
       before do
         get "/api/v2/providers/#{provider.provider_code}/sites",
             headers: { 'HTTP_AUTHORIZATION' => credentials }
@@ -135,7 +135,7 @@ describe 'Sites API v2', type: :request do
   describe 'PATCH update' do
     def perform_site_update
       patch(
-        api_v2_provider_site_path(provider.provider_code, site1),
+        api_v2_provider_site_path(provider.provider_code, site1.reload),
         headers: { 'HTTP_AUTHORIZATION' => credentials },
         params: params
       )
@@ -405,7 +405,9 @@ describe 'Sites API v2', type: :request do
       let(:postcode)      { 'SW1A 1AA' }
       let(:region_code)   { 'west_midlands' }
 
-      let(:site) { provider.reload.sites.last }
+      let(:site) {
+        provider.reload.sites.last
+      }
 
       describe 'permitted parameters' do
         before do

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -9,11 +9,12 @@ describe 'Sites API v2', type: :request do
     ActionController::HttpAuthentication::Token.encode_credentials(token)
   end
 
-  let(:site1) { create :site, location_name: 'Main site 1', provider: provider }
-  let(:site2) { create :site, location_name: 'Main site 2', provider: provider }
+  let(:site1) { build :site, location_name: 'Main site 1' }
+  let(:site2) { build :site, location_name: 'Main site 2' }
   let!(:provider) {
     create(:provider,
-           organisations: [organisation])
+           organisations: [organisation],
+           sites: [site1, site2])
   }
 
   subject { response }
@@ -343,7 +344,7 @@ describe 'Sites API v2', type: :request do
 
             context 'within another provider' do
               let!(:provider2) { create :provider, sites: [site3] }
-              let!(:site3) { create :site, location_name: site1.location_name }
+              let(:site3) { build :site, location_name: site1.location_name }
               let(:location_name) { site3.location_name }
 
               it { should have_http_status(:success) }


### PR DESCRIPTION
### Context

Pull request No. 6 to clean up the associations in our factories. This PR removes with_site_statuses from the course factory.

### Changes proposed in this pull request

- Remove with_site_statuses from the course factory

### Guidance to review

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
