### PR TITLE
[AL-11] skip providers with no args

### DIFF
--- a/app/models/concerns/allocations_report.rb
+++ b/app/models/concerns/allocations_report.rb
@@ -57,6 +57,7 @@ module AllocationsReport
         [allocations_report_headers] +
           all
             .include_allocations_report_data
+            .select { |course| course.provider.organisations.any? }
             .map(&:allocations_report_fields).flatten(1)
       end
     end

--- a/app/models/concerns/allocations_report.rb
+++ b/app/models/concerns/allocations_report.rb
@@ -54,7 +54,10 @@ module AllocationsReport
       end
 
       def allocations_report_data
-        [allocations_report_headers] + all.map(&:allocations_report_fields).flatten(1)
+        [allocations_report_headers] +
+          all
+            .include_allocations_report_data
+            .map(&:allocations_report_fields).flatten(1)
       end
     end
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -68,6 +68,11 @@ class Provider < ApplicationRecord
 
   scope :in_order, -> { order(:provider_name) }
 
+  # For some reason organisations is a has_and_belongs_to_many. Until we fix
+  # this and set it to a singular relationship, we should make sure we don't
+  # get any extra data in our db.
+  validates_length_of :organisations, maximum: 1
+
   # Currently Provider#contact_info isn't used but will likely be needed when
   # we need to expose the candidate-facing contact info.
   #

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -151,4 +151,8 @@ class Provider < ApplicationRecord
   def to_s
     "#{provider_name} (#{provider_code})"
   end
+
+  def organisation
+    organisations.first
+  end
 end

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -25,5 +25,10 @@ FactoryBot.define do
       subject_name { 'Special Educational Needs' }
       subject_code { 'U3' }
     end
+
+    trait :primary do
+      subject_name { 'Primary' }
+      subject_code { '00' }
+    end
   end
 end

--- a/spec/models/concerns/allocations_report_spec.rb
+++ b/spec/models/concerns/allocations_report_spec.rb
@@ -15,6 +15,15 @@ describe Course do
       expect(subject.last)
         .to eq course.allocations_report_fields.flatten
     end
+
+    context 'a course whose provider has no organisation' do
+      let(:provider) { create :provider, organisations: [] }
+      let(:course) { create :course, provider: provider, subjects: subjects }
+
+      it 'is not included in the output' do
+        expect(subject[1..]).to be_empty
+      end
+    end
   end
 
   describe '#allocations_report_fields' do

--- a/spec/models/concerns/allocations_report_spec.rb
+++ b/spec/models/concerns/allocations_report_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+describe Course do
+  let(:subjects) { [create(:subject, :primary), create(:subject, :english)] }
+  let(:course) { create :course, subjects: subjects }
+
+  describe '#allocations_report_data' do
+    subject { Course.where(id: course.id).allocations_report_data }
+
+    it 'returns the headers' do
+      expect(subject.first).to eq Course.allocations_report_headers
+    end
+
+    it 'returns the field data' do
+      expect(subject.last)
+        .to eq course.allocations_report_fields.flatten
+    end
+  end
+
+  describe '#allocations_report_fields' do
+    subject { course.allocations_report_fields.flatten }
+
+    its([0]) { should eq '2020/21' }
+    its([1]) { should be_nil }
+    its([3]) { should eq course.provider.provider_name }
+
+    context 'course has an accrediting provider' do
+      let(:accrediting_provider) { create :provider, :accredited_body }
+      let(:course) do
+        create(:course,
+               accrediting_provider: accrediting_provider,
+               subjects: subjects)
+      end
+
+      its([1]) { should eq accrediting_provider.provider_name }
+    end
+  end
+end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -50,6 +50,10 @@ describe Provider, type: :model do
     it { should validate_length_of(:organisations) }
   end
 
+  describe '#organisation' do
+    its(:organisation) { should eq subject.organisations.first }
+  end
+
   describe 'changed_at' do
     it 'is set on create' do
       provider = Provider.create

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -45,6 +45,11 @@ describe Provider, type: :model do
     it { should have_many(:contacts) }
   end
 
+  describe 'organisations association' do
+    it { should have_and_belong_to_many(:organisations) }
+    it { should validate_length_of(:organisations) }
+  end
+
   describe 'changed_at' do
     it 'is set on create' do
       provider = Provider.create


### PR DESCRIPTION
### Context

Some providers have no organisations.

### Changes proposed in this pull request

Don't generate an allocations report for providers that don't belong to an organisation.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
