### PR TITLE
[1687] 'mcb courses edit' should pick the right course to edit

### DIFF
--- a/lib/mcb/courses_editor.rb
+++ b/lib/mcb/courses_editor.rb
@@ -14,7 +14,7 @@ module MCB
 
       @provider = provider
       @requester = requester
-      @courses = course_codes.present? ? find_courses(course_codes) : provider.courses
+      @courses = course_codes.present? ? find_courses(provider, course_codes) : provider.courses
 
       check_authorisation
     end
@@ -88,8 +88,8 @@ module MCB
       @courses.order(:course_code).pluck(:course_code)
     end
 
-    def find_courses(course_codes)
-      courses = Course.where(course_code: course_codes)
+    def find_courses(provider, course_codes)
+      courses = provider.courses.where(course_code: course_codes)
       missing_course_codes = course_codes - courses.pluck(:course_code)
       raise ArgumentError, "Couldn't find course " + missing_course_codes.join(", ") unless missing_course_codes.empty?
 

--- a/spec/lib/mcb/courses_editor_spec.rb
+++ b/spec/lib/mcb/courses_editor_spec.rb
@@ -258,6 +258,38 @@ describe MCB::CoursesEditor do
       end
     end
 
+    context 'when there are several courses with the same course code' do
+      let(:another_provider) { create(:provider) }
+      let!(:another_course_with_the_same_course_code) {
+        create(:course,
+               provider: another_provider,
+               course_code: course.course_code,
+               name: 'Another name')
+      }
+
+      it 'edits the course from the specified provider' do
+        expect { run_editor("edit title", "Mathematics", "exit") }.
+          to change { course.reload.name }.
+          from("Original name").to("Mathematics")
+      end
+    end
+
+    context "when trying to edit a course code that doesn't exist on this provider but exists on another one" do
+      let(:course_code) { 'ABCD' }
+      let(:another_provider) { create(:provider) }
+      let!(:another_course_with_another_provider) {
+        create(:course,
+               provider: another_provider,
+               course_code: 'XYZ1',
+               name: 'Another name')
+      }
+      subject { described_class.new(provider: provider, course_codes: %w{XYZ1}, requester: requester) }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(ArgumentError, /Couldn't find course XYZ1/)
+      end
+    end
+
     describe 'tries to edit a non-existent course' do
       let(:course_codes) { [course_code, "ABCD"] }
 


### PR DESCRIPTION
### Context
`mcb courses edit` picks the wrong course to edit when there are two courses with the same course code across two different providers.

### Changes proposed in this pull request
Use the provider when filtering courses to edit.

### Guidance to review
😞 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
