### PR TITLE
[1685] Update validation when enrichments are blank

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,10 @@ en:
               blank: "is missing"
             postcode:
               blank: "is missing"
+        course:
+          attributes:
+            enrichments:
+              blank: "^Complete your course information before publishing"
         course_enrichment:
           attributes:
             salary_details:

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -124,7 +124,7 @@ describe 'Publish API v2', type: :request do
         it 'has validation errors' do
           expect(json_data.count).to eq 1
           expect(response.body).to include('Invalid enrichment')
-          expect(response.body).to include("Enrichments can't be blank")
+          expect(response.body).to include("Complete your course information before publishing")
         end
       end
 


### PR DESCRIPTION
### Context

Users get a message which relates to "enrichments," which is confusing.

### Changes proposed in this pull request

Change the validation message.

### Guidance to review

:shipit:

### Screenshot

<img width="1022" alt="Screenshot 2019-06-28 at 11 27 31" src="https://user-images.githubusercontent.com/1650875/60336234-b9eded80-9997-11e9-9bf2-044929baab3f.png">

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally