### PR TITLE
Fix showing subcommands of subcommands in help

### DIFF
--- a/bin/mcb
+++ b/bin/mcb
@@ -48,13 +48,10 @@ $mcb = Cri::Command.define do
 
   flag :h, :help, 'show help for this command' do |_value, cmd|
     puts cmd.help
-    puts
-    puts Rainbow("SUBCOMMANDS").red.bright
-    prefix = "    "
-    cmd.commands.each do |c|
-      show_all_commands(c, prefix + c.name + " ")
-      puts
-    end
+
+    prefix = "    #{cmd.name == "mcb" ? "bin/mcb" : cmd.name} "
+    puts_command_index(cmd, prefix, 1)
+
     # Don't exit if we're in repl-mode.
     exit 0 unless $mcb_repl_mode
   end
@@ -65,13 +62,29 @@ $mcb = Cri::Command.define do
   end
 end
 
-def show_all_commands(cmd, prefix)
-  cmd.commands.each do |c|
-    aligned_cmd_name = (prefix + c.name).ljust(37, ' ')
-    coloured_name = Rainbow(aligned_cmd_name).green
-    puts "#{coloured_name} #{c.summary}"
-    show_all_commands(c, prefix + c.name + " ")
+def puts_command_index(cmd, prefix, depth)
+  if depth == 1
+    return if cmd.commands.empty?
+
+    puts
+    puts Rainbow("INDEX").red.bright
   end
+
+  # split up top level groups
+  puts "    ---" if depth == 2 && !cmd.commands.count.zero?
+
+  pretty_cmd(cmd, prefix)
+
+  # recurse
+  cmd.commands.sort_by(&:name).each do |c|
+    puts_command_index(c, prefix + c.name + " ", depth + 1)
+  end
+end
+
+def pretty_cmd(cmd, prefix)
+  aligned_cmd_name = prefix.ljust(35, ' ')
+  coloured_name = Rainbow(aligned_cmd_name).green
+  puts "#{coloured_name} #{cmd.summary}"
 end
 
 MCB.load_commands($mcb, "#{lib_dir}/mcb/commands")


### PR DESCRIPTION
### Context

Had accidentally clipped first items in list for help of subcommands.

It was quick to fix and annoying me.

It's a bit of a hack doing the string compare but it's the first thing I could think of and this isn't user value so didn't want to spend more time on this. Suggestions welcome :pray: 

### Changes proposed in this pull request

E.g. `bin/mcb az -h` only showed help for subcommands rather than the
direct descendants

before:

```
bin/mcb -h
...
SUBCOMMANDS
    apps pg_dump                      backup the psql server for an app
    apps config                       read webapp config from azure,...
```

after:

```
bin/mcb -h
...
INDEX
    bin/mcb                         wrapper for management of manage-curses-backend app
    ---
    bin/mcb apiv1                   Commands that target the V1 providers endpoint
    bin/mcb apiv1 courses           Operate on courses via the V1 API
    bin/mcb apiv1 courses find      Find a particular provider course entry
```

and for a subcommand:

```
bin/mcb az apiv1 -h
...
INDEX
    apiv1                           Commands that target the V1 providers endpoint
    ---
    apiv1 courses                   Operate on courses via the V1 API
    apiv1 courses find              Find a particular provider course entry
```


### Guidance to review

:ship: 


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
