### PR TITLE
[1679] The course enrichments can be 2019 or 2020 recruitment cycle

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -78,11 +78,12 @@ class Course < ApplicationRecord
            -> { merge(SiteStatus.where(status: %i[new_status running])) },
            through: :site_statuses
 
+  # has_many :enrichments,
+  #          ->(course) { where(provider_code: course.provider.provider_code) },
+  #          foreign_key: :ucas_course_code,
+  #          primary_key: :course_code,
+  #          class_name: 'CourseEnrichment' do
   has_many :enrichments,
-           ->(course) { where(provider_code: course.provider.provider_code) },
-           foreign_key: :ucas_course_code,
-           primary_key: :course_code,
-           inverse_of: 'course',
            class_name: 'CourseEnrichment' do
     def find_or_initialize_draft
       # This is a ruby search as opposed to an AR search, because calling `draft`

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -78,11 +78,6 @@ class Course < ApplicationRecord
            -> { merge(SiteStatus.where(status: %i[new_status running])) },
            through: :site_statuses
 
-  # has_many :enrichments,
-  #          ->(course) { where(provider_code: course.provider.provider_code) },
-  #          foreign_key: :ucas_course_code,
-  #          primary_key: :course_code,
-  #          class_name: 'CourseEnrichment' do
   has_many :enrichments,
            class_name: 'CourseEnrichment' do
     def find_or_initialize_draft

--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -36,18 +36,11 @@ class CourseEnrichment < ApplicationRecord
 
   belongs_to :course
 
-  # belongs_to :provider, foreign_key: :provider_code, primary_key: :provider_code
-  # belongs_to :course,
-  #            ->(enrichment) { where(provider_id: enrichment.provider.id) },
-  #            foreign_key: :ucas_course_code,
-  #            primary_key: :course_code
-
   scope :latest_first, -> { order(created_at: :desc, id: :desc) }
 
   validates :ucas_course_code, presence: true
   validates :course, presence: true
   validates :provider_code, presence: true
-  validates :provider, presence: true
 
   # About this course
 

--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -34,12 +34,13 @@ class CourseEnrichment < ApplicationRecord
                  qualifications: [:string, store_key: 'Qualifications'],
                  salary_details: [:string, store_key: 'SalaryDetails']
 
-  belongs_to :provider, foreign_key: :provider_code, primary_key: :provider_code # rubocop:disable Rails/InverseOf
-  belongs_to :course,
-             ->(enrichment) { where(provider_id: enrichment.provider.id) },
-             foreign_key: :ucas_course_code,
-             primary_key: :course_code,
-             inverse_of: 'enrichments'
+  belongs_to :course
+
+  # belongs_to :provider, foreign_key: :provider_code, primary_key: :provider_code
+  # belongs_to :course,
+  #            ->(enrichment) { where(provider_id: enrichment.provider.id) },
+  #            foreign_key: :ucas_course_code,
+  #            primary_key: :course_code
 
   scope :latest_first, -> { order(created_at: :desc, id: :desc) }
 

--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -17,7 +17,7 @@
 
 class CourseEnrichment < ApplicationRecord
   include TouchCourse
-  after_validation :set_defaults
+  before_create :set_defaults
   enum status: %i[draft published]
 
   jsonb_accessor :json_data,
@@ -113,11 +113,8 @@ class CourseEnrichment < ApplicationRecord
 private
 
   def set_defaults
-    is_new_enrichment = self.id.nil? && self.course_id.present?
-    if is_new_enrichment
     # NOTE: Both ucas_course_code & provider_code can be removed after C# counterpart is retired.
-      self.ucas_course_code = course.course_code
-      self.provider_code = course.provider.provider_code
-    end
+    self.ucas_course_code = course.course_code
+    self.provider_code = course.provider.provider_code
   end
 end

--- a/db/migrate/20190626132627_add_course_ref_to_course_enrichment.rb
+++ b/db/migrate/20190626132627_add_course_ref_to_course_enrichment.rb
@@ -1,0 +1,23 @@
+class AddCourseRefToCourseEnrichment < ActiveRecord::Migration[5.2]
+  def up
+    add_reference :course_enrichment, :course, index: true, type: :int
+
+    execute <<-SQL
+    UPDATE course_enrichment
+    SET    course_id =
+           (
+                  SELECT course.id
+                  FROM   course
+                  join   provider
+                  ON     course.provider_id                 = provider.id
+                  AND    course_enrichment.provider_code    = provider.provider_code
+                  AND    course_enrichment.ucas_course_code = course.course_code)
+    SQL
+
+    change_column_null :course_enrichment, :course_id, false
+  end
+
+  def down
+    remove_reference :course_enrichment, :course
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_21_125905) do
+ActiveRecord::Schema.define(version: 2019_06_26_132627) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -102,6 +102,8 @@ ActiveRecord::Schema.define(version: 2019_06_21_125905) do
     t.text "ucas_course_code", null: false
     t.integer "updated_by_user_id"
     t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
