### PR TITLE
[1763] change accrediting provider assocation to use code

### DIFF
--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -14,7 +14,6 @@ module API
           @courses = Course
                        .includes(:provider,
                                  :site_statuses,
-                                 :accrediting_provider,
                                  :subjects,
                                  site_statuses: [:site])
                        .changed_since(changed_since)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -2,24 +2,24 @@
 #
 # Table name: course
 #
-#  id                      :integer          not null, primary key
-#  age_range               :text
-#  course_code             :text
-#  name                    :text
-#  profpost_flag           :text
-#  program_type            :text
-#  qualification           :integer          not null
-#  start_date              :datetime
-#  study_mode              :text
-#  accrediting_provider_id :integer
-#  provider_id             :integer          default(0), not null
-#  modular                 :text
-#  english                 :integer
-#  maths                   :integer
-#  science                 :integer
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  changed_at              :datetime         not null
+#  id                        :integer          not null, primary key
+#  age_range                 :text
+#  course_code               :text
+#  name                      :text
+#  profpost_flag             :text
+#  program_type              :text
+#  qualification             :integer          not null
+#  start_date                :datetime
+#  study_mode                :text
+#  provider_id               :integer          default(0), not null
+#  modular                   :text
+#  english                   :integer
+#  maths                     :integer
+#  science                   :integer
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  changed_at                :datetime         not null
+#  accrediting_provider_code :text
 #
 
 class Course < ApplicationRecord
@@ -68,7 +68,14 @@ class Course < ApplicationRecord
   enum science: ENTRY_REQUIREMENT_OPTIONS, _suffix: :for_science
 
   belongs_to :provider
-  belongs_to :accrediting_provider, class_name: 'Provider', optional: true
+
+  belongs_to :accrediting_provider,
+             ->(c) { where(recruitment_cycle: c.recruitment_cycle) },
+             class_name: 'Provider',
+             foreign_key: :accrediting_provider_code,
+             primary_key: :provider_code,
+             inverse_of: :accredited_courses,
+             optional: true
 
   has_many :course_subjects
   has_many :subjects, through: :course_subjects

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -63,6 +63,13 @@ class Provider < ApplicationRecord
   has_many :courses
   has_one :ucas_preferences, class_name: 'ProviderUCASPreference'
   has_many :contacts
+  has_many :accredited_courses,
+           class_name: 'Course',
+           foreign_key: :accrediting_provider_code,
+           primary_key: :provider_code,
+           inverse_of: :accrediting_provider
+
+
 
   scope :changed_since, ->(timestamp) do
     if timestamp.present?

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -34,7 +34,6 @@ class Site < ApplicationRecord
   validates :location_name, uniqueness: { scope: :provider_id }
   validates :location_name,
             :address1,
-            :address3,
             :postcode,
             presence: true
   validates :postcode, postcode: true

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -2,24 +2,24 @@
 #
 # Table name: course
 #
-#  id                      :integer          not null, primary key
-#  age_range               :text
-#  course_code             :text
-#  name                    :text
-#  profpost_flag           :text
-#  program_type            :text
-#  qualification           :integer          not null
-#  start_date              :datetime
-#  study_mode              :text
-#  accrediting_provider_id :integer
-#  provider_id             :integer          default(0), not null
-#  modular                 :text
-#  english                 :integer
-#  maths                   :integer
-#  science                 :integer
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  changed_at              :datetime         not null
+#  id                        :integer          not null, primary key
+#  age_range                 :text
+#  course_code               :text
+#  name                      :text
+#  profpost_flag             :text
+#  program_type              :text
+#  qualification             :integer          not null
+#  start_date                :datetime
+#  study_mode                :text
+#  provider_id               :integer          default(0), not null
+#  modular                   :text
+#  english                   :integer
+#  maths                     :integer
+#  science                   :integer
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  changed_at                :datetime         not null
+#  accrediting_provider_code :text
 #
 
 class CourseSerializer < ActiveModel::Serializer

