### PR TITLE
[1657] Improved string representation of models

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -283,6 +283,10 @@ class Course < ApplicationRecord
     dfe_subjects&.first&.scholarship_amount
   end
 
+  def to_s
+    "#{name} (#{course_code})"
+  end
+
 private
 
   def add_enrichment_errors(enrichment)

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -46,7 +46,7 @@ class Site < ApplicationRecord
     self.code ||= pick_next_available_code(available_codes: provider&.unassigned_site_codes)
   end
 
-  def description
+  def to_s
     "#{location_name} (code: #{code})"
   end
 

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -89,10 +89,6 @@ class SiteStatus < ApplicationRecord
     end
   end
 
-  def description
-    "#{site.description} – #{status}/#{publish}"
-  end
-
   def has_vacancies?
     SiteStatus.findable.with_vacancies.any?
   end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -16,4 +16,8 @@ class Subject < ApplicationRecord
   def is_send?
     subject_code.casecmp('U3').zero?
   end
+
+  def to_s
+    subject_name
+  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -25,8 +25,10 @@
 require 'rails_helper'
 
 RSpec.describe Course, type: :model do
-  let(:course) { create(:course) }
+  let(:course) { create(:course, name: 'Biology', course_code: '3X9F') }
   let(:subject) { course }
+
+  its(:to_s) { should eq('Biology (3X9F)') }
 
   describe 'auditing' do
     it { should be_audited.except(:changed_at) }

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -75,6 +75,6 @@ describe Provider, type: :model do
 
   describe "description" do
     subject { build(:site, location_name: 'Foo', code: '1') }
-    its(:description) { should eq 'Foo (code: 1)' }
+    its(:to_s) { should eq 'Foo (code: 1)' }
   end
 end

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -175,11 +175,6 @@ RSpec.describe SiteStatus, type: :model do
     end
   end
 
-  describe "description" do
-    subject { build(:site_status, :running, :unpublished, site: create(:site, location_name: 'Foo', code: '1')) }
-    its(:description) { should eq 'Foo (code: 1) – running/unpublished' }
-  end
-
   describe "default_vac_status_given" do
     subject { SiteStatus }
     it "should return correct default_vac_status" do

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -10,7 +10,8 @@
 require 'rails_helper'
 
 RSpec.describe Subject, type: :model do
-  subject { create(:subject) }
+  subject { create(:subject, subject_name: 'Mathematics') }
 
   it { should have_many(:courses).through(:course_subjects) }
+  its(:to_s) { should eq('Mathematics') }
 end


### PR DESCRIPTION
### Context
The support tooling displays sites and subjects to the support agents in various places.

### Changes proposed in this pull request
- remove `SiteStatus#description` (no longer used)
- add `Site#to_s` and `Subject#to_s`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
