### PR TITLE
Make provider_enrichment.provider_id nullable

### DIFF
--- a/db/migrate/20190704134543_make_provider_id_nullable.rb
+++ b/db/migrate/20190704134543_make_provider_id_nullable.rb
@@ -1,0 +1,5 @@
+class MakeProviderIdNullable < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :provider_enrichment, :provider_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_27_151832) do
+ActiveRecord::Schema.define(version: 2019_07_04_134543) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -197,7 +197,7 @@ ActiveRecord::Schema.define(version: 2019_06_27_151832) do
     t.integer "created_by_user_id"
     t.datetime "last_published_at"
     t.integer "status", default: 0, null: false
-    t.integer "provider_id", null: false
+    t.integer "provider_id"
     t.index ["created_by_user_id"], name: "IX_provider_enrichment_created_by_user_id"
     t.index ["provider_code"], name: "IX_provider_enrichment_provider_code"
     t.index ["provider_id"], name: "index_provider_enrichment_on_provider_id"


### PR DESCRIPTION
### Context

Previous pr was merged too soon:

https://github.com/DFE-Digital/manage-courses-backend/pull/561

### Changes proposed in this pull request

This rollback making the provider_id not nullable as it's preventing providers
from editing their information (new provider enrichments can't be created).

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
