### PR TITLE
[1638] site status fixes

### DIFF
--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -28,7 +28,7 @@ class SiteStatus < ApplicationRecord
   end
 
   def destroy
-    if course.site_statuses.any?(&:status_new_status?)
+    if self.status_new_status?
       self.delete
     else
       self.status_suspended!

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -39,10 +39,12 @@ RSpec.describe SiteStatus, type: :model do
   end
 
   describe 'creation' do
+    let(:provider)    { build(:provider) }
+    let(:course) { create(:course, provider: provider) }
+    let(:site1) { build(:site, provider: provider) }
+    let(:site2) { build(:site, provider: provider) }
+
     context 'when course has a running site' do
-      let(:provider)    { build(:provider) }
-      let(:site1)       { build(:site, provider: provider) }
-      let(:site2)       { build(:site, provider: provider) }
       let(:site_status) { build(:site_status, :running, site: site1) }
       let(:course) do
         create(:course, provider: provider, site_statuses: [site_status])
@@ -72,11 +74,7 @@ RSpec.describe SiteStatus, type: :model do
     end
 
     context 'when course has a new site' do
-      let(:provider)    { build(:provider) }
-      let(:site1)       { build(:site, provider: provider) }
-      let(:course)      { create(:course, provider: provider) }
       let(:site_status) { build(:site_status, :new, site: site1, course: course) }
-      let(:site2)       { build(:site, provider: provider) }
 
       before do
         site_status
@@ -102,7 +100,6 @@ RSpec.describe SiteStatus, type: :model do
     end
 
     context 'when course has no sites' do
-      let(:course) { create(:course) }
       let(:site2)  { create(:site) }
 
       before do
@@ -128,12 +125,8 @@ RSpec.describe SiteStatus, type: :model do
     end
 
     context "when course has new and running sites" do
-      let(:provider) { build(:provider) }
-      let(:site1) { build(:site, provider: provider) }
-      let(:site2) { build(:site, provider: provider) }
       let!(:site_status1) { create(:site_status, :running, :published, site: site1, course: course) }
       let!(:site_status2) { create(:site_status, :new, site: site2, course: course) }
-      let(:course) { create(:course, provider: provider) }
       let(:site3) { build(:site, provider: provider) }
 
       before do

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -141,6 +141,30 @@ RSpec.describe SiteStatus, type: :model do
         end
       end
     end
+
+    context "when course has suspended sites" do
+      let!(:site_status1) { create(:site_status, :suspended, :published, site: site1, course: course) }
+      let(:site3) { build(:site, provider: provider) }
+
+      before do
+        expect(course.reload.ucas_status).to be(:not_running)
+      end
+
+      describe "the status" do
+        it "is set to running if a completely new site is added" do
+          new_site_status = SiteStatus.create course: course, site: site3
+
+          expect(new_site_status).to be_status_running
+        end
+
+        it "is set to running if the suspended site is re-added" do
+          course.sites << [site1]
+
+          expect(course.site_statuses.reload.size).to eq(1)
+          expect(course.site_statuses.find_by(site: site1)).to be_status_running
+        end
+      end
+    end
   end
 
   describe 'destruction' do

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -215,6 +215,43 @@ RSpec.describe SiteStatus, type: :model do
         end
       end
     end
+
+    context 'when course has a mixture of new and running sites' do
+      let(:site_status1) { create(:site_status, :published, :new, site: site1, course: course) }
+      let(:site_status2) { create(:site_status, :published, :running, site: site2, course: course) }
+
+      before do
+        site_status1
+        site_status2
+
+        expect(course.reload.ucas_status).to eq(:running)
+      end
+
+      describe 'the new record' do
+        it 'is destroyed' do
+          site_status1.destroy
+
+          expect(SiteStatus.exists?(site_status1.id)).to be_falsey
+        end
+      end
+
+      describe 'the running record' do
+        it 'is suspended' do
+          site_status2.destroy
+
+          expect(SiteStatus.exists?(site_status2.id)).to be_truthy
+        end
+      end
+
+      describe 'using courses association' do
+        it 'it is destroyed' do
+          course.sites = []
+
+          expect(SiteStatus.exists?(site_status1.id)).to be_falsey
+          expect(SiteStatus.exists?(site_status2.id)).to be_truthy
+        end
+      end
+    end
   end
 
   describe 'associations' do


### PR DESCRIPTION
### Context
- Un-suspending a site on a course creates duplicate site statuses
- Taking sites off a course with new and running site statuses deletes running site statuses (these should be suspended instead)

### Changes proposed in this pull request
- a fix to comment flagged here: https://github.com/DFE-Digital/manage-courses-backend/pull/451/files#r293711836

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
