### PR TITLE
[XXX] 'mcb courses audit' to see the audit trail on courses

### DIFF
--- a/lib/mcb/commands/courses/audit.rb
+++ b/lib/mcb/commands/courses/audit.rb
@@ -1,0 +1,26 @@
+summary 'Show changes made to a course record'
+usage 'audit <provider_code> <course_code>'
+param :provider_code, transform: ->(code) { code.upcase }
+param :course_code, transform: ->(code) { code.upcase }
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
+  provider = Provider.find_by!(provider_code: args[:provider_code])
+  course = provider.courses.find_by!(course_code: args[:course_code])
+
+  table = Tabulo::Table.new course.audits do |t|
+    t.add_column(:user_id, header: "user\nid", width: 6)
+    t.add_column(:user, header: "user email") { |a| a.user&.email }
+    t.add_column(:action, width: 8)
+    t.add_column(:associated_id, header: "associated\nid", width: 10)
+    t.add_column(:associated_type, header: "associated\ntype", width: 10)
+    t.add_column(:audited_changes,
+                 header: "changes",
+                 formatter: ->(v) { PP.pp(v, StringIO.new, 40).string },
+                 width: 40)
+    t.add_column(:created_at, width: 23)
+    t.add_column(:comment)
+  end
+  puts table.pack(max_table_width: 120)
+end

--- a/spec/lib/mcb/commands/courses/audit_spec.rb
+++ b/spec/lib/mcb/commands/courses/audit_spec.rb
@@ -1,0 +1,31 @@
+require 'mcb_helper'
+
+describe 'mcb courses audit' do
+  let(:lib_dir) { Rails.root.join('lib') }
+  let(:cmd) do
+    Cri::Command.load_file(
+      "#{lib_dir}/mcb/commands/courses/audit.rb"
+    )
+  end
+  let(:admin_user) { create :user, :admin, email: 'h@i' }
+  let(:course) { create(:course, name: 'P') }
+
+  before do
+    Audited.store[:audited_user] = admin_user
+  end
+
+  it 'shows the list of changes for a given course' do
+    course.update(name: 'B')
+
+    output = with_stubbed_stdout do
+      cmd.run([course.provider.provider_code, course.course_code])
+    end
+
+    expect(output).to have_text_table_row(admin_user.id,
+                                          'h@i',
+                                          'update',
+                                          '',
+                                          '',
+                                          '{"name"=>["P", "B"],')
+  end
+end


### PR DESCRIPTION
### Context
It's helpful seeing the audit trail on courses when investigating some discrepancy between Find, Publish and Apply.

### Changes proposed in this pull request
Introduce an `mcb courses audit` command which prints out the audit log for the specified course.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