--- a/db/migrate/20190711074433_change_course_accrediting_provider_id_to_code.rb
+++ b/db/migrate/20190711074433_change_course_accrediting_provider_id_to_code.rb
@@ -1,0 +1,44 @@
+class ChangeCourseAccreditingProviderIdToCode < ActiveRecord::Migration[5.2]
+  class Course < ApplicationRecord
+    belongs_to :accrediting_provider, class_name: 'Provider', optional: true
+  end
+
+  def change
+    add_column :course, :accrediting_provider_code, :text
+    add_index :course, :accrediting_provider_code
+
+    reversible do |dir|
+      say_with_time 'updating accrediting provider on courses' do
+        Course.all.each do |course|
+          dir.up {
+            course.update accrediting_provider_code:
+                            course.accrediting_provider&.provider_code
+          }
+          # manage_courses_backend_development=# select count(*) from course where accrediting_provider_id is null;
+          #   count
+          # -------
+          #   3403
+
+          # manage_courses_backend_development=# select count(*) from course where accrediting_provider_code is null;
+          #   count
+          # -------
+          #   3403
+          dir.down {
+            course.update accrediting_provider_id:
+                            course.accrediting_provider&.id
+          }
+        end
+      end
+    end
+
+    revert do
+      add_column :course, :accrediting_provider_id, :integer
+      add_foreign_key :course,
+                      :provider,
+                      column: :accrediting_provider_id,
+                      name: "FK_course_provider_accrediting_provider_id"
+      add_index :course, %w[accrediting_provider_id],
+                name: "IX_course_accrediting_provider_id"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_04_134543) do
+ActiveRecord::Schema.define(version: 2019_07_11_074433) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -76,7 +76,6 @@ ActiveRecord::Schema.define(version: 2019_07_04_134543) do
     t.integer "qualification", null: false
     t.datetime "start_date"
     t.text "study_mode"
-    t.integer "accrediting_provider_id"
     t.integer "provider_id", default: 0, null: false
     t.text "modular"
     t.integer "english"
@@ -85,7 +84,7 @@ ActiveRecord::Schema.define(version: 2019_07_04_134543) do
     t.datetime "created_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.datetime "changed_at", default: -> { "timezone('utc'::text, now())" }, null: false
-    t.index ["accrediting_provider_id"], name: "IX_course_accrediting_provider_id"
+    t.text "accrediting_provider_code"
     t.index ["changed_at"], name: "index_course_on_changed_at", unique: true
     t.index ["provider_id", "course_code"], name: "IX_course_provider_id_course_code", unique: true
   end
@@ -266,7 +265,6 @@ ActiveRecord::Schema.define(version: 2019_07_04_134543) do
   end
 
   add_foreign_key "access_request", "\"user\"", column: "requester_id", name: "FK_access_request_user_requester_id", on_delete: :nullify
-  add_foreign_key "course", "provider", column: "accrediting_provider_id", name: "FK_course_provider_accrediting_provider_id"
   add_foreign_key "course", "provider", name: "FK_course_provider_provider_id", on_delete: :cascade
   add_foreign_key "course_enrichment", "\"user\"", column: "created_by_user_id", name: "FK_course_enrichment_user_created_by_user_id"
   add_foreign_key "course_enrichment", "\"user\"", column: "updated_by_user_id", name: "FK_course_enrichment_user_updated_by_user_id"

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -2,24 +2,24 @@
 #
 # Table name: course
 #
-#  id                      :integer          not null, primary key
-#  age_range               :text
-#  course_code             :text
-#  name                    :text
-#  profpost_flag           :text
-#  program_type            :text
-#  qualification           :integer          not null
-#  start_date              :datetime
-#  study_mode              :text
-#  accrediting_provider_id :integer
-#  provider_id             :integer          default(0), not null
-#  modular                 :text
-#  english                 :integer
-#  maths                   :integer
-#  science                 :integer
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  changed_at              :datetime         not null
+#  id                        :integer          not null, primary key
+#  age_range                 :text
+#  course_code               :text
+#  name                      :text
+#  profpost_flag             :text
+#  program_type              :text
+#  qualification             :integer          not null
+#  start_date                :datetime
+#  study_mode                :text
+#  provider_id               :integer          default(0), not null
+#  modular                   :text
+#  english                   :integer
+#  maths                     :integer
+#  science                   :integer
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  changed_at                :datetime         not null
+#  accrediting_provider_code :text
 #
 
 FactoryBot.define do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2,24 +2,24 @@
 #
 # Table name: course
 #
-#  id                      :integer          not null, primary key
-#  age_range               :text
-#  course_code             :text
-#  name                    :text
-#  profpost_flag           :text
-#  program_type            :text
-#  qualification           :integer          not null
-#  start_date              :datetime
-#  study_mode              :text
-#  accrediting_provider_id :integer
-#  provider_id             :integer          default(0), not null
-#  modular                 :text
-#  english                 :integer
-#  maths                   :integer
-#  science                 :integer
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  changed_at              :datetime         not null
+#  id                        :integer          not null, primary key
+#  age_range                 :text
+#  course_code               :text
+#  name                      :text
+#  profpost_flag             :text
+#  program_type              :text
+#  qualification             :integer          not null
+#  start_date                :datetime
+#  study_mode                :text
+#  provider_id               :integer          default(0), not null
+#  modular                   :text
+#  english                   :integer
+#  maths                     :integer
+#  science                   :integer
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  changed_at                :datetime         not null
+#  accrediting_provider_code :text
 #
 
 require 'rails_helper'
@@ -38,7 +38,12 @@ RSpec.describe Course, type: :model do
 
   describe 'associations' do
     it { should belong_to(:provider) }
-    it { should belong_to(:accrediting_provider).optional }
+    it {
+      should belong_to(:accrediting_provider)
+                  .with_foreign_key(:accrediting_provider_code)
+                  .with_primary_key(:provider_code)
+                  .optional
+    }
     it { should have_many(:subjects).through(:course_subjects) }
     it { should have_many(:site_statuses) }
     it { should have_many(:sites) }

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -27,7 +27,6 @@ describe Provider, type: :model do
 
   it { is_expected.to validate_presence_of(:location_name) }
   it { is_expected.to validate_presence_of(:address1) }
-  it { is_expected.to validate_presence_of(:address3) }
   it { is_expected.to validate_presence_of(:postcode) }
   it { is_expected.to validate_uniqueness_of(:location_name).scoped_to(:provider_id) }
   it { is_expected.to validate_uniqueness_of(:code).case_insensitive.scoped_to(:provider_id) }

--- a/spec/requests/api/v2/providers/courses/update_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_spec.rb
@@ -113,14 +113,14 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
       another_provider = create(:provider)
       update_course    = build(
         :course,
-        accrediting_provider_id: another_provider.id,
-        provider:                provider
+        accrediting_provider: another_provider,
+        provider:             provider
       )
       update_course.id = course.id
 
       perform_request(course)
 
-      expect(course.reload.accrediting_provider_id).not_to eq(another_provider.id)
+      expect(course.reload.accrediting_provider).not_to eq(another_provider)
     end
   end
 

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -377,14 +377,13 @@ describe 'Sites API v2', type: :request do
           context 'with missing attributes' do
             let(:location_name) { '' }
             let(:address1)      { '' }
-            let(:address3)      { '' }
             let(:postcode)      { '' }
             let(:region_code)   { '' }
 
             it { should have_http_status(:unprocessable_entity) }
 
             it 'has the right amount of errors' do
-              expect(json_data.count).to eq 5
+              expect(json_data.count).to eq 4
             end
 
             it 'checks the location_name is present' do
@@ -395,11 +394,6 @@ describe 'Sites API v2', type: :request do
             it 'checks the address1 is present' do
               expect(response.body).to include('Invalid address1')
               expect(response.body).to include("Building and street is missing")
