### PR TITLE
[1623] Validate numericality of course fees

### DIFF
--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -23,8 +23,8 @@ class CourseEnrichment < ApplicationRecord
                  about_course: [:string, store_key: 'AboutCourse'],
                  course_length: [:string, store_key: 'CourseLength'],
                  fee_details: [:string, store_key: 'FeeDetails'],
-                 fee_international: [:string, store_key: 'FeeInternational'],
-                 fee_uk_eu: [:string, store_key: 'FeeUkEu'],
+                 fee_international: [:integer, store_key: 'FeeInternational'],
+                 fee_uk_eu: [:integer, store_key: 'FeeUkEu'],
                  financial_support: [:string, store_key: 'FinancialSupport'],
                  how_school_placements_work: [:string,
                                               store_key: 'HowSchoolPlacementsWork'],
@@ -53,6 +53,8 @@ class CourseEnrichment < ApplicationRecord
   validates :qualifications, words_count: { maximum: 100 }, on: %i[save publish]
 
   validates :fee_uk_eu, presence: true, on: :publish, if: :is_fee_based?
+  validates :fee_uk_eu, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100000 }, on: %i[save publish], if: :is_fee_based?
+  validates :fee_international, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100000 }, on: %i[save publish], if: :is_fee_based?
   validates :fee_details, words_count: { maximum: 250 }, on: %i[save publish], if: :is_fee_based?
   validates :financial_support, words_count: { maximum: 250 }, on: %i[save publish], if: :is_fee_based?
 

--- a/spec/factories/course_enrichments.rb
+++ b/spec/factories/course_enrichments.rb
@@ -54,8 +54,8 @@ FactoryBot.define do
         "Fees are made payable to the University.",
       ].sample
     end
-    fee_uk_eu         { Faker::Number.within(0..100000) }
-    fee_international { Faker::Number.within(0..100000) }
+    fee_uk_eu         { Faker::Number.within(0..100000).to_i }
+    fee_international { Faker::Number.within(0..100000).to_i }
     financial_support do
       [
         "Please get in contact with the school for any further details.",

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -99,6 +99,9 @@ describe CourseEnrichment, type: :model do
       it { should validate_presence_of(:about_course).on(:publish) }
       it { should validate_presence_of(:qualifications).on(:publish) }
       it { should validate_presence_of(:course_length).on(:publish) }
+      it { should validate_presence_of(:fee_uk_eu).on(:publish) }
+      it { should validate_numericality_of(:fee_uk_eu).on(:publish) }
+      it { should validate_numericality_of(:fee_international).on(:publish) }
 
       it 'validates maximum word count for about_course' do
         course_enrichment.about_course = Faker::Lorem.sentence(400 + 1)
@@ -154,6 +157,9 @@ describe CourseEnrichment, type: :model do
       it { should validate_presence_of(:about_course).on(:publish) }
       it { should validate_presence_of(:qualifications).on(:publish) }
       it { should validate_presence_of(:course_length).on(:publish) }
+      it { should_not validate_presence_of(:fee_uk_eu).on(:publish) }
+      it { should_not validate_numericality_of(:fee_uk_eu).on(:publish) }
+      it { should_not validate_numericality_of(:fee_international).on(:publish) }
 
       it 'validates maximum word count for about_course' do
         course_enrichment.about_course = Faker::Lorem.sentence(400 + 1)

--- a/spec/requests/api/v2/providers/courses/update_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_spec.rb
@@ -41,8 +41,8 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
       about_course: 'new about course',
       course_length: 'new course length',
       fee_details: 'new fee details',
-      fee_international: 'new fee international',
-      fee_uk_eu: 'new fee uk eu',
+      fee_international: 0,
+      fee_uk_eu: 0,
       financial_support: 'new financial support',
       how_school_placements_work: 'new how school placements work',
       interview_process: 'new interview process',
@@ -191,9 +191,9 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
       expect(json_response).to have_attribute(:fee_details)
         .with_value('new fee details')
       expect(json_response).to have_attribute(:fee_international)
-        .with_value('new fee international')
+        .with_value(0)
       expect(json_response).to have_attribute(:fee_uk_eu)
-        .with_value('new fee uk eu')
+        .with_value(0)
       expect(json_response).to have_attribute(:financial_support)
         .with_value('new financial support')
       expect(json_response).to have_attribute(:how_school_placements_work)
@@ -266,8 +266,8 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
         {
           about_course: "",
           fee_details: "",
-          fee_international: "",
-          fee_uk_eu: "",
+          fee_international: 0,
+          fee_uk_eu: 0,
           financial_support: "",
           how_school_placements_work: "",
           interview_process: "",


### PR DESCRIPTION
### Context
Revert of https://github.com/DFE-Digital/manage-courses-backend/pull/338/files

### Changes proposed in this pull request
Ensure we validate numerically of uk and international fees

### Guidance to review
Try and submit a non-numerical character

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
