### PR TITLE
[1564] [Part 2] add routes and recruitment cycles to controller

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -3,6 +3,7 @@
 module API
   module V2
     class CoursesController < API::V2::ApplicationController
+      before_action :build_recruitment_cycle
       before_action :build_provider
       before_action :build_course, except: :index
 
@@ -107,7 +108,15 @@ module API
       end
 
       def build_provider
-        @provider = Provider.find_by!(provider_code: params[:provider_code].upcase)
+        @provider = @recruitment_cycle.providers.find_by!(
+          provider_code: params[:provider_code].upcase
+        )
+      end
+
+      def build_recruitment_cycle
+        @recruitment_cycle = RecruitmentCycle.find_by(
+          year: params[:recruitment_cycle_year]
+        ) || RecruitmentCycle.current_recruitment_cycle
       end
 
       def build_course

--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -2,23 +2,42 @@ module API
   module V2
     class ProvidersController < API::V2::ApplicationController
       before_action :get_user, if: -> { params[:user_id].present? }
+      before_action :build_recruitment_cycle
+      before_action :build_provider, except: :index
 
       def index
         authorize Provider
-        providers = policy_scope(Provider).include_courses_counts
+        providers = policy_scope(@recruitment_cycle.providers)
+                      .include_courses_counts
         providers = providers.where(id: @user.providers) if @user.present?
 
-        render jsonapi: providers.in_order, fields: { providers: %i[provider_code provider_name courses] }
+        render jsonapi: providers.in_order,
+               fields: { providers: %i[provider_code provider_name courses
+                                       recruitment_cycle_year] }
       end
 
       def show
-        provider = Provider.includes(:latest_published_enrichment).find_by!(provider_code: params[:code].upcase)
-        authorize provider, :show?
+        authorize @provider, :show?
 
-        render jsonapi: provider, include: params[:include]
+        render jsonapi: @provider, include: params[:include]
       end
 
     private
+
+      def build_recruitment_cycle
+        @recruitment_cycle = RecruitmentCycle.find_by(
+          year: params[:recruitment_cycle_year]
+        ) || RecruitmentCycle.current_recruitment_cycle
+      end
+
+      def build_provider
+        code = params.fetch(:code, params[:provider_code])
+        @provider = @recruitment_cycle.providers
+                      .includes(:latest_published_enrichment)
+                      .find_by!(
+                        provider_code: code.upcase
+                      )
+      end
 
       def get_user
         @user = User.find(params[:user_id])

--- a/app/controllers/api/v2/recruitment_cycles_controller.rb
+++ b/app/controllers/api/v2/recruitment_cycles_controller.rb
@@ -1,0 +1,19 @@
+module API
+  module V2
+    class RecruitmentCyclesController < ApplicationController
+      before_action :build_recruitment_cycle
+
+      def show
+        authorize @recruitment_cycle, :show?
+
+        render jsonapi: @recruitment_cycle, include: params[:include]
+      end
+
+    private
+
+      def build_recruitment_cycle
+        @recruitment_cycle = RecruitmentCycle.find_by(year: params[:year])
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/sites_controller.rb
+++ b/app/controllers/api/v2/sites_controller.rb
@@ -5,6 +5,7 @@ module API
                               only: %i[update create],
                               class: API::V2::DeserializableSite
 
+      before_action :build_recruitment_cycle
       before_action :build_provider
       before_action :build_site, except: %i[index create]
 
@@ -16,8 +17,7 @@ module API
       end
 
       def create
-        @site = Site.new(site_params)
-        @site.provider = @provider
+        @site = @provider.sites.new(site_params)
         authorize @site
 
         if @site.save
@@ -59,7 +59,15 @@ module API
       end
 
       def build_provider
-        @provider = Provider.find_by!(provider_code: params[:provider_code].upcase)
+        @provider = @recruitment_cycle.providers.find_by!(
+          provider_code: params[:provider_code].upcase
+        )
+      end
+
+      def build_recruitment_cycle
+        @recruitment_cycle = RecruitmentCycle.find_by(
+          year: params[:recruitment_cycle_year]
+        ) || RecruitmentCycle.current_recruitment_cycle
       end
 
       def build_site

--- a/app/policies/recruitment_cycle_policy.rb
+++ b/app/policies/recruitment_cycle_policy.rb
@@ -1,0 +1,26 @@
+class RecruitmentCyclePolicy
+  attr_reader :user, :recruitment_cycle
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      # If a user is logged in, they can view all recruitment cycles
+      scope
+    end
+  end
+
+  def initialize(user, recycle)
+    @user = user
+    @recruitment_cycle = recycle
+  end
+
+  def show?
+    user.present?
+  end
+end

--- a/app/serializers/api/v2/serializable_recruitment_cycle.rb
+++ b/app/serializers/api/v2/serializable_recruitment_cycle.rb
@@ -1,0 +1,11 @@
+module API
+  module V2
+    class SerializableRecruitmentCycle < JSONAPI::Serializable::Resource
+      type 'recruitment_cycles'
+
+      attributes :year, :application_start_date, :application_end_date
+
+      has_many :providers
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,50 +1,84 @@
 # == Route Map
 #
