### PR TITLE
[1645] Return dynamic recruitment year for V1 courses

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -24,8 +24,6 @@
 #
 
 class Course < ApplicationRecord
-  DEFAULT_RECRUITMENT_CYCLE_YEAR = "2019".freeze
-
   include WithQualifications
   include ChangedAt
 
@@ -146,10 +144,6 @@ class Course < ApplicationRecord
 
   def saveable?
     valid? :save
-  end
-
-  def recruitment_cycle_year
-    DEFAULT_RECRUITMENT_CYCLE_YEAR
   end
 
   def findable?

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -74,6 +74,6 @@ class CourseSerializer < ActiveModel::Serializer
   end
 
   def recruitment_cycle
-    object.recruitment_cycle_year
+    object.recruitment_cycle.year
   end
 end

--- a/lib/mcb/courses_editor_cli.rb
+++ b/lib/mcb/courses_editor_cli.rb
@@ -91,7 +91,7 @@ module MCB
     end
 
     def ask_start_date
-      Date.parse(@cli.ask("Start date?  ") { |q| q.default = "September #{Course::DEFAULT_RECRUITMENT_CYCLE_YEAR}" })
+      Date.parse(@cli.ask("Start date?  ") { |q| q.default = "September #{Settings.current_recruitment_cycle}" })
     end
 
     def ask_application_opening_date

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -641,11 +641,6 @@ RSpec.describe Course, type: :model do
     end
   end
 
-  describe '#recruitment_cycle_year' do
-    subject { create(:course) }
-    its(:recruitment_cycle_year) { should eq('2019') }
-  end
-
   describe '#enrichments' do
     describe '#find_or_initialize_draft' do
       let(:course) { create(:course, enrichments: enrichments) }

--- a/spec/serializers/course_serializer_spec.rb
+++ b/spec/serializers/course_serializer_spec.rb
@@ -31,4 +31,5 @@ RSpec.describe CourseSerializer do
 
   it { should include(course_code: course.course_code) }
   it { should include(name: course.name) }
+  it { should include(recruitment_cycle: course.recruitment_cycle.year) }
 end


### PR DESCRIPTION
### Context
RE: The `courses` endpoint on the V1 API. 
At present, we return a hardcoded year stored in the course model but we now have a recruitment cycle model.

### Changes proposed in this pull request
Replace hardcoded value with the dynamic value from `course.recruitment_cycle`

### Guidance to review
`/api/v1/2019/courses`

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
