### PR TITLE
[1680] Enable auditing on the Course#changed_at timestamp

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -30,7 +30,7 @@ class Course < ApplicationRecord
   after_initialize :set_defaults
 
   has_associated_audits
-  audited except: :changed_at
+  audited
   validates :course_code, uniqueness: { scope: :provider_id }
 
   enum program_type: {

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Course, type: :model do
   its(:modular) { should eq('') }
 
   describe 'auditing' do
-    it { should be_audited.except(:changed_at) }
+    it { should be_audited }
     it { should have_associated_audits }
   end
 


### PR DESCRIPTION
### Context
This field is very important for for investigating sync process issues with downstream, even if
it will probably generate quite a bit of data.

### Changes proposed in this pull request
- audit `Course#changed_at`

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
