### PR TITLE
[1644] Refactor course recruitment_year to recruitment_cycle_year

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -121,7 +121,7 @@ class Course < ApplicationRecord
     valid? :save
   end
 
-  def recruitment_cycle
+  def recruitment_cycle_year
     DEFAULT_RECRUITMENT_CYCLE_YEAR
   end
 

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -73,6 +73,6 @@ class CourseSerializer < ActiveModel::Serializer
   end
 
   def recruitment_cycle
-    object.recruitment_cycle
+    object.recruitment_cycle_year
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -636,4 +636,9 @@ RSpec.describe Course, type: :model do
       end
     end
   end
+
+  describe '#recruitment_cycle_year' do
+    subject { create(:course) }
+    its(:recruitment_cycle_year) { should eq('2019') }
+  end
 end


### PR DESCRIPTION
### Context

So we can add a `belongs_to` recruitment_cycle_year to Course later.

### Changes proposed in this pull request

- Refactor Course#recruitment_year to Course#recruitment_cycle_year

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
