### PR TITLE
[1657] Add 'mcb courses create' subcommand for creating new courses

### DIFF
--- a/lib/mcb/base_cli.rb
+++ b/lib/mcb/base_cli.rb
@@ -31,6 +31,14 @@ module MCB
       end
     end
 
+    def confirm_creation?
+      @cli.agree("Continue? ")
+    end
+
+    def enter_to_continue
+      @cli.ask("Press Enter to continue")
+    end
+
   private
 
     def define_choices_for_each_possible_item(menu:, selected_items:, possible_items:, hidden_label:)

--- a/lib/mcb/commands/courses/create.rb
+++ b/lib/mcb/commands/courses/create.rb
@@ -1,0 +1,18 @@
+summary 'Create a new course in db'
+usage 'create <provider_code>'
+param :provider_code, transform: ->(code) { code.upcase }
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
+  Course.connection.transaction do
+    provider = RecruitmentCycle.current_recruitment_cycle.providers.find_by!(provider_code: args[:provider_code])
+    requester = User.find_by!(email: MCB.config[:email])
+
+    MCB::CoursesEditor.new(
+      provider: provider,
+      requester: requester,
+      courses: [provider.courses.build]
+    ).new_course_wizard
+  end
+end

--- a/lib/mcb/courses_editor.rb
+++ b/lib/mcb/courses_editor.rb
@@ -43,8 +43,7 @@ module MCB
 
       puts "\nAbout to create the following course:"
       print_at_most_two_courses
-      if @cli.confirm_creation?
-        try_saving_course
+      if @cli.confirm_creation? && try_saving_course
         edit_subjects
         edit_sites
         edit(:application_opening_date)
@@ -165,9 +164,11 @@ module MCB
       if course.valid?
         puts "Saving the course"
         course.save!
+        true
       else
         puts "Course isn't valid:"
         course.errors.full_messages.each { |error| puts " - #{error}" }
+        false
       end
     end
 

--- a/lib/mcb/courses_editor.rb
+++ b/lib/mcb/courses_editor.rb
@@ -9,12 +9,12 @@ module MCB
       application_opening_date: :applications_open_from,
     }.freeze
 
-    def initialize(provider:, requester:, course_codes: [])
+    def initialize(provider:, requester:, course_codes: [], courses: nil)
       @cli = CoursesEditorCLI.new(provider)
 
       @provider = provider
       @requester = requester
-      @courses = course_codes.present? ? find_courses(provider, course_codes) : provider.courses
+      @courses = courses || load_courses(provider, course_codes)
 
       check_authorisation
     end
@@ -31,6 +31,25 @@ module MCB
         else
           perform_action(choice)
         end
+      end
+    end
+
+    def new_course_wizard
+      %i[title qualifications study_mode accredited_body start_date route maths
+         english science age_range course_code].each do |attribute|
+        edit(attribute)
+      end
+
+      puts "\nAbout to create the following course:"
+      print_at_most_two_courses
+      if @cli.confirm_creation?
+        try_saving_course
+        edit_subjects
+        edit_sites
+        edit(:application_opening_date)
+        print_summary
+      else
+        puts "Aborting"
       end
     end
 
@@ -100,6 +119,11 @@ module MCB
       course.reload
     end
 
+    def load_courses(provider, course_codes)
+      (course_codes.present? ? find_courses(provider, course_codes) : provider.courses).
+        order(:course_code)
+    end
+
     def course
       if @courses.count != 1
         raise ArgumentError, "Cannot do this operation when there are multiple courses"
@@ -118,16 +142,42 @@ module MCB
     end
 
     def print_existing(attribute_name)
-      puts "Existing values for course #{attribute_name}:"
-      table = Tabulo::Table.new @courses.order(:course_code) do |t|
-        t.add_column(:course_code, header: "course\ncode", width: 4)
-        t.add_column(attribute_name) unless attribute_name == :course_code
+      # don't print the existing attributes when creating a new course, since
+      # this will be null in the majority of cases
+      if @courses.select(&:persisted?).all?
+        puts "Existing values for course #{attribute_name}:"
+        table = Tabulo::Table.new @courses do |t|
+          t.add_column(:course_code, header: "course\ncode", width: 4)
+          t.add_column(attribute_name) unless attribute_name == :course_code
+        end
+        puts table.pack(max_table_width: nil), table.horizontal_rule
       end
-      puts table.pack(max_table_width: nil), table.horizontal_rule
+    end
+
+    def print_summary
+      puts "\nHere's the final course that's been created:"
+      print_at_most_two_courses
+      @cli.enter_to_continue
+    end
+
+    def try_saving_course
+      if course.valid?
+        puts "Saving the course"
+        course.save!
+      else
+        puts "Course isn't valid:"
+        course.errors.full_messages.each { |error| puts " - #{error}" }
+      end
     end
 
     def update(attrs)
-      @courses.each { |course| course.update(attrs) }
+      @courses.each do |course|
+        if course.new_record?
+          attrs.each { |key, value| course.send("#{key}=".to_sym, value) }
+        else
+          course.update(attrs)
+        end
+      end
     end
 
     def can_update?(course)

