### PR TITLE
[1731] Add option to change recruitment year for list commands

### DIFF
--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -247,6 +247,9 @@ module MCB
     def remote_connect_options
       envs = env_to_azure_map.keys.join(', ')
       Proc.new do
+        option :R, 'recruitment_year',
+               "Set the recruitment year, defaults to the current recruitment year",
+               argument: :required
         option :E, 'env',
                "Connect to a pre-defined environment: #{envs}",
                argument: :required

--- a/lib/mcb/commands/apiv1/courses.rb
+++ b/lib/mcb/commands/apiv1/courses.rb
@@ -6,6 +6,3 @@ option :a, :all, 'Perform on all courses, not just the first page returned.',
        default: false
 option :c, :'changed-since', 'Perform only on providers changed since this date',
        argument: :required
-option :e, :endpoint, 'Path to the endpoint to use for providers',
-       argument: :required,
-       default: '/api/v1/2019/courses'

--- a/lib/mcb/commands/apiv1/courses/list.rb
+++ b/lib/mcb/commands/apiv1/courses/list.rb
@@ -10,7 +10,7 @@ run do |opts, _args, _cmd|
   last_context = nil
 
   table = Terminal::Table.new headings: %w[Code Name Provider\ Code Provider\ Name] do |t|
-    MCB.each_v1_provider(opts).each do |course, context|
+    MCB.each_v1_course(opts).each do |course, context|
       last_context = context
       provider_info = course['provider']
                         .slice('institution_code', 'institution_name')

--- a/lib/mcb/commands/apiv1/providers.rb
+++ b/lib/mcb/commands/apiv1/providers.rb
@@ -6,6 +6,3 @@ option :a, :all, 'Perform on all providers, not just the first page returned.',
        default: false
 option :c, :'changed-since', 'Perform only on providers changed since this date',
        argument: :required
-option :e, :endpoint, 'Path to the endpoint to use for providers',
-       argument: :required,
-       default: '/api/v1/2019/providers'

--- a/lib/mcb/commands/courses/list.rb
+++ b/lib/mcb/commands/courses/list.rb
@@ -4,11 +4,7 @@ summary 'List courses in db'
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
-  recruitment_cycle = if opts[:recruitment_year].nil?
-                        RecruitmentCycle.current_recruitment_cycle
-                      else
-                        RecruitmentCycle.find_by(year: opts[:recruitment_year])
-                      end
+  recruitment_cycle = MCB.get_recruitment_cycle(opts)
 
   courses = recruitment_cycle.courses
   courses = courses.where(course_code: args.map(&:upcase)) if args.any?

--- a/lib/mcb/commands/courses/list.rb
+++ b/lib/mcb/commands/courses/list.rb
@@ -4,11 +4,14 @@ summary 'List courses in db'
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
-  courses = if args.any?
-              Course.where(course_code: args.to_a.map(&:upcase))
-            else
-              Course.all
-            end
+  recruitment_cycle = if opts[:recruitment_year].nil?
+                        RecruitmentCycle.current_recruitment_cycle
+                      else
+                        RecruitmentCycle.find_by(year: opts[:recruitment_year])
+                      end
+
+  courses = recruitment_cycle.courses
+  courses = courses.where(course_code: args.map(&:upcase)) if args.any?
 
   tp.set :capitalize_headers, false
 

--- a/lib/mcb/commands/providers/list.rb
+++ b/lib/mcb/commands/providers/list.rb
@@ -12,7 +12,7 @@ run do |opts, args, _cmd|
                       end
 
   providers = recruitment_cycle.providers
-  providers = providers.where(provider_code: args.to_a) if args.any?
+  providers = providers.where(provider_code: args.map(&:upcase)) if args.any?
 
   output = [
     'Providers:',

--- a/lib/mcb/commands/providers/list.rb
+++ b/lib/mcb/commands/providers/list.rb
@@ -5,11 +5,7 @@ summary 'List providers in db'
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
-  recruitment_cycle = if opts[:recruitment_year].nil?
-                        RecruitmentCycle.current_recruitment_cycle
-                      else
-                        RecruitmentCycle.find_by(year: opts[:recruitment_year])
-                      end
+  recruitment_cycle = MCB.get_recruitment_cycle(opts)
 
   providers = recruitment_cycle.providers
   providers = providers.where(provider_code: args.map(&:upcase)) if args.any?

--- a/lib/mcb/commands/providers/list.rb
+++ b/lib/mcb/commands/providers/list.rb
@@ -1,14 +1,18 @@
 name 'list'
+usage 'list [<code>...]'
 summary 'List providers in db'
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
-  providers = if args.any?
-                Provider.where(provider_code: args.to_a.map(&:upcase))
-              else
-                Provider.all
-              end
+  recruitment_cycle = if opts[:recruitment_year].nil?
+                        RecruitmentCycle.current_recruitment_cycle
+                      else
+                        RecruitmentCycle.find_by(year: opts[:recruitment_year])
+                      end
+
+  providers = recruitment_cycle.providers
+  providers = providers.where(provider_code: args.to_a) if args.any?
 
   output = [
     'Providers:',

--- a/spec/lib/mcb/commands/apiv1/courses/find_spec.rb
+++ b/spec/lib/mcb/commands/apiv1/courses/find_spec.rb
@@ -10,7 +10,7 @@ describe '"mcb apiv1 courses find"' do
     course2 = create(:course, subjects: [subject], site_statuses: [site_status])
 
 
-    url = 'http://localhost:3001/api/v1/2019/courses'
+    url = "http://localhost:3001/api/v1/#{RecruitmentCycle.current_recruitment_cycle.year}/courses"
     next_url = url + '&' + {
         changed_since: course2.created_at.utc.strftime('%FT%T.%6NZ'),
         per_page: 100

--- a/spec/lib/mcb/commands/apiv1/courses/list_spec.rb
+++ b/spec/lib/mcb/commands/apiv1/courses/list_spec.rb
@@ -1,0 +1,97 @@
+require 'mcb_helper'
+
+describe '"mcb apiv1 courses list"' do
+  let(:current_cycle) { find_or_create(:recruitment_cycle, year: '2019') }
+  let(:next_cycle) { find_or_create(:recruitment_cycle, year: '2020') }
+  let(:provider1) { create(:provider, recruitment_cycle: current_cycle) }
+  let(:provider2) { create(:provider, recruitment_cycle: next_cycle) }
+  let(:course1) { create(:course, provider: provider1) }
+  let(:course2) { create(:course, provider: provider2) }
+
+  it 'lists courses for the default recruitment year' do
+    url = "http://localhost:3001/api/v1/#{RecruitmentCycle.current_recruitment_cycle.year}/courses"
+    next_url = url + '&' + {
+        changed_since: course2.created_at.utc.strftime('%FT%T.%6NZ'),
+        per_page: 100
+      }.to_query
+    json = ActiveModel::Serializer::CollectionSerializer.new(
+      [
+        course1,
+        course2
+      ],
+      serializer: CourseSerializer
+    )
+
+    stub_request(:get, url)
+      .with(headers: {
+              'Authorization' => 'Bearer bats'
+            })
+      .to_return(status: 200,
+                 body: json.to_json,
+                 headers: {
+                   link: next_url + '; rel="next"'
+                 })
+    stub_request(:get, next_url)
+      .to_return(status: 200,
+                 body: [].to_json,
+                 headers: {
+                   link: next_url + '; rel="next"'
+                 })
+
+    output = with_stubbed_stdout do
+      $mcb.run(%W[apiv1
+                  courses
+                  list])
+    end
+
+    expect(output).to have_text_table_row('Code',
+                                          'Name',
+                                          'Provider Code',
+                                          'Provider Name')
+    expect(output).to have_text_table_row(course1.course_code, course1.name)
+    expect(output).to have_text_table_row(course2.course_code, course2.name)
+  end
+
+  it 'lists courses for a given recruitment year' do
+    url = "http://localhost:3001/api/v1/#{next_cycle.year}/courses"
+    next_url = url + '&' + {
+        changed_since: course2.created_at.utc.strftime('%FT%T.%6NZ'),
+        per_page: 100
+      }.to_query
+    json = ActiveModel::Serializer::CollectionSerializer.new(
+      [
+        course2
+      ],
+      serializer: CourseSerializer
+    )
+
+    stub_request(:get, url)
+      .with(headers: {
+              'Authorization' => 'Bearer bats'
+            })
+      .to_return(status: 200,
+                 body: json.to_json,
+                 headers: {
+                   link: next_url + '; rel="next"'
+                 })
+    stub_request(:get, next_url)
+      .to_return(status: 200,
+                 body: [].to_json,
+                 headers: {
+                   link: next_url + '; rel="next"'
+                 })
+
+    output = with_stubbed_stdout do
+      $mcb.run(%W[apiv1
+                  courses
+                  list -r #{next_cycle.year}])
+    end
+
+    expect(output).to have_text_table_row('Code',
+                                          'Name',
+                                          'Provider Code',
+                                          'Provider Name')
+    expect(output).to have_text_table_row(course2.course_code, course2.name)
+    expect(output).not_to have_text_table_row(course1.course_code, course1.name)
+  end
+end

--- a/spec/lib/mcb/commands/apiv1/providers/find_spec.rb
+++ b/spec/lib/mcb/commands/apiv1/providers/find_spec.rb
@@ -9,7 +9,7 @@ describe '"mcb apiv1 providers find"' do
   let(:provider2) { create(:provider, sites: [site2], contacts: [contact2]) }
 
   it 'displays the info for the given provider' do
-    url = 'http://localhost:3001/api/v1/2019/providers'
+    url = "http://localhost:3001/api/v1/#{RecruitmentCycle.current_recruitment_cycle.year}/providers"
     next_url = url + '&' + {
         changed_since: provider2.created_at.utc.strftime('%FT%T.%16NZ'),
         per_page: 100

--- a/spec/lib/mcb/commands/apiv1/providers/list_spec.rb
+++ b/spec/lib/mcb/commands/apiv1/providers/list_spec.rb
@@ -1,0 +1,91 @@
+require 'mcb_helper'
+
+describe '"mcb apiv1 providers list"' do
+  let(:current_cycle) { find_or_create(:recruitment_cycle, year: '2019') }
+  let(:next_cycle) { find_or_create(:recruitment_cycle, year: '2020') }
+  let(:provider1) { create(:provider, recruitment_cycle: current_cycle) }
+  let(:provider2) { create(:provider, recruitment_cycle: next_cycle) }
+
+  it 'lists providers for the default recruitment year' do
+    url = "http://localhost:3001/api/v1/#{RecruitmentCycle.current_recruitment_cycle.year}/providers"
+    next_url = url + '&' + {
+        changed_since: provider2.created_at.utc.strftime('%FT%T.%6NZ'),
+        per_page: 100
+      }.to_query
+    json = ActiveModel::Serializer::CollectionSerializer.new(
+      [
+        provider1,
+        provider2
+      ],
+      serializer: ProviderSerializer
+    )
+
+    stub_request(:get, url)
+      .with(headers: {
+              'Authorization' => 'Bearer bats'
+            })
+      .to_return(status: 200,
+                 body: json.to_json,
+                 headers: {
+                   link: next_url + '; rel="next"'
+                 })
+    stub_request(:get, next_url)
+      .to_return(status: 200,
+                 body: [].to_json,
+                 headers: {
+                   link: next_url + '; rel="next"'
+                 })
+
+    output = with_stubbed_stdout do
+      $mcb.run(%W[apiv1
+                  providers
+                  list])
+    end
+
+    expect(output).to have_text_table_row('Code',
+                                          'Name')
+    expect(output).to have_text_table_row(provider1.provider_code, provider1.provider_name)
+    expect(output).to have_text_table_row(provider2.provider_code, provider2.provider_name)
+  end
+
+  it 'lists providers for a given recruitment year' do
+    url = "http://localhost:3001/api/v1/#{next_cycle.year}/providers"
+    next_url = url + '&' + {
+        changed_since: provider2.created_at.utc.strftime('%FT%T.%6NZ'),
+        per_page: 100
+      }.to_query
+    json = ActiveModel::Serializer::CollectionSerializer.new(
+      [
+        provider2
+      ],
+      serializer: ProviderSerializer
+    )
+
+    stub_request(:get, url)
+      .with(headers: {
+              'Authorization' => 'Bearer bats'
+            })
+      .to_return(status: 200,
+                 body: json.to_json,
+                 headers: {
+                   link: next_url + '; rel="next"'
+                 })
+    stub_request(:get, next_url)
+      .to_return(status: 200,
+                 body: [].to_json,
+                 headers: {
+                   link: next_url + '; rel="next"'
+                 })
+
+    output = with_stubbed_stdout do
+      $mcb.run(%W[apiv1
+                  providers
+                  list -r #{next_cycle.year}])
+    end
+
+    expect(output).to have_text_table_row('Code',
+                                          'Name')
+    expect(output).to have_text_table_row(provider2.provider_code, provider2.provider_name)
+    expect(output).not_to have_text_table_row(provider1.provider_code, provider1.provider_name)
+  end
+end

--- a/spec/lib/mcb/commands/courses/list_spec.rb
+++ b/spec/lib/mcb/commands/courses/list_spec.rb
@@ -1,0 +1,94 @@
+require 'mcb_helper'
+
+describe 'mcb providers list' do
+  def list(*arguments)
+    stderr = nil
+    output = with_stubbed_stdout(stdin: "", stderr: stderr) do
+      $mcb.run %W[courses list] + arguments
+    end
+    { stdout: output, stderr: stderr }
+  end
+
+  let(:current_cycle) { RecruitmentCycle.current_recruitment_cycle }
+  let(:additional_cycle) { find_or_create(:recruitment_cycle, year: '2020') }
+
+  context 'when recruitment cycle is unspecified' do
+    let(:provider1) { create(:provider, provider_code: 'X13', provider_name: 'Learning Provider', recruitment_cycle: current_cycle) }
+    let(:provider2) { create(:provider, provider_code: 'A12', provider_name: 'Provider of Learning', recruitment_cycle: current_cycle) }
+
+    let(:course1) { create(:course, provider: provider1, course_code: 'Y2K', name: "New course") }
+    let(:course2) { create(:course, provider: provider2, course_code: 'M33', name: "Later course") }
+
+    context 'when course is specified' do
+      it 'displays the provider information' do
+        course1
+        course2
+
+        command_output = list('Y2K')[:stdout]
+
+        expect(command_output).to match(/Y2K/)
+        expect(command_output).to match(/New course/)
+
+        expect(command_output).not_to match(/M33/)
+        expect(command_output).not_to match(/Later course/)
+      end
+
+      it 'displays all specified providers' do
+        course1
+        course2
+
+        command_output = list('Y2K', 'M33')[:stdout]
+
+        expect(command_output).to match(/Y2K/)
+        expect(command_output).to match(/New course/)
+
+        expect(command_output).to match(/M33/)
+        expect(command_output).to match(/Later course/)
+      end
+
+      it 'is case insensitive' do
+        course1
+        course2
+
+        command_output = list('m33')[:stdout]
+        expect(command_output).to match(/M33/)
+      end
+    end
+
+    context 'when provider is unspecified' do
+      it 'displays information about courses for the current recruitment cycle' do
+        course1
+        course2
+
+        command_output = list[:stdout]
+
+        expect(command_output).to match(/Y2K/)
+        expect(command_output).to match(/New course/)
+
+        expect(command_output).to match(/M33/)
+        expect(command_output).to match(/Later course/)
+      end
+    end
+  end
+
+  context 'when recruitment cycle is specified' do
+    let(:provider1) { create(:provider, provider_code: 'A12', provider_name: 'Provider of Learning', recruitment_cycle: current_cycle) }
+    let(:provider2) { create(:provider, provider_code: 'X13', provider_name: 'Learning Provider', recruitment_cycle: additional_cycle) }
+
+    let(:course1) { create(:course, provider: provider1, course_code: 'Y2K', name: "New course") }
+    let(:course2) { create(:course, provider: provider2, course_code: 'M33', name: "Later course") }
+
+    it 'displays information about courses for the specified recruitment cycle' do
+      course1
+      course2
+
+      command_output = list("-R", additional_cycle.year)[:stdout]
+
+      expect(command_output).to match(/M33/)
+      expect(command_output).to match(/Later course/)
+
+      expect(command_output).not_to match(/Y2K/)
+      expect(command_output).not_to match(/New course/)
+    end
+  end
+end

--- a/spec/lib/mcb/commands/courses/list_spec.rb
+++ b/spec/lib/mcb/commands/courses/list_spec.rb
@@ -10,48 +10,67 @@ describe 'mcb providers list' do
   end
 
   let(:current_cycle) { RecruitmentCycle.current_recruitment_cycle }
-  let(:additional_cycle) { find_or_create(:recruitment_cycle, year: '2020') }
+  let(:additional_cycle) { find_or_create(:recruitment_cycle, year: '2018') }
 
   context 'when recruitment cycle is unspecified' do
-    let(:provider1) { create(:provider, provider_code: 'X13', provider_name: 'Learning Provider', recruitment_cycle: current_cycle) }
-    let(:provider2) { create(:provider, provider_code: 'A12', provider_name: 'Provider of Learning', recruitment_cycle: current_cycle) }
+    let(:provider1) { create(:provider, recruitment_cycle: current_cycle) }
+    let(:provider2) { create(:provider, recruitment_cycle: current_cycle) }
+    let(:provider3) { create(:provider, recruitment_cycle: additional_cycle) }
 
-    let(:course1) { create(:course, provider: provider1, course_code: 'Y2K', name: "New course") }
-    let(:course2) { create(:course, provider: provider2, course_code: 'M33', name: "Later course") }
+    let(:course1) { create(:course, provider: provider1) }
+    let(:course2) { create(:course, provider: provider2) }
+    let(:course3) { create(:course, provider: provider3) }
+
+    it 'lists all courses for the default recruitment cycle' do
+      course1
+      course2
+      course3
+
+      command_output = list[:stdout]
+
+      expect(command_output).to include(course1.course_code)
+      expect(command_output).to include(course1.name)
+
+      expect(command_output).to include(course2.course_code)
+      expect(command_output).to include(course2.name)
+
+      expect(command_output).not_to include(course3.course_code)
+      expect(command_output).not_to include(course3.name)
+    end
 
     context 'when course is specified' do
       it 'displays the provider information' do
         course1
         course2
 
-        command_output = list('Y2K')[:stdout]
+        command_output = list(course1.course_code)[:stdout]
 
-        expect(command_output).to match(/Y2K/)
-        expect(command_output).to match(/New course/)
+        expect(command_output).to include(course1.course_code)
+        expect(command_output).to include(course1.name)
 
-        expect(command_output).not_to match(/M33/)
-        expect(command_output).not_to match(/Later course/)
+        expect(command_output).not_to include(course2.course_code)
+        expect(command_output).not_to include(course2.name)
       end
 
-      it 'displays all specified providers' do
+      it 'displays multiple specified courses' do
         course1
         course2
 
-        command_output = list('Y2K', 'M33')[:stdout]
+        command_output = list(course1.course_code, course2.course_code)[:stdout]
 
-        expect(command_output).to match(/Y2K/)
-        expect(command_output).to match(/New course/)
+        expect(command_output).to include(course1.course_code)
+        expect(command_output).to include(course1.name)
 
-        expect(command_output).to match(/M33/)
-        expect(command_output).to match(/Later course/)
+        expect(command_output).to include(course2.course_code)
+        expect(command_output).to include(course2.name)
       end
 
       it 'is case insensitive' do
         course1
         course2
 
-        command_output = list('m33')[:stdout]
-        expect(command_output).to match(/M33/)
+        command_output = list(course2.course_code.downcase)[:stdout]
+        expect(command_output).to include(course2.course_code)
       end
     end
 
@@ -62,33 +81,33 @@ describe 'mcb providers list' do
 
         command_output = list[:stdout]
 
-        expect(command_output).to match(/Y2K/)
-        expect(command_output).to match(/New course/)
+        expect(command_output).to include(course1.course_code)
+        expect(command_output).to include(course1.name)
 
-        expect(command_output).to match(/M33/)
-        expect(command_output).to match(/Later course/)
+        expect(command_output).to include(course2.course_code)
+        expect(command_output).to include(course2.name)
       end
     end
   end
 
   context 'when recruitment cycle is specified' do
-    let(:provider1) { create(:provider, provider_code: 'A12', provider_name: 'Provider of Learning', recruitment_cycle: current_cycle) }
-    let(:provider2) { create(:provider, provider_code: 'X13', provider_name: 'Learning Provider', recruitment_cycle: additional_cycle) }
+    let(:provider1) { create(:provider, recruitment_cycle: current_cycle) }
+    let(:provider2) { create(:provider, recruitment_cycle: additional_cycle) }
 
-    let(:course1) { create(:course, provider: provider1, course_code: 'Y2K', name: "New course") }
-    let(:course2) { create(:course, provider: provider2, course_code: 'M33', name: "Later course") }
+    let(:course1) { create(:course, provider: provider1) }
+    let(:course2) { create(:course, provider: provider2) }
 
     it 'displays information about courses for the specified recruitment cycle' do
       course1
       course2
 
-      command_output = list("-R", additional_cycle.year)[:stdout]
+      command_output = list("-r", additional_cycle.year)[:stdout]
 
-      expect(command_output).to match(/M33/)
-      expect(command_output).to match(/Later course/)
+      expect(command_output).to include(course2.course_code)
+      expect(command_output).to include(course2.name)
 
-      expect(command_output).not_to match(/Y2K/)
-      expect(command_output).not_to match(/New course/)
+      expect(command_output).not_to include(course1.course_code)
+      expect(command_output).not_to include(course1.name)
     end
   end
 end

--- a/spec/lib/mcb/commands/providers/list_spec.rb
+++ b/spec/lib/mcb/commands/providers/list_spec.rb
@@ -1,0 +1,84 @@
+require 'mcb_helper'
+
+describe 'mcb providers list' do
+  def list(*arguments)
+    stderr = nil
+    output = with_stubbed_stdout(stdin: "", stderr: stderr) do
+      $mcb.run %W[provider list] + arguments
+    end
+    { stdout: output, stderr: stderr }
+  end
+
+  let(:email) { 'user@education.gov.uk' }
+
+  before do
+    allow(MCB).to receive(:config).and_return(email: email)
+  end
+
+  let(:current_cycle) { RecruitmentCycle.current_recruitment_cycle }
+  let(:additional_cycle) { find_or_create(:recruitment_cycle, year: '2020') }
+
+  context 'when recruitment cycle is unspecified' do
+    let(:provider1) { create(:provider, provider_code: 'X13', provider_name: 'Learning Provider', recruitment_cycle: current_cycle) }
+    let(:provider2) { create(:provider, provider_code: 'A12', provider_name: 'Provider of Learning', recruitment_cycle: current_cycle) }
+    context 'when provider is specified' do
+      it 'displays the provider information' do
+        provider1
+        provider2
+
+        command_output = list('X13')[:stdout]
+
+        expect(command_output).to match(/X13/)
+        expect(command_output).to match(/Learning Provider/)
+
+        expect(command_output).not_to match(/A12/)
+        expect(command_output).not_to match(/Provider of Learning/)
+      end
+
+      it 'displays all specified providers' do
+        provider1
+        provider2
+
+        command_output = list('X13', 'A12')[:stdout]
+
+        expect(command_output).to match(/X13/)
+        expect(command_output).to match(/Learning Provider/)
+
+        expect(command_output).to match(/A12/)
+        expect(command_output).to match(/Provider of Learning/)
+      end
+    end
+
+    context 'when provider is unspecified' do
+      it 'displays information about providers for the current recruitment cycle' do
+        provider1
+        provider2
+
+        command_output = list[:stdout]
+
+        expect(command_output).to match(/A12/)
+        expect(command_output).to match(/Provider of Learning/)
+
+        expect(command_output).to match(/X13/)
+        expect(command_output).to match(/Learning Provider/)
+      end
+    end
+  end
+
+  context 'when recruitment cycle is specified' do
+    let(:provider1) { create(:provider, provider_code: 'A12', provider_name: 'Provider of Learning', recruitment_cycle: current_cycle) }
+    let(:provider2) { create(:provider, provider_code: 'X13', provider_name: 'Learning Provider', recruitment_cycle: additional_cycle) }
+
+    it 'displays information about providers for the specified recruitment cycle' do
+      provider1
+      provider2
+
+      command_output = list("-R", additional_cycle.year)[:stdout]
+      expect(command_output).to match(/X13/)
+      expect(command_output).to match(/Learning Provider/)
+
+      expect(command_output).not_to match(/A12/)
+      expect(command_output).not_to match(/Provider of Learning/)
+    end
+  end
+end

--- a/spec/lib/mcb/commands/providers/list_spec.rb
+++ b/spec/lib/mcb/commands/providers/list_spec.rb
@@ -10,44 +10,63 @@ describe 'mcb providers list' do
   end
 
   let(:current_cycle) { RecruitmentCycle.current_recruitment_cycle }
-  let(:additional_cycle) { find_or_create(:recruitment_cycle, year: '2020') }
+  let(:additional_cycle) { find_or_create(:recruitment_cycle, year: '2018') }
 
   context 'when recruitment cycle is unspecified' do
-    let(:provider1) { create(:provider, provider_code: 'X13', provider_name: 'Learning Provider', recruitment_cycle: current_cycle) }
-    let(:provider2) { create(:provider, provider_code: 'A12', provider_name: 'Provider of Learning', recruitment_cycle: current_cycle) }
+    let(:provider1) { create(:provider, recruitment_cycle: current_cycle) }
+    let(:provider2) { create(:provider, recruitment_cycle: current_cycle) }
+    let(:provider3) { create(:provider, recruitment_cycle: additional_cycle) }
+
+    it 'lists all courses for the default recruitment cycle' do
+      provider1
+      provider2
+      provider3
+
+      command_output = list[:stdout]
+
+      expect(command_output).to include(provider1.provider_code)
+      expect(command_output).to include(provider1.provider_name)
+
+      expect(command_output).to include(provider2.provider_code)
+      expect(command_output).to include(provider2.provider_name)
+
+      expect(command_output).not_to include(provider3.provider_name)
+      expect(command_output).not_to include(provider3.provider_code)
+    end
+
     context 'when provider is specified' do
       it 'displays the provider information' do
         provider1
         provider2
 
-        command_output = list('X13')[:stdout]
+        command_output = list(provider1.provider_code)[:stdout]
 
-        expect(command_output).to match(/X13/)
-        expect(command_output).to match(/Learning Provider/)
+        expect(command_output).to include(provider1.provider_code)
+        expect(command_output).to include(provider1.provider_name)
 
-        expect(command_output).not_to match(/A12/)
-        expect(command_output).not_to match(/Provider of Learning/)
+        expect(command_output).not_to include(provider2.provider_code)
+        expect(command_output).not_to include(provider2.provider_name)
       end
 
-      it 'displays all specified providers' do
+      it 'displays multiple specified providers' do
         provider1
         provider2
 
-        command_output = list('X13', 'A12')[:stdout]
+        command_output = list(provider1.provider_code, provider2.provider_code)[:stdout]
 
-        expect(command_output).to match(/X13/)
-        expect(command_output).to match(/Learning Provider/)
+        expect(command_output).to include(provider1.provider_code)
+        expect(command_output).to include(provider1.provider_name)
 
-        expect(command_output).to match(/A12/)
-        expect(command_output).to match(/Provider of Learning/)
+        expect(command_output).to include(provider2.provider_code)
+        expect(command_output).to include(provider2.provider_name)
       end
 
       it 'is case insensitive' do
         provider1
         provider2
 
-        command_output = list('x13')[:stdout]
-        expect(command_output).to match(/X13/)
+        command_output = list(provider1.provider_code.downcase)[:stdout]
+        expect(command_output).to include(provider1.provider_code)
       end
     end
 
@@ -58,29 +77,29 @@ describe 'mcb providers list' do
 
         command_output = list[:stdout]
 
-        expect(command_output).to match(/A12/)
-        expect(command_output).to match(/Provider of Learning/)
+        expect(command_output).to include(provider1.provider_code)
+        expect(command_output).to include(provider1.provider_name)
 
-        expect(command_output).to match(/X13/)
-        expect(command_output).to match(/Learning Provider/)
+        expect(command_output).to include(provider2.provider_code)
+        expect(command_output).to include(provider2.provider_name)
       end
     end
   end
 
   context 'when recruitment cycle is specified' do
-    let(:provider1) { create(:provider, provider_code: 'A12', provider_name: 'Provider of Learning', recruitment_cycle: current_cycle) }
-    let(:provider2) { create(:provider, provider_code: 'X13', provider_name: 'Learning Provider', recruitment_cycle: additional_cycle) }
+    let(:provider1) { create(:provider, recruitment_cycle: current_cycle) }
+    let(:provider2) { create(:provider, recruitment_cycle: additional_cycle) }
 
     it 'displays information about providers for the specified recruitment cycle' do
       provider1
       provider2
 
-      command_output = list("-R", additional_cycle.year)[:stdout]
-      expect(command_output).to match(/X13/)
-      expect(command_output).to match(/Learning Provider/)
+      command_output = list("-r", additional_cycle.year)[:stdout]
+      expect(command_output).to include(provider2.provider_code)
+      expect(command_output).to include(provider2.provider_name)
 
-      expect(command_output).not_to match(/A12/)
-      expect(command_output).not_to match(/Provider of Learning/)
+      expect(command_output).not_to include(provider1.provider_code)
+      expect(command_output).not_to include(provider1.provider_code)
     end
   end
 end

--- a/spec/lib/mcb/commands/providers/list_spec.rb
+++ b/spec/lib/mcb/commands/providers/list_spec.rb
@@ -9,12 +9,6 @@ describe 'mcb providers list' do
     { stdout: output, stderr: stderr }
   end
 
-  let(:email) { 'user@education.gov.uk' }
-
-  before do
-    allow(MCB).to receive(:config).and_return(email: email)
-  end
-
   let(:current_cycle) { RecruitmentCycle.current_recruitment_cycle }
   let(:additional_cycle) { find_or_create(:recruitment_cycle, year: '2020') }
 
@@ -46,6 +40,14 @@ describe 'mcb providers list' do
 
         expect(command_output).to match(/A12/)
         expect(command_output).to match(/Provider of Learning/)
+      end
+
+      it 'is case insensitive' do
+        provider1
+        provider2
+
+        command_output = list('x13')[:stdout]
+        expect(command_output).to match(/X13/)
       end
     end
 


### PR DESCRIPTION
### Context
Rollover wasn't yet reflected in MCB.

### Changes proposed in this pull request
Allow the specification of the current recruitment year, or default to the current recruitment year.

### Guidance to review
  
Main concern is test style.  
![](https://github.trello.services/images/mini-trello-icon.png) [Add option to specify recruitment cycle to mcb commands.](https://trello.com/c/T5oYvmB1/1731-add-option-to-specify-recruitment-cycle-to-mcb-commands)  
  
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
