### PR TITLE
[1624] Add deserializable site class

### DIFF
--- a/app/controllers/api/v2/sites_controller.rb
+++ b/app/controllers/api/v2/sites_controller.rb
@@ -45,7 +45,7 @@ module API
 
       def site_params
         params
-          .require(:site)
+          .fetch(:site, {})
           .except(:id, :type)
           .permit(
             :location_name,

--- a/app/controllers/api/v2/sites_controller.rb
+++ b/app/controllers/api/v2/sites_controller.rb
@@ -1,7 +1,9 @@
 module API
   module V2
     class SitesController < API::V2::ApplicationController
-      deserializable_resource :site, only: %i[update create]
+      deserializable_resource :site,
+                              only: %i[update create],
+                              class: API::V2::DeserializableSite
 
       before_action :build_provider
       before_action :build_site, except: %i[index create]

--- a/app/deserializers/api/v2/deserializable_site.rb
+++ b/app/deserializers/api/v2/deserializable_site.rb
@@ -1,0 +1,14 @@
+module API
+  module V2
+    class DeserializableSite < JSONAPI::Deserializable::Resource
+      attributes :address1,
+                 :address2,
+                 :address3,
+                 :address4,
+                 :code,
+                 :location_name,
+                 :postcode,
+                 :region_code
+    end
+  end
+end

--- a/spec/desieralizers/api/v2/deserializable_site_spec.rb
+++ b/spec/desieralizers/api/v2/deserializable_site_spec.rb
@@ -1,0 +1,25 @@
+describe API::V2::DeserializableSite do
+  let(:site) { build(:site) }
+  let(:site_jsonapi) do
+    JSON.parse(jsonapi_renderer.render(
+      site,
+      class: {
+        Site: API::V2::SerializableSite
+      }
+    ).to_json)['data']
+  end
+  let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+
+  subject { described_class.new(site_jsonapi).to_h }
+
+  describe 'attributes' do
+    it { should include(address1: site.address1) }
+    it { should include(address2: site.address2) }
+    it { should include(address3: site.address3) }
+    it { should include(address4: site.address4) }
+    it { should include(code: site.code) }
+    it { should include(location_name: site.location_name) }
+    it { should include(postcode: site.postcode) }
+    it { should include(region_code: site.region_code) }
+  end
+end

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -207,6 +207,16 @@ describe 'Sites API v2', type: :request do
         )
       end
 
+      context 'with empty params' do
+        before do
+          site_params.clear
+        end
+
+        it 'does not raise an error' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
       it 'updates the location name of the site' do
         expect { subject }.to change { site1.reload.location_name }
           .from(site1.location_name)


### PR DESCRIPTION
### Context

json-api will auto-generate one for us, but it's better to use an explicit one instead because that way we have more finely grained control over what attributes get exposed.

### Changes proposed in this pull request

Add DeserializableSite and use it in the site_controller.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally