### PR TITLE
[1564] [Part 1] move recruitment cycle to provider

### DIFF
--- a/app/controllers/api/v2/sites_controller.rb
+++ b/app/controllers/api/v2/sites_controller.rb
@@ -17,7 +17,6 @@ module API
 
       def create
         @site = Site.new(site_params)
-        @site.recruitment_cycle = RecruitmentCycle.find_by(year: Settings.current_recruitment_cycle)
         @site.provider = @provider
         authorize @site
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -20,7 +20,6 @@
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  changed_at              :datetime         not null
-#  recruitment_cycle_id    :integer          not null
 #
 
 class Course < ApplicationRecord
@@ -70,7 +69,7 @@ class Course < ApplicationRecord
 
   belongs_to :provider
   belongs_to :accrediting_provider, class_name: 'Provider', optional: true
-  belongs_to :recruitment_cycle
+
   has_many :course_subjects
   has_many :subjects, through: :course_subjects
   has_many :site_statuses
@@ -114,13 +113,19 @@ class Course < ApplicationRecord
     end.order(:changed_at, :id)
   end
 
-  scope :by_recruitment_cycle, ->(recruitment_year) { joins(:recruitment_cycle).merge(RecruitmentCycle.where(year: recruitment_year)) }
+  scope :by_recruitment_cycle, ->(recruitment_year) {
+    joins(provider: :recruitment_cycle).merge(RecruitmentCycle.where(year: recruitment_year))
+  }
 
   validates :enrichments, presence: true, on: :publish
   validate :validate_enrichment_publishable, on: :publish
   validate :validate_enrichment
 
   after_validation :remove_unnecessary_enrichments_validation_message
+
+  def recruitment_cycle
+    provider.recruitment_cycle
+  end
 
   def accrediting_provider_description
     return nil if accrediting_provider.blank?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -24,6 +24,7 @@
 #  accrediting_provider :text
 #  last_published_at    :datetime
 #  changed_at           :datetime         not null
+#  recruitment_cycle_id :integer          not null
 #
 
 class Provider < ApplicationRecord
@@ -45,6 +46,8 @@ class Provider < ApplicationRecord
     accredited_body: 'Y',
     not_an_accredited_body: 'N',
   }
+
+  belongs_to :recruitment_cycle
 
   has_and_belongs_to_many :organisations, join_table: :organisation_provider
   has_many :users, through: :organisations
@@ -109,10 +112,6 @@ class Provider < ApplicationRecord
     # itself, so we don't want to alter the semantics of updated_at which
     # represents changes to just the provider record.
     update_columns changed_at: timestamp
-  end
-
-  def recruitment_cycle
-    "2019"
   end
 
   def unassigned_site_codes

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -11,10 +11,18 @@
 #
 
 class RecruitmentCycle < ApplicationRecord
-  has_many :courses
-  has_many :sites
+  has_many :providers
+  # Because this is through a has_many, these associations can't be updated,
+  # which is a good thing since we don't have a good way to "move" a course or
+  # a site to a new recruitment_cycle
+  has_many :courses, through: :providers
+  has_many :sites, through: :providers
 
   validates :year, presence: true
+
+  def self.current_recruitment_cycle
+    all.first
+  end
 
   def to_s
     following_year = Date.new(year.to_i, 1, 1) + 1.year

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -2,19 +2,18 @@
 #
 # Table name: site
 #
-#  id                   :integer          not null, primary key
-#  address2             :text
-#  address3             :text
-#  address4             :text
-#  code                 :text             not null
-#  location_name        :text
-#  postcode             :text
-#  address1             :text
-#  provider_id          :integer          default(0), not null
-#  region_code          :integer
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  recruitment_cycle_id :integer          not null
+#  id            :integer          not null, primary key
+#  address2      :text
+#  address3      :text
+#  address4      :text
+#  code          :text             not null
+#  location_name :text
+#  postcode      :text
+#  address1      :text
+#  provider_id   :integer          default(0), not null
+#  region_code   :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 
 class Site < ApplicationRecord
@@ -31,7 +30,6 @@ class Site < ApplicationRecord
   audited associated_with: :provider
 
   belongs_to :provider
-  belongs_to :recruitment_cycle
 
   validates :location_name, uniqueness: { scope: :provider_id }
   validates :location_name,
@@ -43,6 +41,10 @@ class Site < ApplicationRecord
   validates :code, uniqueness: { scope: :provider_id, case_sensitive: false },
                    inclusion: { in: POSSIBLE_CODES, message: "must be A-Z, 0-9 or -" },
                    presence: true
+
+  def recruitment_cycle
+    provider.recruitment_cycle
+  end
 
   def assign_code
     self.code ||= pick_next_available_code(available_codes: provider&.unassigned_site_codes)

--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -50,6 +50,10 @@ module API
         @object.external_contact_info['website']
       end
 
+      attribute :recruitment_cycle_year do
+        @object.recruitment_cycle.year
+      end
+
       enrichment_attribute :train_with_us
       enrichment_attribute :train_with_disability
 

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -20,7 +20,6 @@
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  changed_at              :datetime         not null
-#  recruitment_cycle_id    :integer          not null
 #
 
 class CourseSerializer < ActiveModel::Serializer

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -24,6 +24,7 @@
 #  accrediting_provider :text
 #  last_published_at    :datetime
 #  changed_at           :datetime         not null
+#  recruitment_cycle_id :integer          not null
 #
 
 class ProviderSerializer < ActiveModel::Serializer
@@ -31,7 +32,7 @@ class ProviderSerializer < ActiveModel::Serializer
 
   attributes :institution_code, :institution_name, :institution_type, :accrediting_provider,
              :address1, :address2, :address3, :address4, :postcode, :region_code, :scheme_member,
-             :recruitment_cycle, :utt_application_alerts, :type_of_gt12
+             :utt_application_alerts, :type_of_gt12
 
              # application alert recipient has not been added into the enum in the contact model
              # as it does not share the name and email attribute. It is simply a contact email
@@ -45,6 +46,10 @@ class ProviderSerializer < ActiveModel::Serializer
     else
       generate_provider_contacts
     end
+  end
+
+  attribute :recruitment_cycle do
+    object.recruitment_cycle.year
   end
 
   def institution_code

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -2,19 +2,18 @@
 #
 # Table name: site
 #
-#  id                   :integer          not null, primary key
-#  address2             :text
-#  address3             :text
-#  address4             :text
-#  code                 :text             not null
-#  location_name        :text
-#  postcode             :text
-#  address1             :text
-#  provider_id          :integer          default(0), not null
-#  region_code          :integer
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  recruitment_cycle_id :integer          not null
+#  id            :integer          not null, primary key
+#  address2      :text
+#  address3      :text
+#  address4      :text
+#  code          :text             not null
+#  location_name :text
+#  postcode      :text
+#  address1      :text
+#  provider_id   :integer          default(0), not null
+#  region_code   :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 
 class SiteSerializer < ActiveModel::Serializer

--- a/db/migrate/20190703130101_move_recruitment_cycle_to_provider.rb
+++ b/db/migrate/20190703130101_move_recruitment_cycle_to_provider.rb
@@ -1,0 +1,73 @@
+require_relative '20190619142449_add_recruitment_cycle_to_course'
+require_relative '20190619144634_add_2019_recruitment_cycle_to_courses'
+require_relative '20190620060536_set_recruitment_cycle_to_not_null'
+require_relative '20190620120944_add_recruitment_cycle_to_site'
+require_relative '20190620121519_add_2019_recruitment_cycle_to_sites'
+require_relative '20190621125905_set_site_recruitment_cycle_to_not_null'
+
+class MoveRecruitmentCycleToProvider < ActiveRecord::Migration[5.2]
+  def up
+    add_reference :provider, :recruitment_cycle, index: false, type: :int, foreign_key: true
+
+    current_recruitment_cycle = RecruitmentCycle.where(year: '2019').first
+
+    say_with_time 'updating provider recruitment cycle' do
+      Provider.connection.update <<~EOSQL
+        UPDATE provider SET recruitment_cycle_id=#{current_recruitment_cycle.id}
+      EOSQL
+    end
+
+    say_with_time 'SetSiteRecruitmentCycleToNotNull' do
+      revert SetSiteRecruitmentCycleToNotNull
+    end
+    say_with_time 'Add2019RecruitmentCycleToSites' do
+      revert Add2019RecruitmentCycleToSites
+    end
+    say_with_time 'AddRecruitmentCycleToSite' do
+      revert AddRecruitmentCycleToSite
+    end
+    say_with_time 'SetRecruitmentCycleToNotNull' do
+      revert SetRecruitmentCycleToNotNull
+    end
+    say_with_time 'Add2019RecruitmentCycleToCourses' do
+      revert Add2019RecruitmentCycleToCourses
+    end
+    say_with_time 'AddRecruitmentCycleToCourse' do
+      revert AddRecruitmentCycleToCourse
+    end
+
+    change_column_null :provider, :recruitment_cycle_id, false
+
+    remove_index :provider, name: 'IX_provider_provider_code'
+    add_index    :provider, %i[recruitment_cycle_id provider_code], unique: true
+  end
+
+  def down
+    add_index    :provider,
+                 :provider_code,
+                 name: 'IX_provider_provider_code',
+                 unique: true
+    remove_index :provider, %i[recruitment_cycle_id provider_code]
+
+    say_with_time 'AddRecruitmentCycleToCourse' do
+      run AddRecruitmentCycleToCourse
+    end
+    say_with_time 'Add2019RecruitmentCycleToCourses' do
+      run Add2019RecruitmentCycleToCourses
+    end
+    say_with_time 'SetRecruitmentCycleToNotNull' do
+      run SetRecruitmentCycleToNotNull
+    end
+    say_with_time 'AddRecruitmentCycleToSite' do
+      run AddRecruitmentCycleToSite
+    end
+    say_with_time 'Add2019RecruitmentCycleToSites' do
+      run Add2019RecruitmentCycleToSites
+    end
+    say_with_time 'SetSiteRecruitmentCycleToNotNull' do
+      run SetSiteRecruitmentCycleToNotNull
+    end
+
+    remove_reference :provider, :recruitment_cycle, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,11 +85,9 @@ ActiveRecord::Schema.define(version: 2019_07_04_134543) do
     t.datetime "created_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.datetime "changed_at", default: -> { "timezone('utc'::text, now())" }, null: false
-    t.integer "recruitment_cycle_id", null: false
     t.index ["accrediting_provider_id"], name: "IX_course_accrediting_provider_id"
     t.index ["changed_at"], name: "index_course_on_changed_at", unique: true
     t.index ["provider_id", "course_code"], name: "IX_course_provider_id_course_code", unique: true
-    t.index ["recruitment_cycle_id"], name: "index_course_on_recruitment_cycle_id"
   end
 
   create_table "course_enrichment", id: :serial, force: :cascade do |t|
@@ -183,9 +181,10 @@ ActiveRecord::Schema.define(version: 2019_07_04_134543) do
     t.text "accrediting_provider"
     t.datetime "last_published_at"
     t.datetime "changed_at", default: -> { "timezone('utc'::text, now())" }, null: false
+    t.integer "recruitment_cycle_id", null: false
     t.index ["changed_at"], name: "index_provider_on_changed_at", unique: true
     t.index ["last_published_at"], name: "IX_provider_last_published_at"
-    t.index ["provider_code"], name: "IX_provider_provider_code", unique: true
+    t.index ["recruitment_cycle_id", "provider_code"], name: "index_provider_on_recruitment_cycle_id_and_provider_code", unique: true
   end
 
   create_table "provider_enrichment", id: :serial, force: :cascade do |t|
@@ -243,9 +242,7 @@ ActiveRecord::Schema.define(version: 2019_07_04_134543) do
     t.integer "region_code"
     t.datetime "created_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
-    t.integer "recruitment_cycle_id", null: false
     t.index ["provider_id", "code"], name: "IX_site_provider_id_code", unique: true
-    t.index ["recruitment_cycle_id"], name: "index_site_on_recruitment_cycle_id"
   end
 
   create_table "subject", id: :serial, force: :cascade do |t|
@@ -283,6 +280,7 @@ ActiveRecord::Schema.define(version: 2019_07_04_134543) do
   add_foreign_key "organisation_provider", "provider", name: "FK_organisation_provider_provider_provider_id"
   add_foreign_key "organisation_user", "\"user\"", column: "user_id", name: "FK_organisation_user_user_user_id"
   add_foreign_key "organisation_user", "organisation", name: "FK_organisation_user_organisation_organisation_id"
+  add_foreign_key "provider", "recruitment_cycle"
   add_foreign_key "provider_enrichment", "\"user\"", column: "created_by_user_id", name: "FK_provider_enrichment_user_created_by_user_id"
   add_foreign_key "provider_enrichment", "\"user\"", column: "updated_by_user_id", name: "FK_provider_enrichment_user_updated_by_user_id"
   add_foreign_key "provider_enrichment", "provider"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,8 +12,6 @@ AccessRequest.destroy_all
 current_recruitment_cycle = RecruitmentCycle.create(year: '2019', application_start_date: Date.new(2018, 10, 9))
 next_recruitment_cycle = RecruitmentCycle.create(year: '2020')
 
-accrediting_provider = Provider.create!(provider_name: 'Acme SCITT', provider_code: 'A01')
-
 {
   "Primary" => "00",
   "Secondary" => "05",
@@ -29,103 +27,89 @@ accrediting_provider = Provider.create!(provider_name: 'Acme SCITT', provider_co
   )
 end
 
-Site.create!(
-  provider: accrediting_provider,
-  code: Faker::Number.unique.number(1),
-  location_name: Faker::Company.name,
-  address1: Faker::Address.building_number,
-  address2: Faker::Address.street_name,
-  address3: Faker::Address.city,
-  address4: Faker::Address.state,
-  postcode: Faker::Address.postcode,
-  recruitment_cycle: current_recruitment_cycle
-)
+def create_standard_provider_and_courses_for_cycle(recruitment_cycle)
+  provider = Provider.create!(
+    provider_name: 'Acme SCITT',
+    provider_code: 'A01',
+    recruitment_cycle: recruitment_cycle
+  )
 
-course1 = Course.create!(
-  name: "Mathematics",
-  course_code: Faker::Number.unique.hexadecimal(3).upcase,
-  provider: accrediting_provider,
-  start_date: Date.new(2019, 9, 1),
-  profpost_flag: "PG",
-  program_type: "SD",
-  maths: 1,
-  english: 9,
-  science: nil,
-  modular: "M",
-  qualification: :pgce_with_qts,
-  subjects: [
-    Subject.find_by(subject_name: "Secondary"),
-    Subject.find_by(subject_name: "Mathematics")
-  ],
-  study_mode: "F",
-  recruitment_cycle: current_recruitment_cycle
-)
+  Site.create!(
+    provider: provider,
+    code: Faker::Number.unique.number(1),
+    location_name: Faker::Company.name,
+    address1: Faker::Address.building_number,
+    address2: Faker::Address.street_name,
+    address3: Faker::Address.city,
+    address4: Faker::Address.state,
+    postcode: Faker::Address.postcode,
+  )
 
-SiteStatus.create!(
-  site: Site.last,
-  vac_status: "F",
-  publish: "Y",
-  course: course1,
-  status: "R",
-  applications_accepted_from: Date.new(2018, 10, 23)
-)
+  course1 = Course.create!(
+    name: "Mathematics",
+    course_code: Faker::Number.unique.hexadecimal(3).upcase,
+    provider: provider,
+    start_date: Date.new(2019, 9, 1),
+    profpost_flag: "PG",
+    program_type: "SD",
+    maths: 1,
+    english: 9,
+    science: nil,
+    modular: "M",
+    qualification: :pgce_with_qts,
+    subjects: [
+      Subject.find_by(subject_name: "Secondary"),
+      Subject.find_by(subject_name: "Mathematics")
+    ],
+    study_mode: "F",
+  )
 
-course2 = Course.create!(
-  name: "Biology",
-  course_code: Faker::Number.unique.hexadecimal(3).upcase,
-  provider: accrediting_provider,
-  start_date: Date.new(2019, 9, 1),
-  profpost_flag: "BO",
-  program_type: "HE",
-  maths: 3,
-  english: 9,
-  science: nil,
-  modular: "",
-  qualification: :pgce_with_qts,
-  subjects: [
-    Subject.find_by(subject_name: "Secondary"),
-    Subject.find_by(subject_name: "Biology"),
-    Subject.find_by(subject_name: "Further Education"),
-  ],
-  study_mode: "B",
-  recruitment_cycle: current_recruitment_cycle
-)
+  SiteStatus.create!(
+    site: Site.last,
+    vac_status: "F",
+    publish: "Y",
+    course: course1,
+    status: "R",
+    applications_accepted_from: Date.new(2018, 10, 23)
+  )
 
-PGDECourse.create!(
-  provider_code: course2.provider.provider_code,
-  course_code: course2.course_code,
-)
+  course2 = Course.create!(
+    name: "Biology",
+    course_code: Faker::Number.unique.hexadecimal(3).upcase,
+    provider: provider,
+    start_date: Date.new(2019, 9, 1),
+    profpost_flag: "BO",
+    program_type: "HE",
+    maths: 3,
+    english: 9,
+    science: nil,
+    modular: "",
+    qualification: :pgce_with_qts,
+    subjects: [
+      Subject.find_by(subject_name: "Secondary"),
+      Subject.find_by(subject_name: "Biology"),
+      Subject.find_by(subject_name: "Further Education"),
+    ],
+    study_mode: "B",
+  )
 
-SiteStatus.create!(
-  site: Site.last,
-  vac_status: "B",
-  publish: "Y",
-  course: course2,
-  status: "N",
-  applications_accepted_from: Date.new(2018, 10, 2)
-)
+  PGDECourse.create!(
+    provider_code: course2.provider.provider_code,
+    course_code: course2.course_code,
+  )
 
-provider2 = Provider.create!(provider_name: "Acme Alliance", provider_code: "A02")
+  SiteStatus.create!(
+    site: Site.last,
+    vac_status: "B",
+    publish: "Y",
+    course: course2,
+    status: "N",
+    applications_accepted_from: Date.new(2018, 10, 2)
+  )
+end
 
-Course.create!(
-  name: Faker::ProgrammingLanguage.name,
-  course_code: "5W2A",
-  provider: provider2,
-  accrediting_provider: accrediting_provider,
-  qualification: :pgce_with_qts,
-  subjects: [
-    Subject.last
-  ],
-  recruitment_cycle: current_recruitment_cycle
-)
-
-Course.create!(
-  name: Faker::ProgrammingLanguage.name,
-  course_code: "9A5Y",
-  provider: Provider.create!(provider_name: 'Big Uni', provider_code: 'B01'),
-  qualification: :pgce_with_qts,
-  recruitment_cycle: next_recruitment_cycle
-)
+create_standard_provider_and_courses_for_cycle(current_recruitment_cycle)
+create_standard_provider_and_courses_for_cycle(next_recruitment_cycle)
 
 User.create!(
   first_name: 'Super',
@@ -138,7 +122,8 @@ User.create!(
 10.times do |i|
   provider = Provider.create!(
     provider_name: "ACME SCITT #{i}",
-    provider_code: "A#{i}"
+    provider_code: "A#{i}",
+    recruitment_cycle: current_recruitment_cycle
   )
 
   organisation = Organisation.create!(name: "ACME#{i}")

--- a/lib/mcb/courses_editor.rb
+++ b/lib/mcb/courses_editor.rb
@@ -52,7 +52,6 @@ module MCB
         "edit age range",
         "edit subjects",
         "edit training locations",
-        "edit recruitment cycle",
         "sync course(s) to Find"
       ]
       filtered_choices = filter_single_course_options_if_necessary(choices)

--- a/lib/mcb/courses_editor_cli.rb
+++ b/lib/mcb/courses_editor_cli.rb
@@ -52,13 +52,6 @@ module MCB
       )
     end
 
-    def ask_recruitment_cycle
-      ask_multiple_choice(
-        prompt: "Recruitment cycle?",
-        choices: RecruitmentCycle.all.order(:year)
-      )
-    end
-
     def ask_accredited_body
       new_accredited_body = nil
       until new_accredited_body.present?

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -20,7 +20,6 @@
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  changed_at              :datetime         not null
-#  recruitment_cycle_id    :integer          not null
 #
 
 FactoryBot.define do
@@ -30,8 +29,7 @@ FactoryBot.define do
     qualification { :pgce_with_qts }
     with_higher_education
 
-    association(:provider)
-    association :recruitment_cycle, strategy: :find_or_create
+    provider
 
     study_mode { :full_time }
     resulting_in_pgce_with_qts

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -24,6 +24,7 @@
 #  accrediting_provider :text
 #  last_published_at    :datetime
 #  changed_at           :datetime         not null
+#  recruitment_cycle_id :integer          not null
 #
 
 FactoryBot.define do
@@ -42,6 +43,7 @@ FactoryBot.define do
     accrediting_provider { 'N' }
     region_code { 'london' }
     organisations { build_list :organisation, 1 }
+    association :recruitment_cycle, strategy: :find_or_create
 
     trait :accredited_body do
       accrediting_provider { 'Y' }

--- a/spec/factories/recruitment_cycles.rb
+++ b/spec/factories/recruitment_cycles.rb
@@ -15,5 +15,9 @@ FactoryBot.define do
     year { '2019' }
     application_start_date { Time.zone.today }
     application_end_date { Time.zone.today + 30 }
+
+    trait :next do
+      year { '2020' }
+    end
   end
 end

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -2,19 +2,18 @@
 #
 # Table name: site
 #
-#  id                   :integer          not null, primary key
-#  address2             :text
-#  address3             :text
-#  address4             :text
-#  code                 :text             not null
-#  location_name        :text
-#  postcode             :text
-#  address1             :text
-#  provider_id          :integer          default(0), not null
-#  region_code          :integer
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  recruitment_cycle_id :integer          not null
+#  id            :integer          not null, primary key
+#  address2      :text
+#  address3      :text
+#  address4      :text
+#  code          :text             not null
+#  location_name :text
+#  postcode      :text
+#  address1      :text
+#  provider_id   :integer          default(0), not null
+#  region_code   :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 
 FactoryBot.define do
@@ -26,8 +25,8 @@ FactoryBot.define do
     address4 { Faker::Address.state }
     postcode { Faker::Address.postcode }
     region_code { 'london' }
-    association(:provider)
-    association :recruitment_cycle, strategy: :find_or_create
+    provider
+
 
     transient do
       age { nil }

--- a/spec/lib/mcb/courses_editor_spec.rb
+++ b/spec/lib/mcb/courses_editor_spec.rb
@@ -34,8 +34,7 @@ describe MCB::CoursesEditor do
            study_mode: 'part_time',
            start_date: Date.new(2019, 8, 1),
            age_range: 'secondary',
-           subjects: [secondary, biology],
-           recruitment_cycle: current_cycle)
+           subjects: [secondary, biology])
   }
   subject { described_class.new(provider: provider, course_codes: course_codes, requester: requester) }
 
