### PR TITLE
Ensure that course and provider code params are upper-cased

### DIFF
--- a/lib/mcb/commands/apiv1/providers/find.rb
+++ b/lib/mcb/commands/apiv1/providers/find.rb
@@ -5,8 +5,7 @@ description <<~EODESCRIPTION
   record.
 EODESCRIPTION
 usage 'find [options] <code>'
-param :code
-
+param :code, transform: ->(code) { code.upcase }
 option :j, 'json', 'show the returned JSON response'
 option :P, 'max-pages', 'maximum number of pages to request',
        default: 20,

--- a/lib/mcb/commands/providers/audit.rb
+++ b/lib/mcb/commands/providers/audit.rb
@@ -1,5 +1,5 @@
 summary 'Show changes made to a user record'
-param :code
+param :code, transform: ->(code) { code.upcase }
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)

--- a/lib/mcb/commands/providers/list.rb
+++ b/lib/mcb/commands/providers/list.rb
@@ -5,7 +5,7 @@ run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
   providers = if args.any?
-                Provider.where(provider_code: args.to_a)
+                Provider.where(provider_code: args.to_a.map(&:upcase))
               else
                 Provider.all
               end

--- a/lib/mcb/commands/providers/sync_to_find.rb
+++ b/lib/mcb/commands/providers/sync_to_find.rb
@@ -1,7 +1,7 @@
 name 'sync_to_find'
 summary 'Send all courses for a particular provider to Find'
 usage 'sync_to_find <provider_code>'
-param :provider_code
+param :provider_code, transform: ->(code) { code.upcase }
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)

--- a/lib/mcb/commands/providers/ucas_preferences/show.rb
+++ b/lib/mcb/commands/providers/ucas_preferences/show.rb
@@ -1,5 +1,5 @@
 summary 'Show UCAS preferences for provider with given code'
-param :code
+param :code, transform: ->(code) { code.upcase }
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)

--- a/lib/mcb/commands/users/grant_access_to_provider.rb
+++ b/lib/mcb/commands/users/grant_access_to_provider.rb
@@ -1,5 +1,5 @@
 summary 'Attach a user to an organisation/provider in the DB'
-param :provider_code
+param :provider_code, transform: ->(code) { code.upcase }
 usage 'grant_access_to_provider <provider_code>'
 
 run do |opts, args, _cmd|


### PR DESCRIPTION
### Context
All provider and course codes are upper-case in production.

### Changes proposed in this pull request
Upper-case all provider and course codes that are passed into the `mcb` tooling, so the tooling is more resilient to fat-fingering by the user.

### Guidance to review
This commit has been part-ported across from the extra tooling branch.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
