### PR TITLE
[1558] use raw SQL when updating recruitment_cycle on sites

### DIFF
--- a/db/data/20190620121519_add2019_recruitment_cycle_to_sites.rb
+++ b/db/data/20190620121519_add2019_recruitment_cycle_to_sites.rb
@@ -1,10 +1,14 @@
 class Add2019RecruitmentCycleToSites < ActiveRecord::Migration[5.2]
   def up
     current_recruitment_cycle = RecruitmentCycle.where(year: '2019').first
-    Site.update(recruitment_cycle: current_recruitment_cycle)
+    Site.connection.update <<~EOSQL
+      UPDATE site SET recruitment_cycle_id=#{current_recruitment_cycle.id}
+    EOSQL
   end
 
   def down
-    Site.update(recruitment_cycle: nil)
+    Site.connection.update <<~EOSQL
+      UPDATE site SET recruitment_cycle_id=NULL
+    EOSQL
   end
 end


### PR DESCRIPTION
### Context

This make the update succeed in <1s (versus ~60s when using AR updates)

### Guidance to review

Issue caught in product review, so this is a tweak to what's already in master.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
