### PR TITLE
[1656] Always run enrichment save validations

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -60,7 +60,7 @@ module API
         update_enrichment
         update_sites
 
-        if @course.errors.empty? && @course.saveable?
+        if @course.errors.empty? && @course.valid?
           render jsonapi: @course.reload
         else
           render jsonapi_errors: @course.errors, status: :unprocessable_entity

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -123,7 +123,7 @@ class Course < ApplicationRecord
 
   validates :enrichments, presence: true, on: :publish
   validate :validate_enrichment_publishable, on: :publish
-  validate :validate_enrichment_saveable, on: :save
+  validate :validate_enrichment
 
   def accrediting_provider_description
     return nil if accrediting_provider.blank?
@@ -146,10 +146,6 @@ class Course < ApplicationRecord
 
   def publishable?
     valid? :publish
-  end
-
-  def saveable?
-    valid? :save
   end
 
   def findable?
@@ -326,7 +322,7 @@ private
     end
   end
 
-  def validate_enrichment(validation_scope)
+  def validate_enrichment(validation_scope = nil)
     latest_enrichment = enrichments.select(&:draft?).last
     return unless latest_enrichment.present?
 
@@ -336,10 +332,6 @@ private
 
   def validate_enrichment_publishable
     validate_enrichment :publish
-  end
-
-  def validate_enrichment_saveable
-    validate_enrichment :save
   end
 
   def set_defaults

--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -42,27 +42,48 @@ class CourseEnrichment < ApplicationRecord
 
   scope :latest_first, -> { order(created_at: :desc, id: :desc) }
 
-  validates :about_course, presence: true, on: :publish
-  validates :how_school_placements_work, presence: true, on: :publish
-  validates :course_length, presence: true, on: :publish
-  validates :qualifications, presence: true, on: :publish
+  validates :ucas_course_code, presence: true
+  validates :course, presence: true
+  validates :provider_code, presence: true
+  validates :provider, presence: true
 
-  validates :about_course, words_count: { maximum: 400 }, on: %i[save publish]
-  validates :interview_process, words_count: { maximum: 250 }, on: %i[save publish]
-  validates :how_school_placements_work, words_count: { maximum: 350 }, on: %i[save publish]
-  validates :qualifications, words_count: { maximum: 100 }, on: %i[save publish]
+  validates :about_course, presence: true, on: :publish
+  validates :about_course, words_count: { maximum: 400 }
+
+  validates :course_length, presence: true, on: :publish
+
+  validates :fee_international,
+            numericality: { only_integer: true,
+                            greater_than_or_equal_to: 0,
+                            less_than_or_equal_to: 100000 },
+            if: :is_fee_based?
+
+  validates :fee_details, words_count: { maximum: 250 }, if: :is_fee_based?
 
   validates :fee_uk_eu, presence: true, on: :publish, if: :is_fee_based?
-  validates :fee_uk_eu, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100000 }, on: %i[save publish], if: :is_fee_based?
-  validates :fee_international, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100000 }, on: %i[save publish], if: :is_fee_based?
-  validates :fee_details, words_count: { maximum: 250 }, on: %i[save publish], if: :is_fee_based?
-  validates :financial_support, words_count: { maximum: 250 }, on: %i[save publish], if: :is_fee_based?
+  validates :fee_uk_eu,
+            numericality: { only_integer: true,
+                            greater_than_or_equal_to: 0,
+                            less_than_or_equal_to: 100000 },
+            if: :is_fee_based?
+
+  validates :financial_support,
+            words_count: { maximum: 250 },
+            if: :is_fee_based?
+
+  validates :how_school_placements_work, presence: true, on: :publish
+  validates :how_school_placements_work, words_count: { maximum: 350 }
+
+  validates :interview_process, words_count: { maximum: 250 }
+
+  validates :qualifications, presence: true, on: :publish
+  validates :qualifications, words_count: { maximum: 100 }
 
   validates :salary_details, presence: true, on: :publish, unless: :is_fee_based?
-  validates :salary_details, words_count: { maximum: 250 }, on: %i[save publish], unless: :is_fee_based?
+  validates :salary_details, words_count: { maximum: 250 }, unless: :is_fee_based?
 
   def is_fee_based?
-    course.is_fee_based?
+    course&.is_fee_based?
   end
 
   def has_been_published_before?

--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -53,7 +53,8 @@ class CourseEnrichment < ApplicationRecord
   validates :course_length, presence: true, on: :publish
 
   validates :fee_international,
