### PR TITLE
[1716] Missing foreign keys

### DIFF
--- a/db/migrate/20190703120737_add_foreign_key_to_course_and_course_enrichment.rb
+++ b/db/migrate/20190703120737_add_foreign_key_to_course_and_course_enrichment.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyToCourseAndCourseEnrichment < ActiveRecord::Migration[5.2]
+  def change
+    add_foreign_key :course_enrichment, :course
+  end
+end

--- a/db/migrate/20190703120855_add_foreign_key_to_provider_and_provider_enrichment.rb
+++ b/db/migrate/20190703120855_add_foreign_key_to_provider_and_provider_enrichment.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyToProviderAndProviderEnrichment < ActiveRecord::Migration[5.2]
+  def change
+    add_foreign_key :provider_enrichment, :provider
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -273,6 +273,7 @@ ActiveRecord::Schema.define(version: 2019_07_04_134543) do
   add_foreign_key "course", "provider", name: "FK_course_provider_provider_id", on_delete: :cascade
   add_foreign_key "course_enrichment", "\"user\"", column: "created_by_user_id", name: "FK_course_enrichment_user_created_by_user_id"
   add_foreign_key "course_enrichment", "\"user\"", column: "updated_by_user_id", name: "FK_course_enrichment_user_updated_by_user_id"
+  add_foreign_key "course_enrichment", "course"
   add_foreign_key "course_site", "course", name: "FK_course_site_course_course_id", on_delete: :cascade
   add_foreign_key "course_site", "site", name: "FK_course_site_site_site_id", on_delete: :cascade
   add_foreign_key "course_subject", "course", name: "FK_course_subject_course_course_id", on_delete: :cascade
@@ -284,6 +285,7 @@ ActiveRecord::Schema.define(version: 2019_07_04_134543) do
   add_foreign_key "organisation_user", "organisation", name: "FK_organisation_user_organisation_organisation_id"
   add_foreign_key "provider_enrichment", "\"user\"", column: "created_by_user_id", name: "FK_provider_enrichment_user_created_by_user_id"
   add_foreign_key "provider_enrichment", "\"user\"", column: "updated_by_user_id", name: "FK_provider_enrichment_user_updated_by_user_id"
+  add_foreign_key "provider_enrichment", "provider"
   add_foreign_key "session", "\"user\"", column: "user_id", name: "FK_session_user_user_id", on_delete: :cascade
   add_foreign_key "site", "provider", name: "FK_site_provider_provider_id", on_delete: :cascade
 end


### PR DESCRIPTION
### Context
Database integrity

### Changes proposed in this pull request
Add foreign keys for -
```ruby
provider_enrichment.provider_id
course_enrichment.course.id
```

### Guidance to review
🚢 

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