--- a/lib/mcb/courses_editor.rb
+++ b/lib/mcb/courses_editor.rb
@@ -22,6 +22,7 @@ module MCB
     def run
       finished = false
       until finished
+        course_codes = @courses.order(:course_code).pluck(:course_code)
         puts "Editing #{course_codes.join(', ')}"
         print_at_most_two_courses
         choice = main_loop
@@ -192,10 +193,6 @@ module MCB
           course.course_code
         )
       end
-    end
-
-    def course_codes
-      @courses.order(:course_code).pluck(:course_code)
     end
 
     def find_courses(provider, course_codes)

--- a/spec/lib/mcb/commands/courses/create_spec.rb
+++ b/spec/lib/mcb/commands/courses/create_spec.rb
@@ -1,0 +1,74 @@
+require 'mcb_helper'
+
+describe 'mcb courses create' do
+  def create_new_course_on(provider_code)
+    cmd.run([provider_code])
+  end
+
+  let(:lib_dir) { Rails.root.join('lib') }
+  let(:cmd) do
+    Cri::Command.load_file("#{lib_dir}/mcb/commands/courses/create.rb")
+  end
+  let(:provider_code) { 'X12' }
+  let(:email) { 'user@education.gov.uk' }
+  let!(:provider) { create(:provider, provider_code: provider_code) }
+
+  before do
+    allow(MCB).to receive(:config).and_return(email: email)
+  end
+
+  context 'for an authorised user' do
+    let!(:requester) { create(:user, email: email, organisations: provider.organisations) }
+
+    it 'launches the courses editor' do
+      allow(MCB::CoursesEditor).to receive(:new).and_return(instance_double(MCB::CoursesEditor, new_course_wizard: nil))
+
+      create_new_course_on(provider_code)
+
+      expect(MCB::CoursesEditor).to have_received(:new)
+    end
+
+    describe 'trying to edit a course on a nonexistent provider' do
+      it 'raises an error' do
+        expect { create_new_course_on("ABC") }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find Provider/)
+      end
+    end
+
+    context 'when the same provider exists across multiple recruitment cycles' do
+      let!(:next_recruitment_cycle) { find_or_create(:recruitment_cycle, :next) }
+      let!(:provider_in_the_next_recruitment_cycle) {
+        create(:provider,
+               provider_code: provider_code,
+               recruitment_cycle: next_recruitment_cycle,
+               organisations: provider.organisations)
+      }
+
+      before do
+        allow(MCB::CoursesEditor).to receive(:new)
+          .and_return(instance_double(MCB::CoursesEditor, new_course_wizard: nil))
+      end
+
+      it 'picks the correct provider' do
+        create_new_course_on(provider_code)
+
+        expect(MCB::CoursesEditor).to have_received(:new)
+      end
+
+      it 'ignores providers associated with the next cycle' do
+        provider.destroy
+
+        expect { create_new_course_on(provider_code) }.
+          to raise_error(ActiveRecord::RecordNotFound, /Couldn't find Provider/)
+        expect(MCB::CoursesEditor).to_not have_received(:new)
+      end
+    end
+  end
+
+  context 'when a non-existent user tries to edit a course' do
+    let!(:requester) { create(:user, email: 'someother@email.com') }
+
+    it 'raises an error' do
+      expect { create_new_course_on(provider_code) }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find User/)
+    end
+  end
+end

--- a/spec/lib/mcb/courses_editor_spec.rb
+++ b/spec/lib/mcb/courses_editor_spec.rb
@@ -515,6 +515,28 @@ describe MCB::CoursesEditor do
         expect(Course.find_by(course_code: desired_attributes[:course_code])).to be_nil
         expect(output).to include("Aborting")
       end
+
+      it "aborts the wizard if specified course fails validation" do
+        output, = run_new_course_wizard(
+          desired_attributes[:title],
+          "", # default qualifications
+          "", # default study mode
+          "", # default start date
+          "", # default accredited body
+          desired_attributes[:route],
+          desired_attributes[:maths],
+          desired_attributes[:english],
+          desired_attributes[:science],
+          desired_attributes[:age_range],
+          course_code, # a duplicate course code
+          desired_attributes[:recruitment_cycle],
+          "y", # confirm creation
+        )
+
+        expect(Course.where(course_code: course_code).count).to eq(1)
+        expect(output).to include("Course isn't valid")
+        expect(output).to include("Aborting")
+      end
     end
   end
 


### PR DESCRIPTION
### Context

New course creation is currently being done through user support using `mcb` dev tooling. The tooling itself is sitting on a code branch that isn't the `master` branch and needs constant updating/rebasing.

The tooling branch code is also missing automated tests, meaning it needs to be manually tested after every change.

### Changes proposed in this pull request

Add an `mcb` command for creating new courses on a given provider.

### Guidance to review

It was a slog getting here 😅 
~This PR ought to be reviewed but probably not merged until the Rollover stuff has been merged, because the recruitment cycle stuff will conflict.~ The `mcb` command adds a new course to the current cycle by default.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