-            numericality: { only_integer: true,
+            numericality: { allow_blank: true,
+                            only_integer: true,
                             greater_than_or_equal_to: 0,
                             less_than_or_equal_to: 100000 },
             if: :is_fee_based?
@@ -62,7 +63,8 @@ class CourseEnrichment < ApplicationRecord
 
   validates :fee_uk_eu, presence: true, on: :publish, if: :is_fee_based?
   validates :fee_uk_eu,
-            numericality: { only_integer: true,
+            numericality: { allow_blank: true,
+                            only_integer: true,
                             greater_than_or_equal_to: 0,
                             less_than_or_equal_to: 100000 },
             if: :is_fee_based?

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -17,6 +17,8 @@
 require 'rails_helper'
 
 describe CourseEnrichment, type: :model do
+  subject { build :course_enrichment }
+
   describe 'associations' do
     it 'belongs to a provider' do
       expect(subject).to belong_to(:provider)
@@ -90,45 +92,139 @@ describe CourseEnrichment, type: :model do
     end
   end
 
+  describe 'about_course attribute' do
+    let(:about_course_text) { 'this course is great' }
+
+    subject { build :course_enrichment, about_course: about_course_text }
+
+    context 'with over 400 words' do
+      let(:about_course_text) { Faker::Lorem.sentence(400 + 1) }
+
+      it { should_not be_valid }
+    end
+
+    context 'when nil' do
+      let(:about_course_text) { nil }
+
+      it { should be_valid }
+
+      describe 'on publish' do
+        it { should_not be_valid :publish }
+      end
+    end
+  end
+
+  describe 'course_length attribute' do
+    let(:course_length_text) { 'this course is great' }
+
+    subject { build :course_enrichment, course_length: course_length_text }
+
+    context 'when nil' do
+      let(:course_length_text) { nil }
+
+      it { should be_valid }
+
+      describe 'on publish' do
+        it { should_not be_valid :publish }
+      end
+    end
+  end
+
+  describe 'how_school_placements_work attribute' do
+    let(:how_school_placements_work_text) { 'this course is great' }
+
+    subject { build :course_enrichment, how_school_placements_work: how_school_placements_work_text }
+
+    context 'with over 400 words' do
+      let(:how_school_placements_work_text) { Faker::Lorem.sentence(400 + 1) }
+
+      it { should_not be_valid }
+    end
+
+    context 'when nil' do
+      let(:how_school_placements_work_text) { nil }
+
+      it { should be_valid }
+
+      describe 'on publish' do
+        it { should_not be_valid :publish }
+      end
+    end
+  end
+
+  describe 'interview_process attribute' do
+    let(:interview_process_text) { 'this course is great' }
+
+    subject { build :course_enrichment, interview_process: interview_process_text }
+
+    context 'with over 250 words' do
+      let(:interview_process_text) { Faker::Lorem.sentence(250 + 1) }
+
+      it { should_not be_valid }
+    end
+  end
+
+  describe 'qualifications attribute' do
+    let(:qualifications_text) { 'this course is great' }
+
+    subject { build :course_enrichment, qualifications: qualifications_text }
+
+    context 'with over 100 words' do
+      let(:qualifications_text) { Faker::Lorem.sentence(100 + 1) }
+
+      it { should_not be_valid }
+    end
+
+    context 'when nil' do
+      let(:qualifications_text) { nil }
+
+      it { should be_valid }
+
+      describe 'on publish' do
+        it { should_not be_valid :publish }
+      end
+    end
+  end
+
+  describe 'salary_details attribute' do
+    let(:salary_details_text) { 'this course is great' }
+
+    subject(:salaried_course) { build :course, :with_salary }
+    subject { build :course_enrichment, salary_details: salary_details_text, course: salaried_course }
+
+    context 'with over 250 words' do
+      let(:salary_details_text) { Faker::Lorem.sentence(250 + 1) }
+
+      it { should_not be_valid }
+    end
+
+    context 'when nil' do
+      let(:salary_details_text) { nil }
+
+      it { should be_valid }
+
+      describe 'on publish' do
+        it { should_not be_valid :publish }
+      end
+    end
+  end
+
   describe 'validation for publish' do
     let(:course_enrichment) { build(:course_enrichment, :with_fee_based_course) }
     subject { course_enrichment }
 
     context 'fee based course' do
       it { should validate_presence_of(:fee_uk_eu).on(:publish) }
-      it { should validate_presence_of(:about_course).on(:publish) }
       it { should validate_presence_of(:qualifications).on(:publish) }
-      it { should validate_presence_of(:course_length).on(:publish) }
       it { should validate_presence_of(:fee_uk_eu).on(:publish) }
       it { should validate_numericality_of(:fee_uk_eu).on(:publish) }
       it { should validate_numericality_of(:fee_international).on(:publish) }
-
-      it 'validates maximum word count for about_course' do
-        course_enrichment.about_course = Faker::Lorem.sentence(400 + 1)
-
-        expect(course_enrichment).not_to be_valid :publish
-        expect(course_enrichment.errors[:about_course]).to be_present
-      end
 
       it 'validates maximum word count for interview_process' do
         course_enrichment.interview_process = Faker::Lorem.sentence(250 + 1)
 
         expect(course_enrichment).not_to be_valid :publish
         expect(course_enrichment.errors[:interview_process]).to be_present
-      end
-
-      it 'validates maximum word count for qualifications' do
-        course_enrichment.qualifications = Faker::Lorem.sentence(100 + 1)
-
-        expect(course_enrichment).not_to be_valid :publish
-        expect(course_enrichment.errors[:qualifications]).to be_present
-      end
-
-      it 'validates maximum word count for how_school_placements_work' do
-        course_enrichment.how_school_placements_work = Faker::Lorem.sentence(350 + 1)
-
-        expect(course_enrichment).not_to be_valid :publish
-        expect(course_enrichment.errors[:how_school_placements_work]).to be_present
       end
 
       it 'validates maximum word count for fee_details' do
@@ -154,39 +250,16 @@ describe CourseEnrichment, type: :model do
       let(:course_enrichment) { build(:course_enrichment, :with_salary_based_course) }
 
       it { should validate_presence_of(:salary_details).on(:publish) }
-      it { should validate_presence_of(:about_course).on(:publish) }
       it { should validate_presence_of(:qualifications).on(:publish) }
-      it { should validate_presence_of(:course_length).on(:publish) }
       it { should_not validate_presence_of(:fee_uk_eu).on(:publish) }
       it { should_not validate_numericality_of(:fee_uk_eu).on(:publish) }
       it { should_not validate_numericality_of(:fee_international).on(:publish) }
-
-      it 'validates maximum word count for about_course' do
-        course_enrichment.about_course = Faker::Lorem.sentence(400 + 1)
-
-        expect(course_enrichment).not_to be_valid :publish
-        expect(course_enrichment.errors[:about_course]).to be_present
-      end
-
-      it 'validates maximum word count for interview_process' do
-        course_enrichment.interview_process = Faker::Lorem.sentence(250 + 1)
-
-        expect(course_enrichment).not_to be_valid :publish
-        expect(course_enrichment.errors[:interview_process]).to be_present
-      end
 
       it 'validates maximum word count for qualifications' do
         course_enrichment.qualifications = Faker::Lorem.sentence(100 + 1)
 
         expect(course_enrichment).not_to be_valid :publish
         expect(course_enrichment.errors[:qualifications]).to be_present
-      end
-
-      it 'validates maximum word count for how_school_placements_work' do
-        course_enrichment.how_school_placements_work = Faker::Lorem.sentence(350 + 1)
-
-        expect(course_enrichment).not_to be_valid :publish
-        expect(course_enrichment.errors[:how_school_placements_work]).to be_present
       end
 
       it 'validates maximum word count for salary_details' do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -49,14 +49,14 @@ RSpec.describe Course, type: :model do
   describe 'validations' do
     it { should validate_uniqueness_of(:course_code).scoped_to(:provider_id) }
 
-    describe 'saveable?' do
+    describe 'valid?' do
       let(:course) { create(:course, enrichments: [invalid_enrichment]) }
       let(:invalid_enrichment) { build(:course_enrichment, about_course: '') }
 
       before do
         subject
         invalid_enrichment.about_course = Faker::Lorem.sentence(1000)
-        subject.saveable?
+        subject.valid?
       end
 
       it 'should add enrichment errors' do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -51,9 +51,11 @@ RSpec.describe Course, type: :model do
 
     describe 'saveable?' do
       let(:course) { create(:course, enrichments: [invalid_enrichment]) }
-      let(:invalid_enrichment) { create(:course_enrichment, about_course: Faker::Lorem.sentence(1000)) }
+      let(:invalid_enrichment) { build(:course_enrichment, about_course: '') }
 
       before do
+        subject
+        invalid_enrichment.about_course = Faker::Lorem.sentence(1000)
         subject.saveable?
       end
 

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -131,29 +131,6 @@ describe 'Publish API v2', type: :request do
       context 'fee type based course' do
         let(:course) { create(:course, :fee_type_based, provider: provider, enrichments: [invalid_enrichment]) }
 
-        context 'invalid enrichment with invalid content exceed word count fields' do
-          let(:invalid_enrichment) {
-            create(:course_enrichment, :with_fee_based_course,
-                   about_course:  Faker::Lorem.sentence(400 + 1),
-                             interview_process:  Faker::Lorem.sentence(250 + 1),
-                             qualifications:  Faker::Lorem.sentence(100 + 1),
-                             how_school_placements_work:  Faker::Lorem.sentence(350 + 1),
-                             fee_details:  Faker::Lorem.sentence(250 + 1),
-                             salary_details:  Faker::Lorem.sentence(250 + 1))
-          }
-
-          it { should have_http_status(:unprocessable_entity) }
-
-          it 'has validation errors' do
-            expect(json_data.count).to eq 5
-            expect(json_data[0]["detail"]).to eq("Reduce the word count for about course")
-            expect(json_data[1]["detail"]).to eq("Reduce the word count for interview process")
-            expect(json_data[2]["detail"]).to eq("Reduce the word count for how school placements work")
-            expect(json_data[3]["detail"]).to eq("Reduce the word count for qualifications")
-            expect(json_data[4]["detail"]).to eq("Reduce the word count for fee details")
-          end
-        end
-
         context 'invalid enrichment with invalid content lack_presence fields' do
           let(:invalid_enrichment) { create(:course_enrichment, :without_content) }
 
@@ -162,10 +139,10 @@ describe 'Publish API v2', type: :request do
           it 'has validation errors' do
             expect(json_data.count).to eq 5
             expect(json_data[0]["detail"]).to eq("Enter details about this course")
-            expect(json_data[1]["detail"]).to eq("Enter details about school placements")
-            expect(json_data[2]["detail"]).to eq("Enter a course length")
-            expect(json_data[3]["detail"]).to eq("Enter details about the qualifications needed")
-            expect(json_data[4]["detail"]).to eq("Give details about the fee for UK and EU students")
+            expect(json_data[1]["detail"]).to eq("Enter a course length")
+            expect(json_data[2]["detail"]).to eq("Give details about the fee for UK and EU students")
+            expect(json_data[3]["detail"]).to eq("Enter details about school placements")
+            expect(json_data[4]["detail"]).to eq("Enter details about the qualifications needed")
           end
         end
       end
@@ -173,28 +150,6 @@ describe 'Publish API v2', type: :request do
       context 'salary type based course' do
         let(:course) { create(:course, :salary_type_based, provider: provider, enrichments: [invalid_enrichment]) }
 
-        context 'invalid enrichment with invalid content exceed word count fields' do
-          let(:invalid_enrichment) {
-            create(:course_enrichment, :with_fee_based_course,
-                   about_course:  Faker::Lorem.sentence(400 + 1),
-                             interview_process:  Faker::Lorem.sentence(250 + 1),
-                             qualifications:  Faker::Lorem.sentence(100 + 1),
-                             how_school_placements_work:  Faker::Lorem.sentence(350 + 1),
-                             fee_details:  Faker::Lorem.sentence(250 + 1),
-                             salary_details:  Faker::Lorem.sentence(250 + 1))
-          }
-
-          it { should have_http_status(:unprocessable_entity) }
-
-          it 'has validation errors' do
-            expect(json_data.count).to eq 5
-            expect(json_data[0]["detail"]).to eq("Reduce the word count for about course")
-            expect(json_data[1]["detail"]).to eq("Reduce the word count for interview process")
-            expect(json_data[2]["detail"]).to eq("Reduce the word count for how school placements work")
-            expect(json_data[3]["detail"]).to eq("Reduce the word count for qualifications")
-            expect(json_data[4]["detail"]).to eq("Reduce the word count for salary details")
-          end
-        end
         context 'invalid enrichment with invalid content lack_presence fields' do
           let(:invalid_enrichment) { create(:course_enrichment, :without_content) }
 
@@ -203,8 +158,8 @@ describe 'Publish API v2', type: :request do
           it 'has validation errors' do
             expect(json_data.count).to eq 5
             expect(json_data[0]["detail"]).to eq("Enter details about this course")
-            expect(json_data[1]["detail"]).to eq("Enter details about school placements")
-            expect(json_data[2]["detail"]).to eq("Enter a course length")
+            expect(json_data[1]["detail"]).to eq("Enter a course length")
+            expect(json_data[2]["detail"]).to eq("Enter details about school placements")
             expect(json_data[3]["detail"]).to eq("Enter details about the qualifications needed")
             expect(json_data[4]["detail"]).to eq("Give details about the salary for this course")
           end


### PR DESCRIPTION
### Context

Currently, it is possible to save enrichments even though they do not pass validations. This is incorrect behaviour when compared to the C# app.

### Changes proposed in this pull request

The changes the `:save` scoped validations to always run whenever we validate enrichments.

### Guidance to review

Review commit by commit.

TODO:

- [x] Clean up `course#saveable?` method, probably can be replaced with `valid?` everywhere
- [x] Uncomment commented specs
- [x] Fix the update hack
- [x] Remove `latest_first` invocations in the rest of the `course` model
- [x] Squash commits that don't add much value

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
