### PR TITLE
[1677] The provider enrichments 2019 vs 2020 recruitment cycle

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -51,14 +51,10 @@ class Provider < ApplicationRecord
 
   has_many :sites
   has_many :enrichments,
-           foreign_key: :provider_code,
-           primary_key: :provider_code,
            class_name: "ProviderEnrichment",
            inverse_of: 'provider'
   has_one :latest_published_enrichment,
           -> { published.latest_published_at },
-          foreign_key: :provider_code,
-          primary_key: :provider_code,
           class_name: "ProviderEnrichment",
           inverse_of: 'provider'
   has_many :courses

--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -11,6 +11,7 @@
 #  created_by_user_id :integer
 #  last_published_at  :datetime
 #  status             :integer          default("draft"), not null
+#  provider_id        :integer          not null
 #
 
 class ProviderEnrichment < ApplicationRecord
@@ -21,8 +22,6 @@ class ProviderEnrichment < ApplicationRecord
   enum status: { draft: 0, published: 1 }
 
   belongs_to :provider,
-             foreign_key: :provider_code,
-             primary_key: :provider_code,
              inverse_of: 'enrichments'
 
   scope :latest_created_at, -> { order(created_at: :desc) }

--- a/db/migrate/20190627151832_add_provider_ref_to_provider_enrichment.rb
+++ b/db/migrate/20190627151832_add_provider_ref_to_provider_enrichment.rb
@@ -1,0 +1,20 @@
+class AddProviderRefToProviderEnrichment < ActiveRecord::Migration[5.2]
+  def up
+    add_reference :provider_enrichment, :provider, index: true, type: :int
+
+    execute <<-SQL
+    UPDATE provider_enrichment
+    SET    provider_id =
+           (
+                  SELECT provider.id
+                  FROM   provider
+                  WHERE  provider_enrichment.provider_code    = provider.provider_code)
+    SQL
+
+    change_column_null :provider_enrichment, :provider_id, false
+  end
+
+  def down
+    remove_reference :provider_enrichment, :provider
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_26_132627) do
+ActiveRecord::Schema.define(version: 2019_06_27_151832) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -197,8 +197,10 @@ ActiveRecord::Schema.define(version: 2019_06_26_132627) do
     t.integer "created_by_user_id"
     t.datetime "last_published_at"
     t.integer "status", default: 0, null: false
+    t.integer "provider_id", null: false
     t.index ["created_by_user_id"], name: "IX_provider_enrichment_created_by_user_id"
     t.index ["provider_code"], name: "IX_provider_enrichment_provider_code"
+    t.index ["provider_id"], name: "index_provider_enrichment_on_provider_id"
     t.index ["updated_by_user_id"], name: "IX_provider_enrichment_updated_by_user_id"
   end
 

--- a/spec/factories/provider_enrichments.rb
+++ b/spec/factories/provider_enrichments.rb
@@ -11,6 +11,7 @@
 #  created_by_user_id :integer
 #  last_published_at  :datetime
 #  status             :integer          default("draft"), not null
+#  provider_id        :integer          not null
 #
 
 
@@ -21,6 +22,7 @@ FactoryBot.define do
     end
 
     provider
+    provider_code { provider.provider_code }
 
     status { :draft }
 

--- a/spec/models/provider_enrichment_spec.rb
+++ b/spec/models/provider_enrichment_spec.rb
@@ -11,6 +11,7 @@
 #  created_by_user_id :integer
 #  last_published_at  :datetime
 #  status             :integer          default("draft"), not null
+#  provider_id        :integer          not null
 #
 
 require 'rails_helper'


### PR DESCRIPTION
### Context
The provider enrichment can be 2019 or 2020 recruitment cycle
### Changes proposed in this pull request

### Guidance to review

The provider enrichment is now associated with a provider, making the need for provider_code redundant as well as making it possible deterministic to get a 2019 or 2020 recruitment cycle for provider enrichments.

### Checklist

There is no provider_enrichment creation...

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
