### PR TITLE
[1713] mcb repl

### DIFF
--- a/bin/mcb
+++ b/bin/mcb
@@ -52,7 +52,8 @@ $mcb = Cri::Command.define do
       show_all_commands(c, prefix + c.name + " ")
       puts
     end
-    exit 0
+    # Don't exit if we're in repl-mode.
+    exit 0 unless $mcb_repl_mode
   end
 
   option :c, :config, 'use provided config file',
@@ -80,4 +81,10 @@ def error(msg)
   puts msg
 end
 
-$mcb.run(ARGV.dup) if File.basename(__FILE__) == File.basename($0)
+if File.basename(__FILE__) == File.basename($0)
+  if ARGV.empty? || ARGV.first == '-E'
+    MCB.start_mcb_repl(ARGV)
+  else
+    $mcb.run(ARGV.dup)
+  end
+end

--- a/bin/mcb
+++ b/bin/mcb
@@ -82,7 +82,7 @@ def error(msg)
 end
 
 if File.basename(__FILE__) == File.basename($0)
-  if ARGV.empty? || ARGV.first == '-E'
+  if MCB.launch_repl?(ARGV)
     MCB.start_mcb_repl(ARGV)
   else
     $mcb.run(ARGV.dup)

--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -331,6 +331,14 @@ module MCB
       ENV["DB_DATABASE"] = "manage_courses_backend_development"
     end
 
+    def pageable_output(output)
+      ::Open3.pipeline_w('less -FX') do |io|
+        io.puts output
+      rescue Errno::EPIPE
+        nil
+      end
+    end
+
     def start_mcb_repl(start_argv)
       $mcb_repl_mode = true
 

--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -1,4 +1,5 @@
 require 'logger'
+require 'open3'
 
 module MCB
   LOGGER = Logger.new(STDERR)

--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -354,7 +354,7 @@ module MCB
                when 'production' then Rainbow(env).red.inverse
                when 'staging'    then Rainbow(env).yellow
                when 'qa'         then Rainbow(env).yellow
-               when nil          then Rainbow(env).green
+               when nil          then Rainbow('local').green
                else                   env
                end
       while (input = Readline.readline("#{prompt}> ", true))
@@ -378,6 +378,10 @@ module MCB
           end
         end
       end
+    end
+
+    def launch_repl?(argv)
+      argv.empty? || (argv.first == '-E' && argv.length == 2)
     end
 
   private

--- a/lib/mcb/commands/courses.rb
+++ b/lib/mcb/commands/courses.rb
@@ -2,3 +2,5 @@ name 'courses'
 summary 'Operate on courses directly in db'
 
 instance_eval(&MCB.remote_connect_options)
+
+default_subcommand :list

--- a/lib/mcb/commands/courses/list.rb
+++ b/lib/mcb/commands/courses/list.rb
@@ -1,0 +1,26 @@
+name 'list'
+summary 'List courses in db'
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
+  courses = if args.any?
+              Course.where(course_code: args.to_a.map(&:upcase))
+            else
+              Course.all
+            end
+
+  tp.set :capitalize_headers, false
+
+  output = [
+    '',
+    'Course:',
+    Tabulo::Table.new(courses) { |t|
+      t.add_column :id
+      t.add_column(:provider_code) { |c| c.provider.provider_code }
+      t.add_column :course_code
+      t.add_column :name
+    }.pack(max_table_width: nil)
+  ]
+  MCB.pageable_output(output)
+end

--- a/lib/mcb/commands/providers/list.rb
+++ b/lib/mcb/commands/providers/list.rb
@@ -10,9 +10,15 @@ run do |opts, args, _cmd|
                 Provider.all
               end
 
-  tp.set :capitalize_headers, false
+  output = [
+    'Providers:',
+    Tabulo::Table.new(providers) { |t|
+      t.add_column :id
+      t.add_column(:provider_code)
+      t.add_column :provider_name
+      t.add_column :provider_type
+    }.pack(max_table_width: nil)
+  ]
 
-  puts "\nProviders:"
-  tp providers, 'id', 'provider_code', 'provider_name', 'provider_type',
-     'postcode'
+  MCB.pageable_output(output)
 end

--- a/spec/mcb_helper.rb
+++ b/spec/mcb_helper.rb
@@ -30,6 +30,21 @@ RSpec.configure do |config|
     allow(MCB).to receive(:run_command)
   end
 
+  # Open3.pipeline_w is used to page stdout through less. For some reason Open3
+  # is undefined in our tests, but even if it were we'd probably want to stub
+  # it out.
+  config.around(:each, mcb_cli: true) do |example|
+    module ::Open3
+      def self.pipeline_w(_cmds)
+        yield STDOUT
+      end
+    end
+
+    example.run
+
+    Object.__send__(:remove_const, :Open3)
+  end
+
   # Ensure that if the config file that is read is not the user's real data,
   # and if saved for any reason it does not over-write the user's.
   config.around(:each, mcb_cli: true) do |example|


### PR DESCRIPTION
### Context

`mcb` is currently slow to startup and running it many times in a row, especially when it comes to connecting to a remote env, can be slow.

### Changes proposed in this pull request

Add a REPL mode to `mcb` so that you only have to startup Rails, and connect to a remote environment, once for a session.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

### Example output

```
% be bin/mcb -E production
As a safety measure, please enter the expected RAILS_ENV for bat-prod-manage-courses-backend-app: production
Audit user: Misha Gorodnitzky <misha.gorodnitzky@digital.education.gov.uk>
Raven 2.9.0 configured not to capture errors: DSN not set
production> course show 2BD 39C8
Course:
+-------------------------+----------------------------------+
| id                      | 12910035                         |
| age_range               | secondary                        |
| course_code             | 39C8                             |
...
production> course show 2BD 39GM
Course:
+-------------------------+----------------------------------+
| id                      | 12910040                         |
| age_range               | secondary                        |
| course_code             | 39GM                             |
...
```