@@ -118,19 +117,6 @@ describe MCB::CoursesEditor do
         it 'updates the study mode setting to full-time by default' do
           expect { run_editor("edit study mode", "", "exit") }.to change { course.reload.study_mode }.
             from("part_time").to("full_time")
-        end
-      end
-
-      describe "(recruitment cycle)" do
-        it 'updates the recruitment cycle' do
-          expect {
-            run_editor(
-              "edit recruitment cycle",
-              "3", # 3rd option should be 2020/21, after exit and 2019/20
-              "exit"
-            )
-          }.to change { course.reload.recruitment_cycle }.
-            from(current_cycle).to(next_cycle)
         end
       end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -20,7 +20,6 @@
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  changed_at              :datetime         not null
-#  recruitment_cycle_id    :integer          not null
 #
 
 require 'rails_helper'
@@ -40,7 +39,6 @@ RSpec.describe Course, type: :model do
   describe 'associations' do
     it { should belong_to(:provider) }
     it { should belong_to(:accrediting_provider).optional }
-    it { should belong_to(:recruitment_cycle) }
     it { should have_many(:subjects).through(:course_subjects) }
     it { should have_many(:site_statuses) }
     it { should have_many(:sites) }
@@ -95,6 +93,8 @@ RSpec.describe Course, type: :model do
       end
     end
   end
