### PR TITLE
[1657] mcb courses edit: recruitment cycle

### DIFF
--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -15,4 +15,9 @@ class RecruitmentCycle < ApplicationRecord
   has_many :sites
 
   validates :year, presence: true
+
+  def to_s
+    following_year = Date.new(year.to_i, 1, 1) + 1.year
+    "#{year}/#{following_year.strftime('%y')}"
+  end
 end

--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -354,7 +354,7 @@ module MCB
           CGI.unescape(opts[:'changed-since']),
           '%FT%T.%NZ'
         ) rescue nil
-        changed_since ||= DateTime.zone.parse(opts[:'changed-since']).utc
+        changed_since ||= DateTime.parse(opts[:'changed-since']) # rubocop:disable Rails/TimeZone
         changed_since_param = CGI.escape(changed_since.strftime('%FT%T.%6NZ'))
         new_url.query = "changed_since=#{changed_since_param}"
       end

--- a/lib/mcb/courses_editor.rb
+++ b/lib/mcb/courses_editor.rb
@@ -28,13 +28,8 @@ module MCB
 
         if choice.nil?
           finished = true
-        elsif choice == 'edit subjects'
-          edit_subjects
-        elsif choice.start_with?("edit")
-          attribute = choice.gsub("edit ", "").gsub(" ", "_").to_sym
-          edit(attribute)
-        elsif choice =~ /sync .* to Find/
-          sync_courses_to_find
+        else
+          perform_action(choice)
         end
       end
     end
@@ -56,6 +51,7 @@ module MCB
         "edit application opening date",
         "edit age range",
         "edit subjects",
+        "edit recruitment cycle",
         "sync course(s) to Find"
       ]
       filtered_choices = filter_single_course_options_if_necessary(choices)
@@ -64,6 +60,17 @@ module MCB
 
     def filter_single_course_options_if_necessary(choices)
       choices.grep_v(->(c) { c.in?(["edit subjects"]) && @courses.count != 1 })
+    end
+
+    def perform_action(choice)
+      if choice == 'edit subjects'
+        edit_subjects
+      elsif choice.start_with?("edit")
+        attribute = choice.gsub("edit ", "").gsub(" ", "_").to_sym
+        edit(attribute)
+      elsif choice =~ /sync .* to Find/
+        sync_courses_to_find
+      end
     end
 
     def edit(logical_attribute)

--- a/lib/mcb/courses_editor_cli.rb
+++ b/lib/mcb/courses_editor_cli.rb
@@ -52,6 +52,13 @@ module MCB
       )
     end
 
+    def ask_recruitment_cycle
+      ask_multiple_choice(
+        prompt: "Recruitment cycle?",
+        choices: RecruitmentCycle.all.order(:year)
+      )
+    end
+
     def ask_accredited_body
       new_accredited_body = nil
       until new_accredited_body.present?

--- a/lib/mcb/render.rb
+++ b/lib/mcb/render.rb
@@ -50,7 +50,8 @@ module MCB
                accrediting_provider:,
                subjects:,
                site_statuses:,
-               enrichments:)
+               enrichments:,
+               recruitment_cycle:)
       [
         course_record(course),
         "\n",
@@ -61,6 +62,8 @@ module MCB
           name: "Accredited body",
           add_columns: [[:accrediting_provider, header: 'accrediting']]
         ),
+        "\n",
+        recruitment_cycle_table(recruitment_cycle),
         "\n",
         subjects_table(subjects),
         "\n",
@@ -194,6 +197,13 @@ module MCB
       [
         "#{name}:",
         render_table_or_none(subjects, subjects_table_columns)
+      ]
+    end
+
+    def recruitment_cycle_table(recruitment_cycle)
+      [
+        "Recruitment cycle:",
+        render_table_or_none([recruitment_cycle], %i[year application_start_date application_end_date])
       ]
     end
 

--- a/lib/mcb/render/active_record.rb
+++ b/lib/mcb/render/active_record.rb
@@ -12,6 +12,7 @@ module MCB
             subjects:             course.subjects,
             site_statuses:        course.site_statuses,
             enrichments:          course.enrichments,
+            recruitment_cycle:    course.recruitment_cycle,
           )
         end
 

--- a/lib/mcb/render/apiv1.rb
+++ b/lib/mcb/render/apiv1.rb
@@ -35,6 +35,7 @@ module MCB
             subjects:             render_course.delete('subjects'),
             site_statuses:        render_course.delete('campus_statuses'),
             enrichments:          nil,
+            recruitment_cycle:    nil,
           )
         end
 

--- a/spec/lib/mcb/courses_editor_spec.rb
+++ b/spec/lib/mcb/courses_editor_spec.rb
@@ -18,6 +18,8 @@ describe MCB::CoursesEditor do
   let!(:mathematics) { find_or_create(:subject, :mathematics) }
   let!(:biology) { find_or_create(:subject, subject_name: "Biology") }
   let!(:secondary) { find_or_create(:subject, :secondary) }
+  let(:current_cycle) { create(:recruitment_cycle, year: '2019') }
+  let!(:next_cycle) { create(:recruitment_cycle, year: '2020') }
   let!(:course) {
     create(:course,
            provider: provider,
@@ -32,7 +34,8 @@ describe MCB::CoursesEditor do
            study_mode: 'part_time',
            start_date: Date.new(2019, 8, 1),
            age_range: 'secondary',
-           subjects: [secondary, biology])
+           subjects: [secondary, biology],
+           recruitment_cycle: current_cycle)
   }
   subject { described_class.new(provider: provider, course_codes: course_codes, requester: requester) }
 
@@ -115,6 +118,19 @@ describe MCB::CoursesEditor do
         it 'updates the study mode setting to full-time by default' do
           expect { run_editor("edit study mode", "", "exit") }.to change { course.reload.study_mode }.
             from("part_time").to("full_time")
+        end
+      end
+
+      describe "(recruitment cycle)" do
+        it 'updates the recruitment cycle' do
+          expect {
+            run_editor(
+              "edit recruitment cycle",
+              "3", # 3rd option should be 2020/21, after exit and 2019/20
+              "exit"
+            )
+          }.to change { course.reload.recruitment_cycle }.
+            from(current_cycle).to(next_cycle)
         end
       end
 

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -13,7 +13,9 @@
 require 'rails_helper'
 
 describe RecruitmentCycle, type: :model do
-  subject { create(:recruitment_cycle) }
+  subject { create(:recruitment_cycle, year: "2019") }
+
+  its(:to_s) { should eq("2019/20") }
 
   it "is valid with valid attributes" do
     expect(subject).to be_valid


### PR DESCRIPTION
### Context
We need to be able to create new courses against different course cycles. 

### Changes proposed in this pull request
- Fix the `-c` flag for the V1 API mcb commands (it was broken when `rubocop-rails` was introduced)
- Print the recruitment cycle when printing the course
- Allow the courses editor to edit recruitment cycle (this will be reused as part of the new course wizard).

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
