### PR TITLE
1651 mcb revoke god user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,6 +49,11 @@ class User < ApplicationRecord
     "#{first_name} #{last_name} <#{email}>"
   end
 
+  # accepts array or single organisation
+  def remove_access_to(organisations_to_remove)
+    self.organisations = self.organisations - [*organisations_to_remove]
+  end
+
 private
 
   def email_is_lowercase

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,7 +51,7 @@ class User < ApplicationRecord
 
   # accepts array or single organisation
   def remove_access_to(organisations_to_remove)
-    self.organisations = self.organisations - [*organisations_to_remove]
+    self.organisations = self.organisations - Array(organisations_to_remove)
   end
 
 private

--- a/lib/mcb/commands/users/revoke.rb
+++ b/lib/mcb/commands/users/revoke.rb
@@ -6,16 +6,11 @@ usage 'revoke <user_id/email/sign_in_user_id> [--provider-code <provider_code>]'
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
-
   cli = HighLine.new
 
-  provider = nil
-  if opts[:provider_code]
-    provider = Provider.find_by!(provider_code: opts[:provider_code])
-  end
-
-
+  provider = Provider.find_by(provider_code: opts[:provider_code])
   user = MCB.find_user_by_identifier args[:id_or_email_or_sign_in_id]
+
   if user == nil
     puts "#{args[:id_or_email_or_sign_in_id]} does not exist."
   else

--- a/lib/mcb/commands/users/revoke.rb
+++ b/lib/mcb/commands/users/revoke.rb
@@ -1,13 +1,19 @@
 summary 'Remove a user from an organisation/provider in the DB.'
 param :id_or_email_or_sign_in_id
-param :provider_code, transform: ->(code) { code.upcase }
-usage 'revoke <user_id/email/sign_in_user_id> <provider_code>'
+option :p, 'provider_code', 'provider code',
+       argument: :optional, transform: ->(code) { code.upcase }
+usage 'revoke <user_id/email/sign_in_user_id> [--provider-code <provider_code>]'
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
   cli = HighLine.new
-  provider = Provider.find_by!(provider_code: args[:provider_code])
+
+  provider = nil
+  if opts[:provider_code]
+    provider = Provider.find_by!(provider_code: opts[:provider_code])
+  end
+
 
   user = MCB.find_user_by_identifier args[:id_or_email_or_sign_in_id]
   if user == nil

--- a/lib/mcb/render.rb
+++ b/lib/mcb/render.rb
@@ -137,6 +137,24 @@ module MCB
       ]
     end
 
+    def organisations_table(organisations,
+                        name: 'Organisations',
+                        add_columns: [])
+      return if organisations.nil?
+
+      [
+        "#{name}:",
+        render_table_or_none(organisations, organisations_table_columns + add_columns)
+      ]
+    end
+
+    def organisations_table_columns
+      [
+        :id,
+        [:name, header: 'name'],
+      ]
+    end
+
     def providers_table(providers,
                         name: 'Providers',
                         add_columns: [])

--- a/lib/mcb/revoke_access_wizard.rb
+++ b/lib/mcb/revoke_access_wizard.rb
@@ -7,25 +7,35 @@ module MCB
     end
 
     def run
-      fetch_organisation
+      fetch_organisations
       puts MCB::Render::ActiveRecord.user @user
       confirm_and_remove_user_from_organisation
     end
 
   private
 
-    def fetch_organisation
-      @organisation = @provider.organisations.first # a provider should only ever be associated with one organisation
+    def fetch_organisations
+      @organisations = if @provider
+        # we use first because a provider should only ever be associated with one organisation
+                         [@provider.organisations.first]
+                       else
+                         @user.organisations
+                       end
     end
 
     def confirm_and_remove_user_from_organisation
-      if @user.in?(@organisation.users)
+      if (@user.organisations & @organisations).any?
         puts "\n"
-        puts "You're revoking access for #{@user.email} to organisation #{@organisation.name}."
-        puts MCB::Render::ActiveRecord.providers_table @organisation.providers, name: "Provider access being revoked"
-        @organisation.users.delete(@user) if @cli.agree("Agree?  ")
+        puts "You're revoking access for #{@user.email} to:"
+        puts MCB::Render::ActiveRecord.organisations_table @organisations, name: "Organisation access being revoked"
+        puts MCB::Render::ActiveRecord.providers_table @organisations.map(&:providers).flatten, name: "Provider access being revoked"
+        unless @cli.agree("Agree?  ")
+          return
+        end
+
+        @user.organisations = @user.organisations - @organisations
       else
-        puts "#{@user.email} already has no access to #{@organisation.name}"
+        puts "#{@user.email} already has no access to #{@provider}"
       end
     end
   end

--- a/lib/mcb/revoke_access_wizard.rb
+++ b/lib/mcb/revoke_access_wizard.rb
@@ -33,7 +33,7 @@ module MCB
           return
         end
 
-        @user.organisations = @user.organisations - @organisations
+        @user.remove_access_to @organisations
       else
         puts "#{@user.email} already has no access to #{@provider}"
       end

--- a/spec/lib/mcb/commands/users/revoke_spec.rb
+++ b/spec/lib/mcb/commands/users/revoke_spec.rb
@@ -17,6 +17,9 @@ describe 'mcb users revoke' do
   end
   let(:organisation) { create(:organisation) }
   let(:provider) { create(:provider, organisations: [organisation]) }
+  let(:other_organisation) { create(:organisation) }
+  let(:other_provider) { create(:provider, organisations: [other_organisation]) }
+  let(:other_user) { create(:user, organisations: [organisation, other_organisation]) }
 
   let(:output) do
     combined_input = input_commands.map { |c| "#{c}\n" }.join
@@ -24,8 +27,6 @@ describe 'mcb users revoke' do
   end
 
   context 'when the user exists and has access to the provider' do
-    let(:other_organisation) { create(:organisation) }
-    let(:other_provider) { create(:provider, organisations: [other_organisation]) }
     let(:id_or_email_or_sign_in_id) { user.email }
     let(:input_commands) { %w[y] }
     let(:user) { create(:user, organisations: [organisation, other_organisation]) }
@@ -37,6 +38,7 @@ describe 'mcb users revoke' do
     it 'revokes organisation membership to that user' do
       user = User.find_by!(email: id_or_email_or_sign_in_id)
       expect(user.reload.organisations).to eq([other_organisation])
+      expect(other_user.organisations).to eq([organisation, other_organisation])
     end
 
     it 'confirms removing organisation membership' do

--- a/spec/lib/mcb/commands/users/revoke_spec.rb
+++ b/spec/lib/mcb/commands/users/revoke_spec.rb
@@ -1,14 +1,6 @@
 require 'mcb_helper'
 
 describe 'mcb users revoke' do
