### PR TITLE
[1657] mcb courses edit subjects

### DIFF
--- a/lib/mcb/courses_editor.rb
+++ b/lib/mcb/courses_editor.rb
@@ -24,20 +24,39 @@ module MCB
       puts "Editing #{course_codes.join(', ')}"
       print_at_most_two_courses
       until finished
-        choice = @cli.main_loop
+        choice = main_loop
 
-        if choice.start_with?("edit")
+        if choice.nil?
+          finished = true
+        elsif choice.start_with?("edit")
           attribute = choice.gsub("edit ", "").gsub(" ", "_").to_sym
           edit(attribute)
         elsif choice =~ /sync .* to Find/
           sync_courses_to_find
-        elsif choice == "exit"
-          finished = true
         end
       end
     end
 
   private
+
+    def main_loop
+      choices = [
+        "edit title",
+        "edit course code",
+        "edit maths",
+        "edit english",
+        "edit science",
+        "edit route",
+        "edit qualifications",
+        "edit study mode",
+        "edit accredited body",
+        "edit start date",
+        "edit application opening date",
+        "edit age range",
+        "sync course(s) to Find"
+      ]
+      @cli.ask_multiple_choice(prompt: "What would you like to edit?", choices: choices)
+    end
 
     def edit(logical_attribute)
       database_attribute = LOGICAL_NAME_TO_DATABASE_NAME_MAPPING[logical_attribute] || logical_attribute

--- a/lib/mcb/courses_editor.rb
+++ b/lib/mcb/courses_editor.rb
@@ -21,9 +21,9 @@ module MCB
 
     def run
       finished = false
-      puts "Editing #{course_codes.join(', ')}"
-      print_at_most_two_courses
       until finished
+        puts "Editing #{course_codes.join(', ')}"
+        print_at_most_two_courses
         choice = main_loop
 
         if choice.nil?

--- a/lib/mcb/courses_editor_cli.rb
+++ b/lib/mcb/courses_editor_cli.rb
@@ -5,27 +5,6 @@ module MCB
       @provider = provider
     end
 
-    def main_loop
-      @cli.choose do |menu|
-        menu.choice("exit")
-        menu.choices(
-          "edit title",
-          "edit course code",
-          "edit maths",
-          "edit english",
-          "edit science",
-          "edit route",
-          "edit qualifications",
-          "edit study mode",
-          "edit accredited body",
-          "edit start date",
-          "edit application opening date",
-          "edit age range",
-        )
-        menu.choice("sync course(s) to Find")
-      end
-    end
-
     def ask_title
       @cli.ask("New course title?  ")
     end
@@ -104,8 +83,6 @@ module MCB
         q.validate = /\S+/
       end
     end
-
-  private
 
     def ask_multiple_choice(prompt:, choices:, default: nil)
       @cli.choose do |menu|

--- a/lib/mcb/courses_editor_cli.rb
+++ b/lib/mcb/courses_editor_cli.rb
@@ -84,6 +84,24 @@ module MCB
       end
     end
 
+    def multiselect(initial_items:, possible_items:)
+      selected_items = initial_items
+      finished = false
+      until finished do
+        @cli.choose do |menu|
+          menu.choice("continue") { finished = true }
+          possible_items.sort_by(&:to_s).each do |item|
+            if item.in?(selected_items)
+              menu.choice("[x] #{item}") { selected_items.delete(item) }
+            else
+              menu.choice("[ ] #{item}") { selected_items << item }
+            end
+          end
+        end
+      end
+      selected_items
+    end
+
     def ask_multiple_choice(prompt:, choices:, default: nil)
       @cli.choose do |menu|
         menu.prompt = prompt + "  "

--- a/lib/mcb/courses_editor_cli.rb
+++ b/lib/mcb/courses_editor_cli.rb
@@ -90,13 +90,11 @@ module MCB
       until finished do
         @cli.choose do |menu|
           menu.choice("continue") { finished = true }
-          possible_items.sort_by(&:to_s).each do |item|
-            if item.in?(selected_items)
-              menu.choice("[x] #{item}") { selected_items.delete(item) }
-            else
-              menu.choice("[ ] #{item}") { selected_items << item }
-            end
-          end
+          define_choices_for_each_possible_item(
+            menu: menu,
+            selected_items: selected_items,
+            possible_items: possible_items
+          )
         end
       end
       selected_items
@@ -108,6 +106,18 @@ module MCB
         menu.choice("exit") { nil }
         menu.choices(*choices)
         menu.default = default if default.present?
+      end
+    end
+
+  private
+
+    def define_choices_for_each_possible_item(menu:, selected_items:, possible_items:)
+      possible_items.sort_by(&:to_s).each do |item|
+        if item.in?(selected_items)
+          menu.choice("[x] #{item}") { selected_items.delete(item) }
+        else
+          menu.choice("[ ] #{item}") { selected_items << item }
+        end
       end
     end
   end

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -12,6 +12,21 @@ FactoryBot.define do
     sequence(:subject_code, &:to_s)
     subject_name { Faker::ProgrammingLanguage.name }
 
+    trait :secondary do
+      subject_name { 'Secondary' }
+      subject_code { '05' }
+    end
+
+    trait :primary do
+      subject_name { 'Primary' }
+      subject_code { '00' }
+    end
+
+    trait :mathematics do
+      subject_name { 'Mathematics' }
+      subject_code { 'G1' }
+    end
+
     factory :further_education_subject do
       subject_name { 'Further Education' }
     end

--- a/spec/lib/mcb/courses_editor_cli_spec.rb
+++ b/spec/lib/mcb/courses_editor_cli_spec.rb
@@ -1,0 +1,59 @@
+require 'mcb_helper'
+
+describe MCB::CoursesEditorCLI do
+  def run_with_input_commands(*input_cmds)
+    stderr = nil
+    output = with_stubbed_stdout(stdin: input_cmds.join("\n"), stderr: stderr) do
+      yield
+    end
+    [output, stderr]
+  end
+
+  subject { described_class.new(nil) } # provider is not needed for these specs
+
+  describe "#multiselect" do
+    let(:initial_items) { ["option A", "option C"] }
+    let(:possible_items) { ["option A", "option B", "option C"] }
+
+    def run_multiselect
+      subject.multiselect(initial_items: initial_items, possible_items: possible_items)
+    end
+
+    it "shows the initial values" do
+      output, = run_with_input_commands("continue") { run_multiselect }
+
+      expect(output).to include("[x] option A")
+      expect(output).to include("[ ] option B")
+      expect(output).to include("[x] option C")
+      expect(output.scan(/option/).count).to eq(3)
+    end
+
+    context "without modifications" do
+      it "returns a result that matches the initial items" do
+        result = nil
+        run_with_input_commands("continue") { result = run_multiselect }
+
+        expect(result).to eq(initial_items)
+      end
+    end
+
+    context "with modifications" do
+      it "shows the updates once an item has been selected or deselected" do
+        output, = run_with_input_commands("[x] option A", "[ ] option B", "continue") { run_multiselect }
+
+        expect(output).to include("[ ] option A")
+        expect(output).to include("[x] option B")
+        expect(output).to include("[x] option C")
+      end
+
+      it "returns the actual updated values once run" do
+        result = nil
+        run_with_input_commands("[x] option A", "[ ] option B", "continue") {
+          result = run_multiselect
+        }
+
+        expect(result.sort).to eq(["option B", "option C"])
+      end
+    end
+  end
+end

--- a/spec/lib/mcb/courses_editor_spec.rb
+++ b/spec/lib/mcb/courses_editor_spec.rb
@@ -15,9 +15,9 @@ describe MCB::CoursesEditor do
   let(:email) { 'user@education.gov.uk' }
   let(:provider) { create(:provider, provider_code: provider_code) }
   let(:accredited_body) { create(:provider, :accredited_body) }
