### PR TITLE
[1530] Move create logic to controller

### DIFF
--- a/app/controllers/api/v2/access_requests_controller.rb
+++ b/app/controllers/api/v2/access_requests_controller.rb
@@ -25,15 +25,11 @@ module API
       end
 
       def create
-        access_request = AccessRequest.new(access_request_params)
-        authorize access_request
+        authorize AccessRequest
+        @access_request = AccessRequest.new(access_request_params)
+        @access_request.add_additonal_attributes(@access_request.requester_email)
 
-        access_request.requester        = User.find_by(email: access_request.requester_email)
-        access_request.request_date_utc = Time.now.utc
-        access_request.status           = :requested
-        access_request.save!
-
-        render jsonapi: access_request
+        render jsonapi: @access_request
       end
 
     private

--- a/app/models/access_request.rb
+++ b/app/models/access_request.rb
@@ -30,6 +30,12 @@ class AccessRequest < ApplicationRecord
     User.new(first_name: first_name, last_name: last_name, email: email_address)
   end
 
+  def add_additonal_attributes(requester_email)
+    self.update(requester: User.find_by(email: requester_email),
+                request_date_utc: Time.now.utc,
+                status: :requested)
+  end
+
   alias_method :approve, :completed!
 
   audited

--- a/spec/models/access_request_spec.rb
+++ b/spec/models/access_request_spec.rb
@@ -75,4 +75,32 @@ describe AccessRequest, type: :model do
       expect(AccessRequest.by_request_date.last).to eq access_request1
     end
   end
+
+  describe '#add_additonal_attributes' do
+    let(:user) { create(:user, organisations: [organisation]) }
+    let(:organisation) { build(:organisation) }
+    let(:access_request) {
+      build(:access_request,
+            organisation: user.organisations.first.name,
+                requester_email: user.email,
+                requester: nil,
+                request_date_utc: nil,
+                status: nil)
+    }
+
+    before do
+      Timecop.freeze
+      access_request.add_additonal_attributes(access_request.requester_email)
+    end
+
+    after do
+      Timecop.return
+    end
+
+    subject { access_request }
+
+    its(:requester)         { should eq user }
+    its(:request_date_utc)  { should be_within(1.second).of Time.now.utc }
+    its(:status)            { should eq 'requested' }
+  end
 end


### PR DESCRIPTION
### Context

The access request controller currently has the logic for adding the requester_id, request_date_utc and the status to the access_request object upon instantiation. 

### Changes proposed in this pull request

- Move updating the above 3 attributes from the controller to the model.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
