### PR TITLE
[1626] accomodate empty attributes when updating from jsonapi

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -118,7 +118,7 @@ module API
 
       def enrichment_params
         params
-          .require(:course)
+          .fetch(:course, {})
           .except(:id, :type, :sites_ids, :sites_types)
           .permit(
             :about_course,
@@ -137,7 +137,7 @@ module API
       end
 
       def site_ids
-        params.require(:course)[:sites_ids]
+        params.fetch(:course, {})[:sites_ids]
       end
     end
   end

--- a/spec/requests/api/v2/providers/courses/update_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_spec.rb
@@ -162,6 +162,16 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
       end
     end
 
+    context "with empty attributes" do
+      let(:permitted_params) { [] }
+
+      it "doesn't create a draft enrichment" do
+        expect {
+          perform_request update_course
+        }.to_not(change { course.reload.enrichments.count })
+      end
+    end
+
     it 'returns ok' do
       perform_request update_course
 


### PR DESCRIPTION
### Context

JSONAPI requests can come in with an empty set of attributes, if there are no attributes to update. When this happens, the deserializer doesn't even bother to create the root parameter (e.g. `course` in this case).

### Changes proposed in this pull request

Default the course update attributes to an empty hash instead of requiring it to be present. i.e. we usually expect the params to come in as:

```
{
  course: {
    about_course: "This is a great course.",
    ...
  }
}
```

so we can do `params.require(:course)`. But now, when `course:` isn't present, we default it to `{}`.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
