### PR TITLE
[1740] Mcb psql connect to backup

### DIFF
--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -86,9 +86,9 @@ module MCB
     `#{cmd}`
   end
 
-  def self.exec_command(cmd)
-    verbose("Running: #{cmd}")
-    exec(cmd)
+  def self.exec_command(cmd, *command_args)
+    verbose("Running: #{cmd} #{command_args}")
+    exec(cmd, *command_args)
   end
 
   def self.apiv1_token(webapp: nil, rgroup: nil)

--- a/lib/mcb/commands/az/apps/psql.rb
+++ b/lib/mcb/commands/az/apps/psql.rb
@@ -1,7 +1,7 @@
 name 'psql'
 summary 'connect to the psql server for an app'
-# h is used for help so used z instead
-option :z, 'host', 'override hostname of database - useful for connecting to restored copies.'\
+# h is used for help so used H instead
+option :H, 'host', 'override hostname of database - useful for connecting to restored copies.'\
        ' Just the hostname, not the fully qualified name. E.g. bat-mcapi-restore-psql',
        argument: :optional
 option :f, 'source_file', 'source sql file to pass to psql to run',

--- a/lib/mcb/commands/az/apps/psql.rb
+++ b/lib/mcb/commands/az/apps/psql.rb
@@ -16,13 +16,19 @@ run do |opts, _args, _cmd|
   end
 
   ENV['PGPASSWORD'] = ENV['DB_PASSWORD']
-  cmd = "psql -h #{ENV['DB_HOSTNAME']} -U #{ENV['DB_USERNAME']} -d #{ENV['DB_DATABASE']}"
+  psql_args = ["-h", ENV['DB_HOSTNAME'], "-U", ENV['DB_USERNAME'], "-d", ENV['DB_DATABASE']]
 
   source_file = opts[:source_file]
-  cmd = "#{cmd} --file '#{source_file}'" if source_file
+  if source_file
+    psql_args << "--file"
+    psql_args << source_file
+  end
 
   sql_command = opts[:sql_command]
-  cmd = "#{cmd} --command '#{sql_command}'" if sql_command
+  if sql_command
+    psql_args << "--command"
+    psql_args << sql_command
+  end
 
-  MCB::exec_command(cmd)
+  MCB::exec_command("psql", *psql_args)
 end

--- a/spec/lib/mcb/commands/az/apps/psql_spec.rb
+++ b/spec/lib/mcb/commands/az/apps/psql_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'mcb_helper'
 
 describe 'mcb az apps psql' do
-  it 'returns the psql of apps' do
+  it 'runs psql for localhost' do
     allow(MCB).to receive(:exec_command).with(
       "psql",
       "-h", "localhost",
@@ -12,6 +12,28 @@ describe 'mcb az apps psql' do
 
     with_stubbed_stdout do
       $mcb.run(%w[az apps psql])
+    end
+  end
+
+  it 'runs psql for azure server' do
+    app_config = {
+      'MANAGE_COURSES_POSTGRESQL_SERVICE_HOST' => 'azhost',
+      'PG_DATABASE'                            => 'pgdb',
+      'PG_USERNAME'                            => 'azuser',
+      'PG_PASSWORD'                            => 'azpass',
+      'RAILS_ENV'                              => 'qa',
+    }
+    allow(MCB::Azure).to(receive(:get_config).and_return(app_config))
+
+    allow(MCB).to receive(:exec_command).with(
+      "psql",
+      "-h", "azhost",
+      "-U", "azuser",
+      "-d", "pgdb"
+    )
+
+    with_stubbed_stdout(stdin: "qa") do
+      $mcb.run(%w[az apps psql -E qa])
     end
   end
 end

--- a/spec/lib/mcb/commands/az/apps/psql_spec.rb
+++ b/spec/lib/mcb/commands/az/apps/psql_spec.rb
@@ -4,8 +4,10 @@ require 'mcb_helper'
 describe 'mcb az apps psql' do
   it 'returns the psql of apps' do
     allow(MCB).to receive(:exec_command).with(
-      "psql -h localhost -U manage_courses_backend " \
-      "-d manage_courses_backend_development"
+      "psql",
+      "-h", "localhost",
+      "-U", "manage_courses_backend",
+      "-d", "manage_courses_backend_development"
     )
 
     with_stubbed_stdout do


### PR DESCRIPTION
### Context

* Using postgres on azure is hard.
* We are testing out db restore strategies.
* Our tooling sorts out username etc for psql connections, but only for our main databases
* Azure postgres restores create a new server with the same username/password and a new hostname

### Changes proposed in this pull request

* Allow connecting to a different database host so that we can use the existing credentials lookup when connecting to a backup / copy of the database

### Guidance to review

1. Feel my pain
2. :ship: 

#### Existing command

```
bundle exec bin/mcb az apps psql -E qa -v \                                
  -c "select changed_at from course order by changed_at desc limit 3;"

INFO: Running: az webapp config appsettings list -g "bat-qa-mcbe-rg"
-n "bat-qa-mcbe-as" --subscription "DFE BAT Development"
As a safety measure, please enter the expected RAILS_ENV for bat-qa-mcbe-as: qa
INFO: Running: psql ["-h", "bat-qa-mcapi-psql.postgres.database.azure.com", "-U",
"manage_courses@bat-qa-mcapi-psql", "-d", "manage_courses", "--command",
"select changed_at from course order by changed_at desc limit 3;"]
         changed_at         
----------------------------
 2019-07-08 14:59:53.276485
 2019-07-05 09:29:00.58752
 2019-07-05 09:27:12.092197
(3 rows)
```

#### Using the new command option

```
bundle exec bin/mcb az apps psql -E qa -v --host bat-qa-restore-for-pr575 \
  -c "select changed_at from course order by changed_at desc limit 3;"

INFO: Running: az webapp config appsettings list -g "bat-qa-mcbe-rg"
-n "bat-qa-mcbe-as" --subscription "DFE BAT Development"
As a safety measure, please enter the expected RAILS_ENV for bat-qa-mcbe-as: qa
INFO: Running: psql ["-h", "bat-qa-restore-for-pr575.postgres.database.azure.com",
 "-U", "manage_courses@bat-qa-restore-for-pr575", "-d", "manage_courses",
 "--command", "select changed_at from course order by changed_at desc limit 3;"]
         changed_at         
----------------------------
 2019-07-08 14:59:53.276485
 2019-07-05 09:29:00.58752
 2019-07-05 09:27:12.092197
(3 rows)
```


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Test coverage
