### PR TITLE
[1664] Override reverse_mapping in deserializable_course

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -7,7 +7,7 @@ module API
       before_action :build_course, except: :index
 
       deserializable_resource :course,
-                              only: %i[update],
+                              only: %i[update publish],
                               class: API::V2::DeserializableCourse
 
       def index

--- a/app/deserializers/api/v2/deserializable_course.rb
+++ b/app/deserializers/api/v2/deserializable_course.rb
@@ -1,22 +1,34 @@
 module API
   module V2
     class DeserializableCourse < JSONAPI::Deserializable::Resource
-      attributes :about_course,
-                 :course_length,
-                 :fee_details,
-                 :fee_international,
-                 :fee_uk_eu,
-                 :financial_support,
-                 :how_school_placements_work,
-                 :interview_process,
-                 :other_requirements,
-                 :personal_qualities,
-                 :salary_details,
-                 :course_code,
-                 :name,
-                 :study_mode
+      COURSE_ATTRIBUTES = %i[
+        about_course
+        course_length
+        fee_details
+        fee_international
+        fee_uk_eu
+        financial_support
+        how_school_placements_work
+        interview_process
+        other_requirements
+        personal_qualities
+        salary_details
+        course_code
+        name
+        study_mode
+        qualifications
+      ].freeze
+
+      attributes(*COURSE_ATTRIBUTES)
 
       has_many :sites
+
+      def reverse_mapping
+        declared_attributes = DeserializableCourse.attr_blocks.keys
+        declared_attributes
+          .map { |key| [key.to_sym, "/data/attributes/#{key}"] }
+          .to_h
+      end
 
       attribute :required_qualifications do |value|
         if value

--- a/spec/deserializers/api/v2/deserializable_course_spec.rb
+++ b/spec/deserializers/api/v2/deserializable_course_spec.rb
@@ -22,4 +22,14 @@ describe API::V2::DeserializableCourse do
       expect(subject[:qualifications]).to eq('test')
     end
   end
+
+  describe "reverse_mapping" do
+    subject { described_class.new({}).reverse_mapping }
+
+    it "always contains all attributes" do
+      API::V2::DeserializableCourse::COURSE_ATTRIBUTES.each do |attribute|
+        expect(subject[attribute.to_sym]).to eq("/data/attributes/#{attribute}")
+      end
+    end
+  end
 end

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -36,7 +36,16 @@ describe 'Publish API v2', type: :request do
     }
 
     subject do
-      post publish_path, headers: { 'HTTP_AUTHORIZATION' => credentials }
+      post publish_path,
+           headers: { 'HTTP_AUTHORIZATION' => credentials },
+           params: {
+             _jsonapi: {
+               data: {
+                 attributes: {},
+                 type: "course"
+               }
+             }
+           }
       response
     end
 
@@ -136,13 +145,21 @@ describe 'Publish API v2', type: :request do
 
           it { should have_http_status(:unprocessable_entity) }
 
-          it 'has validation errors' do
+          it 'has validation error details' do
             expect(json_data.count).to eq 5
             expect(json_data[0]["detail"]).to eq("Enter details about this course")
             expect(json_data[1]["detail"]).to eq("Enter details about school placements")
             expect(json_data[2]["detail"]).to eq("Enter a course length")
             expect(json_data[3]["detail"]).to eq("Give details about the fee for UK and EU students")
             expect(json_data[4]["detail"]).to eq("Enter details about the qualifications needed")
+          end
+
+          it 'has validation error pointers' do
+            expect(json_data[0]["source"]["pointer"]).to eq("/data/attributes/about_course")
+            expect(json_data[1]["source"]["pointer"]).to eq("/data/attributes/how_school_placements_work")
+            expect(json_data[2]["source"]["pointer"]).to eq("/data/attributes/course_length")
+            expect(json_data[3]["source"]["pointer"]).to eq("/data/attributes/fee_uk_eu")
+            expect(json_data[4]["source"]["pointer"]).to eq("/data/attributes/qualifications")
           end
         end
       end


### PR DESCRIPTION
### Context

Publish validations are hacky on the frontend because the backend does not give us source pointers which map the errors to their appropriate fields.

### Changes proposed in this pull request

`reverse_mapping` is responsible for generating the `pointer` attributes in a JSON API response which contains validation errors. The way it works is `jsonapi-rails` will inspect the `params` and based on the attributes provided, populate `reverse_mapping`. This means that the only attributes that can be associated with errors are ones that get passed in as part of the request.

When we do the `publish` action, we don't pass in any attributes, because they already exist on the model. This means that without help, `jsonapi-rails` can't figure out to which attributes the fields we're showing errors on should map back to. In this scenario, it silently moves on without setting pointers.

We need validation errors to always have pointers, so it makes sense to force it to always include them by overriding the default `reverse_mapping`.

The qualifications are also added to the `attributes` call, to allow them to correctly map.

### Guidance to review

🤕 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally