### PR TITLE
Updated base_url to use service domain in new_staging.yml

### DIFF
--- a/config/settings/new_staging.yml
+++ b/config/settings/new_staging.yml
@@ -1,6 +1,6 @@
 manage_api:
-  base_url: https://bat-stg-mcapi-as.azurewebsites.net
+  base_url: https://api.staging.publish-teacher-training-courses.service.gov.uk
   secret: please_change_me
 search_api:
-  base_url: https://bat-stg-sacapi-as.azurewebsites.net
+  base_url: https://api.staging.find-postgraduate-teacher-training.service.gov.uk
   secret: please_change_me


### PR DESCRIPTION
### Context
Update new staging environment to use non-Azure domains

### Changes proposed in this pull request
Change base_url value in New_staging.yml file from default azure web app .azurewebsites.net urls to service domains

### Guidance to review
base_url updated in new_staging.yml file only. New staging service domain urls are as follows:
mcapi: https://api.staging.publish-teacher-training-courses.service.gov.uk
mcbe: https://api2.staging.publish-teacher-training-courses.service.gov.uk
mcfe: https://www2.staging.publish-teacher-training-courses.service.gov.uk
mcspt: https://support.staging.publish-teacher-training-courses.service.gov.uk
mcui: https://www.staging.publish-teacher-training-courses.service.gov.uk
sacapi: https://api.staging.find-postgraduate-teacher-training.service.gov.uk
sacui: https://www.staging.find-postgraduate-teacher-training.service.gov.uk
