### PR TITLE
[1765] remove site address3 validation

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -34,7 +34,6 @@ class Site < ApplicationRecord
   validates :location_name, uniqueness: { scope: :provider_id }
   validates :location_name,
             :address1,
-            :address3,
             :postcode,
             presence: true
   validates :postcode, postcode: true

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -27,7 +27,6 @@ describe Provider, type: :model do
 
   it { is_expected.to validate_presence_of(:location_name) }
   it { is_expected.to validate_presence_of(:address1) }
-  it { is_expected.to validate_presence_of(:address3) }
   it { is_expected.to validate_presence_of(:postcode) }
   it { is_expected.to validate_uniqueness_of(:location_name).scoped_to(:provider_id) }
   it { is_expected.to validate_uniqueness_of(:code).case_insensitive.scoped_to(:provider_id) }

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -377,14 +377,13 @@ describe 'Sites API v2', type: :request do
           context 'with missing attributes' do
             let(:location_name) { '' }
             let(:address1)      { '' }
-            let(:address3)      { '' }
             let(:postcode)      { '' }
             let(:region_code)   { '' }
 
             it { should have_http_status(:unprocessable_entity) }
 
             it 'has the right amount of errors' do
-              expect(json_data.count).to eq 5
+              expect(json_data.count).to eq 4
             end
 
             it 'checks the location_name is present' do
@@ -395,11 +394,6 @@ describe 'Sites API v2', type: :request do
             it 'checks the address1 is present' do
               expect(response.body).to include('Invalid address1')
               expect(response.body).to include("Building and street is missing")
-            end
-
-            it 'checks the address3 is present' do
-              expect(response.body).to include('Invalid address3')
-              expect(response.body).to include("Town or city is missing")
             end
 
             it 'checks the postcode is present' do
@@ -559,7 +553,6 @@ describe 'Sites API v2', type: :request do
             location_name: location_name,
             address1: address1,
             address2: address2,
-            address3: address3,
             address4: address4,
             postcode: postcode,
             region_code: region_code
@@ -570,14 +563,13 @@ describe 'Sites API v2', type: :request do
         context 'with missing attributes' do
           let(:location_name) { '' }
           let(:address1)      { '' }
-          let(:address3)      { '' }
           let(:postcode)      { '' }
           let(:region_code)   { '' }
 
           it { should have_http_status(:unprocessable_entity) }
 
           it 'has the right amount of errors' do
-            expect(json_data.count).to eq 5
+            expect(json_data.count).to eq 4
           end
         end
       end


### PR DESCRIPTION
### Context

We have a bunch of legacy sites in the db that are invalid because they're missing a value for `address3`, and it's becoming increasingly difficult to work-around this validation. Fox example for the rollover, copying the sites is failing because they're invalid, and even creating the data in a spec is painful.

### Changes proposed in this pull request

Remove the presence validation we have on `site.address3`.

### Guidance to review

I'm looking for some validation that this is a good idea, let me know if you think that there's a better approach to this, or if we should just suck it up and do the work to disable validations for tests & rollover.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