-  let!(:mathematics) { create(:subject, subject_name: "Mathematics") }
-  let!(:biology) { create(:subject, subject_name: "Biology") }
-  let!(:secondary) { create(:subject, subject_name: "Secondary") }
+  let!(:mathematics) { find_or_create(:subject, :mathematics) }
+  let!(:biology) { find_or_create(:subject, subject_name: "Biology") }
+  let!(:secondary) { find_or_create(:subject, :secondary) }
   let!(:course) {
     create(:course,
            provider: provider,

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -446,13 +446,13 @@ RSpec.describe Course, type: :model do
     end
 
     context 'with primary subjects' do
-      subject { create(:course, subjects: [create(:subject, subject_name: "primary")]) }
+      subject { create(:course, subjects: [find_or_create(:subject, :primary)]) }
       its(:level) { should eq(:primary) }
       its(:dfe_subjects) { should eq([DFESubject.new("Primary")]) }
     end
 
     context 'with secondary subjects' do
-      subject { create(:course, subjects: [create(:subject, subject_name: "physical education")]) }
+      subject { create(:course, subjects: [find_or_create(:subject, subject_name: "physical education")]) }
       its(:level) { should eq(:secondary) }
       its(:dfe_subjects) { should eq([DFESubject.new("Physical education")]) }
     end
@@ -476,8 +476,8 @@ RSpec.describe Course, type: :model do
     describe "bursaries and scholarships" do
       let(:subjects) {
         [
-          build(:subject, subject_name: 'mathematics'),
-          build(:subject, subject_name: 'secondary'),
+          build(:subject, :mathematics),
+          build(:subject, :secondary),
         ]
       }
       subject { create(:course, subjects: subjects) }

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -10,7 +10,7 @@
 require 'rails_helper'
 
 RSpec.describe Subject, type: :model do
-  subject { create(:subject, subject_name: 'Mathematics') }
+  subject { find_or_create(:subject, :mathematics) }
 
   it { should have_many(:courses).through(:course_subjects) }
   its(:to_s) { should eq('Mathematics') }

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -29,8 +29,8 @@ describe "Courses API", type: :request do
     context "without changed_since parameter" do
       before do
         site = FactoryBot.create(:site, code: "-", location_name: "Main Site", provider: provider)
-        subject1 = FactoryBot.create(:subject, subject_code: "1", subject_name: "Secondary")
-        subject2 = FactoryBot.create(:subject, subject_code: "2", subject_name: "Mathematics")
+        subject1 = FactoryBot.find_or_create(:subject, :secondary)
+        subject2 = FactoryBot.find_or_create(:subject, :mathematics)
 
         course = FactoryBot.create(:course,
                                    course_code: "2HPF",
@@ -101,11 +101,11 @@ describe "Courses API", type: :request do
                                 ],
                                 "subjects" => [
                                   {
-                                    "subject_code" => "1",
+                                    "subject_code" => "05",
                                     "subject_name" => "Secondary"
                                   },
                                   {
-                                    "subject_code" => "2",
+                                    "subject_code" => "G1",
                                     "subject_name" => "Mathematics"
                                   }
                                 ],

--- a/spec/requests/api/v1/subject_spec.rb
+++ b/spec/requests/api/v1/subject_spec.rb
@@ -3,12 +3,10 @@ require "rails_helper"
 RSpec.describe "Subjecs API", type: :request do
   describe 'GET index' do
     before do
-      FactoryBot.create(:subject,
-                        subject_name: "Mathematics",
-                        subject_code: "B1")
-      FactoryBot.create(:subject,
-                        subject_name: "Biology",
-                        subject_code: "M4")
+      FactoryBot.find_or_create(:subject, :mathematics)
+      FactoryBot.find_or_create(:subject,
+                                subject_name: "Biology",
+                                subject_code: "M4")
     end
 
     it "returns http success" do
@@ -28,7 +26,7 @@ RSpec.describe "Subjecs API", type: :request do
       expect(json).to eq([
                            {
                              "subject_name" => "Mathematics",
-                             "subject_code" => "B1",
+                             "subject_code" => "G1",
                            },
                            {
                              "subject_name" => "Biology",

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -8,8 +8,8 @@ describe 'Courses API v2', type: :request do
   let(:credentials) do
     ActionController::HttpAuthentication::Token.encode_credentials(token)
   end
-  let(:course_subject_primary) { find_or_create(:subject, subject_name: 'Primary', subject_code: 'P') }
-  let(:course_subject_mathematics) { find_or_create(:subject, subject_name: 'Mathematics', subject_code: 'M') }
+  let(:course_subject_primary) { find_or_create(:subject, :primary) }
+  let(:course_subject_mathematics) { find_or_create(:subject, :mathematics) }
   let(:course_subject_send) { find_or_create(:send_subject) }
 
   let(:findable_open_course) {

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -131,7 +131,7 @@ describe API::V2::SerializableCourse do
     it { expect(subject["attributes"]).to include("is_send?" => false) }
 
     context "with a SEND subject" do
-      let(:course) { create(:course, subjects: [create(:send_subject)]) }
+      let(:course) { create(:course, subjects: [find_or_create(:send_subject)]) }
       it { expect(subject["attributes"]).to include("is_send?" => true) }
     end
   end
@@ -140,13 +140,13 @@ describe API::V2::SerializableCourse do
     let(:course) { create(:course, subjects: subjects) }
 
     describe 'are taken from the course' do
-      let(:subjects) { [create(:subject, subject_name: "primary")] }
+      let(:subjects) { [find_or_create(:subject, :primary)] }
       it { expect(subject["attributes"]).to include("level" => "primary") }
       it { expect(subject["attributes"]).to include("subjects" => %w[Primary]) }
     end
 
     describe 'determine bursary and scholarship info' do
-      let(:subjects) { [create(:subject, subject_name: "Secondary"), create(:subject, subject_name: "Russian")] }
+      let(:subjects) { [find_or_create(:subject, :secondary), find_or_create(:subject, subject_name: "Russian")] }
       it { expect(subject["attributes"]).to include("has_bursary?" => true) }
       it { expect(subject["attributes"]).to include("has_scholarship_and_bursary?" => false) }
     end


### PR DESCRIPTION
### Context

New course creation is currently being done through user support using `mcb` dev tooling. The tooling itself is sitting on a code branch that isn't the `master` branch and needs constant updating/rebasing.

The code is also missing automated tests, meaning it needs to be manually tested after every change.

### Changes proposed in this pull request

Introduce editing subjects to `mcb courses edit` which is both useful for editing courses, as well as being a stepping stone towards the new course creation.

## Comments for reviewers

This PR is best reviewed commit by commit.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
