### PR TITLE
[1670] Introduce enum for Provider#accrediting_provider

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -41,6 +41,11 @@ class Provider < ApplicationRecord
     invalid_value: "0", # there is only one of these in the data
   }
 
+  enum accrediting_provider: {
+    accredited_body: 'Y',
+    not_an_accredited_body: 'N',
+  }
+
   has_and_belongs_to_many :organisations, join_table: :organisation_provider
   has_many :users, through: :organisations
 
@@ -110,10 +115,6 @@ class Provider < ApplicationRecord
 
   def recruitment_cycle
     "2019"
-  end
-
-  def accredited_body?
-    accrediting_provider == 'Y'
   end
 
   def unassigned_site_codes

--- a/app/serializers/course_provider_serializer.rb
+++ b/app/serializers/course_provider_serializer.rb
@@ -41,4 +41,8 @@ class CourseProviderSerializer < ActiveModel::Serializer
   def institution_type
     object.provider_type_before_type_cast
   end
+
+  def accrediting_provider
+    object.accrediting_provider_before_type_cast
+  end
 end

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -71,6 +71,10 @@ class ProviderSerializer < ActiveModel::Serializer
     @object.ucas_preferences&.type_of_gt12_before_type_cast
   end
 
+  def accrediting_provider
+    object.accrediting_provider_before_type_cast
+  end
+
 private
 
   def select_value_for_provider(provider_code, values)

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -210,6 +210,13 @@ describe Provider, type: :model do
     end
   end
 
+  it 'defines an enum for accrediting_provider' do
+    expect(subject)
+      .to define_enum_for("accrediting_provider")
+            .backed_by_column_of_type(:text)
+            .with_values('accredited_body' => 'Y', 'not_an_accredited_body' => 'N')
+  end
+
   describe "courses" do
     let!(:provider) { create(:provider) }
     let!(:course) { create(:course, provider: provider) }

--- a/spec/serializers/course_provider_serializer_spec.rb
+++ b/spec/serializers/course_provider_serializer_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe CourseProviderSerializer do
+  let(:provider) { create :provider }
+  subject { serialize(provider, serializer_class: described_class) }
+
+  it { should include(accrediting_provider: provider.accrediting_provider_before_type_cast) }
+end

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -43,7 +43,7 @@ describe ProviderSerializer do
   it { should include(postcode: provider.postcode) }
   it { should include(region_code: "%02d" % provider.region_code_before_type_cast) }
   it { should include(institution_type: provider.provider_type) }
-  it { should include(accrediting_provider: provider.accrediting_provider) }
+  it { should include(accrediting_provider: provider.accrediting_provider_before_type_cast) }
 
   describe 'type_of_gt12' do
     subject { serialize(provider)['type_of_gt12'] }


### PR DESCRIPTION
### Context
Providers are either accredited bodies or they're not. There is information stored on the record to interrogate this.

### Changes proposed in this pull request
Replace an existing helper method with an enum, in order to get the scope and both possible values.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
