### PR TITLE
[1657] Don't create duplicate recruitment cycles in factories

### DIFF
--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
     with_higher_education
 
     association(:provider)
-    association(:recruitment_cycle)
+    association :recruitment_cycle, strategy: :find_or_create
 
     study_mode { :full_time }
     resulting_in_pgce_with_qts

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
     postcode { Faker::Address.postcode }
     region_code { 'london' }
     association(:provider)
-    association(:recruitment_cycle)
+    association :recruitment_cycle, strategy: :find_or_create
 
     transient do
       age { nil }


### PR DESCRIPTION
### Context
Course and site factories create duplicate recruitment cycles. 

### Changes proposed in this pull request
Find or create associated recruitment cycles. 

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
