### PR TITLE
[1646] Make recruitment year dynamic for V1 API

### DIFF
--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -25,7 +25,8 @@ module API
         set_next_link_header_using_changed_since_or_last_object(
           @courses.last,
           changed_since: changed_since,
-          per_page: per_page
+          per_page: per_page,
+          recruitment_year: recruitment_year
         )
 
         render json: @courses

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -5,14 +5,9 @@ module API
       include FirstItemFromNextPage
 
       def index
-        # only return 2019 courses until rollover is supported
-        if params[:recruitment_year].present? && params[:recruitment_year] != '2019'
-          render json: [], status: 404
-          return
-        end
-
         per_page = (params[:per_page] || 100).to_i
         changed_since = params[:changed_since]
+        recruitment_year = params[:recruitment_year]
 
         ActiveRecord::Base.transaction do
           ActiveRecord::Base.connection.execute('LOCK provider, provider_enrichment, site IN SHARE UPDATE EXCLUSIVE MODE')
@@ -23,6 +18,7 @@ module API
                                  :subjects,
                                  site_statuses: [:site])
                        .changed_since(changed_since)
+                       .by_recruitment_cycle(recruitment_year)
                        .limit(per_page)
         end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -117,6 +117,8 @@ class Course < ApplicationRecord
     end.order(:changed_at, :id)
   end
 
+  scope :by_recruitment_cycle, ->(recruitment_year) { joins(:recruitment_cycle).merge(RecruitmentCycle.where(year: recruitment_year)) }
+
   validates :enrichments, presence: true, on: :publish
   validate :validate_enrichment_publishable, on: :publish
   validate :validate_enrichment_saveable, on: :save

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -12,7 +12,8 @@ describe API::V1::CoursesController, type: :controller do
     # Default sensible params used by tests.
     let(:params) do
       {
-        changed_since: format_timestamp(changed_since)
+        changed_since: format_timestamp(changed_since),
+        recruitment_year: '2019'
       }
     end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -277,6 +277,20 @@ RSpec.describe Course, type: :model do
     its(:has_vacancies?) { should be false }
   end
 
+  describe '#by_recruitment_cycle' do
+    context 'with valid recruitment_year parameter' do
+      let(:current_cycle) { create(:recruitment_cycle, year: '2019') }
+      let(:next_cycle) { create(:recruitment_cycle, year: '2020') }
+      let(:course_1) { create(:course, recruitment_cycle: current_cycle) }
+      let(:course_2) { create(:course, recruitment_cycle: next_cycle) }
+
+      subject { Course.by_recruitment_cycle('2019') }
+
+      it { should include course_1 }
+      it { should_not include course_2 }
+    end
+  end
+
   describe '#changed_since' do
     context 'with no parameters' do
       let!(:old_course) { create(:course, age: 1.hour.ago) }

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -133,14 +133,15 @@ describe "Courses API", type: :request do
                                          age: timestamp_of_last_course,
                                          provider: provider)
 
-        get '/api/v1/courses',
+        get '/api/v1/2019/courses',
             headers: { 'HTTP_AUTHORIZATION' => credentials }
 
         expect(response.headers).to have_key "Link"
         url = url_for(
           params: {
             changed_since: timestamp_of_last_course.utc.strftime('%FT%T.%6NZ'),
-            per_page: 100
+            per_page: 100,
+            recruitment_year: 2019
           }
         )
 
@@ -154,7 +155,7 @@ describe "Courses API", type: :request do
           old_course = create(:course, course_code: "SINCE1", age: 1.hour.ago)
           updated_course = create(:course, course_code: "SINCE2", age: 5.minutes.ago)
 
-          get '/api/v1/courses',
+          get '/api/v1/2019/courses',
               headers: { 'HTTP_AUTHORIZATION' => credentials },
               params: { changed_since: 10.minutes.ago.utc.iso8601 }
 
@@ -179,7 +180,7 @@ describe "Courses API", type: :request do
                                          age: timestamp_of_last_course,
                                          provider: provider)
 
-        get '/api/v1/courses',
+        get '/api/v1/2019/courses',
             headers: { 'HTTP_AUTHORIZATION' => credentials },
             params: { changed_since: 30.minutes.ago.utc.iso8601 }
 
@@ -187,7 +188,8 @@ describe "Courses API", type: :request do
         expect(response.headers).to have_key "Link"
         url = url_for(params: {
                         changed_since: timestamp_of_last_course.utc.strftime('%FT%T.%6NZ'),
-                        per_page: 100
+                        per_page: 100,
+                        recruitment_year: 2019
                       })
         expect(response.headers["Link"]).to match "#{url}; rel=\"next\""
       end
@@ -222,7 +224,7 @@ describe "Courses API", type: :request do
         end
 
         it 'pages properly' do
-          get_next_courses '/api/v1/courses', per_page: 10
+          get_next_courses '/api/v1/courses', per_page: 10, recruitment_year: 2019
 
           expect(response.body)
             .to have_courses(@courses[0..9])
@@ -259,7 +261,7 @@ describe "Courses API", type: :request do
 
 
         it 'pages properly' do
-          get_next_courses '/api/v1/courses', per_page: 10
+          get_next_courses '/api/v1/courses', per_page: 10, recruitment_year: 2019
           expect(response.body)
             .to have_courses(@courses[0..9])
 


### PR DESCRIPTION
### Context
Rollover

### Changes proposed in this pull request
Add a model scope to filter courses by recruitment year passed into the endpoint

### Guidance to review
No change to current year i.e. `http://localhost:3001/api/v1/2019/courses` but if you update the `recruitment_cycle` on a course to another year then change the endpoint you'll see a filtered list of courses

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
