### PR TITLE
Add Course.get_by_codes convenience method

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -131,6 +131,12 @@ class Course < ApplicationRecord
 
   after_validation :remove_unnecessary_enrichments_validation_message
 
+  def self.get_by_codes(year, provider_code, course_code)
+    RecruitmentCycle.find_by(year: year)
+      .providers.find_by(provider_code: provider_code)
+      .courses.find_by(course_code: course_code)
+  end
+
   def recruitment_cycle
     provider.recruitment_cycle
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 2019_07_11_074433) do
     t.integer "qualification", null: false
     t.datetime "start_date"
     t.text "study_mode"
+    t.integer "accrediting_provider_id"
     t.integer "provider_id", default: 0, null: false
     t.text "modular"
     t.integer "english"
@@ -85,7 +86,6 @@ ActiveRecord::Schema.define(version: 2019_07_11_074433) do
     t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.datetime "changed_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.text "accrediting_provider_code"
-    t.integer "accrediting_provider_id"
     t.index ["accrediting_provider_code"], name: "index_course_on_accrediting_provider_code"
     t.index ["accrediting_provider_id"], name: "IX_course_accrediting_provider_id"
     t.index ["changed_at"], name: "index_course_on_changed_at", unique: true

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -769,4 +769,14 @@ RSpec.describe Course, type: :model do
       end
     end
   end
+
+  describe 'self.get_by_codes' do
+    it 'should return the found course' do
+      expect(Course.get_by_codes(
+               course.recruitment_cycle.year,
+               course.provider.provider_code,
+               course.course_code
+             )).to eq course
+    end
+  end
 end


### PR DESCRIPTION
### Context

Super handy at the console, and maybe other places too!

### Changes proposed in this pull request

Add a command to conveniently get a course using it's recruitment cycle, provider code and course code.

### Guidance to review

The `schema.rb` change came along for the ride and I can't be bothered to see if there's a better way to sort it.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
