### PR TITLE
[1564] add /recruitment_cycle index listing

### DIFF
--- a/app/controllers/api/v2/recruitment_cycles_controller.rb
+++ b/app/controllers/api/v2/recruitment_cycles_controller.rb
@@ -3,6 +3,22 @@ module API
     class RecruitmentCyclesController < ApplicationController
       before_action :build_recruitment_cycle
 
+      def index
+        authorize RecruitmentCycle
+
+        @recruitment_cycles =
+          if params.key? :provider_code
+            policy_scope(Provider)
+              .where(provider_code: params[:provider_code])
+              .includes(:recruitment_cycle)
+              .map(&:recruitment_cycle)
+          else
+            policy_scope(RecruitmentCycle).all
+          end
+
+        render jsonapi: @recruitment_cycles, include: params[:include]
+      end
+
       def show
         authorize @recruitment_cycle, :show?
 

--- a/app/policies/recruitment_cycle_policy.rb
+++ b/app/policies/recruitment_cycle_policy.rb
@@ -20,6 +20,10 @@ class RecruitmentCyclePolicy
     @recruitment_cycle = recycle
   end
 
+  def index?
+    user.present?
+  end
+
   def show?
     user.present?
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,18 +102,19 @@ Rails.application.routes.draw do
         patch :accept_rollover_screen, on: :member
       end
 
-      concern :courses_and_sites do
+      concern :provider_routes do
         resources :courses, param: :code, only: %i[index create show update] do
           post :sync_with_search_and_compare, on: :member
           post :publish, on: :member
           post :publishable, on: :member
         end
         resources :sites, only: %i[index update show create]
+        resources :recruitment_cycles, only: %i[index]
       end
 
       resources :providers,
                 param: :code,
-                concerns: :courses_and_sites do
+                concerns: :provider_routes do
         resources :recruitment_cycles, only: :index
       end
 
@@ -123,7 +124,7 @@ Rails.application.routes.draw do
         resources :providers,
                   only: %i[index show],
                   param: :code,
-                  concerns: :courses_and_sites
+                  concerns: :provider_routes
       end
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@
 #                                                           api_v2_user GET    /api/v2/users/:id(.:format)                                                                                                      api/v2/users#show
 #                                                                       PATCH  /api/v2/users/:id(.:format)                                                                                                      api/v2/users#update
 #                                                                       PUT    /api/v2/users/:id(.:format)                                                                                                      api/v2/users#update
+#                                    api_v2_provider_recruitment_cycles GET    /api/v2/providers/:provider_code/recruitment_cycles(.:format)                                                                    api/v2/recruitment_cycles#index
 #                   sync_with_search_and_compare_api_v2_provider_course POST   /api/v2/providers/:provider_code/courses/:code/sync_with_search_and_compare(.:format)                                            api/v2/courses#sync_with_search_and_compare
 #                                        publish_api_v2_provider_course POST   /api/v2/providers/:provider_code/courses/:code/publish(.:format)                                                                 api/v2/courses#publish
 #                                    publishable_api_v2_provider_course POST   /api/v2/providers/:provider_code/courses/:code/publishable(.:format)                                                             api/v2/courses#publishable
@@ -64,6 +65,8 @@
 #                                                                       PUT    /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/sites/:id(.:format)                                  api/v2/sites#update
 #                                    api_v2_recruitment_cycle_providers GET    /api/v2/recruitment_cycles/:recruitment_cycle_year/providers(.:format)                                                           api/v2/providers#index
 #                                     api_v2_recruitment_cycle_provider GET    /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:code(.:format)                                                     api/v2/providers#show
+#                                             api_v2_recruitment_cycles GET    /api/v2/recruitment_cycles(.:format)                                                                                             api/v2/recruitment_cycles#index
+#                                              api_v2_recruitment_cycle GET    /api/v2/recruitment_cycles/:year(.:format)                                                                                       api/v2/recruitment_cycles#show
 #                                                       api_v2_sessions GET    /api/v2/sessions(.:format)                                                                                                       api/v2/sessions#show
 #                                                                       PATCH  /api/v2/sessions(.:format)                                                                                                       api/v2/sessions#update
 #                                                                       PUT    /api/v2/sessions(.:format)                                                                                                       api/v2/sessions#update
@@ -111,10 +114,11 @@ Rails.application.routes.draw do
       resources :providers,
                 param: :code,
                 concerns: :courses_and_sites do
+        resources :recruitment_cycles, only: :index
       end
 
       resources :recruitment_cycles,
-                only: :show,
+                only: %i[index show],
                 param: :year do
         resources :providers,
                   only: %i[index show],

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -72,5 +72,9 @@ FactoryBot.define do
         provider.update changed_at: evaluator.changed_at
       end
     end
+
+    trait :next_recruitment_cycle do
+      recruitment_cycle { find_or_create :recruitment_cycle, :next }
+    end
   end
 end

--- a/spec/policies/recruitment_cycle_policy_spec.rb
+++ b/spec/policies/recruitment_cycle_policy_spec.rb
@@ -18,6 +18,12 @@ describe RecruitmentCyclePolicy do
 
   subject { described_class }
 
+  permissions :index? do
+    let(:user) { create(:user) }
+
+    it { should permit(user, RecruitmentCycle) }
+  end
+
   permissions :show? do
     let(:user) { create(:user) }
 

--- a/spec/requests/api/v2/recruitment_cycle_spec.rb
+++ b/spec/requests/api/v2/recruitment_cycle_spec.rb
@@ -81,7 +81,7 @@ describe '/api/v2/recruitment_cycle', type: :request do
     end
   end
 
-  describe '/api/v2/providers/:provider_code/recruitment_cycles' do
+  describe '/api/v2/recruitment_cycles/:year/providers/:provider_code/recruitment_cycles' do
     let(:recruitment_cycle)      { find_or_create :recruitment_cycle }
     let(:next_recruitment_cycle) { find_or_create :recruitment_cycle, :next }
     let(:provider) { create :provider, organisations: [organisation] }
@@ -94,7 +94,9 @@ describe '/api/v2/recruitment_cycle', type: :request do
     let(:provider2) { create :provider }
 
     let(:request_path) {
-      "/api/v2/providers/#{provider.provider_code}/recruitment_cycles"
+      "/api/v2/recruitment_cycles/#{recruitment_cycle.year}" \
+      "/providers/#{provider.provider_code}" \
+      "/recruitment_cycles"
     }
 
     describe 'the JSON response' do

--- a/spec/requests/api/v2/recruitment_cycle_spec.rb
+++ b/spec/requests/api/v2/recruitment_cycle_spec.rb
@@ -1,28 +1,162 @@
 require "rails_helper"
 
 describe '/api/v2/recruitment_cycle', type: :request do
-  describe '/api/v2/recruitment_cycle/%<year>' do
-    let(:user) { create(:user, organisations: [organisation]) }
-    let(:organisation) { create(:organisation) }
-    let(:payload) { { email: user.email } }
-    let(:token) do
-      JWT.encode payload,
-                 Settings.authentication.secret,
-                 Settings.authentication.algorithm
-    end
-    let(:credentials) do
-      ActionController::HttpAuthentication::Token.encode_credentials(token)
-    end
+  let(:user) { create(:user, organisations: [organisation]) }
+  let(:organisation) { create(:organisation) }
+  let(:payload) { { email: user.email } }
+  let(:token) do
+    JWT.encode payload,
+               Settings.authentication.secret,
+               Settings.authentication.algorithm
+  end
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+  let(:request_params) { {} }
 
+  def perform_request
+    get request_path,
+        headers: { 'HTTP_AUTHORIZATION' => credentials },
+        params: request_params
+  end
+
+  let(:json_response) { JSON.parse(response.body) }
+
+  describe '/api/v2/recruitment_cycles' do
+    let(:recruitment_cycle)      { find_or_create :recruitment_cycle }
+    let(:next_recruitment_cycle) { find_or_create :recruitment_cycle, :next }
+    let(:request_path) { "/api/v2/recruitment_cycles" }
+
+    describe 'the JSON response' do
+      it 'displays che correct jsonapi response' do
+        next_recruitment_cycle
+
+        perform_request
+
+        expect(json_response)
+          .to(eq(
+                'data' => [
+                  {
+                    'id' => recruitment_cycle.id.to_s,
+                    'type' => 'recruitment_cycles',
+                    'attributes' => {
+                      'year' => recruitment_cycle.year,
+                      'application_start_date' =>
+                        recruitment_cycle.application_start_date.to_s,
+                      'application_end_date' =>
+                        recruitment_cycle.application_end_date.to_date.to_s,
+                    },
+                    'relationships' => {
+                      'providers' => {
+                        'meta' => {
+                          'included' => false
+                        }
+                      },
+                    }
+                  },
+                  {
+                    'id' => next_recruitment_cycle.id.to_s,
+                    'type' => 'recruitment_cycles',
+                    'attributes' => {
+                      'year' => next_recruitment_cycle.year,
+                      'application_start_date' =>
+                        next_recruitment_cycle.application_start_date.to_s,
+                      'application_end_date' =>
+                        next_recruitment_cycle.application_end_date.to_date.to_s,
+                    },
+                    'relationships' => {
+                      'providers' => {
+                        'meta' => {
+                          'included' => false
+                        }
+                      },
+                    }
+                  }
+                ],
+                'jsonapi' => {
+                  'version' => '1.0'
+                }
+              ))
+      end
+    end
+  end
+
+  describe '/api/v2/providers/:provider_code/recruitment_cycles' do
+    let(:recruitment_cycle)      { find_or_create :recruitment_cycle }
+    let(:next_recruitment_cycle) { find_or_create :recruitment_cycle, :next }
+    let(:provider) { create :provider, organisations: [organisation] }
+    let(:next_provider) {
+      create :provider,
+             :next_recruitment_cycle,
+             organisations: [organisation],
+             provider_code: provider.provider_code
+    }
+    let(:provider2) { create :provider }
+
+    let(:request_path) {
+      "/api/v2/providers/#{provider.provider_code}/recruitment_cycles"
+    }
+
+    describe 'the JSON response' do
+      it 'displays che correct jsonapi response' do
+        provider
+        next_provider
+        provider2
+
+        perform_request
+
+        expect(json_response)
+          .to(eq(
+                'data' => [
+                  {
+                    'id' => recruitment_cycle.id.to_s,
+                    'type' => 'recruitment_cycles',
+                    'attributes' => {
+                      'year' => recruitment_cycle.year,
+                      'application_start_date' =>
+                        recruitment_cycle.application_start_date.to_s,
+                      'application_end_date' =>
+                        recruitment_cycle.application_end_date.to_date.to_s,
+                    },
+                    'relationships' => {
+                      'providers' => {
+                        'meta' => {
+                          'included' => false
+                        }
+                      },
+                    }
+                  },
+                  {
+                    'id' => next_recruitment_cycle.id.to_s,
+                    'type' => 'recruitment_cycles',
+                    'attributes' => {
+                      'year' => next_recruitment_cycle.year,
+                      'application_start_date' =>
+                        next_recruitment_cycle.application_start_date.to_s,
+                      'application_end_date' =>
+                        next_recruitment_cycle.application_end_date.to_date.to_s,
+                    },
+                    'relationships' => {
+                      'providers' => {
+                        'meta' => {
+                          'included' => false
+                        }
+                      },
+                    }
+                  }
+                ],
+                'jsonapi' => {
+                  'version' => '1.0'
+                }
+              ))
+      end
+    end
+  end
+
+  describe '/api/v2/recruitment_cycles/:year' do
     let(:recruitment_cycle) { find_or_create :recruitment_cycle }
     let(:request_params) { {} }
     let(:request_path) { "/api/v2/recruitment_cycles/#{recruitment_cycle.year}" }
-
-    def perform_request
-      get request_path,
-          headers: { 'HTTP_AUTHORIZATION' => credentials },
-          params: request_params
-    end
 
     let(:expected_response) {
       {
@@ -47,7 +181,6 @@ describe '/api/v2/recruitment_cycle', type: :request do
         }
       }
     }
-    let(:json_response) { JSON.parse(response.body) }
 
     describe 'the JSON response' do
       it 'should be the correct jsonapi response' do


### PR DESCRIPTION
### Context

@dankmitchell pointed out that he could use a list of the recruitment cycles available for a provider in the front-end.

### Changes proposed in this pull request

Add an index view for `recruitment_cycles`, both a global list and a provider-specific list.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
