### PR TITLE
[1721] move recruitment year from param to route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ coverage/
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+
+*.patch

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -8,7 +8,6 @@ module API
         build_recruitment_cycle
         per_page = (params[:per_page] || 100).to_i
         changed_since = params[:changed_since]
-        recruitment_year = @recruitment_cycle.year
 
         ActiveRecord::Base.transaction do
           ActiveRecord::Base.connection.execute('LOCK provider, provider_enrichment, site IN SHARE UPDATE EXCLUSIVE MODE')
@@ -27,6 +26,7 @@ module API
           @courses.last,
           changed_since: changed_since,
           per_page: per_page,
+          recruitment_year: params[:recruitment_year]
         )
 
         render json: @courses

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -5,9 +5,10 @@ module API
       include FirstItemFromNextPage
 
       def index
+        build_recruitment_cycle
         per_page = (params[:per_page] || 100).to_i
         changed_since = params[:changed_since]
-        recruitment_year = params[:recruitment_year]
+        recruitment_year = @recruitment_cycle.year
 
         ActiveRecord::Base.transaction do
           ActiveRecord::Base.connection.execute('LOCK provider, provider_enrichment, site IN SHARE UPDATE EXCLUSIVE MODE')
@@ -18,7 +19,7 @@ module API
                                  :subjects,
                                  site_statuses: [:site])
                        .changed_since(changed_since)
-                       .by_recruitment_cycle(recruitment_year)
+                       .by_recruitment_cycle(@recruitment_cycle.year)
                        .limit(per_page)
         end
 
@@ -26,12 +27,17 @@ module API
           @courses.last,
           changed_since: changed_since,
           per_page: per_page,
-          recruitment_year: recruitment_year
         )
 
         render json: @courses
       rescue ActiveRecord::StatementInvalid
         render json: { status: 400, message: 'Invalid changed_since value, the format should be an ISO8601 UTC timestamp, for example: `2019-01-01T12:01:00Z`' }.to_json, status: :bad_request
+      end
+
+      def build_recruitment_cycle
+        @recruitment_cycle = RecruitmentCycle.find_by(
+          year: params[:recruitment_year]
+        ) || RecruitmentCycle.current_recruitment_cycle
       end
     end
   end

--- a/app/controllers/concerns/next_link_header.rb
+++ b/app/controllers/concerns/next_link_header.rb
@@ -5,12 +5,21 @@ private
 
   def set_next_link_header_using_changed_since_or_last_object(last_object,
                                                               params = {})
+    next_url_params = {}
+    next_url_params[:changed_since] = params[:changed_since]
+    next_url_params[:per_page] = params[:per_page]
+
     if last_object.present?
-      params[:changed_since] =
+      next_url_params[:changed_since] =
         incremental_load_timestamp_format last_object.changed_at
     end
 
-    response.headers['Link'] = "#{url_for(params: params)}; rel=\"next\""
+    if params[:recruitment_year].nil?
+      response.headers['Link'] = "#{url_for(recruitment_year: Settings.current_recruitment_cycle, params: next_url_params)}; rel=\"next\""
+      return
+    end
+
+    response.headers['Link'] = "#{url_for(recruitment_year: params[:recruitment_year], params: next_url_params)}; rel=\"next\""
   end
 
   def incremental_load_timestamp_format(timestamp)

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -73,6 +73,6 @@ class CourseSerializer < ActiveModel::Serializer
   end
 
   def recruitment_cycle
-    object.recruitment_cycle.year
+    object.provider.recruitment_cycle.year
   end
 end

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -114,7 +114,9 @@ describe API::V1::CoursesController, type: :controller do
     end
 
     context "for next recruitment year" do
-      let!(:course) { create(:course) }
+      let!(:course) { create(:course, provider: provider) }
+      let(:provider) { build(:provider, recruitment_cycle: next_cycle) }
+      let(:next_cycle) { build(:recruitment_cycle, year: '2020') }
       let(:params) {
         { recruitment_year: '2020' }
       }
@@ -126,7 +128,7 @@ describe API::V1::CoursesController, type: :controller do
       describe 'returned courses in JSON' do
         subject { response.body }
 
-        it { should_not have_courses }
+        it { should include course.course_code }
       end
     end
   end

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -206,7 +206,34 @@ describe "Courses API", type: :request do
         end
       end
 
+      context 'with recruitment year specified in params' do
+        it 'includes the correct next link in the header' do
+          create(:course,
+                 course_code: "LAST1",
+                 age: 10.minutes.ago,
+                 provider: provider)
 
+          timestamp_of_last_course = 2.minutes.ago
+          _last_course_in_results = create(:course,
+                                           course_code: "LAST2",
+                                           age: timestamp_of_last_course,
+                                           provider: provider)
+
+          get '/api/v1/courses?recruitment_year=2019',
+              headers: { 'HTTP_AUTHORIZATION' => credentials },
+              params: { changed_since: 30.minutes.ago.utc.iso8601 }
+
+
+          expect(response.headers).to have_key "Link"
+          url = url_for(
+            recruitment_year: 2019,
+            params: {
+              changed_since: timestamp_of_last_course.utc.strftime('%FT%T.%6NZ'),
+              per_page: 100,
+            })
+          expect(response.headers["Link"]).to match "#{url}; rel=\"next\""
+        end
+      end
 
       it 'includes correct next link in response headers' do
         create(:course,

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -138,10 +138,10 @@ describe "Courses API", type: :request do
 
         expect(response.headers).to have_key "Link"
         url = url_for(
+          recruitment_year: 2019,
           params: {
             changed_since: timestamp_of_last_course.utc.strftime('%FT%T.%6NZ'),
-            per_page: 100,
-            recruitment_year: 2019
+            per_page: 100
           }
         )
 
@@ -226,11 +226,13 @@ describe "Courses API", type: :request do
 
 
         expect(response.headers).to have_key "Link"
-        url = url_for(params: {
-                        changed_since: timestamp_of_last_course.utc.strftime('%FT%T.%6NZ'),
-                        per_page: 100,
-                        recruitment_year: 2019
-                      })
+        url = url_for(
+          recruitment_year: 2019,
+          params: {
+            changed_since: timestamp_of_last_course.utc.strftime('%FT%T.%6NZ'),
+            per_page: 100
+          }
+)
         expect(response.headers["Link"]).to match "#{url}; rel=\"next\""
       end
 
@@ -241,7 +243,21 @@ describe "Courses API", type: :request do
             headers: { 'HTTP_AUTHORIZATION' => credentials },
             params: { changed_since: provided_timestamp }
 
-        url = url_for(params: {
+        url = url_for(recruitment_year: 2019, params: {
+                        changed_since: provided_timestamp,
+                        per_page: 100
+                      })
+        expect(response.headers["Link"]).to match "#{url}; rel=\"next\""
+      end
+
+      it 'includes correct next link when there is an empty set' do
+        provided_timestamp = 5.seconds.ago.utc.iso8601
+
+        get '/api/v1/2020/courses',
+            headers: { 'HTTP_AUTHORIZATION' => credentials },
+            params: { changed_since: provided_timestamp }
+
+        url = url_for(recruitment_year: 2020, params: {
                         changed_since: provided_timestamp,
                         per_page: 100
                       })
@@ -264,7 +280,7 @@ describe "Courses API", type: :request do
         end
 
         it 'pages properly' do
-          get_next_courses '/api/v1/courses', per_page: 10, recruitment_year: 2019
+          get_next_courses '/api/v1/courses', per_page: 10
 
           expect(response.body)
             .to have_courses(@courses[0..9])
@@ -290,6 +306,7 @@ describe "Courses API", type: :request do
       end
 
       context "with many courses updated in the same second" do
+        let!(:next_cycle) { create(:recruitment_cycle, year: '2020') }
         timestamp = 1.second.ago
         before do
           @courses = Array.new(25) do |i|
@@ -322,6 +339,11 @@ describe "Courses API", type: :request do
           get_next_courses response.headers['Link'].split(';').first
           expect(response.body)
             .to have_courses([random_course])
+        end
+
+        it 'pages properly with specified recruitment year' do
+          get_next_courses '/api/v1/2020/courses', per_page: 10
+          expect(response.body).to eq '[]'
         end
       end
     end

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -149,6 +149,46 @@ describe "Courses API", type: :request do
       end
     end
 
+
+    context 'with multiple recruitment cycles' do
+      describe 'JSON body response' do
+        let(:provider) { build(:provider, recruitment_cycle: current_cycle) }
+        let(:current_cycle) { build(:recruitment_cycle, year: '2019') }
+        let(:course) { create(:course, provider: provider) }
+        let(:provider2) { build(:provider, recruitment_cycle: next_cycle) }
+        let(:next_cycle) { build(:recruitment_cycle, year: '2020') }
+        let(:course2) { create(:course, provider: provider2) }
+
+        before do
+          course
+          course2
+          get_index
+        end
+
+        context 'with no cycle specified in the route' do
+          let(:get_index) { get '/api/v1/courses', headers: { 'HTTP_AUTHORIZATION' => credentials } }
+
+          it 'defaults to the current cycle when year' do
+            returned_course_codes = get_course_codes_from_body(response.body)
+
+            expect(returned_course_codes).not_to include course2.course_code
+            expect(returned_course_codes).to include course.course_code
+          end
+        end
+        context 'with a future recruitment cycle specified in the route' do
+          let(:get_index) { get '/api/v1/2020/courses', headers: { 'HTTP_AUTHORIZATION' => credentials } }
+
+          it 'only returns courses from the requested cycle' do
+            returned_course_codes = get_course_codes_from_body(response.body)
+
+            expect(returned_course_codes).to include course2.course_code
+            expect(returned_course_codes).not_to include course.course_code
+          end
+        end
+      end
+    end
+
+
     context "with changed_since parameter" do
       describe "JSON body response" do
         it 'contains expected courses' do

--- a/spec/serializers/course_serializer_spec.rb
+++ b/spec/serializers/course_serializer_spec.rb
@@ -25,10 +25,11 @@
 require "rails_helper"
 
 RSpec.describe CourseSerializer do
-  let(:course) { create :course }
+  let(:course) { create :course, provider: provider }
+  let(:provider) { build(:provider) }
   subject { serialize(course) }
 
   it { should include(course_code: course.course_code) }
   it { should include(name: course.name) }
-  it { should include(recruitment_cycle: course.recruitment_cycle.year) }
+  it { should include(recruitment_cycle: course.provider.recruitment_cycle.year) }
 end


### PR DESCRIPTION
### Context
UCAS expects the URL to allow the specification of the year as part of the route.

### Changes proposed in this pull request
Allow the specification of the recruitment year in the route rather than as a URL parameter.

### Guidance to review
https://trello.com/c/yi5k5MeS/1743-refactor-course-v1-controller-controller-serializers-to-reflect-the-new-data-model  
  
### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [ ] Rebased master
- [x] Cleaned commit history
- [X] Tested by running locally
