### PR TITLE
1489 Sync a single course to S&C from mc-be

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -22,16 +22,12 @@ module API
       end
 
       def sync_with_search_and_compare
-        if @course.syncable?
-          response = SearchAndCompareAPIService::Request.sync(
-            [@course]
+        if has_synced?
+          head :ok
+        else
+          raise RuntimeError.new(
+            'error received when syncing with search and compare'
           )
-          if response
-          else
-            raise RuntimeError.new(
-              'error received when syncing with search and compare'
-            )
-          end
         end
       end
 
@@ -39,22 +35,14 @@ module API
         if @course.publishable?
           @course.publish_sites
           @course.publish_enrichment(@current_user)
-          if @course.syncable?
-            has_synced = SearchAndCompareAPIService::Request.sync(
-              [@course]
-            )
-            if has_synced
-              head :ok
-            else
-              raise RuntimeError.new(
-                'error received when syncing with search and compare'
-              )
-            end
+          if has_synced?
+            head :ok
           else
             raise RuntimeError.new(
-              'course is not syncable'
+              'error received when syncing with search and compare'
             )
           end
+
         else
           render jsonapi_errors: @course.errors, status: :unprocessable_entity
         end
@@ -71,6 +59,7 @@ module API
       def update
         update_enrichment
         update_sites
+        has_synced? if site_ids.present?
 
         if @course.errors.empty? && @course.valid?
           render jsonapi: @course.reload
@@ -98,8 +87,6 @@ module API
         # but we can't actually revert easily from what I can tell because of the
         # remove_site! side effects that occur when it's called.
         @course.errors[:sites] << "^You must choose at least one location" if site_ids.empty?
-
-        sync_with_search_and_compare if site_ids.any?
       end
 
       def build_provider
@@ -134,6 +121,16 @@ module API
 
       def site_ids
         params.fetch(:course, {})[:sites_ids]
+      end
+
+      def has_synced?
+        if @course.syncable?
+          SearchAndCompareAPIService::Request.sync([@course])
+        else
+          raise RuntimeError.new(
+            'course is not syncable'
+          )
+        end
       end
     end
   end

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -38,10 +38,8 @@ module API
           @course.publish_sites
           @course.publish_enrichment(@current_user)
 
-          response = ManageCoursesAPIService::Request.sync_course_with_search_and_compare(
-            @current_user.email,
-            @provider.provider_code,
-            @course.course_code
+          response = SearchAndCompareAPIService::Request.sync(
+            [@course]
           )
 
           if response

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -119,6 +119,7 @@ class Course < ApplicationRecord
   validates :enrichments, presence: true, on: :publish
   validate :validate_enrichment_publishable, on: :publish
   validate :validate_enrichment
+  validate :validate_course_syncable, on: :sync
 
   after_validation :remove_unnecessary_enrichments_validation_message
 
@@ -143,6 +144,10 @@ class Course < ApplicationRecord
 
   def publishable?
     valid? :publish
+  end
+
+  def syncable?
+    valid? :sync
   end
 
   def findable?
@@ -307,10 +312,6 @@ class Course < ApplicationRecord
     "#{name} (#{course_code})"
   end
 
-  def syncable?
-    findable?.present? && dfe_subjects.present?
-  end
-
 private
 
   def add_enrichment_errors(enrichment)
@@ -341,5 +342,14 @@ private
 
   def remove_unnecessary_enrichments_validation_message
     self.errors.delete :enrichments if self.errors[:enrichments] == ['is invalid']
+  end
+
+  def validate_course_syncable
+    if findable?.blank?
+      errors.add :site_statuses, 'No findable sites.'
+    end
+    if dfe_subjects.blank?
+      errors.add :dfe_subjects, 'No DfE subject.'
+    end
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -307,6 +307,10 @@ class Course < ApplicationRecord
     "#{name} (#{course_code})"
   end
 
+  def syncable?
+    findable?.present? && dfe_subjects.present?
+  end
+
 private
 
   def add_enrichment_errors(enrichment)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -21,7 +21,6 @@
 #  updated_at              :datetime         not null
 #  changed_at              :datetime         not null
 #  recruitment_cycle_id    :integer          not null
-#
 
 class Course < ApplicationRecord
   include WithQualifications

--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -11,7 +11,7 @@
 #  created_by_user_id :integer
 #  last_published_at  :datetime
 #  status             :integer          default("draft"), not null
-#  provider_id        :integer          not null
+#  provider_id        :integer
 #
 
 class ProviderEnrichment < ApplicationRecord

--- a/spec/factories/provider_enrichments.rb
+++ b/spec/factories/provider_enrichments.rb
@@ -11,7 +11,7 @@
 #  created_by_user_id :integer
 #  last_published_at  :datetime
 #  status             :integer          default("draft"), not null
-#  provider_id        :integer          not null
+#  provider_id        :integer
 #
 
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -741,4 +741,28 @@ RSpec.describe Course, type: :model do
       end
     end
   end
+
+  describe '#syncable?' do
+    let(:subjects) { [build(:subject, subject_name: "primary")] }
+    let(:site_status) { build(:site_status, :findable) }
+
+    subject { create(:course, subjects: subjects, site_statuses: [site_status]) }
+
+    context 'course which is valid' do
+      let(:subject) { create(:course, subjects: subjects, site_statuses: [site_status]) }
+      its(:syncable?) { should be_truthy }
+    end
+
+    context'invalid courses' do
+      context 'course which has a dfe subject, but no findable site statuses' do
+        let(:site_status) { build(:site_status, :suspended) }
+        its(:syncable?) { should be_falsey }
+      end
+
+      context 'course which has a findable site status, but no dfe_subject' do
+        let(:subjects) { [build(:subject, subject_name: "secondary")] }
+        its(:syncable?) { should be_falsey }
+      end
+    end
+  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -743,15 +743,12 @@ RSpec.describe Course, type: :model do
   end
 
   describe '#syncable?' do
-    let(:subjects) { [build(:subject, subject_name: "primary")] }
+    let(:courses_subjects) { [build(:subject, subject_name: "primary")] }
     let(:site_status) { build(:site_status, :findable) }
 
-    subject { create(:course, subjects: subjects, site_statuses: [site_status]) }
+    subject { create(:course, subjects: courses_subjects, site_statuses: [site_status]) }
 
-    context 'course which is valid' do
-      let(:subject) { create(:course, subjects: subjects, site_statuses: [site_status]) }
-      its(:syncable?) { should be_truthy }
-    end
+    its(:syncable?) { should be_truthy }
 
     context'invalid courses' do
       context 'course which has a dfe subject, but no findable site statuses' do
@@ -760,7 +757,7 @@ RSpec.describe Course, type: :model do
       end
 
       context 'course which has a findable site status, but no dfe_subject' do
-        let(:subjects) { [build(:subject, subject_name: "secondary")] }
+        let(:courses_subjects) { [build(:subject, subject_name: "secondary")] }
         its(:syncable?) { should be_falsey }
       end
     end

--- a/spec/models/provider_enrichment_spec.rb
+++ b/spec/models/provider_enrichment_spec.rb
@@ -11,7 +11,7 @@
 #  created_by_user_id :integer
 #  last_published_at  :datetime
 #  status             :integer          default("draft"), not null
-#  provider_id        :integer          not null
+#  provider_id        :integer
 #
 
 require 'rails_helper'

--- a/spec/requests/api/v2/providers/courses/update_sites_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_sites_spec.rb
@@ -10,7 +10,9 @@ describe 'PATCH /providers/:provider_code/courses/:course_code with sites' do
     ActionController::HttpAuthentication::Token.encode_credentials(token)
   end
 
-  let(:course) { create :course, provider: provider }
+  let(:course) { create :course, provider: provider, site_statuses: [site_status], subjects: [subject] }
+  let(:site_status) { build(:site_status) }
+  let(:subject) { build(:subject, subject_name: 'primary') }
   let(:site_to_add) { create :site, provider: provider }
   let(:unwanted_site) { create :site, provider: provider }
   let(:existing_site) { create :site, provider: provider }
@@ -43,8 +45,9 @@ describe 'PATCH /providers/:provider_code/courses/:course_code with sites' do
     }
   end
 
+
   let!(:sync_courses_request_stub) do
-    stub_request(:post, %r{#{Settings.manage_api.base_url}/api/Publish/internal/course/})
+    stub_request(:put, %r{#{Settings.search_api.base_url}/api/courses/})
       .to_return(
         status: 200,
         body: '{ "result": true }'

--- a/spec/requests/api/v2/providers/courses/update_sites_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_sites_spec.rb
@@ -10,9 +10,9 @@ describe 'PATCH /providers/:provider_code/courses/:course_code with sites' do
     ActionController::HttpAuthentication::Token.encode_credentials(token)
   end
 
-  let(:course) { create :course, provider: provider, site_statuses: [site_status], subjects: [subject] }
+  let(:course) { create :course, provider: provider, site_statuses: [site_status], subjects: [primary_subject] }
   let(:site_status) { build(:site_status) }
-  let(:subject) { build(:subject, subject_name: 'primary') }
+  let(:primary_subject) { build(:subject, subject_name: 'primary') }
   let(:site_to_add) { create :site, provider: provider }
   let(:unwanted_site) { create :site, provider: provider }
   let(:existing_site) { create :site, provider: provider }


### PR DESCRIPTION
### Context
 **Part 1** 
We want to do all the course publishing in Rails instead of C#. This PR focuses on syncing a single course to search and compare.

### Changes proposed in this pull request
- Uses the new S&C service to hit S&C directly rather than via ManageAPI
- Adds validations to only sync valid courses (findable & a DfE subject)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
