### PR TITLE
[1586] Improvements to applications open from

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -71,7 +71,7 @@ class Course < ApplicationRecord
   has_many :subjects, through: :course_subjects
   has_many :site_statuses
   has_many :sites,
-           -> { merge(SiteStatus.where(status: %i[new_status running])) },
+           -> { merge(SiteStatus.findable_or_new) },
            through: :site_statuses
 
   has_many :enrichments,
@@ -149,7 +149,7 @@ class Course < ApplicationRecord
 
   def applications_open_from
     site_statuses
-      .findable
+      .findable_or_new
       .with_vacancies
       .order("applications_accepted_from ASC")
       .first

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -158,6 +158,10 @@ class Course < ApplicationRecord
       &.iso8601
   end
 
+  def applications_open_from=(new_date)
+    site_statuses.each { |ss| ss.update(applications_accepted_from: new_date) }
+  end
+
   def has_vacancies?
     site_statuses.findable.with_vacancies.any?
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -149,7 +149,8 @@ class Course < ApplicationRecord
 
   def applications_open_from
     site_statuses
-      .open_for_applications
+      .findable
+      .with_vacancies
       .order("applications_accepted_from ASC")
       .first
       &.applications_accepted_from

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -155,7 +155,6 @@ class Course < ApplicationRecord
       &.applications_accepted_from
       &.to_datetime
       &.utc
-      &.iso8601
   end
 
   def applications_open_from=(new_date)

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -69,6 +69,7 @@ class SiteStatus < ApplicationRecord
   belongs_to :course
 
   scope :findable, -> { status_running.published_on_ucas }
+  scope :findable_or_new, -> { findable.or(status_new_status) }
   scope :applications_being_accepted_now, -> {
     where.not(applications_accepted_from: nil).
     where('applications_accepted_from <= ?', Time.now.utc)

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -34,6 +34,10 @@ module API
         @object.accrediting_provider_description
       end
 
+      attribute :applications_open_from do
+        @object.applications_open_from&.iso8601
+      end
+
       belongs_to :provider
       belongs_to :accrediting_provider
 

--- a/app/serializers/search_and_compare/course_serializer.rb
+++ b/app/serializers/search_and_compare/course_serializer.rb
@@ -71,7 +71,7 @@ module SearchAndCompare
     # Campuses_related_Mapping
     attribute(:Campuses)                              { campuses }
     # using server date time not utc, so it's local date time?
-    attribute(:ApplicationsAcceptedFrom)              { object.applications_open_from.to_date.strftime('%Y-%m-%dT%H:%M:%S') }
+    attribute(:ApplicationsAcceptedFrom)              { object.applications_open_from.strftime('%Y-%m-%dT%H:%M:%S') }
     attribute(:HasVacancies)                          { object.has_vacancies? }
 
     # Course_direct_enrichment_Mapping

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -477,7 +477,7 @@ RSpec.describe Course, type: :model do
       end
     end
 
-    its(:applications_open_from) { should eq("2018-10-01T00:00:00Z") }
+    its(:applications_open_from) { should eq(DateTime.new(2018, 10, 1, 0, 0, 0).utc) }
 
     describe "#applications_open_from=" do
       it "updates the applications_accepted_from date on the site statuses" do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -455,6 +455,26 @@ RSpec.describe Course, type: :model do
     end
   end
 
+  describe "#applications_open_from=" do
+    let(:provider) { create(:provider) }
+    let(:sites) { create_list(:site, 3, provider: provider) }
+    let!(:existing_site_status) {
+      sites.each do |site|
+        create(:site_status,
+               :running,
+               site: site,
+               course: subject,
+               applications_accepted_from: Date.new(2018, 10, 9))
+      end
+    }
+
+    it "updates the applications_accepted_from date on the site statuses" do
+      expect { subject.applications_open_from = Date.new(2018, 10, 23) }.
+        to change { subject.reload.site_statuses.pluck(:applications_accepted_from).uniq }.
+        from([Date.new(2018, 10, 9)]).to([Date.new(2018, 10, 23)])
+    end
+  end
+
   describe "adding and removing sites on a course" do
     let(:provider) { create(:provider) }
     let(:new_site) { create(:site, provider: provider) }


### PR DESCRIPTION
### Context

A draft PR indicating potential improvements to Course#applications_open_from based on @benilovj's branch.

"Applications open from" should be the earliest date in any of the sites. Currently it's restricted to looking at just the sites with open applications.

This means that no date is available if applications haven't opened yet.
The wrong date might show if some of the sites have no vacancies.
No date available if the site is new and not yet running.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