-#                Prefix Verb   URI Pattern                                              Controller#Action
-#      api_v1_providers GET    /api/v1(/:recruitment_year)/providers(.:format)          api/v1/providers#index
-#                       POST   /api/v1(/:recruitment_year)/providers(.:format)          api/v1/providers#create
-#       api_v1_provider GET    /api/v1(/:recruitment_year)/providers/:id(.:format)      api/v1/providers#show
-#                       PATCH  /api/v1(/:recruitment_year)/providers/:id(.:format)      api/v1/providers#update
-#                       PUT    /api/v1(/:recruitment_year)/providers/:id(.:format)      api/v1/providers#update
-#                       DELETE /api/v1(/:recruitment_year)/providers/:id(.:format)      api/v1/providers#destroy
-#       api_v1_subjects GET    /api/v1(/:recruitment_year)/subjects(.:format)           api/v1/subjects#index
-#                       POST   /api/v1(/:recruitment_year)/subjects(.:format)           api/v1/subjects#create
-#        api_v1_subject GET    /api/v1(/:recruitment_year)/subjects/:id(.:format)       api/v1/subjects#show
-#                       PATCH  /api/v1(/:recruitment_year)/subjects/:id(.:format)       api/v1/subjects#update
-#                       PUT    /api/v1(/:recruitment_year)/subjects/:id(.:format)       api/v1/subjects#update
-#                       DELETE /api/v1(/:recruitment_year)/subjects/:id(.:format)       api/v1/subjects#destroy
-#        api_v1_courses GET    /api/v1(/:recruitment_year)/courses(.:format)            api/v1/courses#index
-#                       POST   /api/v1(/:recruitment_year)/courses(.:format)            api/v1/courses#create
-#         api_v1_course GET    /api/v1(/:recruitment_year)/courses/:id(.:format)        api/v1/courses#show
-#                       PATCH  /api/v1(/:recruitment_year)/courses/:id(.:format)        api/v1/courses#update
-#                       PUT    /api/v1(/:recruitment_year)/courses/:id(.:format)        api/v1/courses#update
-#                       DELETE /api/v1(/:recruitment_year)/courses/:id(.:format)        api/v1/courses#destroy
-#      api_v2_providers GET    /api/v2/providers(.:format)                              api/v2/providers#index
-#                       POST   /api/v2/providers(.:format)                              api/v2/providers#create
-#       api_v2_provider GET    /api/v2/providers/:id(.:format)                          api/v2/providers#show
-#                       PATCH  /api/v2/providers/:id(.:format)                          api/v2/providers#update
-#                       PUT    /api/v2/providers/:id(.:format)                          api/v2/providers#update
-#                       DELETE /api/v2/providers/:id(.:format)                          api/v2/providers#destroy
-# api_v2_user_providers GET    /api/v2/users/:user_id/providers(.:format)               api/v2/providers#index
-#                       POST   /api/v2/users/:user_id/providers(.:format)               api/v2/providers#create
-#  api_v2_user_provider GET    /api/v2/users/:user_id/providers/:id(.:format)           api/v2/providers#show
-#                       PATCH  /api/v2/users/:user_id/providers/:id(.:format)           api/v2/providers#update
-#                       PUT    /api/v2/users/:user_id/providers/:id(.:format)           api/v2/providers#update
-#                       DELETE /api/v2/users/:user_id/providers/:id(.:format)           api/v2/providers#destroy
-#          api_v2_users GET    /api/v2/users(.:format)                                  api/v2/users#index
-#                       POST   /api/v2/users(.:format)                                  api/v2/users#create
-#           api_v2_user GET    /api/v2/users/:id(.:format)                              api/v2/users#show
-#                       PATCH  /api/v2/users/:id(.:format)                              api/v2/users#update
-#                       PUT    /api/v2/users/:id(.:format)                              api/v2/users#update
-#                       DELETE /api/v2/users/:id(.:format)                              api/v2/users#destroy
-#        api_v2_courses GET    /api/v2/providers(/:provider_code)/courses(.:format)     api/v2/courses#index
-#                       POST   /api/v2/providers(/:provider_code)/courses(.:format)     api/v2/courses#create
-#         api_v2_course GET    /api/v2/providers(/:provider_code)/courses/:id(.:format) api/v2/courses#show
-#                       PATCH  /api/v2/providers(/:provider_code)/courses/:id(.:format) api/v2/courses#update
-#                       PUT    /api/v2/providers(/:provider_code)/courses/:id(.:format) api/v2/courses#update
-#                       DELETE /api/v2/providers(/:provider_code)/courses/:id(.:format) api/v2/courses#destroy
-#             error_500 GET    /error_500(.:format)                                     error#error_500
-#            error_nodb GET    /error_nodb(.:format)                                    error#error_nodb
+#                                                                Prefix Verb   URI Pattern                                                                                                                      Controller#Action
+#                                                      api_v1_providers GET    /api/v1(/:recruitment_year)/providers(.:format)                                                                                  api/v1/providers#index
+#                                                                       POST   /api/v1(/:recruitment_year)/providers(.:format)                                                                                  api/v1/providers#create
+#                                                       api_v1_provider GET    /api/v1(/:recruitment_year)/providers/:id(.:format)                                                                              api/v1/providers#show
+#                                                                       PATCH  /api/v1(/:recruitment_year)/providers/:id(.:format)                                                                              api/v1/providers#update
+#                                                                       PUT    /api/v1(/:recruitment_year)/providers/:id(.:format)                                                                              api/v1/providers#update
+#                                                                       DELETE /api/v1(/:recruitment_year)/providers/:id(.:format)                                                                              api/v1/providers#destroy
+#                                                       api_v1_subjects GET    /api/v1(/:recruitment_year)/subjects(.:format)                                                                                   api/v1/subjects#index
+#                                                                       POST   /api/v1(/:recruitment_year)/subjects(.:format)                                                                                   api/v1/subjects#create
+#                                                        api_v1_subject GET    /api/v1(/:recruitment_year)/subjects/:id(.:format)                                                                               api/v1/subjects#show
+#                                                                       PATCH  /api/v1(/:recruitment_year)/subjects/:id(.:format)                                                                               api/v1/subjects#update
+#                                                                       PUT    /api/v1(/:recruitment_year)/subjects/:id(.:format)                                                                               api/v1/subjects#update
+#                                                                       DELETE /api/v1(/:recruitment_year)/subjects/:id(.:format)                                                                               api/v1/subjects#destroy
+#                                                        api_v1_courses GET    /api/v1(/:recruitment_year)/courses(.:format)                                                                                    api/v1/courses#index
+#                                                                       POST   /api/v1(/:recruitment_year)/courses(.:format)                                                                                    api/v1/courses#create
+#                                                         api_v1_course GET    /api/v1(/:recruitment_year)/courses/:id(.:format)                                                                                api/v1/courses#show
+#                                                                       PATCH  /api/v1(/:recruitment_year)/courses/:id(.:format)                                                                                api/v1/courses#update
+#                                                                       PUT    /api/v1(/:recruitment_year)/courses/:id(.:format)                                                                                api/v1/courses#update
+#                                                                       DELETE /api/v1(/:recruitment_year)/courses/:id(.:format)                                                                                api/v1/courses#destroy
+#                                                 api_v2_user_providers GET    /api/v2/users/:user_id/providers(.:format)                                                                                       api/v2/providers#index
+#                                                                       POST   /api/v2/users/:user_id/providers(.:format)                                                                                       api/v2/providers#create
+#                                                  api_v2_user_provider GET    /api/v2/users/:user_id/providers/:id(.:format)                                                                                   api/v2/providers#show
+#                                                                       PATCH  /api/v2/users/:user_id/providers/:id(.:format)                                                                                   api/v2/providers#update
+#                                                                       PUT    /api/v2/users/:user_id/providers/:id(.:format)                                                                                   api/v2/providers#update
+#                                                                       DELETE /api/v2/users/:user_id/providers/:id(.:format)                                                                                   api/v2/providers#destroy
+#                                  accept_transition_screen_api_v2_user PATCH  /api/v2/users/:id/accept_transition_screen(.:format)                                                                             api/v2/users#accept_transition_screen
+#                                    accept_rollover_screen_api_v2_user PATCH  /api/v2/users/:id/accept_rollover_screen(.:format)                                                                               api/v2/users#accept_rollover_screen
+#                                                           api_v2_user GET    /api/v2/users/:id(.:format)                                                                                                      api/v2/users#show
+#                                                                       PATCH  /api/v2/users/:id(.:format)                                                                                                      api/v2/users#update
+#                                                                       PUT    /api/v2/users/:id(.:format)                                                                                                      api/v2/users#update
+#                   sync_with_search_and_compare_api_v2_provider_course POST   /api/v2/providers/:provider_code/courses/:code/sync_with_search_and_compare(.:format)                                            api/v2/courses#sync_with_search_and_compare
+#                                        publish_api_v2_provider_course POST   /api/v2/providers/:provider_code/courses/:code/publish(.:format)                                                                 api/v2/courses#publish
+#                                    publishable_api_v2_provider_course POST   /api/v2/providers/:provider_code/courses/:code/publishable(.:format)                                                             api/v2/courses#publishable
+#                                               api_v2_provider_courses GET    /api/v2/providers/:provider_code/courses(.:format)                                                                               api/v2/courses#index
+#                                                                       POST   /api/v2/providers/:provider_code/courses(.:format)                                                                               api/v2/courses#create
+#                                                api_v2_provider_course GET    /api/v2/providers/:provider_code/courses/:code(.:format)                                                                         api/v2/courses#show
+#                                                                       PATCH  /api/v2/providers/:provider_code/courses/:code(.:format)                                                                         api/v2/courses#update
+#                                                                       PUT    /api/v2/providers/:provider_code/courses/:code(.:format)                                                                         api/v2/courses#update
+#                                                 api_v2_provider_sites GET    /api/v2/providers/:provider_code/sites(.:format)                                                                                 api/v2/sites#index
+#                                                                       POST   /api/v2/providers/:provider_code/sites(.:format)                                                                                 api/v2/sites#create
+#                                                  api_v2_provider_site GET    /api/v2/providers/:provider_code/sites/:id(.:format)                                                                             api/v2/sites#show
+#                                                                       PATCH  /api/v2/providers/:provider_code/sites/:id(.:format)                                                                             api/v2/sites#update
+#                                                                       PUT    /api/v2/providers/:provider_code/sites/:id(.:format)                                                                             api/v2/sites#update
+#                                                      api_v2_providers GET    /api/v2/providers(.:format)                                                                                                      api/v2/providers#index
+#                                                                       POST   /api/v2/providers(.:format)                                                                                                      api/v2/providers#create
+#                                                       api_v2_provider GET    /api/v2/providers/:code(.:format)                                                                                                api/v2/providers#show
+#                                                                       PATCH  /api/v2/providers/:code(.:format)                                                                                                api/v2/providers#update
+#                                                                       PUT    /api/v2/providers/:code(.:format)                                                                                                api/v2/providers#update
+#                                                                       DELETE /api/v2/providers/:code(.:format)                                                                                                api/v2/providers#destroy
+# sync_with_search_and_compare_api_v2_recruitment_cycle_provider_course POST   /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/courses/:code/sync_with_search_and_compare(.:format) api/v2/courses#sync_with_search_and_compare
+#                      publish_api_v2_recruitment_cycle_provider_course POST   /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/courses/:code/publish(.:format)                      api/v2/courses#publish
+#                  publishable_api_v2_recruitment_cycle_provider_course POST   /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/courses/:code/publishable(.:format)                  api/v2/courses#publishable
+#                             api_v2_recruitment_cycle_provider_courses GET    /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/courses(.:format)                                    api/v2/courses#index
+#                                                                       POST   /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/courses(.:format)                                    api/v2/courses#create
+#                              api_v2_recruitment_cycle_provider_course GET    /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/courses/:code(.:format)                              api/v2/courses#show
+#                                                                       PATCH  /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/courses/:code(.:format)                              api/v2/courses#update
+#                                                                       PUT    /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/courses/:code(.:format)                              api/v2/courses#update
+#                               api_v2_recruitment_cycle_provider_sites GET    /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/sites(.:format)                                      api/v2/sites#index
+#                                                                       POST   /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/sites(.:format)                                      api/v2/sites#create
+#                                api_v2_recruitment_cycle_provider_site GET    /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/sites/:id(.:format)                                  api/v2/sites#show
+#                                                                       PATCH  /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/sites/:id(.:format)                                  api/v2/sites#update
+#                                                                       PUT    /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/sites/:id(.:format)                                  api/v2/sites#update
+#                                    api_v2_recruitment_cycle_providers GET    /api/v2/recruitment_cycles/:recruitment_cycle_year/providers(.:format)                                                           api/v2/providers#index
+#                                     api_v2_recruitment_cycle_provider GET    /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:code(.:format)                                                     api/v2/providers#show
+#                                                       api_v2_sessions GET    /api/v2/sessions(.:format)                                                                                                       api/v2/sessions#show
+#                                                                       PATCH  /api/v2/sessions(.:format)                                                                                                       api/v2/sessions#update
+#                                                                       PUT    /api/v2/sessions(.:format)                                                                                                       api/v2/sessions#update
+#                                                                       DELETE /api/v2/sessions(.:format)                                                                                                       api/v2/sessions#destroy
+#                                                                       POST   /api/v2/sessions(.:format)                                                                                                       api/v2/sessions#create
+#                                                    api_v2_site_status PATCH  /api/v2/site_statuses/:id(.:format)                                                                                              api/v2/site_statuses#update
+#                                                                       PUT    /api/v2/site_statuses/:id(.:format)                                                                                              api/v2/site_statuses#update
+#                                         approve_api_v2_access_request POST   /api/v2/access_requests/:id/approve(.:format)                                                                                    api/v2/access_requests#approve
+#                                                api_v2_access_requests GET    /api/v2/access_requests(.:format)                                                                                                api/v2/access_requests#index
+#                                                                       POST   /api/v2/access_requests(.:format)                                                                                                api/v2/access_requests#create
+#                                                 api_v2_access_request GET    /api/v2/access_requests/:id(.:format)                                                                                            api/v2/access_requests#show
+#                                                                       PATCH  /api/v2/access_requests/:id(.:format)                                                                                            api/v2/access_requests#update
+#                                                                       PUT    /api/v2/access_requests/:id(.:format)                                                                                            api/v2/access_requests#update
+#                                                             error_500 GET    /error_500(.:format)                                                                                                             error#error_500
+#                                                            error_nodb GET    /error_nodb(.:format)                                                                                                            error#error_nodb
 
 # rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
