### PR TITLE
[1489] Add endpoint for provider to sync courses to S&C

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -59,9 +59,10 @@ module API
 
       def sync_courses_with_search_and_compare
         authorize @provider
-        if @recruitment_cycle.year != Settings.current_recruitment_cycle.to_s
+
+        if !@recruitment_cycle.current?
           raise RuntimeError.new(
-            "provider is not from the current recrutiment cycle"
+            "#{@provider} is not from the current recruitment cycle"
           )
         end
         if courses_synced?(@provider.syncable_courses)

--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -60,11 +60,7 @@ module API
       def sync_courses_with_search_and_compare
         provider = Provider.find_by!(provider_code: params[:code].upcase)
         authorize provider
-        syncable_courses = provider.syncable_courses
-        response = SearchAndCompareAPIService::Request.sync(
-          syncable_courses
-        )
-        if response
+        if courses_synced?(provider.syncable_courses)
           head :ok
         else
           raise RuntimeError.new(
@@ -122,6 +118,12 @@ module API
             :postcode,
             :region_code
           )
+      end
+
+      def courses_synced?(syncable_courses)
+        SearchAndCompareAPIService::Request.sync(
+          syncable_courses
+        )
       end
     end
   end

--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -58,13 +58,17 @@ module API
       end
 
       def sync_courses_with_search_and_compare
-        provider = Provider.find_by!(provider_code: params[:code].upcase)
-        authorize provider
-        if courses_synced?(provider.syncable_courses)
+        authorize @provider
+        if @recruitment_cycle.year != Settings.current_recruitment_cycle.to_s
+          raise RuntimeError.new(
+            "provider is not from the current recrutiment cycle"
+          )
+        end
+        if courses_synced?(@provider.syncable_courses)
           head :ok
         else
           raise RuntimeError.new(
-            'error received when syncing courses with search and compare'
+            "#{@provider} failed to sync these courses #{@provider.syncable_courses.pluck(:course_code)}"
           )
         end
       end

--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -57,6 +57,22 @@ module API
         end
       end
 
+      def sync_courses_with_search_and_compare
+        provider = Provider.find_by!(provider_code: params[:code].upcase)
+        authorize provider
+        syncable_courses = provider.syncable_courses
+        response = SearchAndCompareAPIService::Request.sync(
+          syncable_courses
+        )
+        if response
+          head :ok
+        else
+          raise RuntimeError.new(
+            'error received when syncing courses with search and compare'
+          )
+        end
+      end
+
     private
 
       def build_recruitment_cycle

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -116,6 +116,10 @@ class Provider < ApplicationRecord
 
   after_validation :remove_unnecessary_enrichments_validation_message
 
+  def syncable_courses
+    courses.select(&:syncable?)
+  end
+
   # Currently Provider#contact_info isn't used but will likely be needed when
   # we need to expose the candidate-facing contact info.
   #

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -32,4 +32,5 @@ class ProviderPolicy
   alias_method :update?, :show?
   alias_method :publish?, :show?
   alias_method :publishable?, :show?
+  alias_method :sync_courses_with_search_and_compare?, :show?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,7 @@ Rails.application.routes.draw do
         end
         resources :sites, only: %i[index update show create]
         resources :recruitment_cycles, only: %i[index]
+        post :sync_courses_with_search_and_compare, on: :member
       end
 
       resources :providers,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,7 @@ Rails.application.routes.draw do
       end
 
       concern :provider_routes do
+        post :sync_courses_with_search_and_compare, on: :member
         resources :courses, param: :code do
           post :sync_with_search_and_compare, on: :member
           post :publish, on: :member

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -272,7 +272,7 @@ describe Provider, type: :model do
     describe '#courses' do
       describe 'discard' do
         it 'reduces courses when one is discarded' do
-          expect { course.discard }.to change { provider.courses.size }.by(-1)
+          expect { course.discard }.to change { provider.reload.courses.size }.by(-1)
         end
       end
     end

--- a/spec/policies/provider_policy_spec.rb
+++ b/spec/policies/provider_policy_spec.rb
@@ -16,6 +16,7 @@ describe ProviderPolicy do
   subject { described_class }
 
   permissions :show?, :update? do
+  permissions :show? do
     let(:user) { create(:user) }
     let(:user_outside_org) { create(:user) }
     let(:provider) { create(:provider) }

--- a/spec/policies/provider_policy_spec.rb
+++ b/spec/policies/provider_policy_spec.rb
@@ -15,8 +15,7 @@ describe ProviderPolicy do
 
   subject { described_class }
 