+    t.integer "course_id", null: false
+    t.index ["course_id"], name: "index_course_enrichment_on_course_id"
     t.index ["created_by_user_id"], name: "IX_course_enrichment_created_by_user_id"
     t.index ["updated_by_user_id"], name: "IX_course_enrichment_updated_by_user_id"
   end

--- a/spec/factories/course_enrichments.rb
+++ b/spec/factories/course_enrichments.rb
@@ -16,10 +16,10 @@
 
 FactoryBot.define do
   factory :course_enrichment do
-    provider { course.provider }
     course
     status { :draft }
-
+    provider_code { course.provider.provider_code }
+    ucas_course_code { course.course_code }
     about_course { Faker::Books::Dune.quote }
     course_length do
       # samples taken from real data

--- a/spec/factories/course_enrichments.rb
+++ b/spec/factories/course_enrichments.rb
@@ -12,6 +12,7 @@
 #  ucas_course_code             :text             not null
 #  updated_by_user_id           :integer
 #  updated_at                   :datetime         not null
+#  course_id                    :integer          not null
 #
 
 FactoryBot.define do

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -37,8 +37,7 @@ FactoryBot.define do
     resulting_in_pgce_with_qts
 
     transient do
-      age                { nil }
-      enrichments        { [] }
+      age { nil }
     end
 
     after(:build) do |course, evaluator|
@@ -52,11 +51,6 @@ FactoryBot.define do
     after(:create) do |course, evaluator|
       # This is important to retain the relationship behaviour between
       # course and it's enrichment
-      course.enrichments += evaluator.enrichments.map do |enrichment|
-        enrichment.tap do |e|
-          e.provider_code = course.provider.provider_code
-        end
-      end
 
       if evaluator.age.present?
         course.created_at = evaluator.age

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -12,6 +12,7 @@
 #  ucas_course_code             :text             not null
 #  updated_by_user_id           :integer
 #  updated_at                   :datetime         not null
+#  course_id                    :integer          not null
 #
 
 require 'rails_helper'

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -20,17 +20,7 @@ describe CourseEnrichment, type: :model do
   subject { build :course_enrichment }
 
   describe 'associations' do
-    it 'belongs to a provider' do
-      expect(subject).to belong_to(:provider)
-                           .with_foreign_key(:provider_code)
-                           .with_primary_key(:provider_code)
-    end
-
-    it 'belongs to a course' do
-      expect(subject).to belong_to(:course)
-                           .with_foreign_key(:ucas_course_code)
-                           .with_primary_key(:course_code)
-    end
+    it { should belong_to(:course) }
   end
 
   describe '#has_been_published_before?' do
@@ -313,8 +303,7 @@ describe CourseEnrichment, type: :model do
     subject {
       create(:course_enrichment, :published,
              last_published_timestamp_utc: last_published_timestamp_utc,
-             course: course,
-             provider: provider)
+             course: course)
     }
 
     describe "to initial draft" do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Course, type: :model do
     it { should have_many(:subjects).through(:course_subjects) }
     it { should have_many(:site_statuses) }
     it { should have_many(:sites) }
+    it { should have_many(:enrichments) }
   end
 
   describe 'validations' do


### PR DESCRIPTION
### Context
The course enrichment can be 2019 or 2020 recruitment cycle

### Changes proposed in this pull request
The course enrichment is now associated with a course, making the need for `ucas_course_code` & `provider_code` redundant as well as making it possible deterministic to get a 2019 or 2020 recruitment cycle for course enrichments.

### Guidance to review
`ucas_course_code` & `provider_code` needs to stay for backwards compatibility with its C# counterpart. 
`ucas_course_code` & `provider_code` original purpose was due to the course records being dropped and imported therefore the `course_id` was not usable.

### Checklist
- [x] update models
- [x] update the record creation
- [x] await #536 to complete

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
