### PR TITLE
1645 mcb add pg dump

### DIFF
--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -85,6 +85,11 @@ module MCB
     `#{cmd}`
   end
 
+  def self.exec_command(cmd)
+    verbose("Running: #{cmd}")
+    exec(cmd)
+  end
+
   def self.apiv1_token(webapp: nil, rgroup: nil)
     if webapp
       verbose "getting config for webapp: #{webapp} rgroup: #{rgroup}"
@@ -316,6 +321,14 @@ module MCB
 
     def connecting_to_remote_db?
       ENV.key?('DB_HOSTNAME')
+    end
+
+    def configure_local_database_env
+      # values to match database.yml
+      ENV["DB_HOSTNAME"] = "localhost"
+      ENV["DB_USERNAME"] = "manage_courses_backend"
+      ENV["DB_PASSWORD"] = "manage_courses_backend"
+      ENV["DB_DATABASE"] = "manage_courses_backend_development"
     end
 
   private

--- a/lib/mcb/commands/az/apps/pg_dump.rb
+++ b/lib/mcb/commands/az/apps/pg_dump.rb
@@ -9,12 +9,14 @@ run do |opts, _args, _cmd|
   MCB.load_env_azure_settings(opts)
   if MCB.requesting_remote_connection? opts
     MCB::Azure.configure_for_webapp(opts)
+  else
+    MCB.configure_local_database_env
   end
 
   ENV['PGPASSWORD'] = ENV['DB_PASSWORD']
   target_file = opts[:target_file]
-  target_file ||= "#{opts[:env]}_#{ENV['DB_DATABASE']}.sql"
+  target_file ||= "#{opts[:env] || ENV['DB_HOSTNAME']}_#{ENV['DB_DATABASE']}.sql"
   cmd = "pg_dump --encoding utf8 --clean --if-exists -h #{ENV['DB_HOSTNAME']} -U #{ENV['DB_USERNAME']} -d #{ENV['DB_DATABASE']} --file '#{target_file}'"
-  verbose cmd
-  exec(cmd)
+
+  MCB::exec_command(cmd)
 end

--- a/lib/mcb/commands/az/apps/pg_dump.rb
+++ b/lib/mcb/commands/az/apps/pg_dump.rb
@@ -1,0 +1,20 @@
+name 'pg_dump'
+summary 'backup the psql server for an app'
+option :f, 'target_file', 'target file',
+  argument: :optional
+
+instance_eval(&MCB.remote_connect_options)
+
+run do |opts, args, _cmd|
+  MCB.load_env_azure_settings(opts)
+  if MCB.requesting_remote_connection? opts
+    MCB::Azure.configure_for_webapp(opts)
+  end
+
+  ENV['PGPASSWORD'] = ENV['DB_PASSWORD']
+  target_file = opts[:target_file]
+  target_file = "#{opts[:env]}_#{ENV['DB_DATABASE']}.sql" unless target_file
+  cmd = "pg_dump --encoding utf8 --clean --if-exists -h #{ENV['DB_HOSTNAME']} -U #{ENV['DB_USERNAME']} -d #{ENV['DB_DATABASE']} --file '#{target_file}'"
+  verbose cmd
+  exec(cmd)
+end

--- a/lib/mcb/commands/az/apps/pg_dump.rb
+++ b/lib/mcb/commands/az/apps/pg_dump.rb
@@ -15,8 +15,11 @@ run do |opts, _args, _cmd|
 
   ENV['PGPASSWORD'] = ENV['DB_PASSWORD']
   target_file = opts[:target_file]
-  target_file ||= "#{opts[:env] || ENV['DB_HOSTNAME']}_#{ENV['DB_DATABASE']}.sql"
-  cmd = "pg_dump --encoding utf8 --clean --if-exists -h #{ENV['DB_HOSTNAME']} -U #{ENV['DB_USERNAME']} -d #{ENV['DB_DATABASE']} --file '#{target_file}'"
+  target_file ||= "#{opts[:env] || ENV['DB_HOSTNAME']}_" \
+    "#{ENV['DB_DATABASE']}_#{Time.now.utc.strftime('%Y%m%d_%H%M%S')}.sql"
+  cmd = "pg_dump --encoding utf8 --clean --if-exists " \
+      "-h #{ENV['DB_HOSTNAME']} -U #{ENV['DB_USERNAME']} -d #{ENV['DB_DATABASE']} " \
+      "--file '#{target_file}'"
 
   MCB::exec_command(cmd)
 end

