### PR TITLE
[1690] Add word count validations for personal qualities and other requirements

### DIFF
--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -92,6 +92,10 @@ class CourseEnrichment < ApplicationRecord
   validates :qualifications, presence: true, on: :publish
   validates :qualifications, words_count: { maximum: 100 }
 
+  validates :personal_qualities, words_count: { maximum: 100 }
+
+  validates :other_requirements, words_count: { maximum: 100 }
+
   def is_fee_based?
     course&.is_fee_based?
   end

--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -47,10 +47,27 @@ class CourseEnrichment < ApplicationRecord
   validates :provider_code, presence: true
   validates :provider, presence: true
 
+  # About this course
+
   validates :about_course, presence: true, on: :publish
   validates :about_course, words_count: { maximum: 400 }
 
+  validates :interview_process, words_count: { maximum: 250 }
+
+  validates :how_school_placements_work, presence: true, on: :publish
+  validates :how_school_placements_work, words_count: { maximum: 350 }
+
+  # Course length and fees
+
   validates :course_length, presence: true, on: :publish
+
+  validates :fee_uk_eu, presence: true, on: :publish, if: :is_fee_based?
+  validates :fee_uk_eu,
+            numericality: { allow_blank: true,
+                            only_integer: true,
+                            greater_than_or_equal_to: 0,
+                            less_than_or_equal_to: 100000 },
+            if: :is_fee_based?
 
   validates :fee_international,
             numericality: { allow_blank: true,
@@ -61,28 +78,19 @@ class CourseEnrichment < ApplicationRecord
 
   validates :fee_details, words_count: { maximum: 250 }, if: :is_fee_based?
 
-  validates :fee_uk_eu, presence: true, on: :publish, if: :is_fee_based?
-  validates :fee_uk_eu,
-            numericality: { allow_blank: true,
-                            only_integer: true,
-                            greater_than_or_equal_to: 0,
-                            less_than_or_equal_to: 100000 },
-            if: :is_fee_based?
-
   validates :financial_support,
             words_count: { maximum: 250 },
             if: :is_fee_based?
 
-  validates :how_school_placements_work, presence: true, on: :publish
-  validates :how_school_placements_work, words_count: { maximum: 350 }
-
-  validates :interview_process, words_count: { maximum: 250 }
-
-  validates :qualifications, presence: true, on: :publish
-  validates :qualifications, words_count: { maximum: 100 }
+  # Course length and salary
 
   validates :salary_details, presence: true, on: :publish, unless: :is_fee_based?
   validates :salary_details, words_count: { maximum: 250 }, unless: :is_fee_based?
+
+  # Requirements and qualifications
+
+  validates :qualifications, presence: true, on: :publish
+  validates :qualifications, words_count: { maximum: 100 }
 
   def is_fee_based?
     course&.is_fee_based?

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -186,6 +186,30 @@ describe CourseEnrichment, type: :model do
     end
   end
 
+  describe 'personal_qualities attribute' do
+    let(:personal_qualities_text) { 'this course is great' }
+
+    subject { build :course_enrichment, personal_qualities: personal_qualities_text }
+
+    context 'with over 100 words' do
+      let(:personal_qualities_text) { Faker::Lorem.sentence(100 + 1) }
+
+      it { should_not be_valid }
+    end
+  end
+
+  describe 'other_requirements attribute' do
+    let(:other_requirements_text) { 'this course is great' }
+
+    subject { build :course_enrichment, other_requirements: other_requirements_text }
+
+    context 'with over 100 words' do
+      let(:other_requirements_text) { Faker::Lorem.sentence(100 + 1) }
+
+      it { should_not be_valid }
+    end
+  end
+
   describe 'salary_details attribute' do
     let(:salary_details_text) { 'this course is great' }
 

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -139,9 +139,9 @@ describe 'Publish API v2', type: :request do
           it 'has validation errors' do
             expect(json_data.count).to eq 5
             expect(json_data[0]["detail"]).to eq("Enter details about this course")
-            expect(json_data[1]["detail"]).to eq("Enter a course length")
-            expect(json_data[2]["detail"]).to eq("Give details about the fee for UK and EU students")
-            expect(json_data[3]["detail"]).to eq("Enter details about school placements")
+            expect(json_data[1]["detail"]).to eq("Enter details about school placements")
+            expect(json_data[2]["detail"]).to eq("Enter a course length")
+            expect(json_data[3]["detail"]).to eq("Give details about the fee for UK and EU students")
             expect(json_data[4]["detail"]).to eq("Enter details about the qualifications needed")
           end
         end
@@ -158,10 +158,10 @@ describe 'Publish API v2', type: :request do
           it 'has validation errors' do
             expect(json_data.count).to eq 5
             expect(json_data[0]["detail"]).to eq("Enter details about this course")
-            expect(json_data[1]["detail"]).to eq("Enter a course length")
-            expect(json_data[2]["detail"]).to eq("Enter details about school placements")
-            expect(json_data[3]["detail"]).to eq("Enter details about the qualifications needed")
-            expect(json_data[4]["detail"]).to eq("Give details about the salary for this course")
+            expect(json_data[1]["detail"]).to eq("Enter details about school placements")
+            expect(json_data[2]["detail"]).to eq("Enter a course length")
+            expect(json_data[3]["detail"]).to eq("Give details about the salary for this course")
+            expect(json_data[4]["detail"]).to eq("Enter details about the qualifications needed")
           end
         end
       end


### PR DESCRIPTION
### Context

We didn’t have validations for word count for:

- personal qualities
- other qualifications

This means users could save long answers to these.

### Changes proposed in this pull request

- Add missing validations
- Group validations by enrichment page, and order based on order they appear in form – this means the error messages shown to users will also appear in the correct order
