### PR TITLE
[1624] Remove latest_enrichment prefix on enrichment errors

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -287,14 +287,11 @@ private
 
   def add_enrichment_errors(enrichment)
     enrichment.errors.messages.map do |field, _error|
-      # Compute a key of `latest_enrichment__FIELD` to allow the frontend to determine
-      # which field should be linked to from the error title.
-      key = "latest_enrichment__#{field}".to_sym
       # `full_messages_for` here will remove any `^`s defined in the validator or en.yml.
       # We still need it for later, so re-add it.
       # jsonapi_errors will throw if it's given an array, so we call `.first`.
       message = "^" + enrichment.errors.full_messages_for(field).first.to_s
-      errors.add key, message
+      errors.add field.to_sym, message
     end
   end
 

--- a/spec/requests/api/v2/providers/courses/update_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_spec.rb
@@ -251,13 +251,12 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
       it "returns validation errors" do
         perform_request update_course
 
-        prefix = "Invalid latest_enrichment__"
-        expect("#{prefix}about_course".in?(subject)).to eq(true)
-        expect("#{prefix}interview_process".in?(subject)).to eq(true)
-        expect("#{prefix}how_school_placements_work".in?(subject)).to eq(true)
-        expect("#{prefix}qualifications".in?(subject)).to eq(true)
-        expect("#{prefix}fee_details".in?(subject)).to eq(true)
-        expect("#{prefix}financial_support".in?(subject)).to eq(true)
+        expect("Invalid about_course".in?(subject)).to eq(true)
+        expect("Invalid interview_process".in?(subject)).to eq(true)
+        expect("Invalid how_school_placements_work".in?(subject)).to eq(true)
+        expect("Invalid qualifications".in?(subject)).to eq(true)
+        expect("Invalid fee_details".in?(subject)).to eq(true)
+        expect("Invalid financial_support".in?(subject)).to eq(true)
       end
     end
 


### PR DESCRIPTION
### Context

These were initially added with the idea that without them, the frontend will not be able to differentiate which errors belong to the course and which errors belong to the course enrichment.

In practice, they actually end up confusing json-api, which will not automatically assign `source: { pointer }`s which are used to then associate validation errors to the appropriate field.

### Changes proposed in this pull request

Because the frontend doesn't need to know about enrichments, it's better if we simply remove this prefix.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally