### PR TITLE
[1586] Fix mcb spec as it fails at a particular point in time

### DIFF
--- a/spec/lib/mcb/courses_editor_spec.rb
+++ b/spec/lib/mcb/courses_editor_spec.rb
@@ -171,10 +171,10 @@ describe MCB::CoursesEditor do
         end
 
         it 'updates the application opening date to today by default' do
-          Timecop.freeze do
+          Timecop.freeze(Time.utc(2019, 6, 1, 12, 0, 0)) do
             expect { run_editor("edit application opening date", "", "exit") }.
               to change { Date.parse(course.reload.applications_open_from) }.
-              from(Date.new(2018, 10, 9)).to(Date.today)
+              from(Date.new(2018, 10, 9)).to(Date.new(2019, 6, 1))
           end
         end
       end


### PR DESCRIPTION
### Context
One of the specs for `mcb courses edit` freezes time and fails on the day boundary.

### Changes proposed in this pull request
Freeze time, rather than freeze date.

### Guidance to review

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
