### PR TITLE
1460 Remove ucas preferences from provider factory

### DIFF
--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -69,10 +69,6 @@ FactoryBot.define do
       if evaluator.changed_at.present?
         provider.update changed_at: evaluator.changed_at
       end
-
-      if provider.ucas_preferences.nil?
-        provider.ucas_preferences = create(:ucas_preferences, provider: provider)
-      end
     end
   end
 end

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -15,7 +15,7 @@ describe 'Sites API v2', type: :request do
 
   let(:provider) {
     build(:provider,
-          organisations: [organisation],)
+          organisations: [organisation])
   }
 
   subject { response }

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -29,7 +29,8 @@
 require "rails_helper"
 
 describe ProviderSerializer do
-  let(:provider) { create :provider }
+  let(:ucas_preferences) { build(:provider_ucas_preference, type_of_gt12: :coming_or_not) }
+  let(:provider) { create :provider, ucas_preferences: ucas_preferences }
 
   subject { serialize(provider) }
 


### PR DESCRIPTION
### Context
 **Do not merge in until #477 #479 have been merged in as this PR is rebased onto #479** 

This is the final PR to clean up the dependencies in the factory. 

### Changes proposed in this pull request

- Removes a ucas_preference being built into the provider in the provider factory
- Fix tests that began to flake post change 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