-            end
-
-            it 'checks the address3 is present' do
-              expect(response.body).to include('Invalid address3')
-              expect(response.body).to include("Town or city is missing")
             end
 
             it 'checks the postcode is present' do
@@ -559,7 +553,6 @@ describe 'Sites API v2', type: :request do
             location_name: location_name,
             address1: address1,
             address2: address2,
-            address3: address3,
             address4: address4,
             postcode: postcode,
             region_code: region_code
@@ -570,14 +563,13 @@ describe 'Sites API v2', type: :request do
         context 'with missing attributes' do
           let(:location_name) { '' }
           let(:address1)      { '' }
-          let(:address3)      { '' }
           let(:postcode)      { '' }
           let(:region_code)   { '' }
 
           it { should have_http_status(:unprocessable_entity) }
 
           it 'has the right amount of errors' do
-            expect(json_data.count).to eq 5
+            expect(json_data.count).to eq 4
           end
         end
       end

--- a/spec/serializers/course_serializer_spec.rb
+++ b/spec/serializers/course_serializer_spec.rb
@@ -2,24 +2,24 @@
 #
 # Table name: course
 #
-#  id                      :integer          not null, primary key
-#  age_range               :text
-#  course_code             :text
-#  name                    :text
-#  profpost_flag           :text
-#  program_type            :text
-#  qualification           :integer          not null
-#  start_date              :datetime
-#  study_mode              :text
-#  accrediting_provider_id :integer
-#  provider_id             :integer          default(0), not null
-#  modular                 :text
-#  english                 :integer
-#  maths                   :integer
-#  science                 :integer
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  changed_at              :datetime         not null
+#  id                        :integer          not null, primary key
+#  age_range                 :text
+#  course_code               :text
+#  name                      :text
+#  profpost_flag             :text
+#  program_type              :text
+#  qualification             :integer          not null
+#  start_date                :datetime
+#  study_mode                :text
+#  provider_id               :integer          default(0), not null
+#  modular                   :text
+#  english                   :integer
+#  maths                     :integer
+#  science                   :integer
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  changed_at                :datetime         not null
+#  accrediting_provider_code :text
 #
 
 require "rails_helper"


### PR DESCRIPTION
### Context

Because when we link it by ID, we link it to a provider in a specific recruitment cycle, which makes rolling-over a bit more complicated. By changing this to provider_code it becomes a simpler relationship that doesn't risk being out-of-sync.

### Changes proposed in this pull request

Change `accrediting_provider_id` to `accrediting_provider_code` in `Course`.

### Guidance to review

Because `Course#accrediting_provider` is now a dynamic association, we can't pre-load it, which leads to a degradation in performance which will probably be most felt on the courses endpoint for api v1. However, with local testing it doesn't seem to bad since Rails can cache these SQL lookups when we're looking up the same provider.

```
[active_model_serializers]   Provider Load (0.2ms)  SELECT  "provider".* FROM "provider" WHERE "provider"."provider_code" = $1 AND "provider"."recruitment_cycle_id" = $2 LIMIT $3  [["provider_code", "N42"], ["recruitment_cycle_id", 1], ["LIMIT", 1]]
[active_model_serializers]   ↳ app/controllers/api/v1/courses_controller.rb:31
[active_model_serializers]   CACHE Provider Load (0.0ms)  SELECT  "provider".* FROM "provider" WHERE "provider"."provider_code" = $1 AND "provider"."recruitment_cycle_id" = $2 LIMIT $3  [["provider_code", "N42"], ["recruitment_cycle_id", 1], ["LIMIT", 1]]
[active_model_serializers]   ↳ app/controllers/api/v1/courses_controller.rb:31
```

Even if for whatever reason we don't get as many cache hits as we'd hope, say if the courses are updated in such a way so that each course on a page of 100 is accredited by a different provider, the timings to perform the lookup on a single one seems to be fast enough to not be an issue (0.2ms in the example above, which looks representative looking at the console output on my laptop).

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
