### PR TITLE
1651 mcb refactor user grant

### DIFF
--- a/lib/mcb/commands/users/grant.rb
+++ b/lib/mcb/commands/users/grant.rb
@@ -1,6 +1,6 @@
 summary 'Attach a user to an organisation/provider in the DB'
 param :provider_code, transform: ->(code) { code.upcase }
-usage 'grant_access_to_provider <provider_code>'
+usage 'grant <provider_code>'
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)

--- a/lib/mcb/commands/users/grant.rb
+++ b/lib/mcb/commands/users/grant.rb
@@ -1,11 +1,12 @@
-summary 'Attach a user to an organisation/provider in the DB'
+summary 'Attach a user to an organisation/provider in the DB. Will prompt to create user if email address is unknown.'
+param :id_or_email_or_sign_in_id
 param :provider_code, transform: ->(code) { code.upcase }
-usage 'grant <provider_code>'
+usage 'grant <id or email or sign-in id> <provider_code>'
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
   cli = HighLine.new
   provider = Provider.find_by!(provider_code: args[:provider_code])
-  MCB::GrantAccessWizard.new(cli, provider).run
+  MCB::GrantAccessWizard.new(cli, args[:id_or_email_or_sign_in_id], provider).run
 end

--- a/lib/mcb/grant_access_wizard.rb
+++ b/lib/mcb/grant_access_wizard.rb
@@ -9,6 +9,8 @@ module MCB
     def run
       fetch_organisation
       return unless find_or_init_user
+
+      puts MCB::Render::ActiveRecord.user @user
       return unless persist_user_if_new
 
       confirm_and_add_user_to_organisation
@@ -58,10 +60,9 @@ module MCB
       if @user.in?(@organisation.users)
         puts "#{@user} already belongs to #{@organisation.name}"
       else
-        puts "You're about to give #{@user} access to #{@organisation.name}. They will manage:"
-        @organisation.providers.each do |p|
-          puts " - #{p.provider_name} (#{p.provider_code})"
-        end
+        puts "\n"
+        puts "You're about to give #{@user} access to organisation #{@organisation.name}. They will manage:"
+        puts MCB::Render::ActiveRecord.providers_table @organisation.providers, name: "Additional Providers"
         @organisation.users << @user if @cli.agree("Agree?  ")
       end
     end

--- a/spec/lib/mcb/commands/users/grant_access_to_provider_spec.rb
+++ b/spec/lib/mcb/commands/users/grant_access_to_provider_spec.rb
@@ -23,7 +23,7 @@ describe 'mcb users grant_access_to_provider' do
     let(:input_commands) { [user.email] }
     let(:user) { create(:user, organisations: [organisation]) }
 
-    it 'informs the support agen that it is not going to do anything' do
+    it 'informs the support agent that it is not going to do anything' do
       expect(output).to include("#{user} already belongs to #{organisation.name}")
     end
   end

--- a/spec/lib/mcb/commands/users/grant_spec.rb
+++ b/spec/lib/mcb/commands/users/grant_spec.rb
@@ -48,7 +48,7 @@ describe 'mcb users grant' do
 
     it 'confirms user creation and organisation membership' do
       expect(output).to include("jsmith@acme.org appears to be a new user")
-      expect(output).to include("You're about to give Jane Smith <jsmith@acme.org> access to #{organisation.name}.")
+      expect(output).to include("You're about to give Jane Smith <jsmith@acme.org> access to organisation #{organisation.name}.")
     end
   end
 
@@ -83,7 +83,7 @@ describe 'mcb users grant' do
     end
 
     it 'confirms user creation and organisation membership' do
-      expect(output).to include("You're about to give #{user} access to #{organisation.name}.")
+      expect(output).to include("You're about to give #{user} access to organisation #{organisation.name}.")
     end
   end
 end

--- a/spec/lib/mcb/commands/users/grant_spec.rb
+++ b/spec/lib/mcb/commands/users/grant_spec.rb
@@ -1,7 +1,7 @@
 require 'mcb_helper'
 
-describe 'mcb users grant_access_to_provider' do
-  def grant_access_to_provider(provider_code, commands)
+describe 'mcb users grant' do
+  def grant(provider_code, commands)
     stderr = ""
     output = with_stubbed_stdout(stdin: commands, stderr: stderr) do
       cmd.run([provider_code])
@@ -12,12 +12,12 @@ describe 'mcb users grant_access_to_provider' do
   let(:lib_dir) { "#{Rails.root}/lib" }
   let(:cmd) do
     Cri::Command.load_file(
-      "#{lib_dir}/mcb/commands/users/grant_access_to_provider.rb"
+      "#{lib_dir}/mcb/commands/users/grant.rb"
     )
   end
   let(:organisation) { create(:organisation) }
   let(:provider) { create(:provider, organisations: [organisation]) }
-  let(:output) { grant_access_to_provider(provider.provider_code, input_commands.join("\n") + "\n").first }
+  let(:output) { grant(provider.provider_code, input_commands.join("\n") + "\n").first }
 
   context 'when the user exists and already has access to the provider' do
     let(:input_commands) { [user.email] }


### PR DESCRIPTION
### Context

Improving `bin/mcb users grant` ready for adding revoke after discussions with @misaka 

### Changes proposed in this pull request

* rename the command to be shorter
* move email address into command arguments instead of prompting for it
* use the new output format, this shows more information about what is being done before prompting to continue

### Guidance to review

new usage:

```
tim@fox:~/repo/dfe/manage/backend(1651-mcb-refactor-user-grant)
$ be bin/mcb users grant bobby.tables@digital.education.gov.uk A1
bobby.tables@digital.education.gov.uk appears to be a new user
First name?  bobby
Last name?  tables
User:
+------------------------+---------------------------------------+
| id                     |                                       |
| email                  | bobby.tables@digital.education.gov.uk |
| first_name             | bobby                                 |
| last_name              | tables                                |
| first_login_date_utc   |                                       |
| last_login_date_utc    |                                       |
| sign_in_user_id        |                                       |
| welcome_email_date_utc |                                       |
| invite_date_utc        |                                       |
| accept_terms_date_utc  |                                       |
| state                  | new                                   |
+------------------------+---------------------------------------+

Has access to providers:
-none-
About to create bobby tables <bobby.tables@digital.education.gov.uk>. Continue? y

You're about to give bobby tables <bobby.tables@digital.education.gov.uk> access to organisation ACME1. They will manage:
Additional Providers:
+-----+--------------+------+
|  id |     name     | code |
+-----+--------------+------+
| 125 | ACME SCITT 1 | A1   |
+-----+--------------+------+
Agree?  y
tim@fox:~/repo/dfe/manage/backend(1651-mcb-refactor-user-grant)
$ be bin/mcb users grant bobby.tables@digital.education.gov.uk A2
User:
+------------------------+---------------------------------------+
| id                     | 115                                   |
| email                  | bobby.tables@digital.education.gov.uk |
| first_name             | bobby                                 |
| last_name              | tables                                |
| first_login_date_utc   |                                       |
| last_login_date_utc    |                                       |
| sign_in_user_id        |                                       |
| welcome_email_date_utc |                                       |
| invite_date_utc        |                                       |
| accept_terms_date_utc  |                                       |
| state                  | new                                   |
+------------------------+---------------------------------------+

Has access to providers:
+-----+--------------+------+
|  id |     name     | code |
+-----+--------------+------+
| 125 | ACME SCITT 1 | A1   |
+-----+--------------+------+

You're about to give bobby tables <bobby.tables@digital.education.gov.uk> access to organisation ACME2. They will manage:
Additional Providers:
+-----+--------------+------+
|  id |     name     | code |
+-----+--------------+------+
| 126 | ACME SCITT 2 | A2   |
+-----+--------------+------+
Agree?  y
```

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Dealt with TODOs in new code
- [ ] Address PR feedback