--- a/lib/mcb/commands/az/apps/pg_dump.rb
+++ b/lib/mcb/commands/az/apps/pg_dump.rb
@@ -1,11 +1,11 @@
 name 'pg_dump'
 summary 'backup the psql server for an app'
 option :f, 'target_file', 'target file',
-  argument: :optional
+       argument: :optional
 
 instance_eval(&MCB.remote_connect_options)
 
-run do |opts, args, _cmd|
+run do |opts, _args, _cmd|
   MCB.load_env_azure_settings(opts)
   if MCB.requesting_remote_connection? opts
     MCB::Azure.configure_for_webapp(opts)
@@ -13,7 +13,7 @@ run do |opts, args, _cmd|
 
   ENV['PGPASSWORD'] = ENV['DB_PASSWORD']
   target_file = opts[:target_file]
-  target_file = "#{opts[:env]}_#{ENV['DB_DATABASE']}.sql" unless target_file
+  target_file ||= "#{opts[:env]}_#{ENV['DB_DATABASE']}.sql"
   cmd = "pg_dump --encoding utf8 --clean --if-exists -h #{ENV['DB_HOSTNAME']} -U #{ENV['DB_USERNAME']} -d #{ENV['DB_DATABASE']} --file '#{target_file}'"
   verbose cmd
   exec(cmd)

--- a/lib/mcb/commands/az/apps/psql.rb
+++ b/lib/mcb/commands/az/apps/psql.rb
@@ -11,17 +11,18 @@ run do |opts, _args, _cmd|
   MCB.load_env_azure_settings(opts)
   if MCB.requesting_remote_connection? opts
     MCB::Azure.configure_for_webapp(opts)
+  else
+    MCB.configure_local_database_env
   end
 
   ENV['PGPASSWORD'] = ENV['DB_PASSWORD']
-  psql = "psql -h #{ENV['DB_HOSTNAME']} -U #{ENV['DB_USERNAME']} -d #{ENV['DB_DATABASE']}"
+  cmd = "psql -h #{ENV['DB_HOSTNAME']} -U #{ENV['DB_USERNAME']} -d #{ENV['DB_DATABASE']}"
+
   source_file = opts[:source_file]
-  psql = "#{psql} --file '#{source_file}'" if source_file
+  cmd = "#{cmd} --file '#{source_file}'" if source_file
+
   sql_command = opts[:sql_command]
-  psql = "#{psql} --command '#{sql_command}'" if sql_command
+  cmd = "#{cmd} --command '#{sql_command}'" if sql_command
 
-  # could have used verbose() here, but it's worth being certain which psql server you are connected to
-  puts psql
-
-  exec(psql)
+  MCB::exec_command(cmd)
 end

--- a/lib/mcb/commands/az/apps/psql.rb
+++ b/lib/mcb/commands/az/apps/psql.rb
@@ -1,5 +1,7 @@
 name 'psql'
 summary 'connect to the psql server for an app'
+option :f, 'source_file', 'source sql file to pass to psql to run',
+       argument: :optional
 
 instance_eval(&MCB.remote_connect_options)
 
@@ -11,6 +13,8 @@ run do |opts, _args, _cmd|
 
   ENV['PGPASSWORD'] = ENV['DB_PASSWORD']
   psql = "psql -h #{ENV['DB_HOSTNAME']} -U #{ENV['DB_USERNAME']} -d #{ENV['DB_DATABASE']}"
+  source_file = opts[:source_file]
+  psql = "#{psql} --file '#{source_file}'" if source_file
 
   # could have used verbose() here, but it's worth being certain which psql server you are connected to
   puts psql

--- a/lib/mcb/commands/az/apps/psql.rb
+++ b/lib/mcb/commands/az/apps/psql.rb
@@ -2,6 +2,8 @@ name 'psql'
 summary 'connect to the psql server for an app'
 option :f, 'source_file', 'source sql file to pass to psql to run',
        argument: :optional
+option :c, 'sql_command', 'sql string to run',
+       argument: :optional
 
 instance_eval(&MCB.remote_connect_options)
 
