### PR TITLE
[1684] fix mcb audit user

### DIFF
--- a/config/initializers/mcb_audit.rb
+++ b/config/initializers/mcb_audit.rb
@@ -1,10 +1,6 @@
-if ENV['MCB_SETUP_AUDIT_USER'].present?
-  require 'mcb'
-  require 'mcb/config'
-
-  def verbose(msg)
-    Rails.logger.info msg
-  end
-
-  MCB.configure_audited_user if MCB.connecting_to_remote_db?
+if ENV.key?('DB_HOSTNAME') && ENV.key?('MCB_AUDIT_USER')
+  user = User.find_by email: ENV['MCB_AUDIT_USER']
+  raise "Could not find user by email: #{ENV['MCB_AUDIT_USER']}" unless user
+  puts "Audit user: #{user}"
+  Audited.store[:audited_user] = user
 end

--- a/config/initializers/mcb_audit.rb
+++ b/config/initializers/mcb_audit.rb
@@ -1,6 +1,8 @@
 if ENV.key?('DB_HOSTNAME') && ENV.key?('MCB_AUDIT_USER')
   user = User.find_by email: ENV['MCB_AUDIT_USER']
+
   raise "Could not find user by email: #{ENV['MCB_AUDIT_USER']}" unless user
+
   puts "Audit user: #{user}"
   Audited.store[:audited_user] = user
 end

--- a/spec/lib/mcb_spec.rb
+++ b/spec/lib/mcb_spec.rb
@@ -2,22 +2,6 @@ require 'spec_helper'
 require 'mcb_helper'
 
 describe 'mcb command' do
-  describe '.init_rails' do
-    before do
-      allow(MCB::Azure).to receive(:configure_for_webapp)
-    end
-
-    context 'connecting to an Azure webapp' do
-      it 'sets the audited user', stub_init_rails: false do
-        user = create :user
-        MCB.config[:email] = user.email
-        allow(ENV).to receive(:key?).with('DB_HOSTNAME').and_return(true)
-        MCB.init_rails
-        expect(Audited.store[:audited_user]).to eq user
-      end
-    end
-  end
-
   describe '.load_commands' do
     include FakeFS::SpecHelpers
 


### PR DESCRIPTION
### Context

Commands that use Rails are busted in mcb.

### Changes proposed in this pull request

Fix the way the audited user is loaded in the mcb Rails initialiser.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
