### PR TITLE
[1564] re-add accrediting_provider_id on courses

### DIFF
--- a/db/migrate/20190711074433_change_course_accrediting_provider_id_to_code.rb
+++ b/db/migrate/20190711074433_change_course_accrediting_provider_id_to_code.rb
@@ -30,15 +30,5 @@ class ChangeCourseAccreditingProviderIdToCode < ActiveRecord::Migration[5.2]
         end
       end
     end
-
-    revert do
-      add_column :course, :accrediting_provider_id, :integer
-      add_foreign_key :course,
-                      :provider,
-                      column: :accrediting_provider_id,
-                      name: "FK_course_provider_accrediting_provider_id"
-      add_index :course, %w[accrediting_provider_id],
-                name: "IX_course_accrediting_provider_id"
-    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,6 +85,9 @@ ActiveRecord::Schema.define(version: 2019_07_11_074433) do
     t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.datetime "changed_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.text "accrediting_provider_code"
+    t.integer "accrediting_provider_id"
+    t.index ["accrediting_provider_code"], name: "index_course_on_accrediting_provider_code"
+    t.index ["accrediting_provider_id"], name: "IX_course_accrediting_provider_id"
     t.index ["changed_at"], name: "index_course_on_changed_at", unique: true
     t.index ["provider_id", "course_code"], name: "IX_course_provider_id_course_code", unique: true
   end
@@ -265,6 +268,7 @@ ActiveRecord::Schema.define(version: 2019_07_11_074433) do
   end
 
   add_foreign_key "access_request", "\"user\"", column: "requester_id", name: "FK_access_request_user_requester_id", on_delete: :nullify
+  add_foreign_key "course", "provider", column: "accrediting_provider_id", name: "FK_course_provider_accrediting_provider_id"
   add_foreign_key "course", "provider", name: "FK_course_provider_provider_id", on_delete: :cascade
   add_foreign_key "course_enrichment", "\"user\"", column: "created_by_user_id", name: "FK_course_enrichment_user_created_by_user_id"
   add_foreign_key "course_enrichment", "\"user\"", column: "updated_by_user_id", name: "FK_course_enrichment_user_updated_by_user_id"


### PR DESCRIPTION
### Context

Just to keep the C# app happy for now, we'll remove it once we've deployed the
change to use accrediting_provider_code.

### Changes proposed in this pull request

Re-add the `accrediting_provider_id` to the `courses` table until we've re-deployed the new C# changes to not use it. It's values will be populated using the associated `accrediting_provider` on a course.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
