### PR TITLE
[XXX] Extend NCTL data importer to bring in UKPRNs

### DIFF
--- a/app/models/nctl_organisation.rb
+++ b/app/models/nctl_organisation.rb
@@ -7,6 +7,7 @@
 #  nctl_id         :text             not null
 #  organisation_id :integer
 #  urn             :integer
+#  ukprn           :integer
 #
 
 class NCTLOrganisation < ApplicationRecord

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -22,5 +22,6 @@ ActiveSupport::Inflector.inflections do |inflect|
   inflect.acronym 'MFL' # Modern foreign languages
   inflect.acronym 'DFE' # Department for Education
   inflect.acronym 'NCTL' # National College for Teaching and Leadership
-  inflect.acronym 'URN'  # School's Unique Reference Number
+  inflect.acronym 'URN' # School's Unique Reference Number
+  inflect.acronym 'UKPRN' # UK Provider Reference Number
 end

--- a/lib/mcb/commands/nctl/import.rb
+++ b/lib/mcb/commands/nctl/import.rb
@@ -18,6 +18,8 @@ run do |opts, args, _cmd|
       error "NCTL id not found: #{row['nctl_id']}"
     elsif row['URN'].present?
       nctl_org.update urn: row['URN'].to_i
+    elsif row['UKPRN'].present?
+      nctl_org.update ukprn: row['UKPRN'].to_i
     end
   end
 end


### PR DESCRIPTION
### Context
We need UKPRN (provider reference numbers) in the courses report.

### Changes proposed in this pull request
- attach a UKPRN to the NCTL organisation if it's specified in the import

### Guidance to review
Each NCTL ID will always be either a UKPRN or a URN, but not both.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
