### PR TITLE
Make integer warnings more friendly for fees

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,9 +33,11 @@ en:
               blank: "^Give details about the fee for UK and EU students"
               greater_than_or_equal_to: "must be greater than or equal to £0"
               less_than_or_equal_to: "must be less than or equal to £100,000"
+              not_an_integer: "must not include pence, like 1000 or 1500"
             fee_international:
               greater_than_or_equal_to: "must be greater than or equal to £0"
               less_than_or_equal_to: "must be less than or equal to £100,000"
+              not_an_integer: "must not include pence, like 1000 or 1500"
             about_course:
               blank: "^Enter details about this course"
             how_school_placements_work:


### PR DESCRIPTION
### Context

Follow guidance from the design system: https://design-system.service.gov.uk/components/text-input/#error-messages

Removes the "must be an integer" warning, which was too technical.

![Screen Shot 2019-07-02 at 13 52 33](https://user-images.githubusercontent.com/319055/60514117-acef3800-9cd0-11e9-9086-87e0134db23e.png)
