### PR TITLE
Remove extra verbose of request response from apiv1 iterator

### DIFF
--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -218,10 +218,6 @@ module MCB
             endpoint_url.to_s,
             headers: { authorization: "Bearer #{token}" }
           )
-          verbose "Response headers:"
-          verbose response.headers
-          verbose "Response body:"
-          verbose response.body
           records = JSON.parse(response.body)
           if records.any?
 


### PR DESCRIPTION
### Context

This verbosity makes the commands that use apiv1 nearly unusable. The raw JSON results can already be displayed with the `--json` option.

### Changes proposed in this pull request

Remove unnecessary verbose output.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
