### PR TITLE
1649 Make V2 course controller #index cycle aware

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -13,8 +13,12 @@ module API
       def index
         authorize @provider, :can_list_courses?
         authorize Course
-
-        render jsonapi: @provider.courses, include: params[:include]
+        recruitment_year = params[:recruitment_year]
+        if recruitment_year.blank?
+          recruitment_year = '2019'
+        end
+        @courses = @provider.requested_cycles_courses(recruitment_year)
+        render jsonapi: @courses, include: params[:include]
       end
 
       def show

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -14,9 +14,6 @@ module API
         authorize @provider, :can_list_courses?
         authorize Course
         recruitment_year = params[:recruitment_year]
-        if recruitment_year.blank?
-          recruitment_year = '2019'
-        end
         @courses = @provider.requested_cycles_courses(recruitment_year)
         render jsonapi: @courses, include: params[:include]
       end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -145,4 +145,8 @@ class Provider < ApplicationRecord
   def to_s
     "#{provider_name} (#{provider_code})"
   end
+
+  def requested_cycles_courses(recruitment_year)
+    courses.select { |course| course.recruitment_cycle.year == recruitment_year }
+  end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -147,6 +147,9 @@ class Provider < ApplicationRecord
   end
 
   def requested_cycles_courses(recruitment_year)
+    if recruitment_year.blank?
+      recruitment_year = '2019'
+    end
     courses.select { |course| course.recruitment_cycle.year == recruitment_year }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,12 @@ Rails.application.routes.draw do
         patch :accept_transition_screen, on: :member
       end
 
+      scope "/(:recruitment_year)" do
+        resources :providers, param: :code  do
+          resources :courses, param: :code, only: %i[index]
+        end
+      end
+
       resources :providers, param: :code do
         resources :courses, param: :code, only: %i[index create show update] do
           post :sync_with_search_and_compare, on: :member

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -262,6 +262,8 @@ describe Provider, type: :model do
 
       it 'should only return the requested cycles courses' do
         expect(provider.requested_cycles_courses('2019')).to eq [course]
+        expect(provider.requested_cycles_courses('2020')).to eq [course2]
+        expect(provider.requested_cycles_courses(nil)).to eq [course]
       end
     end
   end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -251,4 +251,18 @@ describe Provider, type: :model do
       end
     end
   end
+
+  describe '#requested_cycles_courses' do
+    context 'with a provider with courses in multiple cycles' do
+      let(:current_cycle) { create(:recruitment_cycle, year: '2019') }
+      let(:next_cycle) { create(:recruitment_cycle, year: '2020') }
+      let(:course) { build(:course, recruitment_cycle_id: current_cycle.id) }
+      let(:course2) { build(:course, recruitment_cycle_id: next_cycle.id) }
+      let(:provider) { create(:provider, courses: [course, course2]) }
+
+      it 'should only return the requested cycles courses' do
+        expect(provider.requested_cycles_courses('2019')).to eq [course]
+      end
+    end
+  end
 end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -206,9 +206,13 @@ describe 'Courses API v2', type: :request do
     end
 
     describe 'JSON generated for courses' do
+      let(:next_cycle) { create(:recruitment_cycle, year: '2020') }
+      let(:course_next_cycle) { create(:course, provider: provider, recruitment_cycle_id: next_cycle.id) }
+
       before do
         findable_open_course
-        get "/api/v2/providers/#{provider.provider_code}/courses",
+        course_next_cycle
+        get "/api/v2/2019/providers/#{provider.provider_code}/courses",
             headers: { 'HTTP_AUTHORIZATION' => credentials }
       end
 


### PR DESCRIPTION
### Context
A new endpoint needs to be put in place that returns a specific recruitment cycles courses for the provider. However, the old endpoint needs to stay in place and default to the current recruitment cycles courses.
 
### Changes proposed in this pull request
- Add a new endpoint for index that allows a recruitment cycle to be input.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
