### PR TITLE
Update to cri 2.15.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
-    cri (2.15.7)
+    cri (2.15.9)
     data_migrate (5.3.2)
       rails (>= 4.2)
     database_cleaner (1.7.0)

--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -180,7 +180,15 @@ module MCB
       user
     end
 
-    def apiv1_opts(**opts)
+    def apiv1_opts(opts)
+      # the following lines are necessary to make opts work with double **splats and default values
+      # See the change introduced in https://github.com/ddfreyne/cri/pull/99 (cri 2.15.8)
+      opts[:url] = opts[:url]
+      opts[:endpoint] = opts[:endpoint]
+      opts[:'max-pages'] = opts[:'max-pages']
+      opts[:token] = opts[:token]
+      opts[:all] = opts[:all]
+
       opts.merge! azure_env_settings_for_opts(**opts)
 
       if requesting_remote_connection?(**opts)


### PR DESCRIPTION
### Context
We want to keep gem dependencies updated. `cri` 2.15.8 changed how default values are set in the `cri` options, meaning some of our `mcb` commands broke.

### Changes proposed in this pull request
Ensure that default values are passed around in the `mcb` code as before.

### Guidance for review

There's more background reading on https://github.com/ddfreyne/cri/pull/99

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
