### PR TITLE
[1651] mcb specs - env var for disabling stderr redirection

### DIFF
--- a/spec/support/with_stubbed_stdout.rb
+++ b/spec/support/with_stubbed_stdout.rb
@@ -7,7 +7,21 @@
 # from that pipe and write to a StringIO object. Unfortunately that
 # implementation isn't threads-safe but this one should be.
 
-def with_stubbed_stdout(stdin: nil, stderr: nil)
+def with_stubbed_stdout(stdin: nil, stderr: nil, &block)
+  # if the parameters are wrong for a cli command then the error is written to
+  # stderr which is lost when we have it mocked out. This env gives us a way to
+  # disable redirection when trying to debug a failure in order to see the error
+  # message.
+  if ENV["WITHOUT_STUBBED_STDOUT"]
+    yield
+  else
+    run stdin: stdin, stderr: stderr, &block
+  end
+end
+
+private
+
+def run(stdin: nil, stderr: nil)
   # Here is where we'll redirect STDOUT to temporarily. Using a StringIO
   # doesn't seem to work, it seems to require a proper file.
   output_file = Tempfile.new('stdout.')


### PR DESCRIPTION
### Context

param errors in mcb usage of cri are hard to debug due to our use of stderr/out redirection in the test harness

extracted this PR while working on #500

### Changes proposed in this pull request

Add environment variable `WITHOUT_STUBBED_STDOUT` to bypass stderr redirection for debugging

### Guidance to review

introduce a local diff that adds a new cri param
```
diff --git a/lib/mcb/commands/users/grant_access_to_provider.rb b/lib/mcb/commands/users/grant_access_to_provider.rb
index eac9372..e510221 100644
--- a/lib/mcb/commands/users/grant_access_to_provider.rb
+++ b/lib/mcb/commands/users/grant_access_to_provider.rb
@@ -1,5 +1,6 @@
 summary 'Attach a user to an organisation/provider in the DB'
 param :provider_code, transform: ->(code) { code.upcase }
+param :xxx
 usage 'grant_access_to_provider <provider_code>'
 
 run do |opts, args, _cmd|
```


without the flag the tests bail with exit code 1 and no clue why
```
$ be rspec spec/lib/mcb/commands/users/grant_access_to_provider_spec.rb
The HashDiff constant used by this gem conflicts with another gem of a similar name.  As of version 1.0 the HashDiff constant will be completely removed and replaced by Hashdiff.  For more information see https://github.com/liufengyun/hashdiff/issues/45.
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}


Finished in 0.56336 seconds (files took 1.54 seconds to load)
1 example, 0 failures

Coverage report generated for RSpec to /home/tim/repo/dfe/manage/backend/coverage. 735 / 1223 LOC (60.1%) covered.
```
with the flag you get the stderr from cri
```
$ WITHOUT_STUBBED_STDOUT=y be rspec spec/lib/mcb/commands/users/grant_access_to_provider_spec.rb
The HashDiff constant used by this gem conflicts with another gem of a similar name.  As of version 1.0 the HashDiff constant will be completely removed and replaced by Hashdiff.  For more information see https://github.com/liufengyun/hashdiff/issues/45.
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}
: incorrect number of arguments given: expected 2, but got 1


Finished in 0.56158 seconds (files took 1.5 seconds to load)
1 example, 0 failures

Coverage report generated for RSpec to /home/tim/repo/dfe/manage/backend/coverage. 735 / 1223 LOC (60.1%) covered.
tim@fox:~/repo/dfe/manage/backend(1651-mcb-spec-stderr-switch*)
```


### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
