### PR TITLE
[1685] Remove unnecessary "Enrichments is invalid" message

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -124,6 +124,8 @@ class Course < ApplicationRecord
   validate :validate_enrichment_publishable, on: :publish
   validate :validate_enrichment
 
+  after_validation :remove_unnecessary_enrichments_validation_message
+
   def accrediting_provider_description
     return nil if accrediting_provider.blank?
 
@@ -335,5 +337,9 @@ private
 
   def set_defaults
     self.modular ||= ''
+  end
+
+  def remove_unnecessary_enrichments_validation_message
+    self.errors.delete :enrichments if self.errors[:enrichments] == ['is invalid']
   end
 end

--- a/spec/requests/api/v2/providers/courses/update_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_spec.rb
@@ -342,6 +342,21 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
         perform_request update_course
       }.to(change { course.reload.content_status }.from(:published).to(:published_with_unpublished_changes))
     end
+
+    context "with invalid data" do
+      let(:updated_attributes) do
+        { about_course: Faker::Lorem.sentence(1000) }
+      end
+
+      subject { JSON.parse(response.body)["errors"].map { |e| e["title"] } }
+
+      it "returns validation errors" do
+        perform_request update_course
+
+        expect("Invalid enrichments".in?(subject)).to eq(false)
+        expect("Invalid about_course".in?(subject)).to eq(true)
+      end
+    end
   end
 
   describe 'from published to draft' do


### PR DESCRIPTION
### Context

Because of the `has_many :enrichments` relationship, Rails will add a `Enrichments is invalid` message on the `Course` model when a new `CourseEnrichment` is created but fails to be saved due to validation issues. This behaviour can occur when users attempt to save a new enrichment (as opposed to updating an already draft one) which has errors.


### Changes proposed in this pull request

Adds an `after_validation` to manually clear the unnecessary validation.

### Guidance to review

I can't seem to find a more idiomatic way of doing this.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally