### PR TITLE
[1732] make mcb courses edit default to current recruitment cycle

### DIFF
--- a/lib/mcb/commands/courses/edit.rb
+++ b/lib/mcb/commands/courses/edit.rb
@@ -10,7 +10,7 @@ run do |opts, args, _cmd|
 
   MCB::CoursesEditor.new(
     requester: User.find_by!(email: MCB.config[:email]),
-    provider: Provider.find_by!(provider_code: provider_code),
+    provider: RecruitmentCycle.current_recruitment_cycle.providers.find_by!(provider_code: provider_code),
     course_codes: course_codes
   ).run
 end

--- a/spec/lib/mcb/commands/courses/edit_spec.rb
+++ b/spec/lib/mcb/commands/courses/edit_spec.rb
@@ -58,6 +58,40 @@ describe 'mcb courses edit' do
           from(["Another name", "Original name"]).to(%w[Mathematics Mathematics])
       end
     end
+
+    context 'when the same course exists across multiple recruitment cycles' do
+      let!(:next_recruitment_cycle) { find_or_create(:recruitment_cycle, :next) }
+      let(:provider_in_the_next_recruitment_cycle) {
+        create(:provider,
+               provider_code: provider_code,
+               recruitment_cycle: next_recruitment_cycle,
+               organisations: provider.organisations)
+      }
+      let!(:course_in_the_next_recruitment_cycle) {
+        create(:course,
+               provider: provider_in_the_next_recruitment_cycle,
+               course_code: course_code,
+               name: 'Original name')
+      }
+
+      it 'picks the correct provider and course' do
+        expect { edit(provider_code, [course_code], "edit title", "Mathematics", "exit") }.
+          to change { course.reload.name }.
+          from("Original name").to("Mathematics")
+
+        expect(course_in_the_next_recruitment_cycle.reload.name).to eq("Original name")
+      end
+
+      it 'ignores providers associated with the next cycle' do
+        provider.destroy
+        course.destroy
+
+        expect { edit(provider_code, [course_code], "edit title", "Mathematics", "exit") }.
+          to raise_error(ActiveRecord::RecordNotFound, /Couldn't find Provider/)
+
+        expect(course_in_the_next_recruitment_cycle.reload.name).to eq("Original name")
+      end
+    end
   end
 
   context 'when a non-existent user tries to edit a course' do


### PR DESCRIPTION
### Context
As we implement rollover by creating duplicate providers and courses, mcb will begin to return duplicate results for providers list or courses list. Also, when expecting to retrieve a single provider, course, site, it will receive multiple which is bound to break things.

### Changes proposed in this pull request

Change the current behaviour in `mcb courses edit` to edit only providers in the current recruitment cycle so that things don't break.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
