### PR TITLE
[1387] Add a rolled_over state for users

### DIFF
--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -21,6 +21,10 @@ module API
         @user.accept_transition_screen!
       end
 
+      def accept_rollover_screen
+        @user.accept_rollover_screen!
+      end
+
     private
 
       def build_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,9 +38,14 @@ class User < ApplicationRecord
   aasm column: 'state' do
     state :new, initial: true
     state :transitioned
+    state :rolled_over
 
     event :accept_transition_screen do
       transitions from: :new, to: :transitioned
+    end
+
+    event :accept_rollover_screen do
+      transitions from: :transitioned, to: :rolled_over
     end
   end
 

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -12,4 +12,5 @@ class UserPolicy
 
   alias_method :update?, :show?
   alias_method :accept_transition_screen?, :update?
+  alias_method :accept_rollover_screen?, :update?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
         resources :providers
 
         patch :accept_transition_screen, on: :member
+        patch :accept_rollover_screen, on: :member
       end
 
       resources :providers, param: :code do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -132,7 +132,7 @@ User.create!(
   last_name: 'Admin',
   accept_terms_date_utc: Time.now.utc,
   email: 'super.admin@education.gov.uk', # matches authentication.rb
-  state: 'transitioned'
+  state: 'rolled_over'
 )
 
 10.times do |i|

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -41,12 +41,21 @@ describe User, type: :model do
     end
   end
 
-  describe 'state events' do
+  describe 'transition state event' do
     before do
       subject.accept_transition_screen!
     end
 
     it { should be_transitioned }
+  end
+
+  describe 'rollover state event' do
+    before do
+      subject.accept_transition_screen!
+      subject.accept_rollover_screen!
+    end
+
+    it { should be_rolled_over }
   end
 
   describe '#admin?' do

--- a/spec/requests/api/v2/users/accept_rollover_screen_spec.rb
+++ b/spec/requests/api/v2/users/accept_rollover_screen_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+describe 'PATCH /api/v2/users/:id/accept_rollover_screen', type: :request do
+  let(:user)    { create(:user, state: 'transitioned') }
+  let(:payload) { { email: user.email } }
+
+  let(:token) do
+    JWT.encode payload,
+               Settings.authentication.secret,
+               Settings.authentication.algorithm
+  end
+
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+
+  def perform_request
+    patch(
+      accept_rollover_screen_api_v2_user_path(user),
+      headers: { 'HTTP_AUTHORIZATION' => credentials },
+      params: {}
+    )
+  end
+
+  context 'when unauthenticated' do
+    let(:payload) { { email: 'foo@bar' } }
+
+    before do
+      perform_request
+    end
+
+    subject { response }
+
+    it { should have_http_status(:unauthorized) }
+  end
+
+  context 'when unauthorized' do
+    let(:unauthorised_user) { create(:user) }
+    let(:payload) { { email: unauthorised_user.email } }
+
+    it "raises an error" do
+      expect { perform_request }.to raise_error Pundit::NotAuthorizedError
+    end
+  end
+
+  context 'when authenticated and authorised' do
+    it 'runs the accept_rollover_screen event on the user' do
+      perform_request
+      expect(user.reload).to be_rolled_over
+    end
+
+    it 'returns success' do
+      perform_request
+      expect(response).to have_http_status(:success)
+    end
+
+    context 'when user is already rolled over' do
+      before do
+        user.accept_rollover_screen!
+      end
+
+      it 'returns error' do
+        expect { perform_request }.to raise_error AASM::InvalidTransition
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Use user state to determine if they've seen the rollover screen
- They must have seen the transition screen first

Goes with https://github.com/DFE-Digital/manage-courses-frontend/pull/430