### PR TITLE
[1586] mcb courses edit: part 4

### DIFF
--- a/lib/mcb/courses_editor.rb
+++ b/lib/mcb/courses_editor.rb
@@ -12,6 +12,7 @@ module MCB
       start_date: :start_date,
       application_opening_date: :applications_open_from,
       age_range: :age_range,
+      course_code: :course_code,
     }.freeze
 
     def initialize(provider:, requester:, course_codes: [])
@@ -66,7 +67,7 @@ module MCB
       puts "Existing values for course #{attribute_name}:"
       table = Tabulo::Table.new @courses.order(:course_code) do |t|
         t.add_column(:course_code, header: "course\ncode", width: 4)
-        t.add_column(attribute_name)
+        t.add_column(attribute_name) unless attribute_name == :course_code
       end
       puts table.pack(max_table_width: nil), table.horizontal_rule
     end

--- a/lib/mcb/courses_editor.rb
+++ b/lib/mcb/courses_editor.rb
@@ -11,6 +11,7 @@ module MCB
       accredited_body: :accrediting_provider,
       start_date: :start_date,
       application_opening_date: :applications_open_from,
+      age_range: :age_range,
     }.freeze
 
     def initialize(provider:, requester:, course_codes: [])

--- a/lib/mcb/courses_editor.rb
+++ b/lib/mcb/courses_editor.rb
@@ -2,17 +2,11 @@ module MCB
   class CoursesEditor
     LOGICAL_NAME_TO_DATABASE_NAME_MAPPING = {
       title: :name,
-      maths: :maths,
-      english: :english,
-      science: :science,
       route: :program_type,
       qualifications: :qualification,
-      study_mode: :study_mode,
       accredited_body: :accrediting_provider,
       start_date: :start_date,
       application_opening_date: :applications_open_from,
-      age_range: :age_range,
-      course_code: :course_code,
     }.freeze
 
     def initialize(provider:, requester:, course_codes: [])
@@ -46,7 +40,7 @@ module MCB
   private
 
     def edit(logical_attribute)
-      database_attribute = LOGICAL_NAME_TO_DATABASE_NAME_MAPPING[logical_attribute]
+      database_attribute = LOGICAL_NAME_TO_DATABASE_NAME_MAPPING[logical_attribute] || logical_attribute
       print_existing(database_attribute)
       user_response_from_cli = @cli.send("ask_#{logical_attribute}".to_sym)
       unless user_response_from_cli.nil?

--- a/lib/mcb/courses_editor_cli.rb
+++ b/lib/mcb/courses_editor_cli.rb
@@ -35,35 +35,33 @@ module MCB
     def ask_science; ask_gcse_subject(:science); end
 
     def ask_gcse_subject(subject)
-      @cli.choose do |menu|
-        menu.prompt = "What's the #{subject} entry requirements?  "
-        menu.choice("exit") { nil }
-        menu.choices(*Course::ENTRY_REQUIREMENT_OPTIONS.keys)
-      end
+      ask_multiple_choice(
+        prompt: "What's the #{subject} entry requirements?",
+        choices: Course::ENTRY_REQUIREMENT_OPTIONS.keys
+      )
     end
 
     def ask_route
-      @cli.choose do |menu|
-        menu.prompt = "What's the route?  "
-        menu.choice("exit") { nil }
-        menu.choices(*Course.program_types.keys)
-      end
+      ask_multiple_choice(
+        prompt: "What's the route?",
+        choices: Course.program_types.keys
+      )
     end
 
     def ask_qualifications
-      @cli.choose do |menu|
-        menu.prompt = "What's the course outcome?  "
-        menu.choices(*Course.qualifications.keys)
-        menu.default = "pgce_with_qts"
-      end
+      ask_multiple_choice(
+        prompt: "What's the course outcome?",
+        choices: Course.qualifications.keys,
+        default: "pgce_with_qts"
+      )
     end
 
     def ask_study_mode
-      @cli.choose do |menu|
-        menu.prompt = "Full time or part time?  "
-        menu.choices(*Course.study_modes.keys)
-        menu.default = "full_time"
-      end
+      ask_multiple_choice(
+        prompt: "Full time or part time?",
+        choices: Course.study_modes.keys,
+        default: "full_time"
+      )
     end
 
     def ask_accredited_body
@@ -89,6 +87,17 @@ module MCB
 
     def ask_application_opening_date
       Date.parse(@cli.ask("Applications opening date?  ") { |q| q.default = Date.today.to_s })
+    end
+
+  private
+
+    def ask_multiple_choice(prompt:, choices:, default: nil)
+      @cli.choose do |menu|
+        menu.prompt = prompt + "  "
+        menu.choice("exit") { nil }
+        menu.choices(*choices)
+        menu.default = default if default.present?
+      end
     end
   end
 end

--- a/lib/mcb/courses_editor_cli.rb
+++ b/lib/mcb/courses_editor_cli.rb
@@ -99,7 +99,7 @@ module MCB
     end
 
     def ask_course_code
-      @cli.ask("Course code?  ") do |q|
+      @cli.ask("Course code?  ", ->(str) { str.upcase }) do |q|
         q.whitespace = :strip_and_collapse
         q.validate = /\S+/
       end

--- a/lib/mcb/courses_editor_cli.rb
+++ b/lib/mcb/courses_editor_cli.rb
@@ -19,6 +19,7 @@ module MCB
           "edit accredited body",
           "edit start date",
           "edit application opening date",
+          "edit age range",
         )
         menu.choice("sync course(s) to Find")
       end
@@ -61,6 +62,13 @@ module MCB
         prompt: "Full time or part time?",
         choices: Course.study_modes.keys,
         default: "full_time"
+      )
+    end
+
+    def ask_age_range
+      ask_multiple_choice(
+        prompt: "Age range?",
+        choices: Course.age_ranges.keys
       )
     end
 

--- a/lib/mcb/courses_editor_cli.rb
+++ b/lib/mcb/courses_editor_cli.rb
@@ -10,6 +10,7 @@ module MCB
         menu.choice("exit")
         menu.choices(
           "edit title",
+          "edit course code",
           "edit maths",
           "edit english",
           "edit science",
@@ -95,6 +96,13 @@ module MCB
 
     def ask_application_opening_date
       Date.parse(@cli.ask("Applications opening date?  ") { |q| q.default = Date.today.to_s })
+    end
+
+    def ask_course_code
+      @cli.ask("Course code?  ") do |q|
+        q.whitespace = :strip_and_collapse
+        q.validate = /\S+/
+      end
     end
 
   private

--- a/spec/lib/mcb/courses_editor_spec.rb
+++ b/spec/lib/mcb/courses_editor_spec.rb
@@ -187,6 +187,20 @@ describe MCB::CoursesEditor do
         end
       end
 
+      describe "(course code)" do
+        it 'updates the course code when that is valid' do
+          expect { run_editor("edit course code", "CXXZ", "exit") }.
+            to change { course.reload.course_code }.
+            from(course_code).to("CXXZ")
+        end
+
+        it 'does not apply an empty course code' do
+          expect { run_editor("edit course code", "", "CXXY", "exit") }.
+            to change { course.reload.course_code }.
+            from(course_code).to("CXXY")
+        end
+      end
+
       context "when syncing to Find" do
         let!(:another_course) { create(:course, provider: provider) }
         let(:course_codes) { [course_code, another_course.course_code] }

--- a/spec/lib/mcb/courses_editor_spec.rb
+++ b/spec/lib/mcb/courses_editor_spec.rb
@@ -27,7 +27,8 @@ describe MCB::CoursesEditor do
            program_type: 'higher_education_programme',
            qualification: 'qts',
            study_mode: 'part_time',
-           start_date: Date.new(2019, 8, 1))
+           start_date: Date.new(2019, 8, 1),
+           age_range: 'secondary')
   }
   subject { described_class.new(provider: provider, course_codes: course_codes, requester: requester) }
 
@@ -175,6 +176,14 @@ describe MCB::CoursesEditor do
               to change { Date.parse(course.reload.applications_open_from) }.
               from(Date.new(2018, 10, 9)).to(Date.today)
           end
+        end
+      end
+
+      describe "(age range)" do
+        it 'updates the course age range when that is valid' do
+          expect { run_editor("edit age range", "primary", "exit") }.
+            to change { course.reload.age_range }.
+            from("secondary").to("primary")
         end
       end
 

--- a/spec/lib/mcb/courses_editor_spec.rb
+++ b/spec/lib/mcb/courses_editor_spec.rb
@@ -194,6 +194,12 @@ describe MCB::CoursesEditor do
             from(course_code).to("CXXZ")
         end
 
+        it 'upper-cases the course code before assigning it' do
+          expect { run_editor("edit course code", "cxxz", "exit") }.
+            to change { course.reload.course_code }.
+            from(course_code).to("CXXZ")
+        end
+
         it 'does not apply an empty course code' do
           expect { run_editor("edit course code", "", "CXXY", "exit") }.
             to change { course.reload.course_code }.


### PR DESCRIPTION
### Context
Follow-up to #446, #449 and #456 

Until we've built all course editing features for publishers to self-serve, we need support tooling to be able to action support requests for changes and new courses.

### Changes proposed in this pull request
- extract out a method for handling multiple choice questions in `CoursesEditorCLI`

As a precursor to the new course creation:
- edit the age range on a record
- edit the course code

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