@@ -65,7 +99,7 @@ Rails.application.routes.draw do
         patch :accept_rollover_screen, on: :member
       end
 
-      resources :providers, param: :code do
+      concern :courses_and_sites do
         resources :courses, param: :code, only: %i[index create show update] do
           post :sync_with_search_and_compare, on: :member
           post :publish, on: :member
@@ -73,6 +107,21 @@ Rails.application.routes.draw do
         end
         resources :sites, only: %i[index update show create]
       end
+
+      resources :providers,
+                param: :code,
+                concerns: :courses_and_sites do
+      end
+
+      resources :recruitment_cycles,
+                only: [],
+                param: :year do
+        resources :providers,
+                  only: %i[index show],
+                  param: :code,
+                  concerns: :courses_and_sites
+      end
+
 
       resource :sessions
       resources :site_statuses, only: :update

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,7 +114,7 @@ Rails.application.routes.draw do
       end
 
       resources :recruitment_cycles,
-                only: [],
+                only: :show,
                 param: :year do
         resources :providers,
                   only: %i[index show],

--- a/spec/policies/recruitment_cycle_policy_spec.rb
+++ b/spec/policies/recruitment_cycle_policy_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe RecruitmentCyclePolicy do
+  let(:current_recruitment_cycle) { find_or_create :recruitment_cycle }
+  let(:next_recruitment_cycle) { create :recruitment_cycle, :next }
+
+  describe 'scope' do
+    let(:user) { create(:user) }
+
+    it 'limits the providers to those the user is assigned to' do
+      current_recruitment_cycle
+      next_recruitment_cycle
+
+      expect(Pundit.policy_scope(user, RecruitmentCycle.all))
+        .to match_array [current_recruitment_cycle, next_recruitment_cycle]
+    end
+  end
+
+  subject { described_class }
+
+  permissions :show? do
+    let(:user) { create(:user) }
+
+    it { should permit(user, current_recruitment_cycle) }
+    it { should permit(user, next_recruitment_cycle) }
+  end
+end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -26,7 +26,13 @@ describe 'Courses API v2', type: :request do
            science: :must_have_qualification_at_application_time)
   }
 