-  permissions :show?, :update? do
-  permissions :show? do
+  permissions :show?, :update?, :sync_courses_with_search_and_compare? do
     let(:user) { create(:user) }
     let(:user_outside_org) { create(:user) }
     let(:provider) { create(:provider) }

--- a/spec/requests/api/v2/providers/sync_courses_with_search_and_compare_spec.rb
+++ b/spec/requests/api/v2/providers/sync_courses_with_search_and_compare_spec.rb
@@ -112,7 +112,7 @@ describe 'Courses API v2', type: :request do
         }
 
         it 'should throw an error' do
-          expect { subject }.to raise_error("provider is not from the current recrutiment cycle")
+          expect { subject }.to raise_error("#{provider} is not from the current recruitment cycle")
         end
       end
     end

--- a/spec/requests/api/v2/providers/sync_courses_with_search_and_compare_spec.rb
+++ b/spec/requests/api/v2/providers/sync_courses_with_search_and_compare_spec.rb
@@ -64,7 +64,7 @@ describe 'Courses API v2', type: :request do
 
     context 'when authorized' do
       context 'when a successful external call to search has been made' do
-      it { should have_http_status(:ok) }
+        it { should have_http_status(:ok) }
       end
 
       context 'when an unsuccessful external call to search has been made' do

--- a/spec/requests/api/v2/providers/sync_courses_with_search_and_compare_spec.rb
+++ b/spec/requests/api/v2/providers/sync_courses_with_search_and_compare_spec.rb
@@ -1,0 +1,78 @@
+describe 'Courses API v2', type: :request do
+  let(:user)         { create(:user) }
+  let(:organisation) { create(:organisation, users: [user]) }
+  let(:payload)      { { email: user.email } }
+  let(:token)        { build_jwt :apiv2, payload: payload }
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+  let(:site) { build(:site) }
+  let(:dfe_subject) { build(:subject, subject_name: "primary") }
+  let(:non_dfe_subject) { build(:subject, subject_name: "secondary") }
+  let(:findable_site_status_1) { build(:site_status, :findable, site: site) }
+  let(:findable_site_status_2) { build(:site_status, :findable, site: site) }
+  let(:suspended_site_status) { build(:site_status, :suspended, site: site) }
+  let(:syncable_course) { build(:course, site_statuses: [findable_site_status_1], subjects: [dfe_subject]) }
+  let(:suspended_course) { build(:course, site_statuses: [suspended_site_status], subjects: [dfe_subject]) }
+  let(:invalid_subject_course) { build(:course, site_statuses: [findable_site_status_2], subjects: [non_dfe_subject]) }
+  let(:provider) { create(:provider, organisations: [organisation], courses: [syncable_course, suspended_course, invalid_subject_course], sites: [site]) }
+
+
+  subject { response }
+
+  describe 'POST ' do
+    let(:sync_path) do
+      "/api/v2/providers/#{provider.provider_code}/sync_courses_with_search_and_compare"
+    end
+    let(:status) { 200 }
+    let(:has_synced) { true }
+
+    before do
+      stub_request(:put, "#{Settings.search_api.base_url}/api/courses/")
+        .to_return(
+          status: status,
+        )
+      allow(SearchAndCompareAPIService::Request).to receive(:sync).with([syncable_course]).and_return(has_synced)
+    end
+
+    subject do
+      post sync_path, headers: { 'HTTP_AUTHORIZATION' => credentials }
+      response
+    end
+
+    context 'when unauthenticated' do
+      let(:payload) { { email: 'foo@bar' } }
+
+      it { should have_http_status(:unauthorized) }
+    end
+
+    context 'when user has not accepted terms' do
+      let(:user)         { create(:user, accept_terms_date_utc: nil) }
+      let(:organisation) { create(:organisation, users: [user]) }
+
+      it { should have_http_status(:forbidden) }
+    end
+
+    context 'when unauthorised' do
+      let(:unauthorised_user) { create(:user) }
+      let(:payload)           { { email: unauthorised_user.email } }
+
+      it "raises an error" do
+        expect { subject }.to raise_error Pundit::NotAuthorizedError
+      end
+    end
+
+    context 'when authorized' do
+      context 'when a successful external call to search has been made' do
+      it { should have_http_status(:ok) }
+      end
+
+      context 'when an unsuccessful external call to search has been made' do
+        let(:has_synced) { false }
+        it 'should throw an error' do
+          expect { subject }.to raise_error('error received when syncing courses with search and compare')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

**Part 2 do not merge until #569 has been merged **
We want to do all the course publishing in Rails instead of C#. 

### Changes proposed in this pull request

This PR adds an endpoint to sync all the providers courses which are `syncable?` to search and compare.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