+
+  its(:recruitment_cycle) { should eq find(:recruitment_cycle) }
 
   describe 'no site statuses' do
     its(:site_statuses) { should be_empty }
@@ -284,8 +284,10 @@ RSpec.describe Course, type: :model do
     context 'with valid recruitment_year parameter' do
       let(:current_cycle) { create(:recruitment_cycle, year: '2019') }
       let(:next_cycle) { create(:recruitment_cycle, year: '2020') }
-      let(:course_1) { create(:course, recruitment_cycle: current_cycle) }
-      let(:course_2) { create(:course, recruitment_cycle: next_cycle) }
+      let(:provider_1) { create(:provider, recruitment_cycle: current_cycle) }
+      let(:provider_2) { create(:provider, recruitment_cycle: next_cycle) }
+      let(:course_1) { create(:course, provider: provider_1) }
+      let(:course_2) { create(:course, provider: provider_2) }
 
       subject { Course.by_recruitment_cycle('2019') }
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -24,6 +24,7 @@
 #  accrediting_provider :text
 #  last_published_at    :datetime
 #  changed_at           :datetime         not null
+#  recruitment_cycle_id :integer          not null
 #
 
 require 'rails_helper'
@@ -47,7 +48,9 @@ describe Provider, type: :model do
 
   describe 'changed_at' do
     it 'is set on create' do