@@ -15,6 +17,8 @@ run do |opts, _args, _cmd|
   psql = "psql -h #{ENV['DB_HOSTNAME']} -U #{ENV['DB_USERNAME']} -d #{ENV['DB_DATABASE']}"
   source_file = opts[:source_file]
   psql = "#{psql} --file '#{source_file}'" if source_file
+  sql_command = opts[:sql_command]
+  psql = "#{psql} --command '#{sql_command}'" if sql_command
 
   # could have used verbose() here, but it's worth being certain which psql server you are connected to
   puts psql

--- a/spec/lib/mcb/commands/az/apps/pg_dump_spec.rb
+++ b/spec/lib/mcb/commands/az/apps/pg_dump_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'mcb_helper'
+
+describe 'mcb az apps pg_dump' do
+  it 'returns the pg_dump of apps' do
+    allow(MCB).to receive(:exec_command)
+                    .with("pg_dump --encoding utf8 --clean --if-exists -h localhost -U manage_courses_backend -d manage_courses_backend_development --file 'localhost_manage_courses_backend_development.sql'")
+
+    with_stubbed_stdout do
+      $mcb.run(%w[az apps pg_dump])
+    end
+  end
+end

--- a/spec/lib/mcb/commands/az/apps/pg_dump_spec.rb
+++ b/spec/lib/mcb/commands/az/apps/pg_dump_spec.rb
@@ -3,11 +3,17 @@ require 'mcb_helper'
 
 describe 'mcb az apps pg_dump' do
   it 'returns the pg_dump of apps' do
-    allow(MCB).to receive(:exec_command)
-                    .with("pg_dump --encoding utf8 --clean --if-exists -h localhost -U manage_courses_backend -d manage_courses_backend_development --file 'localhost_manage_courses_backend_development.sql'")
+    Timecop.freeze do
+      allow(MCB).to receive(:exec_command).with(
+        "pg_dump --encoding utf8 --clean --if-exists " \
+        "-h localhost -U manage_courses_backend " \
+        "-d manage_courses_backend_development " \
+        "--file 'localhost_manage_courses_backend_development_#{Time.now.utc.strftime('%Y%m%d_%H%M%S')}.sql'"
+      )
 
-    with_stubbed_stdout do
-      $mcb.run(%w[az apps pg_dump])
+      with_stubbed_stdout do
+        $mcb.run(%w[az apps pg_dump])
+      end
     end
   end
 end

--- a/spec/lib/mcb/commands/az/apps/psql_spec.rb
+++ b/spec/lib/mcb/commands/az/apps/psql_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'mcb_helper'
+
+describe 'mcb az apps psql' do
+  it 'returns the psql of apps' do
+    allow(MCB).to receive(:exec_command)
+                    .with('psql -h localhost -U manage_courses_backend -d manage_courses_backend_development')
+
+    with_stubbed_stdout do
+      $mcb.run(%w[az apps psql])
+    end
+  end
+end

--- a/spec/lib/mcb/commands/az/apps/psql_spec.rb
+++ b/spec/lib/mcb/commands/az/apps/psql_spec.rb
@@ -3,8 +3,10 @@ require 'mcb_helper'
 
 describe 'mcb az apps psql' do
   it 'returns the psql of apps' do
-    allow(MCB).to receive(:exec_command)
-                    .with('psql -h localhost -U manage_courses_backend -d manage_courses_backend_development')
+    allow(MCB).to receive(:exec_command).with(
+      "psql -h localhost -U manage_courses_backend " \
+      "-d manage_courses_backend_development"
+    )
 
     with_stubbed_stdout do
       $mcb.run(%w[az apps psql])


### PR DESCRIPTION
### Context

Needed to reset qa database to eliminate drift before testing.

### Changes proposed in this pull request

* Add pg_dump to apps command
* Add input file / sql-string to psql command


new things:
```
be bin/mcb az apps psql -h
...
    -c --sql_command[=<value>]      sql string to run
    -f --source_file[=<value>]      source sql file to pass to psql to run

be bin/mcb az apps -h     
...
SUBCOMMANDS
...
    pg_dump     backup the psql server for an app
...
```


### Guidance to review

Comments on desired test coverage might be handy

```
$ be bin/mcb az apps psql -v -E qa -c "select * from recruitment_cycle;"
$ be bin/mcb az apps pg_dump -E qa qa-dump.sql
```


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [x] Tested by running locally