-  def revoke(id_or_email_or_sign_in_id, provider_code, commands)
-    stderr = ""
-    output = with_stubbed_stdout(stdin: commands, stderr: stderr) do
-      cmd.run([id_or_email_or_sign_in_id, provider_code])
-    end
-    [output, stderr]
-  end
-
   let(:lib_dir) { "#{Rails.root}/lib" }
   let(:cmd) do
     Cri::Command.load_file(
@@ -21,61 +13,106 @@ describe 'mcb users revoke' do
   let(:other_provider) { create(:provider, organisations: [other_organisation]) }
   let(:other_user) { create(:user, organisations: [organisation, other_organisation]) }
 
-  let(:output) do
-    combined_input = input_commands.map { |c| "#{c}\n" }.join
-    revoke(id_or_email_or_sign_in_id, provider.provider_code, combined_input).first
-  end
-
-  context 'when the user exists and has access to the provider' do
-    let(:id_or_email_or_sign_in_id) { user.email }
-    let(:input_commands) { %w[y] }
-    let(:user) { create(:user, organisations: [organisation, other_organisation]) }
-
-    before do
-      output
+  describe 'one provider' do
+    def revoke(id_or_email_or_sign_in_id, provider_code, commands)
+      stderr = ""
+      output = with_stubbed_stdout(stdin: commands, stderr: stderr) do
+        cmd.run([id_or_email_or_sign_in_id, '-p', provider_code])
+      end
+      [output, stderr]
     end
 
-    it 'revokes organisation membership to that user' do
-      user = User.find_by!(email: id_or_email_or_sign_in_id)
-      expect(user.reload.organisations).to eq([other_organisation])
-      expect(other_user.organisations).to eq([organisation, other_organisation])
+    let(:output) do
+      combined_input = input_commands.map { |c| "#{c}\n" }.join
+      revoke(id_or_email_or_sign_in_id, provider.provider_code, combined_input).first
     end
 
-    it 'confirms removing organisation membership' do
-      expect(output).to include("You're revoking access for #{user.email} to organisation #{organisation.name}.")
-    end
-  end
+    context 'when the user exists and has access to the provider' do
+      let(:id_or_email_or_sign_in_id) { user.email }
+      let(:input_commands) { %w[y] }
+      let(:user) { create(:user, organisations: [organisation, other_organisation]) }
 
-  context 'when the user does not exist' do
-    let(:id_or_email_or_sign_in_id) { 'jsmith@acme.org' }
-    let(:input_commands) { %w[Jane Smith y y] }
+      before do
+        output
+      end
 
-    before do
-      output
-    end
+      it 'revokes organisation membership to that user' do
+        user = User.find_by!(email: id_or_email_or_sign_in_id)
+        expect(user.reload.organisations).to eq([other_organisation])
+        expect(other_user.organisations).to eq([organisation, other_organisation])
+      end
 
-    it 'informs the support agent that it is not going to do anything' do
-      expect(output).to include("#{id_or_email_or_sign_in_id} does not exist")
-    end
-  end
-
-  context 'when the user exists but is not a member of the org' do
-    let(:other_organisation) { create(:organisation) }
-    let(:other_provider) { create(:provider, organisations: [other_organisation]) }
-    let(:user) { create(:user, organisations: [other_organisation]) }
-    let(:id_or_email_or_sign_in_id) { user.email }
-    let(:input_commands) { %w[y] }
-
-    before do
-      output
+      it 'confirms removing organisation membership' do
+        expect(output).to include("You're revoking access for #{user.email}")
+      end
     end
 
-    it "leaves membership alone" do
-      expect(user.reload.organisations).to eq([other_organisation])
+    context 'when the user does not exist' do
+      let(:id_or_email_or_sign_in_id) { 'jsmith@acme.org' }
+      let(:input_commands) { %w[Jane Smith y y] }
+
+      before do
+        output
+      end
+
+      it 'informs the support agent that it is not going to do anything' do
+        expect(output).to include("#{id_or_email_or_sign_in_id} does not exist")
+      end
     end
 
-    it 'informs the support agent that it is not going to do anything' do
-      expect(output).to include("#{id_or_email_or_sign_in_id} already has no access to #{organisation.name}")
+    context 'when the user exists but is not a member of the org' do
+      let(:other_organisation) { create(:organisation) }
+      let(:other_provider) { create(:provider, organisations: [other_organisation]) }
+      let(:user) { create(:user, organisations: [other_organisation]) }
+      let(:id_or_email_or_sign_in_id) { user.email }
+      let(:input_commands) { %w[y] }
+
+      before do
+        output
+      end
+
+      it "leaves membership alone" do
+        expect(user.reload.organisations).to eq([other_organisation])
+      end
+
+      it 'informs the support agent that it is not going to do anything' do
+        expect(output).to include("#{id_or_email_or_sign_in_id} already has no access to #{provider.provider_name}")
+      end
+    end
+
+    describe 'all providers' do
+      def revoke_all(id_or_email_or_sign_in_id, commands)
+        stderr = ""
+        output = with_stubbed_stdout(stdin: commands, stderr: stderr) do
+          cmd.run([id_or_email_or_sign_in_id])
+        end
+        [output, stderr]
+      end
+
+      let(:output) do
+        combined_input = input_commands.map { |c| "#{c}\n" }.join
+        revoke_all(id_or_email_or_sign_in_id, combined_input).first
+      end
+
+      context 'when the user exists and has access to the provider' do
+        let(:id_or_email_or_sign_in_id) { user.email }
+        let(:input_commands) { %w[y] }
+        let(:user) { create(:user, organisations: [organisation, other_organisation]) }
+
+        before do
+          output
+        end
+
+        it 'revokes organisation membership to that user' do
+          user = User.find_by!(email: id_or_email_or_sign_in_id)
+          expect(user.reload.organisations).to eq([])
+          expect(other_user.organisations).to eq([organisation, other_organisation])
+        end
+
+        it 'confirms removing organisation membership' do
+          expect(output).to include("You're revoking access for #{user.email}")
+        end
+      end
     end
   end
 end

--- a/spec/lib/mcb/commands/users/revoke_spec.rb
+++ b/spec/lib/mcb/commands/users/revoke_spec.rb
@@ -36,7 +36,7 @@ describe 'mcb users revoke' do
 
     it 'revokes organisation membership to that user' do
       user = User.find_by!(email: id_or_email_or_sign_in_id)
-      expect(user.organisations).to eq([other_organisation])
+      expect(user.reload.organisations).to eq([other_organisation])
     end
 
     it 'confirms removing organisation membership' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -89,4 +89,32 @@ describe User, type: :model do
       expect(User.active).to eq([active_user])
     end
   end
+
+  describe '#remove_access_to' do
+    let(:organisation) { create(:organisation) }
+    let(:other_organisation) { create(:organisation) }
+    let(:yet_other_organisation) { create(:organisation) }
+
+    describe 'one organisation' do
+      before do
+        subject.organisations = [organisation, other_organisation]
+        subject.remove_access_to organisation
+      end
+
+      it 'removes the right organisation'do
+        expect(subject.reload.organisations).to eq([other_organisation])
+      end
+    end
+
+    describe 'multiple organisations' do
+      before do
+        subject.organisations = [organisation, other_organisation, yet_other_organisation]
+        subject.remove_access_to [organisation, yet_other_organisation]
+      end
+
+      it 'removes the right organisation'do
+        expect(subject.reload.organisations).to eq([other_organisation])
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

We have users with access to many orgs, when they leave it takes too long to loop through removing access. We can't just kill their sign-in acc because they might use it for other things, we need to control our own access.

cri params can't be optional, but options can so the provider code is now a named parameter - `-p XYZ` so the usage of the existing `users revoke` has changed from `users revoke email@address XY1` to `users revoke email@address -p XY1`

### Changes proposed in this pull request

Make provider code for revoke optional and named. If not supplied all access will be removed.

### Guidance to review

```
tim@fox:~/repo/dfe/manage/backend(1651-mcb-revoke-god-user)
$ be bin/mcb user revoke x@y      
User:
+------------------------+-----+
| id                     | 114 |
| email                  | x@y |
| first_name             | x   |
| last_name              | y   |
| first_login_date_utc   |     |
| last_login_date_utc    |     |
| sign_in_user_id        |     |
| welcome_email_date_utc |     |
| invite_date_utc        |     |
| accept_terms_date_utc  |     |
| state                  | new |
+------------------------+-----+

Has access to providers:
+-----+--------------+------+
|  id |     name     | code |
+-----+--------------+------+
| 125 | ACME SCITT 1 | A1   |
| 127 | ACME SCITT 3 | A3   |
+-----+--------------+------+

You're revoking access for x@y to:
Organisation access being revoked:
+----+-------+
| id |  name |
+----+-------+
| 92 | ACME1 |
| 94 | ACME3 |
+----+-------+
Provider access being revoked:
+-----+--------------+------+
|  id |     name     | code |
+-----+--------------+------+
| 125 | ACME SCITT 1 | A1   |
| 127 | ACME SCITT 3 | A3   |
+-----+--------------+------+
Agree?  y
tim@fox:~/repo/dfe/manage/backend(1651-mcb-revoke-god-user)
$ be bin/mcb user show x@y  
User:
+------------------------+-----+
| id                     | 114 |
| email                  | x@y |
| first_name             | x   |
| last_name              | y   |
| first_login_date_utc   |     |
| last_login_date_utc    |     |
| sign_in_user_id        |     |
| welcome_email_date_utc |     |
| invite_date_utc        |     |
| accept_terms_date_utc  |     |
| state                  | new |
+------------------------+-----+

Has access to providers:
-none-
```

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
