### PR TITLE
[1624] Match word count validator to frontend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,9 +83,6 @@ gem 'data_migrate'
 # Allows writing of error full_messages for validations that don't start with the attribute name
 gem 'custom_error_message', git: 'https://github.com/nanamkim/custom-err-msg.git', ref: 'd72fb18'
 
-# Word count for validations
-gem 'words_counted'
-
 group :development, :test do
   # add info about db structure to models and other files
   gem 'annotate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,7 +400,6 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    words_counted (1.0.2)
 
 PLATFORMS
   ruby
@@ -468,7 +467,6 @@ DEPENDENCIES
   tzinfo-data
   uk_postcode
   webmock
-  words_counted
 
 RUBY VERSION
    ruby 2.6.1p33

--- a/app/validators/words_count_validator.rb
+++ b/app/validators/words_count_validator.rb
@@ -2,7 +2,7 @@ class WordsCountValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if value.blank?
 
-    if WordsCounted.count(value).token_count > options[:maximum]
+    if value.scan(/\S+/).size > options[:maximum]
       record.errors[attribute] << (options[:message] || "^Reduce the word count for #{attribute.to_s.humanize(capitalize: false)}")
     end
   end

--- a/spec/validators/words_count_validator_spec.rb
+++ b/spec/validators/words_count_validator_spec.rb
@@ -15,6 +15,8 @@ describe WordsCountValidator do
     model
   }
 
+  let(:expected_errors) { ['^Reduce the word count for some words'] }
+
   subject! {
     model.valid?
   }
@@ -39,7 +41,25 @@ describe WordsCountValidator do
 
     it { should be false }
     it 'adds an error' do
-      expect(model.errors[:some_words]).to match_array ['^Reduce the word count for some words']
+      expect(model.errors[:some_words]).to match_array expected_errors
+    end
+  end
+
+  context 'with newlines' do
+    let(:some_words_field) { (%w[word] * maximum).join("\n") + ' popped' }
+
+    it { should be false }
+    it 'adds an error' do
+      expect(model.errors[:some_words]).to match_array expected_errors
+    end
+  end
+
+  context 'with non-words such as markdown' do
+    let(:some_words_field) { (%w[word] * maximum).join(' ') + ' *' }
+
+    it { should be false }
+    it 'adds an error' do
+      expect(model.errors[:some_words]).to match_array expected_errors
     end
   end
 end


### PR DESCRIPTION
### Context

The word count component in the frontend isn't doing anything as sophisticated as the word count library, which causes a mismatch between the frontend and the backend when submitting e.g. markdown tokens.

### Changes proposed in this pull request

This changes to the same [RegExp used in the frontend](https://github.com/alphagov/govuk-frontend/blob/063cd8e2470b62b824c6e50ca66342ac7a95d2d8/src/govuk/components/character-count/character-count.js#L80), and removes the words_counted library.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally