### PR TITLE
[1640] Add recruitment cycle to courses

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -20,6 +20,7 @@
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  changed_at              :datetime         not null
+#  recruitment_cycle_id    :integer
 #
 
 class Course < ApplicationRecord
@@ -69,6 +70,7 @@ class Course < ApplicationRecord
 
   belongs_to :provider
   belongs_to :accrediting_provider, class_name: 'Provider', optional: true
+  belongs_to :recruitment_cycle
   has_many :course_subjects
   has_many :subjects, through: :course_subjects
   has_many :site_statuses

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -11,5 +11,7 @@
 #
 
 class RecruitmentCycle < ApplicationRecord
+  has_many :courses
+
   validates :year, presence: true
 end

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -20,6 +20,7 @@
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  changed_at              :datetime         not null
+#  recruitment_cycle_id    :integer
 #
 
 class CourseSerializer < ActiveModel::Serializer

--- a/db/data/20190619144634_add_2019_recruitment_cycle_to_courses.rb
+++ b/db/data/20190619144634_add_2019_recruitment_cycle_to_courses.rb
@@ -1,0 +1,10 @@
+class Add2019RecruitmentCycleToCourses < ActiveRecord::Migration[5.2]
+  def up
+    current_recruitment_cycle = RecruitmentCycle.where(year: '2019').first
+    Course.update(recruitment_cycle: current_recruitment_cycle)
+  end
+
+  def down
+    Course.update(recruitment_cycle: nil)
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,3 +1,3 @@
 # encoding: UTF-8
 
-DataMigrate::Data.define(version: 20190619132129)
+DataMigrate::Data.define(version: 20190619144634)

--- a/db/migrate/20190619142449_add_recruitment_cycle_to_course.rb
+++ b/db/migrate/20190619142449_add_recruitment_cycle_to_course.rb
@@ -1,0 +1,5 @@
+class AddRecruitmentCycleToCourse < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :course, :recruitment_cycle, index: true, type: :int
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_19_114150) do
+ActiveRecord::Schema.define(version: 2019_06_19_142449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -85,9 +85,11 @@ ActiveRecord::Schema.define(version: 2019_06_19_114150) do
     t.datetime "created_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.datetime "changed_at", default: -> { "timezone('utc'::text, now())" }, null: false
+    t.integer "recruitment_cycle_id"
     t.index ["accrediting_provider_id"], name: "IX_course_accrediting_provider_id"
     t.index ["changed_at"], name: "index_course_on_changed_at", unique: true
     t.index ["provider_id", "course_code"], name: "IX_course_provider_id_course_code", unique: true
+    t.index ["recruitment_cycle_id"], name: "index_course_on_recruitment_cycle_id"
   end
 
   create_table "course_enrichment", id: :serial, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,9 @@ SiteStatus.destroy_all
 Provider.destroy_all
 User.destroy_all
 AccessRequest.destroy_all
-RecruitmentCycle.destroy_all
+
+current_recruitment_cycle = RecruitmentCycle.create(year: '2019', application_start_date: Date.new(2018, 10, 9))
+next_recruitment_cycle = RecruitmentCycle.create(year: '2020')
 
 accrediting_provider = Provider.create!(provider_name: 'Acme SCITT', provider_code: 'A01')
 
@@ -55,6 +57,7 @@ course1 = Course.create!(
     Subject.find_by(subject_name: "Mathematics")
   ],
   study_mode: "F",
+  recruitment_cycle: current_recruitment_cycle
 )
 
 SiteStatus.create!(
@@ -84,6 +87,7 @@ course2 = Course.create!(
     Subject.find_by(subject_name: "Further Education"),
   ],
   study_mode: "B",
+  recruitment_cycle: current_recruitment_cycle
 )
 
 PGDECourse.create!(
@@ -110,14 +114,16 @@ Course.create!(
   qualification: :pgce_with_qts,
   subjects: [
     Subject.last
-  ]
+  ],
+  recruitment_cycle: current_recruitment_cycle
 )
 
 Course.create!(
   name: Faker::ProgrammingLanguage.name,
   course_code: "9A5Y",
   provider: Provider.create!(provider_name: 'Big Uni', provider_code: 'B01'),
-  qualification: :pgce_with_qts
+  qualification: :pgce_with_qts,
+  recruitment_cycle: next_recruitment_cycle
 )
 
 User.create!(
@@ -158,8 +164,4 @@ access_requester_user = User.all.reject(&:admin?).sample
     request_date_utc: rand(1..20).days.ago,
     status: %i[requested completed].sample
   )
-end
-
-%w[2019 2020].each do |year|
-  RecruitmentCycle.create(year: year)
 end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -20,6 +20,7 @@
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  changed_at              :datetime         not null
+#  recruitment_cycle_id    :integer
 #
 
 FactoryBot.define do
@@ -30,6 +31,7 @@ FactoryBot.define do
     with_higher_education
 
     association(:provider)
+    association(:recruitment_cycle)
 
     study_mode { :full_time }
     resulting_in_pgce_with_qts

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -20,6 +20,7 @@
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  changed_at              :datetime         not null
+#  recruitment_cycle_id    :integer
 #
 
 require 'rails_helper'
@@ -36,6 +37,7 @@ RSpec.describe Course, type: :model do
   describe 'associations' do
     it { should belong_to(:provider) }
     it { should belong_to(:accrediting_provider).optional }
+    it { should belong_to(:recruitment_cycle) }
     it { should have_many(:subjects).through(:course_subjects) }
     it { should have_many(:site_statuses) }
     it { should have_many(:sites) }

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -20,4 +20,8 @@ describe RecruitmentCycle, type: :model do
   end
 
   it { is_expected.to validate_presence_of(:year) }
+
+  describe 'associations' do
+    it { should have_many(:courses) }
+  end
 end

--- a/spec/serializers/course_serializer_spec.rb
+++ b/spec/serializers/course_serializer_spec.rb
@@ -20,6 +20,7 @@
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  changed_at              :datetime         not null
+#  recruitment_cycle_id    :integer
 #
 
 require "rails_helper"


### PR DESCRIPTION
### Context
Add the 2019 recruitment cycle to ALL courses

### Changes proposed in this pull request
- Setup association between course and recruitment cycle
- Add data migration to add 2019 recruitment cycle to all courses

### Guidance to review
Run `bundle exec rake db:migrate:with_data`

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
