### PR TITLE
[1635] Make word count validation more robust

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,9 @@ gem 'data_migrate'
 # Allows writing of error full_messages for validations that don't start with the attribute name
 gem 'custom_error_message', git: 'https://github.com/nanamkim/custom-err-msg.git', ref: 'd72fb18'
 
+# Word count for validations
+gem 'words_counted'
+
 group :development, :test do
   # add info about db structure to models and other files
   gem 'annotate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -378,6 +378,7 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    words_counted (1.0.2)
 
 PLATFORMS
   ruby
@@ -445,6 +446,7 @@ DEPENDENCIES
   tzinfo-data
   uk_postcode
   webmock
+  words_counted
 
 RUBY VERSION
    ruby 2.6.1p33

--- a/app/validators/words_count_validator.rb
+++ b/app/validators/words_count_validator.rb
@@ -2,7 +2,7 @@ class WordsCountValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if value.blank?
 
-    unless /^\s*(\S+\s+|\S+$){0,#{options[:maximum]}}$/i.match?(value)
+    if WordsCounted.count(value).token_count > options[:maximum]
       record.errors[attribute] << (options[:message] || "^Reduce the word count for #{attribute.to_s.humanize(capitalize: false)}")
     end
   end


### PR DESCRIPTION
### Context
Apparently counting words is hard. Have a play http://rubywordcount.com/

### Changes proposed in this pull request
Add [words_counted](https://github.com/abitdodgy/words_counted) gem and remove home grown regex

### Guidance to review
```ruby
pry(main)> ce = CourseEnrichment.new(provider: Provider.first, course: Course.first)
pry(main)> ce.about_course = 'foo ' * 451
pry(main)> ce.valid? :save
=> false
pry(main)> ce.errors.messages
=> {:about_course=>["^Reduce the word count for about course"]}
pry(main)> ce.about_course = 'foo\n' * 451
pry(main)> ce.valid? :save
=> false # previsouly this was true 
pry(main)> ce.errors.messages
=> {:about_course=>["^Reduce the word count for about course"]}
```

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
