### PR TITLE
[1651] Use render system for showing user info

### DIFF
--- a/lib/mcb/commands/users/show.rb
+++ b/lib/mcb/commands/users/show.rb
@@ -9,13 +9,6 @@ run do |opts, args, _cmd|
   if user.nil?
     error "User not found: #{args[:id_or_email_or_sign_in_id]}"
   else
-    puts "User:"
-    puts Terminal::Table.new rows: user.attributes
-    puts ''
-    puts "Providers:"
-    puts Tabulo::Table.new(user.providers,
-                           :id,
-                           :provider_name,
-                           :provider_code).pack
+    puts MCB::Render::ActiveRecord.user(user)
   end
 end

--- a/lib/mcb/render.rb
+++ b/lib/mcb/render.rb
@@ -13,6 +13,31 @@ module MCB
       %i[type name email telephone]
     end
 
+    # Render a user for output to the terminal.
+    #
+    # Takes care of rendering out all the attributes and related objects in
+    # the correct format. Associations are specified as params to allow the
+    # caller to decide how they are retrieved (ActiveRecord objects will
+    # access attributes and associations differently from JSON API
+    # responses).
+    def user(user,
+             providers:)
+      [
+        user_record(user),
+        "\n",
+        providers_table(providers, name: "Has access to providers"),
+      ]
+    end
+
+    def user_record(user, name: 'User')
+      user_table = Terminal::Table.new rows: user
+
+      [
+        "#{name}:",
+        *user_table,
+      ]
+    end
+
     # Render a course for output to the terminal.
     #
     # Takes care of rendering out all the attributes and related objects in

--- a/lib/mcb/render/active_record.rb
+++ b/lib/mcb/render/active_record.rb
@@ -14,6 +14,13 @@ module MCB
             enrichments:          course.enrichments,
           )
         end
+
+        def user(user)
+          super(
+            user.attributes,
+            providers: user.providers,
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

Working towards providing ability to revoke a user's access to an organisation

### Changes proposed in this pull request

Update `user show` command to new style. This will allow us to preview the changes when we get to access modification.

### Guidance to review

```
tim@fox:~/repo/dfe/manage/backend(1651-mcb-use-grid-for-user-show)
$ be bin/mcb users show "larae@dicki.info"            
User:
+------------------------+------------------+
| id                     | 102              |
| email                  | larae@dicki.info |
| first_name             | Mandie           |
| last_name              | Hilll            |
| first_login_date_utc   |                  |
| last_login_date_utc    |                  |
| sign_in_user_id        |                  |
| welcome_email_date_utc |                  |
| invite_date_utc        |                  |
| accept_terms_date_utc  |                  |
| state                  | new              |
+------------------------+------------------+

Has access to providers:
+-----+--------------+------+
|  id |     name     | code |
+-----+--------------+------+
| 124 | ACME SCITT 0 | A0   |
+-----+--------------+------+
```

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