-  let(:courses_site_status)    { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_from_2019) }
+  let(:courses_site_status) {
+    build(:site_status,
+          :findable,
+          :with_any_vacancy,
+          :applications_being_accepted_from_2019,
+          site: create(:site, provider: provider))
+  }
   let(:enrichment)     { build :course_enrichment, :published }
   let(:provider)       { create :provider, organisations: [organisation] }
   let(:course_subject) { course.subjects.first }
@@ -205,16 +211,23 @@ describe 'Courses API v2', type: :request do
       end
     end
 
+    def perform_request
+      findable_open_course
+      get request_path,
+          headers: { 'HTTP_AUTHORIZATION' => credentials }
+      response
+    end
+
     describe 'JSON generated for courses' do
-      before do
-        findable_open_course
-        get "/api/v2/providers/#{provider.provider_code}/courses",
-            headers: { 'HTTP_AUTHORIZATION' => credentials }
-      end
+      let(:request_path) { "/api/v2/providers/#{provider.provider_code}/courses" }
+
+      subject { perform_request }
 
       it { should have_http_status(:success) }
 
       it 'has a data section with the correct attributes' do
+        perform_request
+
         json_response = JSON.parse response.body
         expect(json_response).to eq(
           "data" => [{
@@ -284,6 +297,56 @@ describe 'Courses API v2', type: :request do
       end
 
       it { should have_http_status(:not_found) }
+    end
+
+    context 'with two recruitment cycles' do
+      let(:next_recruitment_cycle) { create :recruitment_cycle, year: '2020' }
+      let(:next_provider) {
+        create :provider,
+               organisations: [organisation],
+               provider_code: provider.provider_code,
+               recruitment_cycle: next_recruitment_cycle
+      }
+      let(:next_course) {
+        create :course,
+               provider: next_provider,
+               course_code: findable_open_course.course_code
+      }
+
+      describe 'making a request without specifying a recruitment cycle' do
+        let(:request_path) { "/api/v2/providers/#{provider.provider_code}/courses" }
+
+        it 'only returns data for the current recruitment cycle' do
+          next_course
+          findable_open_course
+
+          perform_request
+
+          json_response = JSON.parse response.body
+          expect(json_response['data'].count).to eq 1
+          expect(json_response['data'].first)
+            .to have_attribute('recruitment_cycle_year').with_value('2019')
+        end
+      end
+
+      describe 'making a request for the next recruitment cycle' do
+        let(:request_path) {
+          "/api/v2/recruitment_cycles/#{next_recruitment_cycle.year}" \
+          "/providers/#{next_provider.provider_code}/courses"
+        }
+
+        it 'only returns data for the next recruitment cycle' do
+          findable_open_course
+          next_course
+
+          perform_request
+
+          json_response = JSON.parse response.body
+          expect(json_response['data'].count).to eq 1
+          expect(json_response['data'].first)
+            .to have_attribute('recruitment_cycle_year').with_value('2020')
+        end
+      end
     end
   end
 end

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -4,6 +4,7 @@ describe 'Providers API v2', type: :request do
   describe 'GET /providers' do
     let(:user) { create(:user, organisations: [organisation]) }
     let(:organisation) { create(:organisation) }
+    let(:recruitment_cycle) { find_or_create :recruitment_cycle }
     let(:payload) { { email: user.email } }
     let(:token) do
       JWT.encode payload,
@@ -21,34 +22,41 @@ describe 'Providers API v2', type: :request do
     }
     let(:enrichment) { build(:provider_enrichment, :published) }
 
-    subject { response }
+    let(:json_response) { JSON.parse(response.body) }
+
+    def perform_request
+      get request_path, headers: { 'HTTP_AUTHORIZATION' => credentials }
+    end
+
+    subject do
+      perform_request
+
+      response
+    end
 
     context 'when unauthorized' do
-      before do
-        get '/api/v2/providers', headers: { 'HTTP_AUTHORIZATION' => credentials }
-      end
-
-      let(:payload) { { email: 'foo@bar' } }
+      let(:request_path) { '/api/v2/providers' }
+      let(:payload)      { { email: 'foo@bar' } }
 
       it { should have_http_status(:unauthorized) }
     end
 
     describe 'JSON generated for a providers' do
-      before do
-        get '/api/v2/providers', headers: { 'HTTP_AUTHORIZATION' => credentials }
-      end
+      let(:request_path) { '/api/v2/providers' }
 
       it { should have_http_status(:success) }
 
       it 'has a data section with the correct attributes' do
-        json_response = JSON.parse(response.body)
+        perform_request
+
         expect(json_response).to eq(
           "data" => [{
             "id" => provider.id.to_s,
             "type" => "providers",
             "attributes" => {
               "provider_code" => provider.provider_code,
-              "provider_name" => provider.provider_name
+              "provider_name" => provider.provider_name,
+              "recruitment_cycle_year" => provider.recruitment_cycle.year,
             },
             "relationships" => {
               "courses" => {
@@ -66,19 +74,19 @@ describe 'Providers API v2', type: :request do
     end
 
     context 'nested within current user' do
-      before do
-        get "/api/v2/users/#{user.id}/providers", headers: { 'HTTP_AUTHORIZATION' => credentials }
-      end
+      let(:request_path) { "/api/v2/users/#{user.id}/providers" }
 
       it 'has a data section with the correct attributes' do
-        json_response = JSON.parse(response.body)
+        perform_request
+
         expect(json_response).to eq(
           "data" => [{
             "id" => provider.id.to_s,
             "type" => "providers",
             "attributes" => {
               "provider_code" => provider.provider_code,
-              "provider_name" => provider.provider_name
+              "provider_name" => provider.provider_name,
+              "recruitment_cycle_year" => provider.recruitment_cycle.year,
             },
             "relationships" => {
               "courses" => {
@@ -97,12 +105,11 @@ describe 'Providers API v2', type: :request do
 
     context 'nested within a different user' do
       let(:different_user) { create(:user) }
-      before do
-        get "/api/v2/users/#{different_user.id}/providers", headers: { 'HTTP_AUTHORIZATION' => credentials }
-      end
+      let(:request_path)   { "/api/v2/users/#{different_user.id}/providers" }
 
       it 'has no providers' do
-        json_response = JSON.parse(response.body)
+        perform_request
+
         expect(json_response).to eq(
           "data" => [],
           "jsonapi" => {
@@ -113,15 +120,22 @@ describe 'Providers API v2', type: :request do
     end
 
     context 'with unalphabetical ordering in the database' do
-      let!(:second_alphabetical_provider) { create(:provider, provider_name: 'Zork', organisations: [organisation]) }
+      let(:second_alphabetical_provider) do
+        create(:provider, provider_name: 'Zork', organisations: [organisation])
+      end
+      let(:request_path) { "/api/v2/users/#{user.id}/providers" }
 
       before do
-        provider.update(provider_name: 'Acme') # This moves it last in the order that it gets fetched by default.
-        get "/api/v2/users/#{user.id}/providers", headers: { 'HTTP_AUTHORIZATION' => credentials }
+        second_alphabetical_provider
+
+        # This moves it last in the order that it gets fetched by default.
+        provider.update(provider_name: 'Acme')
       end
 
       let(:provider_names_in_response) {
-        JSON.parse(response.body)["data"].map { |provider| provider["attributes"]["provider_name"] }
+        JSON.parse(subject.body)["data"].map { |provider|
+          provider["attributes"]["provider_name"]
+        }
       }
 
       it 'returns them in alphabetical order' do
@@ -147,7 +161,19 @@ describe 'Providers API v2', type: :request do
 
     let!(:provider) { create(:provider, sites: [site], organisations: [organisation], enrichments: [enrichment]) }
 
-    subject { response }
+    let(:request_params) { {} }
+
+    subject do
+      perform_request
+
+      response
+    end
+
+    def perform_request
+      get request_path,
+          headers: { 'HTTP_AUTHORIZATION' => credentials },
+          params: request_params
+    end
 
     let(:expected_response) {
       {
@@ -190,101 +216,116 @@ describe 'Providers API v2', type: :request do
         }
       }
     }
+    let(:json_response) { JSON.parse(response.body) }
 
     context 'including sites' do
-      before do
-        get "/api/v2/providers/#{provider.provider_code}",
-            headers: { 'HTTP_AUTHORIZATION' => credentials },
-            params: { include: "sites" }
-
-        it { should have_http_status(:success) }
-
-        it 'has a data section with the correct attributes' do
-          json_response = JSON.parse(response.body)
-          expect(json_response).to eq(
-            "data" => [{
-              "id" => provider.id.to_s,
-              "type" => "providers",
-              "attributes" => {
-                "provider_code" => provider.provider_code,
-                "provider_name" => provider.provider_name,
-                "accredited_body?" => false,
-                "can_add_more_sites?" => true,
-                "train_with_us" => enrichment.train_with_us,
-                "train_with_disability" => enrichment.train_with_disability,
-              },
-              "relationships" => {
-                "sites" => {
-                  "data" => [
-                    {
-                      "type" => "sites",
-                      "id" => "1"
-                    }
-                  ]
-                },
-                "courses" => {
-                  "meta" => {
-                    "count" => provider.courses.count
-                  }
-                }
-              }
-            }],
-            "included": [
-              {
-                "id" => provider.site.id.to_s,
-                "type" => "sites",
-                "attributes" => {
-                  "code" => provider.site.code,
-                  "location_name" => provider.site.location_name
-                }
-              }
-            ],
-            "jsonapi" => {
-              "version" => "1.0"
-            }
-          )
-        end
-      end
-    end
-
-    context "with the maximum number of sites" do
-      let(:sites) { (('A'..'Z').to_a + %w[0 -] + ('1'..'9').to_a).map { |code| build(:site, code: code) } }
-      let(:provider) { create(:provider, sites: sites, organisations: [organisation]) }
-
-
-      before do
-        get "/api/v2/providers/#{provider.provider_code}",
-            headers: { 'HTTP_AUTHORIZATION' => credentials }
-      end
-
-      it 'has can_add_more_sites? set to false' do
-        json_response = JSON.parse(response.body)
-        expect(json_response["data"]["attributes"]["can_add_more_sites?"]).to eq(false)
-      end
-    end
-
-    describe 'JSON generated for a provider' do
-      before do
-        get "/api/v2/providers/#{provider.provider_code}", headers: { 'HTTP_AUTHORIZATION' => credentials }
-      end
+      let(:request_path) { "/api/v2/providers/#{provider.provider_code}" }
+      let(:request_params) { { include: "sites" } }
 
       it { should have_http_status(:success) }
 
       it 'has a data section with the correct attributes' do
-        json_response = JSON.parse(response.body)
+        perform_request
+
+        expect(json_response).to eq(
+          "data" => {
+            "id" => provider.id.to_s,
+            "type" => "providers",
+            "attributes" => {
+              "provider_code" => provider.provider_code,
+              "provider_name" => provider.provider_name,
+              "accredited_body?" => false,
+              "can_add_more_sites?" => true,
+              "train_with_us" => enrichment.train_with_us,
+              "train_with_disability" => enrichment.train_with_disability,
+              "address1" => provider.address1,
+              "address2" => provider.address2,
+              "address3" => provider.address3,
+              "address4" => provider.address4,
+              "postcode" => provider.postcode,
+              "region_code" => provider.region_code,
+              "telephone" => provider.telephone,
+              "email" => provider.email,
+              "website" => provider.url,
+              "recruitment_cycle_year" => provider.recruitment_cycle.year,
+            },
+            "relationships" => {
+              "sites" => {
+                "data" => [
+                  {
+                    "type" => "sites",
+                    "id" => site.id.to_s,
+                  }
+                ]
+              },
+              "courses" => {
+                "meta" => {
+                  "count" => provider.courses.count
+                }
+              }
+            }
+          },
+          "included" => [
+            {
+              "id" => site.id.to_s,
+              "type" => "sites",
+              "attributes" => {
+                "code" => site.code,
+                "location_name" => site.location_name,
+                "address1" => site.address1,
+                "address2" => site.address2,
+                "address3" => site.address3,
+                "address4" => site.address4,
+                "postcode" => site.postcode,
+                "region_code" => site.region_code,
+                "recruitment_cycle_year" => site.recruitment_cycle.year,
+              }
+            }
+          ],
+          "jsonapi" => {
+            "version" => "1.0"
+          }
+        )
+      end
+    end
+
+    context "with the maximum number of sites" do
+      let(:sites) {
+        [*'A'..'Z', '0', '-', *'1'..'9'].map { |code|
+          build(:site, code: code)
+        }
+      }
+      let(:provider) { create(:provider, sites: sites, organisations: [organisation]) }
+      let(:request_path) { "/api/v2/providers/#{provider.provider_code}" }
+
+      it 'has can_add_more_sites? set to false' do
+        perform_request
+
+        expect(json_response['data'])
+          .to have_attribute(:can_add_more_sites?).with_value(false)
+      end
+    end
+
+    describe 'JSON generated for a provider' do
+      let(:request_path) { "/api/v2/providers/#{provider.provider_code}" }
+
+      it { should have_http_status(:success) }
+
+      it 'has a data section with the correct attributes' do
+        perform_request
+
         expect(json_response).to eq(expected_response)
       end
     end
 
     describe "with lowercase provider code" do
-      before do
-        get "/api/v2/providers/#{provider.provider_code.downcase}", headers: { 'HTTP_AUTHORIZATION' => credentials }
-      end
+      let(:request_path) { "/api/v2/providers/#{provider.provider_code.downcase}" }
 
       it { should have_http_status(:success) }
 
       it 'has a data section with the correct attributes' do
-        json_response = JSON.parse(response.body)
+        perform_request
+
         expect(json_response).to eq(expected_response)
       end
     end

--- a/spec/requests/api/v2/recruitment_cycle_spec.rb
+++ b/spec/requests/api/v2/recruitment_cycle_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+describe '/api/v2/recruitment_cycle', type: :request do
+  describe '/api/v2/recruitment_cycle/%<year>' do
+    let(:user) { create(:user, organisations: [organisation]) }
+    let(:organisation) { create(:organisation) }
+    let(:payload) { { email: user.email } }
+    let(:token) do
+      JWT.encode payload,
+                 Settings.authentication.secret,
+                 Settings.authentication.algorithm
+    end
+    let(:credentials) do
+      ActionController::HttpAuthentication::Token.encode_credentials(token)
+    end
+
+    let(:recruitment_cycle) { find_or_create :recruitment_cycle }
+    let(:request_params) { {} }
+    let(:request_path) { "/api/v2/recruitment_cycles/#{recruitment_cycle.year}" }
+
+    def perform_request
+      get request_path,
+          headers: { 'HTTP_AUTHORIZATION' => credentials },
+          params: request_params
+    end
+
+    let(:expected_response) {
+      {
+        'data' => {
+          'id' => recruitment_cycle.id.to_s,
+          'type' => 'recruitment_cycles',
+          'attributes' => {
+            'year' => recruitment_cycle.year,
+            'application_start_date' => recruitment_cycle.application_start_date.to_s,
+            'application_end_date' =>   recruitment_cycle.application_end_date.to_date.to_s,
+          },
+          'relationships' => {
+            'providers' => {
+              'meta' => {
+                'included' => false
+              }
+            },
+          }
+        },
+        'jsonapi' => {
+          'version' => '1.0'
+        }
+      }
+    }
+    let(:json_response) { JSON.parse(response.body) }
+
+    describe 'the JSON response' do
+      it 'should be the correct jsonapi response' do
+        perform_request
+
+        expect(json_response).to eq expected_response
+      end
+    end
+  end
+end

--- a/spec/serializers/api/v2/serializable_recruitment_cycle_spec.rb
+++ b/spec/serializers/api/v2/serializable_recruitment_cycle_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe API::V2::SerializableRecruitmentCycle do
+  let(:recruitment_cycle) { create :recruitment_cycle }
+  let(:resource) { described_class.new object: recruitment_cycle }
+
+  it 'sets type to recruitment_cycles' do
+    expect(resource.jsonapi_type).to eq :recruitment_cycles
+  end
+
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
+
+  it { should have_type 'recruitment_cycles' }
+  it { should have_attribute(:year).with_value(recruitment_cycle.year) }
+  it { should have_attribute(:application_start_date).with_value(recruitment_cycle.application_start_date.to_s) }
+  it { should have_attribute(:application_end_date).with_value(recruitment_cycle.application_end_date.to_s) }
+end


### PR DESCRIPTION
### Context

This work is to support rollover and this builds on the first PR by adding routes and changing controllers that operate within a recruitment cycle to instantiate a recruitment cycle, defaulting to the current one if none is provided.

The route added looks like this:

```
/api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/courses/:code
/api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/sites/:id
```

(not sure why site has `id`, that feels like it's wrong, but that's outside the scope of this PR)

### Guidance to review

This is being merged into the intermediary branch until this whole package is ready to merge into master. It's been cut up into multiple PRs to be easier to review.

I've tried to keep the commits pretty isolated, try reviewing them individually if the entire changeset is too big.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