-      provider = Provider.create
+      provider = Provider.create(
+        recruitment_cycle: find_or_create(:recruitment_cycle)
+      )
       expect(provider.changed_at).to be_present
       expect(provider.changed_at).to eq provider.updated_at
     end
@@ -180,6 +183,8 @@ describe Provider, type: :model do
       expect(provider.updated_at).to eq timestamp
     end
   end
+
+  its(:recruitment_cycle) { should eq find(:recruitment_cycle) }
 
   describe '#unassigned_site_codes' do
     subject { create(:provider) }

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -24,7 +24,7 @@ describe RecruitmentCycle, type: :model do
   it { is_expected.to validate_presence_of(:year) }
 
   describe 'associations' do
-    it { should have_many(:courses) }
-    it { should have_many(:sites) }
+    it { should have_many(:courses).through(:providers) }
+    it { should have_many(:sites).through(:providers) }
   end
 end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -2,19 +2,18 @@
 #
 # Table name: site
 #
-#  id                   :integer          not null, primary key
-#  address2             :text
-#  address3             :text
-#  address4             :text
-#  code                 :text             not null
-#  location_name        :text
-#  postcode             :text
-#  address1             :text
-#  provider_id          :integer          default(0), not null
-#  region_code          :integer
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  recruitment_cycle_id :integer          not null
+#  id            :integer          not null, primary key
+#  address2      :text
+#  address3      :text
+#  address4      :text
+#  code          :text             not null
+#  location_name :text
+#  postcode      :text
+#  address1      :text
+#  provider_id   :integer          default(0), not null
+#  region_code   :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 
 require 'rails_helper'
@@ -37,7 +36,6 @@ describe Provider, type: :model do
 
   describe 'associations' do
     it { should belong_to(:provider) }
-    it { should belong_to(:recruitment_cycle) }
   end
 
   describe '#touch_provider' do
@@ -74,6 +72,8 @@ describe Provider, type: :model do
       expect(subject.code).to eq('A')
     end
   end
+
+  its(:recruitment_cycle) { should eq find(:recruitment_cycle) }
 
   describe "description" do
     subject { build(:site, location_name: 'Foo', code: '1') }

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -169,7 +169,8 @@ describe 'Providers API v2', type: :request do
             "region_code" => provider.region_code,
             "telephone" => provider.telephone,
             "email" => provider.email,
-            "website" => provider.url
+            "website" => provider.url,
+            "recruitment_cycle_year" => provider.recruitment_cycle.year,
           },
           "relationships" => {
             "sites" => {

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -19,11 +19,16 @@ describe API::V2::SerializableCourse do
   subject { parsed_json['data'] }
 
   it { should have_type('courses') }
-  it {
-    should have_attributes(:start_date, :content_status, :ucas_status,
-                           :funding, :subjects, :applications_open_from,
-                           :is_send?, :level, :provider_code)
-  }
+  it { should have_attributes :start_date }
+  it { should have_attribute :content_status }
+  it { should have_attribute :ucas_status }
+  it { should have_attribute :funding }
+  it { should have_attribute :subjects }
+  it { should have_attribute :applications_open_from }
+  it { should have_attribute :is_send? }
+  it { should have_attribute :level }
+  it { should have_attribute :provider_code }
+  it { should have_attribute(:recruitment_cycle_year).with_value(course.recruitment_cycle.year) }
 
   context 'with a provider' do
     let(:provider) { course.provider }

--- a/spec/serializers/api/v2/serializable_provider_spec.rb
+++ b/spec/serializers/api/v2/serializable_provider_spec.rb
@@ -11,10 +11,9 @@ describe API::V2::SerializableProvider do
   subject { JSON.parse(resource.as_jsonapi.to_json) }
 
   it { should have_type 'providers' }
-  it {
-    should have_attribute(:provider_code).with_value(provider.provider_code)
-    should have_attribute(:provider_name).with_value(provider.provider_name)
-    should have_attribute(:accredited_body?).with_value(true)
-    should have_attribute(:can_add_more_sites?).with_value(true)
-  }
+  it { should have_attribute(:provider_code).with_value(provider.provider_code) }
+  it { should have_attribute(:provider_name).with_value(provider.provider_name) }
+  it { should have_attribute(:accredited_body?).with_value(true) }
+  it { should have_attribute(:can_add_more_sites?).with_value(true) }
+  it { should have_attribute(:recruitment_cycle_year).with_value(provider.recruitment_cycle.year) }
 end

--- a/spec/serializers/api/v2/serializable_site_spec.rb
+++ b/spec/serializers/api/v2/serializable_site_spec.rb
@@ -11,13 +11,12 @@ describe API::V2::SerializableSite do
   subject { JSON.parse(resource.as_jsonapi.to_json) }
 
   it { should have_type 'sites' }
-  it {
-    should have_attribute(:location_name).with_value(site.location_name)
-    should have_attribute(:address1).with_value(site.address1)
-    should have_attribute(:address2).with_value(site.address2)
-    should have_attribute(:address3).with_value(site.address3)
-    should have_attribute(:address4).with_value(site.address4)
-    should have_attribute(:postcode).with_value(site.postcode)
-    should have_attribute(:region_code).with_value(site.region_code)
-  }
+  it { should have_attribute(:location_name).with_value(site.location_name) }
+  it { should have_attribute(:address1).with_value(site.address1) }
+  it { should have_attribute(:address2).with_value(site.address2) }
+  it { should have_attribute(:address3).with_value(site.address3) }
+  it { should have_attribute(:address4).with_value(site.address4) }
+  it { should have_attribute(:postcode).with_value(site.postcode) }
+  it { should have_attribute(:region_code).with_value(site.region_code) }
+  it { should have_attribute(:recruitment_cycle_year).with_value(site.recruitment_cycle.year) }
 end

--- a/spec/serializers/course_serializer_spec.rb
+++ b/spec/serializers/course_serializer_spec.rb
@@ -20,7 +20,6 @@
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  changed_at              :datetime         not null
-#  recruitment_cycle_id    :integer          not null
 #
 
 require "rails_helper"

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -24,6 +24,7 @@
 #  accrediting_provider :text
 #  last_published_at    :datetime
 #  changed_at           :datetime         not null
+#  recruitment_cycle_id :integer          not null
 #
 
 require "rails_helper"

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -2,19 +2,18 @@
 #
 # Table name: site
 #
-#  id                   :integer          not null, primary key
-#  address2             :text
-#  address3             :text
-#  address4             :text
-#  code                 :text             not null
-#  location_name        :text
-#  postcode             :text
-#  address1             :text
-#  provider_id          :integer          default(0), not null
-#  region_code          :integer
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  recruitment_cycle_id :integer          not null
+#  id            :integer          not null, primary key
+#  address2      :text
+#  address3      :text
+#  address4      :text
+#  code          :text             not null
+#  location_name :text
+#  postcode      :text
+#  address1      :text
+#  provider_id   :integer          default(0), not null
+#  region_code   :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 
 require "rails_helper"

--- a/spec/support/reference_data.rb
+++ b/spec/support/reference_data.rb
@@ -1,0 +1,21 @@
+# Reference data that gets created for every test as a matter of convenience.
+#
+# There is some data that we can assume will always be in the db, and, where
+# it's cheap enough to do so, we can create by default so that it's always
+# there. Any such reference data should be find_or_create-able so that specs
+# can easily re-use it, and should also be disable-able for tests that don't
+# want it.
+
+RSpec.configure do |config|
+  # It will be pretty standard to always have a recruitment cycle in the db,
+  # and adding it here is much cheaper and less noisy than adding it to 90% of
+  # the tests.
+  #
+  # Disable with the tag: no_default_recycle: true
+  # Retrieve with: find_or_create(:recruitment_cycle)
+  config.before(:each) do |example|
+    unless example.metadata[:no_default_recycle] == true
+      find_or_create :recruitment_cycle
+    end
+  end
+end


### PR DESCRIPTION
### Context

This work is to support rollover. But instead of having `course` and `site` attached to a specific `recruitment_cycle`, we want `provider` to be attached. This gives us one place to express this relationship and keeps code tidier and easier to work with.

### Changes proposed in this pull request

Remove the association of `recruitment_cycle` to `course` and `site`, replace it with an association to `provider`.

### Guidance to review

This is the first PR of a few (probably 3-4) to change this association. They are being cut against a feature branch, not master, so that we review the changes in smaller batches and then release them all in one go.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
