### PR TITLE
[1643] Add recruitment cycles to database

### DIFF
--- a/db/data/20190619132129_create_recruitment_cycles.rb
+++ b/db/data/20190619132129_create_recruitment_cycles.rb
@@ -1,0 +1,10 @@
+class CreateRecruitmentCycles < ActiveRecord::Migration[5.2]
+  def up
+    RecruitmentCycle.create(year: '2019', application_start_date: Date.new(2018, 10, 9))
+    RecruitmentCycle.create(year: '2020')
+  end
+
+  def down
+    RecruitmentCycle.destroy_all
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,3 +1,3 @@
 # encoding: UTF-8
 
-DataMigrate::Data.define(version: 20190424094003)
+DataMigrate::Data.define(version: 20190619132129)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,6 +8,7 @@ SiteStatus.destroy_all
 Provider.destroy_all
 User.destroy_all
 AccessRequest.destroy_all
+RecruitmentCycle.destroy_all
 
 accrediting_provider = Provider.create!(provider_name: 'Acme SCITT', provider_code: 'A01')
 
@@ -157,4 +158,8 @@ access_requester_user = User.all.reject(&:admin?).sample
     request_date_utc: rand(1..20).days.ago,
     status: %i[requested completed].sample
   )
+end
+
+%w[2019 2020].each do |year|
+  RecruitmentCycle.create(year: year)
 end


### PR DESCRIPTION
### Context
We need `RecruitmentCycle`'s in our database

### Changes proposed in this pull request
Data migration to add the 2019 and 2020 recruitment cycles

### Guidance to review
Run `bundle exec rake db:migrate:with_data`

```
$ bundle exec rails c
$ RecruitmentCycle.all

[#<RecruitmentCycle:0x00007fa9d00f3f30
  id: 2,
  year: "2019",
  application_start_date: nil,
  application_end_date: nil,
  created_at: Wed, 19 Jun 2019 13:27:46 UTC +00:00,
  updated_at: Wed, 19 Jun 2019 13:27:46 UTC +00:00>,
 #<RecruitmentCycle:0x00007fa9d00e0188
  id: 3,
  year: "2020",
  application_start_date: nil,
  application_end_date: nil,
  created_at: Wed, 19 Jun 2019 13:27:46 UTC +00:00,
  updated_at: Wed, 19 Jun 2019 13:27:46 UTC +00:00>]
```

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
