### PR TITLE
[1682] remove rails data:migrate from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN apk add --update --no-cache --virtual build-dependances \
 
 ADD . $APP_HOME/
 
-CMD bundle exec rails db:migrate && bundle exec rake data:migrate && bundle exec rails server -b 0.0.0.0
+CMD bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0


### PR DESCRIPTION
### Context

We've removed the data migrations and gem, but not it being run.

### Changes proposed in this pull request

Remove 'rails data:migrate' from Dockerfile.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
