### PR TITLE
[1558] Add recruitment cycle to sites

### DIFF
--- a/app/controllers/api/v2/sites_controller.rb
+++ b/app/controllers/api/v2/sites_controller.rb
@@ -17,6 +17,7 @@ module API
 
       def create
         @site = Site.new(site_params)
+        @site.recruitment_cycle = RecruitmentCycle.find_by(year: Settings.current_recruitment_cycle)
         @site.provider = @provider
         authorize @site
 

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -12,6 +12,7 @@
 
 class RecruitmentCycle < ApplicationRecord
   has_many :courses
+  has_many :sites
 
   validates :year, presence: true
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -2,18 +2,19 @@
 #
 # Table name: site
 #
-#  id            :integer          not null, primary key
-#  address2      :text
-#  address3      :text
-#  address4      :text
-#  code          :text             not null
-#  location_name :text
-#  postcode      :text
-#  address1      :text
-#  provider_id   :integer          default(0), not null
-#  region_code   :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id                   :integer          not null, primary key
+#  address2             :text
+#  address3             :text
+#  address4             :text
+#  code                 :text             not null
+#  location_name        :text
+#  postcode             :text
+#  address1             :text
+#  provider_id          :integer          default(0), not null
+#  region_code          :integer
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  recruitment_cycle_id :integer
 #
 
 class Site < ApplicationRecord
@@ -30,6 +31,7 @@ class Site < ApplicationRecord
   audited associated_with: :provider
 
   belongs_to :provider
+  belongs_to :recruitment_cycle
 
   validates :location_name, uniqueness: { scope: :provider_id }
   validates :location_name,

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -2,18 +2,19 @@
 #
 # Table name: site
 #
-#  id            :integer          not null, primary key
-#  address2      :text
-#  address3      :text
-#  address4      :text
-#  code          :text             not null
-#  location_name :text
-#  postcode      :text
-#  address1      :text
-#  provider_id   :integer          default(0), not null
-#  region_code   :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id                   :integer          not null, primary key
+#  address2             :text
+#  address3             :text
+#  address4             :text
+#  code                 :text             not null
+#  location_name        :text
+#  postcode             :text
+#  address1             :text
+#  provider_id          :integer          default(0), not null
+#  region_code          :integer
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  recruitment_cycle_id :integer
 #
 
 class SiteSerializer < ActiveModel::Serializer

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,3 +13,4 @@ search_api:
   base_url: http://localhost:5001
   # Auth token used between backend and search-and-compare-api to authorize requests.
   secret: banana
+current_recruitment_cycle: 2019

--- a/db/data/20190620121519_add2019_recruitment_cycle_to_sites.rb
+++ b/db/data/20190620121519_add2019_recruitment_cycle_to_sites.rb
@@ -1,0 +1,10 @@
+class Add2019RecruitmentCycleToSites < ActiveRecord::Migration[5.2]
+  def up
+    current_recruitment_cycle = RecruitmentCycle.where(year: '2019').first
+    Site.update(recruitment_cycle: current_recruitment_cycle)
+  end
+
+  def down
+    Site.update(recruitment_cycle: nil)
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,3 +1,3 @@
 # encoding: UTF-8
 
-DataMigrate::Data.define(version: 20190619144634)
+DataMigrate::Data.define(version: 20190620121519)

--- a/db/migrate/20190620120944_add_recruitment_cycle_to_site.rb
+++ b/db/migrate/20190620120944_add_recruitment_cycle_to_site.rb
@@ -1,0 +1,5 @@
+class AddRecruitmentCycleToSite < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :site, :recruitment_cycle, index: true, type: :int
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_19_142449) do
+ActiveRecord::Schema.define(version: 2019_06_20_120944) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -239,7 +239,9 @@ ActiveRecord::Schema.define(version: 2019_06_19_142449) do
     t.integer "region_code"
     t.datetime "created_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
+    t.integer "recruitment_cycle_id"
     t.index ["provider_id", "code"], name: "IX_site_provider_id_code", unique: true
+    t.index ["recruitment_cycle_id"], name: "index_site_on_recruitment_cycle_id"
   end
 
   create_table "subject", id: :serial, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -38,6 +38,7 @@ Site.create!(
   address3: Faker::Address.city,
   address4: Faker::Address.state,
   postcode: Faker::Address.postcode,
+  recruitment_cycle: current_recruitment_cycle
 )
 
 course1 = Course.create!(

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -2,18 +2,19 @@
 #
 # Table name: site
 #
-#  id            :integer          not null, primary key
-#  address2      :text
-#  address3      :text
-#  address4      :text
-#  code          :text             not null
-#  location_name :text
-#  postcode      :text
-#  address1      :text
-#  provider_id   :integer          default(0), not null
-#  region_code   :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id                   :integer          not null, primary key
+#  address2             :text
+#  address3             :text
+#  address4             :text
+#  code                 :text             not null
+#  location_name        :text
+#  postcode             :text
+#  address1             :text
+#  provider_id          :integer          default(0), not null
+#  region_code          :integer
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  recruitment_cycle_id :integer
 #
 
 FactoryBot.define do
@@ -26,6 +27,7 @@ FactoryBot.define do
     postcode { Faker::Address.postcode }
     region_code { 'london' }
     association(:provider)
+    association(:recruitment_cycle)
 
     transient do
       age { nil }

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -23,5 +23,6 @@ describe RecruitmentCycle, type: :model do
 
   describe 'associations' do
     it { should have_many(:courses) }
+    it { should have_many(:sites) }
   end
 end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -2,18 +2,19 @@
 #
 # Table name: site
 #
-#  id            :integer          not null, primary key
-#  address2      :text
-#  address3      :text
-#  address4      :text
-#  code          :text             not null
-#  location_name :text
-#  postcode      :text
-#  address1      :text
-#  provider_id   :integer          default(0), not null
-#  region_code   :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id                   :integer          not null, primary key
+#  address2             :text
+#  address3             :text
+#  address4             :text
+#  code                 :text             not null
+#  location_name        :text
+#  postcode             :text
+#  address1             :text
+#  provider_id          :integer          default(0), not null
+#  region_code          :integer
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  recruitment_cycle_id :integer
 #
 
 require 'rails_helper'
@@ -36,6 +37,7 @@ describe Provider, type: :model do
 
   describe 'associations' do
     it { should belong_to(:provider) }
+    it { should belong_to(:recruitment_cycle) }
   end
 
   describe '#touch_provider' do

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -2,18 +2,19 @@
 #
 # Table name: site
 #
-#  id            :integer          not null, primary key
-#  address2      :text
-#  address3      :text
-#  address4      :text
-#  code          :text             not null
-#  location_name :text
-#  postcode      :text
-#  address1      :text
-#  provider_id   :integer          default(0), not null
-#  region_code   :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id                   :integer          not null, primary key
+#  address2             :text
+#  address3             :text
+#  address4             :text
+#  code                 :text             not null
+#  location_name        :text
+#  postcode             :text
+#  address1             :text
+#  provider_id          :integer          default(0), not null
+#  region_code          :integer
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  recruitment_cycle_id :integer
 #
 
 require "rails_helper"


### PR DESCRIPTION
### Context
Add the 2019 recruitment cycle to ALL sites

### Changes proposed in this pull request
- Setup association between site and recruitment cycle
- Add data migration to add 2019 recruitment cycle to all sites

### Guidance to review
Run `bundle exec rake db:migrate:with_data`

Follow up PR to make recruitment cycle not nullable for sites AND courses

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
