### PR TITLE
[1657] Course defaults and aligned data

### DIFF
--- a/app/models/concerns/with_qualifications.rb
+++ b/app/models/concerns/with_qualifications.rb
@@ -39,13 +39,7 @@ module WithQualifications
     # subjects this course was tagged to.
     #
     # Defined here: https://github.com/DFE-Digital/manage-courses-api/blob/master/src/ManageCourses.Domain/Models/CourseQualification.cs
-    enum qualification: %i[
-      qts
-      pgce_with_qts
-      pgde_with_qts
-      pgce
-      pgde
-    ]
+    enum qualification: %i[qts pgce_with_qts pgde_with_qts pgce pgde]
 
     # This field may seem like an unnecessary overhead when there is already a
     # database-backed `qualification` field. However it's misleading, from the

--- a/app/models/concerns/with_qualifications.rb
+++ b/app/models/concerns/with_qualifications.rb
@@ -63,5 +63,10 @@ module WithQualifications
     def qualifications_description
       qualifications.map(&:upcase).sort.join(" with ")
     end
+
+    def qualification=(value)
+      super(value)
+      self.profpost_flag = qts? ? :recommendation_for_qts : :postgraduate
+    end
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -28,6 +28,8 @@ class Course < ApplicationRecord
   include WithQualifications
   include ChangedAt
 
+  after_initialize :set_defaults
+
   has_associated_audits
   audited except: :changed_at
   validates :course_code, uniqueness: { scope: :provider_id }
@@ -338,5 +340,9 @@ private
 
   def validate_enrichment_saveable
     validate_enrichment :save
+  end
+
+  def set_defaults
+    self.modular ||= ''
   end
 end

--- a/spec/models/concerns/with_qualifications_spec.rb
+++ b/spec/models/concerns/with_qualifications_spec.rb
@@ -13,11 +13,31 @@ RSpec.describe WithQualifications, type: :model do
     specs.each do |spec|
       spec.each do |qualification, expected|
         context "course with qualification=#{qualification}" do
-          subject { create(:course, qualification: qualification) }
+          subject { build(:course, qualification: qualification) }
 
           its(:qualifications) { should eq(expected[:values]) }
           its(:qualifications_description) { should eq(expected[:description]) }
         end
+      end
+    end
+  end
+
+  describe "#qualification= and its dependent attribute profpost_flag" do
+    subject { build(:course, qualification: :pgce_with_qts) }
+
+    context "when the qualification is QTS only" do
+      before { subject.qualification = :qts }
+
+      its(:qualification) { should eq("qts") }
+      its(:profpost_flag) { should eq("recommendation_for_qts") }
+    end
+
+    (Course.qualifications.keys - %w[qts]).each do |qualification|
+      context "when the qualification is #{qualification}" do
+        before { subject.qualification = qualification }
+
+        its(:qualification) { should eq(qualification) }
+        its(:profpost_flag) { should eq("postgraduate") }
       end
     end
   end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Course, type: :model do
   let(:subject) { course }
 
   its(:to_s) { should eq('Biology (3X9F)') }
+  its(:modular) { should eq('') }
 
   describe 'auditing' do
     it { should be_audited.except(:changed_at) }


### PR DESCRIPTION
### Context
When new courses are created, we need to ensure that the correct downstream data is derived. In future we should move these attributes to the API V1 serialisers and drop the underlying columns.

### Changes proposed in this pull request
- add a default for `Course#modular`
- set `Course#profpost_flag` when `Course#qualification` is set

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
