### PR TITLE
[1731] Fix API v1 commands not initialising rails

### DIFF
--- a/lib/mcb/commands/apiv1/courses/find.rb
+++ b/lib/mcb/commands/apiv1/courses/find.rb
@@ -15,6 +15,8 @@ option :P, 'max-pages', 'maximum number of pages to request',
 
 
 run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
   opts = MCB.apiv1_opts(opts)
   opts[:all] ||= true
 

--- a/lib/mcb/commands/apiv1/courses/list.rb
+++ b/lib/mcb/commands/apiv1/courses/list.rb
@@ -6,6 +6,7 @@ option :P, 'max-pages', 'maximum number of pages to request',
        transform: method(:Integer)
 
 run do |opts, _args, _cmd|
+  MCB.init_rails(opts)
   opts = MCB.apiv1_opts(opts)
   last_context = nil
 

--- a/lib/mcb/commands/apiv1/providers/find.rb
+++ b/lib/mcb/commands/apiv1/providers/find.rb
@@ -14,6 +14,8 @@ option :P, 'max-pages', 'maximum number of pages to request',
 
 
 run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+
   opts = MCB.apiv1_opts(opts)
   opts[:all] ||= true
 

--- a/lib/mcb/commands/apiv1/providers/list.rb
+++ b/lib/mcb/commands/apiv1/providers/list.rb
@@ -7,6 +7,8 @@ option :P, 'max-pages', 'maximum number of pages to request',
        transform: method(:Integer)
 
 run do |opts, _args, _cmd|
+  MCB.init_rails(opts)
+
   opts = MCB.apiv1_opts(opts)
   last_context = nil
 


### PR DESCRIPTION
### Context
The test environment already initialises rails so I missed the fact it wasn't being initialised in the apiv1 commands. Rails must be initialised in order to get the current recruitment year.  

### Changes proposed in this pull request  
Initialise Rails for all APIv1 commands.  

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
