### PR TITLE
[1731] Recruitment cycles for other course commands

### DIFF
--- a/lib/mcb/commands/courses/audit.rb
+++ b/lib/mcb/commands/courses/audit.rb
@@ -6,7 +6,8 @@ param :course_code, transform: ->(code) { code.upcase }
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
-  provider = Provider.find_by!(provider_code: args[:provider_code])
+  pp MCB.get_recruitment_cycle(opts).providers
+  provider = MCB.get_recruitment_cycle(opts).providers.find_by!(provider_code: args[:provider_code])
   course = provider.courses.find_by!(course_code: args[:course_code])
 
   table = Tabulo::Table.new course.audits do |t|

--- a/lib/mcb/commands/courses/audit.rb
+++ b/lib/mcb/commands/courses/audit.rb
@@ -6,7 +6,6 @@ param :course_code, transform: ->(code) { code.upcase }
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
-  pp MCB.get_recruitment_cycle(opts).providers
   provider = MCB.get_recruitment_cycle(opts).providers.find_by!(provider_code: args[:provider_code])
   course = provider.courses.find_by!(course_code: args[:course_code])
 

--- a/lib/mcb/commands/courses/edit.rb
+++ b/lib/mcb/commands/courses/edit.rb
@@ -10,7 +10,7 @@ run do |opts, args, _cmd|
 
   MCB::CoursesEditor.new(
     requester: User.find_by!(email: MCB.config[:email]),
-    provider: RecruitmentCycle.current_recruitment_cycle.providers.find_by!(provider_code: provider_code),
+    provider: MCB.get_recruitment_cycle(opts).providers.find_by!(provider_code: provider_code),
     course_codes: course_codes
   ).run
 end

--- a/lib/mcb/commands/courses/show.rb
+++ b/lib/mcb/commands/courses/show.rb
@@ -8,7 +8,7 @@ param :course_code, transform: ->(code) { code.upcase }
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
-  provider = Provider.find_by!(provider_code: args[:provider_code])
+  provider = MCB.get_recruitment_cycle(opts).providers.find_by!(provider_code: args[:provider_code])
   course = provider.courses.find_by!(course_code: args[:course_code])
 
   puts MCB::Render::ActiveRecord.course(course)

--- a/lib/mcb/commands/courses/touch.rb
+++ b/lib/mcb/commands/courses/touch.rb
@@ -6,7 +6,7 @@ param :course_code
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
-  provider = Provider.find_by!(provider_code: args[:provider_code].upcase)
+  provider = MCB.get_recruitment_cycle(opts).providers.find_by!(provider_code: args[:provider_code].upcase)
   course = provider.courses.find_by!(course_code: args[:course_code].upcase)
   course.touch
   course.update! audit_comment: 'timestamps updated to expose in api v1'

--- a/spec/lib/mcb/commands/courses/audit_spec.rb
+++ b/spec/lib/mcb/commands/courses/audit_spec.rb
@@ -5,7 +5,7 @@ describe 'mcb courses audit' do
 
   let(:admin_user) { create :user, :admin, email: 'h@i' }
 
-  let(:recruitment_year1) { create :recruitment_cycle, year: '2018' }
+  let(:recruitment_year1) { create :recruitment_cycle, :next }
   let(:recruitment_year2) { RecruitmentCycle.current_recruitment_cycle }
 
   let(:provider) { create :provider, updated_at: 1.day.ago, changed_at: 1.day.ago, recruitment_cycle: recruitment_year1 }

--- a/spec/lib/mcb/commands/courses/audit_spec.rb
+++ b/spec/lib/mcb/commands/courses/audit_spec.rb
@@ -1,13 +1,7 @@
 require 'mcb_helper'
 
 describe 'mcb courses audit' do
-  def audit(*arguments)
-    stderr = nil
-    output = with_stubbed_stdout(stdin: "", stderr: stderr) do
-      $mcb.run(%W[courses audit] + arguments)
-    end
-    { stdout: output, stderr: stderr }
-  end
+  let(:audit) { MCBCommand.new('courses', 'audit') }
 
   let(:admin_user) { create :user, :admin, email: 'h@i' }
 
@@ -39,7 +33,12 @@ describe 'mcb courses audit' do
       rolled_over_course.update(name: 'Y')
       course.update(name: 'B')
 
-      output = audit(rolled_over_provider.provider_code, rolled_over_course.course_code)[:stdout]
+      output = audit.execute(
+        arguments: [
+          rolled_over_provider.provider_code,
+          rolled_over_course.course_code
+        ]
+      )[:stdout]
 
       expect(output).to have_text_table_row(admin_user.id,
                                             'h@i',
@@ -62,7 +61,14 @@ describe 'mcb courses audit' do
       rolled_over_course.update(name: 'Y')
       course.update(name: 'B')
 
-      output = audit(provider.provider_code, course.course_code, '-r', recruitment_year1.year)[:stdout]
+      output = audit.execute(
+        arguments: [
+          provider.provider_code,
+          course.course_code,
+          '-r',
+          recruitment_year1.year
+        ]
+      )[:stdout]
 
       expect(output).to have_text_table_row(admin_user.id,
                                             'h@i',

--- a/spec/lib/mcb/commands/courses/audit_spec.rb
+++ b/spec/lib/mcb/commands/courses/audit_spec.rb
@@ -1,31 +1,82 @@
 require 'mcb_helper'
 
 describe 'mcb courses audit' do
-  let(:lib_dir) { Rails.root.join('lib') }
-  let(:cmd) do
-    Cri::Command.load_file(
-      "#{lib_dir}/mcb/commands/courses/audit.rb"
-    )
+  def audit(*arguments)
+    stderr = nil
+    output = with_stubbed_stdout(stdin: "", stderr: stderr) do
+      $mcb.run(%W[courses audit] + arguments)
+    end
+    { stdout: output, stderr: stderr }
   end
+
   let(:admin_user) { create :user, :admin, email: 'h@i' }
-  let(:course) { create(:course, name: 'P') }
+
+  let(:recruitment_year1) { create :recruitment_cycle, year: '2018' }
+  let(:recruitment_year2) { RecruitmentCycle.current_recruitment_cycle }
+
+  let(:provider) { create :provider, updated_at: 1.day.ago, changed_at: 1.day.ago, recruitment_cycle: recruitment_year1 }
+  let(:rolled_over_provider) do
+    new_provider = provider.dup
+    new_provider.update(recruitment_cycle: recruitment_year2)
+    new_provider.save
+    new_provider
+  end
+
+  let(:course) { create(:course, name: 'P', provider: provider) }
+  let(:rolled_over_course) do
+    new_course = course.dup
+    new_course.update(provider: rolled_over_provider)
+    new_course.save
+    new_course
+  end
 
   before do
     Audited.store[:audited_user] = admin_user
   end
 
-  it 'shows the list of changes for a given course' do
-    course.update(name: 'B')
+  context 'when the recruitment year is unspecified' do
+    it 'shows the list of changes for a given course' do
+      rolled_over_course.update(name: 'Y')
+      course.update(name: 'B')
 
-    output = with_stubbed_stdout do
-      cmd.run([course.provider.provider_code, course.course_code])
+      output = audit(rolled_over_provider.provider_code, rolled_over_course.course_code)[:stdout]
+
+      expect(output).to have_text_table_row(admin_user.id,
+                                            'h@i',
+                                            'update',
+                                            '',
+                                            '',
+                                            '{"name"=>["P", "Y"],')
+
+      expect(output).not_to have_text_table_row(admin_user.id,
+                                                'h@i',
+                                                'update',
+                                                '',
+                                                '',
+                                                '{"name"=>["P", "B"],')
     end
+  end
 
-    expect(output).to have_text_table_row(admin_user.id,
-                                          'h@i',
-                                          'update',
-                                          '',
-                                          '',
-                                          '{"name"=>["P", "B"],')
+  context 'when the recruitment year is specified' do
+    it 'shows the list of changes for a given course' do
+      rolled_over_course.update(name: 'Y')
+      course.update(name: 'B')
+
+      output = audit(provider.provider_code, course.course_code, '-r', recruitment_year1.year)[:stdout]
+
+      expect(output).to have_text_table_row(admin_user.id,
+                                            'h@i',
+                                            'update',
+                                            '',
+                                            '',
+                                            '{"name"=>["P", "B"],')
+
+      expect(output).not_to have_text_table_row(admin_user.id,
+                                                'h@i',
+                                                'update',
+                                                '',
+                                                '',
+                                                '{"name"=>["P", "Y"],')
+    end
   end
 end

--- a/spec/lib/mcb/commands/courses/list_spec.rb
+++ b/spec/lib/mcb/commands/courses/list_spec.rb
@@ -1,13 +1,7 @@
 require 'mcb_helper'
 
 describe 'mcb providers list' do
-  def list(*arguments)
-    stderr = nil
-    output = with_stubbed_stdout(stdin: "", stderr: stderr) do
-      $mcb.run %W[courses list] + arguments
-    end
-    { stdout: output, stderr: stderr }
-  end
+  let(:list) { MCBCommand.new('courses', 'list') }
 
   let(:current_cycle) { RecruitmentCycle.current_recruitment_cycle }
   let(:additional_cycle) { find_or_create(:recruitment_cycle, year: '2020') }
@@ -26,7 +20,7 @@ describe 'mcb providers list' do
       course2
       course3
 
-      command_output = list[:stdout]
+      command_output = list.execute[:stdout]
 
       expect(command_output).to include(course1.course_code)
       expect(command_output).to include(course1.name)
@@ -43,7 +37,7 @@ describe 'mcb providers list' do
         course1
         course2
 
-        command_output = list(course1.course_code)[:stdout]
+        command_output = list.execute(arguments: [course1.course_code])[:stdout]
 
         expect(command_output).to include(course1.course_code)
         expect(command_output).to include(course1.name)
@@ -56,7 +50,7 @@ describe 'mcb providers list' do
         course1
         course2
 
-        command_output = list(course1.course_code, course2.course_code)[:stdout]
+        command_output = list.execute(arguments: [course1.course_code, course2.course_code])[:stdout]
 
         expect(command_output).to include(course1.course_code)
         expect(command_output).to include(course1.name)
@@ -69,7 +63,7 @@ describe 'mcb providers list' do
         course1
         course2
 
-        command_output = list(course2.course_code.downcase)[:stdout]
+        command_output = list.execute(arguments: [course2.course_code.downcase])[:stdout]
         expect(command_output).to include(course2.course_code)
       end
     end
@@ -79,7 +73,7 @@ describe 'mcb providers list' do
         course1
         course2
 
-        command_output = list[:stdout]
+        command_output = list.execute[:stdout]
 
         expect(command_output).to include(course1.course_code)
         expect(command_output).to include(course1.name)
@@ -101,7 +95,7 @@ describe 'mcb providers list' do
       course1
       course2
 
-      command_output = list("-r", additional_cycle.year)[:stdout]
+      command_output = list.execute(arguments: ["-r", additional_cycle.year])[:stdout]
 
       expect(command_output).to include(course2.course_code)
       expect(command_output).to include(course2.name)

--- a/spec/lib/mcb/commands/courses/list_spec.rb
+++ b/spec/lib/mcb/commands/courses/list_spec.rb
@@ -4,7 +4,7 @@ describe 'mcb providers list' do
   let(:list) { MCBCommand.new('courses', 'list') }
 
   let(:current_cycle) { RecruitmentCycle.current_recruitment_cycle }
-  let(:additional_cycle) { find_or_create(:recruitment_cycle, year: '2020') }
+  let(:additional_cycle) { find_or_create(:recruitment_cycle, :next) }
 
   context 'when recruitment cycle is unspecified' do
     let(:provider1) { create(:provider, recruitment_cycle: current_cycle) }

--- a/spec/lib/mcb/commands/courses/show_spec.rb
+++ b/spec/lib/mcb/commands/courses/show_spec.rb
@@ -1,39 +1,83 @@
 require 'mcb_helper'
 
-describe '"mcb courses show"' do
-  let(:lib_dir) { Rails.root.join('lib') }
-  let(:cmd) do
-    Cri::Command.load_file(
-      "#{lib_dir}/mcb/commands/courses/show.rb"
-    )
+describe 'mcb courses show' do
+  let(:show) { MCBCommand.new('courses', 'show') }
+
+  let(:recruitment_year1) { create :recruitment_cycle, year: '2020' }
+  let(:recruitment_year2) { RecruitmentCycle.current_recruitment_cycle }
+
+  let(:provider) { create :provider, updated_at: 1.day.ago, changed_at: 1.day.ago, recruitment_cycle: recruitment_year1 }
+  let(:rolled_over_provider) do
+    new_provider = provider.dup
+    new_provider.update(recruitment_cycle: recruitment_year2)
+    new_provider.save
+    new_provider
   end
 
-  it 'displays the course info' do
-    subject = build(:subject)
-    site_status = build(:site_status)
+  let(:subject1) { build(:subject) }
+  let(:subject2) { build(:subject) }
+  let(:site_status1) { build(:site_status) }
+  let(:site_status2) { build(:site_status) }
 
-    course = create(:course, subjects: [subject], site_statuses: [site_status])
+  let(:course) { create(:course, name: 'P', provider: provider, subjects: [subject1], site_statuses: [site_status1]) }
+  let(:rolled_over_course) do
+    new_course = course.dup
+    new_course.update(provider: rolled_over_provider)
+    new_course.update(subjects: [subject2])
+    new_course.update(site_statuses: [site_status2])
+    new_course.save
+    new_course
+  end
 
-    output = with_stubbed_stdout do
-      cmd.run([course.provider.provider_code, course.course_code])
-    end
+  context 'when the recruitment year is unspecified' do
+    it 'displays the course info with the default recruitment year' do
+      rolled_over_course
 
-    expect(output).to have_text_table_row('course_code',
-                                          course.course_code)
+      output = show.execute(arguments: [rolled_over_provider.provider_code, rolled_over_course.course_code])[:stdout]
 
-    expect(output).to have_text_table_row(subject.subject_code,
-                                          subject.subject_name)
+      expect(output).to have_text_table_row('course_code',
+                                            rolled_over_course.course_code)
 
-    expect(output).to(
-      have_text_table_row(
-        site_status.id,
-        site_status.site.code,
-        site_status.site.location_name,
-        site_status.vac_status,
-        site_status.status,
-        site_status.publish,
-        site_status.applications_accepted_from.strftime('%Y-%m-%d')
+      expect(output).to have_text_table_row(subject2.subject_code,
+                                            subject2.subject_name)
+
+      expect(output).to(
+        have_text_table_row(
+          site_status2.id,
+          site_status2.site.code,
+          site_status2.site.location_name,
+          site_status2.vac_status,
+          site_status2.status,
+          site_status2.publish,
+          site_status2.applications_accepted_from.strftime('%Y-%m-%d')
+        )
       )
-    )
+    end
+  end
+
+  context 'when the recruitment year is specified' do
+    it 'displays the course info for the specified recruitment year' do
+      rolled_over_course
+
+      output = show.execute(arguments: [provider.provider_code, course.course_code, '-r', recruitment_year1.year])[:stdout]
+
+      expect(output).to have_text_table_row('course_code',
+                                            course.course_code)
+
+      expect(output).to have_text_table_row(subject1.subject_code,
+                                            subject1.subject_name)
+
+      expect(output).to(
+        have_text_table_row(
+          site_status1.id,
+          site_status1.site.code,
+          site_status1.site.location_name,
+          site_status1.vac_status,
+          site_status1.status,
+          site_status1.publish,
+          site_status1.applications_accepted_from.strftime('%Y-%m-%d')
+        )
+      )
+    end
   end
 end

--- a/spec/lib/mcb/commands/courses/touch_spec.rb
+++ b/spec/lib/mcb/commands/courses/touch_spec.rb
@@ -2,7 +2,7 @@ require 'mcb_helper'
 
 describe 'mcb courses touch' do
   let(:touch) { MCBCommand.new('courses', 'touch') }
-  let(:recruitment_year1) { create :recruitment_cycle, year: '2018' }
+  let(:recruitment_year1) { create :recruitment_cycle, :next }
   let(:recruitment_year2) { RecruitmentCycle.current_recruitment_cycle }
 
   let(:provider) { create :provider, updated_at: 1.day.ago, changed_at: 1.day.ago, recruitment_cycle: recruitment_year1 }

--- a/spec/lib/mcb/commands/courses/touch_spec.rb
+++ b/spec/lib/mcb/commands/courses/touch_spec.rb
@@ -1,37 +1,104 @@
 require 'mcb_helper'
 
-describe '"mcb courses touch"' do
-  let(:course)   { create :course, updated_at: 1.day.ago, changed_at: 1.day.ago }
-  let(:provider) { course.provider }
+describe 'mcb courses touch', :focus do
+  let(:recruitment_year1) { create :recruitment_cycle, year: '2018' }
+  let(:recruitment_year2) { RecruitmentCycle.current_recruitment_cycle }
 
-  it 'updates the courses updated_at' do
-    Timecop.freeze do
-      with_stubbed_stdout do
-        $mcb.run(%W[course touch #{provider.provider_code} #{course.course_code}])
+  let(:provider) { create :provider, updated_at: 1.day.ago, changed_at: 1.day.ago, recruitment_cycle: recruitment_year1 }
+  let(:rolled_over_provider) do
+    new_provider = provider.dup
+    new_provider.update(recruitment_cycle: recruitment_year2)
+    new_provider.save
+    new_provider
+  end
+
+  let(:course) { create :course, updated_at: 1.day.ago, changed_at: 1.day.ago, provider: provider }
+  let(:rolled_over_course) do
+    new_course = course.dup
+    new_course.update(provider: rolled_over_provider)
+    new_course.save
+    new_course
+  end
+
+  context 'when the recruitment year is unspecified' do
+    it 'updates the course updated_at for the current recruitment cycle' do
+      rolled_over_course
+
+      Timecop.freeze(Date.today + 1) do
+        with_stubbed_stdout do
+          $mcb.run(%W[courses touch #{rolled_over_provider.provider_code} #{rolled_over_course.course_code}])
+        end
+
+        # Use to_i compare seconds since epoch and side-step sub-second
+        # differences that show up even with Timecop on certain platforms.
+        expect(rolled_over_course.reload.updated_at.to_i).to eq Time.now.to_i
+        expect(course.reload.updated_at.to_i).not_to eq Time.now.to_i
       end
+    end
 
-      # Use to_i compare seconds since epoch and side-step sub-second
-      # differences that show up even with Timecop on certain platforms.
-      expect(course.reload.updated_at.to_i).to eq Time.now.to_i
+    it 'updates the course changed_at' do
+      rolled_over_course
+
+      Timecop.freeze(Date.today + 1) do
+        with_stubbed_stdout do
+          $mcb.run(%W[courses touch #{rolled_over_provider.provider_code} #{rolled_over_course.course_code}])
+        end
+
+        expect(rolled_over_course.reload.changed_at.to_i).to eq Time.now.to_i
+        expect(course.reload.changed_at.to_i).not_to eq Time.now.to_i
+      end
+    end
+
+    it 'adds audit comment' do
+      rolled_over_course
+
+      expect {
+        with_stubbed_stdout do
+          $mcb.run(%W[courses touch #{rolled_over_provider.provider_code} #{rolled_over_course.course_code}])
+        end
+      }.to change { rolled_over_course.reload.audits.count }
+             .from(1).to(2)
     end
   end
 
-  it 'updates the courses changed_at' do
-    Timecop.freeze do
-      with_stubbed_stdout do
-        $mcb.run(%W[course touch #{provider.provider_code} #{course.course_code}])
-      end
+  context 'when the recruitment year is specified' do
+    it 'updates the course updated_at' do
+      rolled_over_course
 
-      expect(course.reload.changed_at.to_i).to eq Time.now.to_i
+      Timecop.freeze(Date.today + 1) do
+        with_stubbed_stdout do
+          $mcb.run(%W[courses touch #{provider.provider_code} #{course.course_code} -r 2018])
+        end
+
+        # Use to_i compare seconds since epoch and side-step sub-second
+        # differences that show up even with Timecop on certain platforms.
+        expect(course.reload.updated_at.to_i).to eq Time.now.to_i
+        expect(rolled_over_course.reload.changed_at.to_i).not_to eq Time.now.to_i
+      end
     end
-  end
 
-  it 'adds audit comment' do
-    expect {
-      with_stubbed_stdout do
-        $mcb.run(%W[course touch #{provider.provider_code} #{course.course_code}])
+    it 'updates the courses changed_at' do
+      rolled_over_course
+
+      Timecop.freeze(Date.today + 1) do
+        with_stubbed_stdout do
+          $mcb.run(%W[courses touch #{provider.provider_code} #{course.course_code} -r 2018])
+        end
+
+        expect(course.reload.changed_at.to_i).to eq Time.now.to_i
+        expect(rolled_over_course.reload.changed_at.to_i).not_to eq Time.now.to_i
       end
-    }.to change { course.reload.audits.count }
-           .from(1).to(2)
+    end
+
+    it 'adds audit comment' do
+      rolled_over_course
+
+      expect {
+        with_stubbed_stdout do
+          $mcb.run(%W[courses touch #{provider.provider_code} #{course.course_code} -r 2018])
+        end
+      }.to change { course.reload.audits.count }
+             .from(1).to(2)
+    end
   end
 end

--- a/spec/lib/mcb/commands/courses/touch_spec.rb
+++ b/spec/lib/mcb/commands/courses/touch_spec.rb
@@ -1,6 +1,7 @@
 require 'mcb_helper'
 
-describe 'mcb courses touch', :focus do
+describe 'mcb courses touch' do
+  let(:touch) { MCBCommand.new('courses', 'touch') }
   let(:recruitment_year1) { create :recruitment_cycle, year: '2018' }
   let(:recruitment_year2) { RecruitmentCycle.current_recruitment_cycle }
 
@@ -25,9 +26,7 @@ describe 'mcb courses touch', :focus do
       rolled_over_course
 
       Timecop.freeze(Date.today + 1) do
-        with_stubbed_stdout do
-          $mcb.run(%W[courses touch #{rolled_over_provider.provider_code} #{rolled_over_course.course_code}])
-        end
+        touch.execute(arguments: [rolled_over_provider.provider_code, rolled_over_course.course_code])
 
         # Use to_i compare seconds since epoch and side-step sub-second
         # differences that show up even with Timecop on certain platforms.
@@ -40,9 +39,7 @@ describe 'mcb courses touch', :focus do
       rolled_over_course
 
       Timecop.freeze(Date.today + 1) do
-        with_stubbed_stdout do
-          $mcb.run(%W[courses touch #{rolled_over_provider.provider_code} #{rolled_over_course.course_code}])
-        end
+        touch.execute(arguments: [rolled_over_provider.provider_code, rolled_over_course.course_code])
 
         expect(rolled_over_course.reload.changed_at.to_i).to eq Time.now.to_i
         expect(course.reload.changed_at.to_i).not_to eq Time.now.to_i
@@ -53,9 +50,7 @@ describe 'mcb courses touch', :focus do
       rolled_over_course
 
       expect {
-        with_stubbed_stdout do
-          $mcb.run(%W[courses touch #{rolled_over_provider.provider_code} #{rolled_over_course.course_code}])
-        end
+        touch.execute(arguments: [rolled_over_provider.provider_code, rolled_over_course.course_code])
       }.to change { rolled_over_course.reload.audits.count }
              .from(1).to(2)
     end
@@ -66,9 +61,7 @@ describe 'mcb courses touch', :focus do
       rolled_over_course
 
       Timecop.freeze(Date.today + 1) do
-        with_stubbed_stdout do
-          $mcb.run(%W[courses touch #{provider.provider_code} #{course.course_code} -r 2018])
-        end
+        touch.execute(arguments: [provider.provider_code, course.course_code, '-r', recruitment_year1.year])
 
         # Use to_i compare seconds since epoch and side-step sub-second
         # differences that show up even with Timecop on certain platforms.
@@ -81,9 +74,7 @@ describe 'mcb courses touch', :focus do
       rolled_over_course
 
       Timecop.freeze(Date.today + 1) do
-        with_stubbed_stdout do
-          $mcb.run(%W[courses touch #{provider.provider_code} #{course.course_code} -r 2018])
-        end
+        touch.execute(arguments: [provider.provider_code, course.course_code, '-r', recruitment_year1.year])
 
         expect(course.reload.changed_at.to_i).to eq Time.now.to_i
         expect(rolled_over_course.reload.changed_at.to_i).not_to eq Time.now.to_i
@@ -94,9 +85,7 @@ describe 'mcb courses touch', :focus do
       rolled_over_course
 
       expect {
-        with_stubbed_stdout do
-          $mcb.run(%W[courses touch #{provider.provider_code} #{course.course_code} -r 2018])
-        end
+        touch.execute(arguments: [provider.provider_code, course.course_code, '-r', recruitment_year1.year])
       }.to change { course.reload.audits.count }
              .from(1).to(2)
     end

--- a/spec/lib/mcb/commands/providers/audit_spec.rb
+++ b/spec/lib/mcb/commands/providers/audit_spec.rb
@@ -12,17 +12,11 @@ describe 'mcb providers audit' do
     new_provider
   end
 
-  def audit(*arguments)
-    stderr = nil
-    output = with_stubbed_stdout(stdin: "", stderr: stderr) do
-      $mcb.run %W[provider audit] + arguments
-    end
-    { stdout: output, stderr: stderr }
-  end
+  let(:audit) { MCBCommand.new('providers', 'audit') }
 
   context 'with an unspecified recruitment year' do
     it 'displays audit for provider for default recruitment year' do
-      output = parse_text_table(audit(rolled_over_provider.provider_code)[:stdout])
+      output = parse_text_table(audit.execute(arguments: [rolled_over_provider.provider_code])[:stdout])
 
       expect(output[0]).to eq(%w[userid useremail action associatedid associatedtype changes created_at])
       expect(output[1][5]).to include("\"recruitment_cycle_id\"=>#{recruitment_year2.id}")
@@ -31,7 +25,7 @@ describe 'mcb providers audit' do
 
   context 'with a specified recruitment year' do
     it 'displays audit for provider for specified recruitment year' do
-      output = parse_text_table(audit(rolled_over_provider.provider_code, '-r', recruitment_year1.year)[:stdout])
+      output = parse_text_table(audit.execute(arguments: [rolled_over_provider.provider_code, '-r', recruitment_year1.year])[:stdout])
 
       expect(output[0]).to eq(%w[userid useremail action associatedid associatedtype changes created_at])
       expect(output[1][5]).to include("\"recruitment_cycle_id\"=>#{recruitment_year1.id}")

--- a/spec/lib/mcb/commands/providers/edit_spec.rb
+++ b/spec/lib/mcb/commands/providers/edit_spec.rb
@@ -1,14 +1,7 @@
 require 'mcb_helper'
 
 describe 'mcb providers edit' do
-  def edit(provider_code, arguments: [], input: [])
-    stderr = nil
-    output = with_stubbed_stdout(stdin: input.join("\n"), stderr: stderr) do
-      $mcb.run(%W[providers edit #{provider_code}] + arguments)
-    end
-
-    { stdout: output, stderr: stderr }
-  end
+  let(:edit) { MCBCommand.new('providers', 'edit') }
 
   let(:email) { 'user@education.gov.uk' }
 
@@ -34,14 +27,14 @@ describe 'mcb providers edit' do
       let!(:requester) { create(:user, email: email, organisations: rolled_over_provider.organisations) }
 
       it 'updates the name of the provider for the default recruitment cycle' do
-        expect { edit(rolled_over_provider.provider_code, input: ["edit provider name", "B", "exit"]) }
+        expect { edit.execute(arguments: [rolled_over_provider.provider_code], input: ["edit provider name", "B", "exit"]) }
           .to change { rolled_over_provider.reload.provider_name }
           .from('A').to('B')
       end
 
       describe 'trying to edit a course on a nonexistent provider' do
         it 'raises an error' do
-          expect { edit("ABC") }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find Provider/)
+          expect { edit.execute(arguments: %w[ABC]) }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find Provider/)
         end
       end
     end
@@ -50,7 +43,7 @@ describe 'mcb providers edit' do
       let!(:requester) { create(:user, email: email, organisations: provider.organisations) }
 
       it 'updates the name of the provider' do
-        expect { edit(provider.provider_code, arguments: ['-r', recruitment_year1.year], input: ["edit provider name", "Y", "exit"]) }
+        expect { edit.execute(arguments: [provider.provider_code, '-r', recruitment_year1.year], input: ["edit provider name", "Y", "exit"]) }
           .to change { provider.reload.provider_name }
           .from('Z').to('Y')
       end
@@ -61,7 +54,7 @@ describe 'mcb providers edit' do
     let!(:requester) { create(:user, email: 'someother@email.com') }
 
     it 'raises an error' do
-      expect { edit(rolled_over_provider.provider_code) }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find User/)
+      expect { edit.execute(arguments: [rolled_over_provider.provider_code]) }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find User/)
     end
   end
 end

--- a/spec/lib/mcb/commands/providers/list_spec.rb
+++ b/spec/lib/mcb/commands/providers/list_spec.rb
@@ -1,13 +1,7 @@
 require 'mcb_helper'
 
 describe 'mcb providers list' do
-  def list(*arguments)
-    stderr = nil
-    output = with_stubbed_stdout(stdin: "", stderr: stderr) do
-      $mcb.run %W[provider list] + arguments
-    end
-    { stdout: output, stderr: stderr }
-  end
+  let(:list) { MCBCommand.new('providers', 'list') }
 
   let(:current_cycle) { RecruitmentCycle.current_recruitment_cycle }
   let(:additional_cycle) { find_or_create(:recruitment_cycle, year: '2020') }
@@ -22,7 +16,7 @@ describe 'mcb providers list' do
       provider2
       provider3
 
-      command_output = list[:stdout]
+      command_output = list.execute[:stdout]
 
       expect(command_output).to include(provider1.provider_code)
       expect(command_output).to include(provider1.provider_name)
@@ -39,7 +33,7 @@ describe 'mcb providers list' do
         provider1
         provider2
 
-        command_output = list(provider1.provider_code)[:stdout]
+        command_output = list.execute(arguments: [provider1.provider_code])[:stdout]
 
         expect(command_output).to include(provider1.provider_code)
         expect(command_output).to include(provider1.provider_name)
@@ -52,7 +46,7 @@ describe 'mcb providers list' do
         provider1
         provider2
 
-        command_output = list(provider1.provider_code, provider2.provider_code)[:stdout]
+        command_output = list.execute(arguments: [provider1.provider_code, provider2.provider_code])[:stdout]
 
         expect(command_output).to include(provider1.provider_code)
         expect(command_output).to include(provider1.provider_name)
@@ -65,7 +59,7 @@ describe 'mcb providers list' do
         provider1
         provider2
 
-        command_output = list(provider1.provider_code.downcase)[:stdout]
+        command_output = list.execute(arguments: [provider1.provider_code.downcase])[:stdout]
         expect(command_output).to include(provider1.provider_code)
       end
     end
@@ -75,7 +69,7 @@ describe 'mcb providers list' do
         provider1
         provider2
 
-        command_output = list[:stdout]
+        command_output = list.execute[:stdout]
 
         expect(command_output).to include(provider1.provider_code)
         expect(command_output).to include(provider1.provider_name)
@@ -94,7 +88,7 @@ describe 'mcb providers list' do
       provider1
       provider2
 
-      command_output = list("-r", additional_cycle.year)[:stdout]
+      command_output = list.execute(arguments: ["-r", additional_cycle.year])[:stdout]
       expect(command_output).to include(provider2.provider_code)
       expect(command_output).to include(provider2.provider_name)
 

--- a/spec/lib/mcb/commands/providers/show_spec.rb
+++ b/spec/lib/mcb/commands/providers/show_spec.rb
@@ -1,13 +1,7 @@
 require 'mcb_helper'
 
 describe 'mcb providers list' do
-  def show(*arguments)
-    stderr = nil
-    output = with_stubbed_stdout(stdin: "", stderr: stderr) do
-      $mcb.run %W[provider show] + arguments
-    end
-    { stdout: output, stderr: stderr }
-  end
+  let(:show) { MCBCommand.new('provider', 'show') }
 
   let(:recruitment_year1) { find_or_create(:recruitment_cycle, year: '2020') }
   let(:recruitment_year2) { RecruitmentCycle.current_recruitment_cycle }
@@ -22,7 +16,7 @@ describe 'mcb providers list' do
 
   context 'when recruitment cycle is unspecified' do
     it 'shows information for the provider with the default recruitment cycle' do
-      output = show(rolled_over_provider.provider_code)[:stdout]
+      output = show.execute(arguments: [rolled_over_provider.provider_code])[:stdout]
 
       expect(output).to have_text_table_row('id', rolled_over_provider.id.to_s)
       expect(output).to have_text_table_row('provider_code', rolled_over_provider.provider_code)
@@ -33,7 +27,7 @@ describe 'mcb providers list' do
     it 'shows information for the provider with the default recruitment cycle' do
       rolled_over_provider
 
-      output = show(provider.provider_code, '-r', recruitment_year1.year)[:stdout]
+      output = show.execute(arguments: [provider.provider_code, '-r', recruitment_year1.year])[:stdout]
       expect(output).to have_text_table_row('id', provider.id.to_s)
       expect(output).to have_text_table_row('provider_code', provider.provider_code)
     end

--- a/spec/lib/mcb/commands/providers/touch_spec.rb
+++ b/spec/lib/mcb/commands/providers/touch_spec.rb
@@ -1,6 +1,8 @@
 require 'mcb_helper'
 
-describe '"mcb providers touch"' do
+describe 'mcb providers touch' do
+  let(:touch) { MCBCommand.new('providers', 'touch') }
+
   let(:recruitment_year1) { create :recruitment_cycle, year: '2018' }
   let(:recruitment_year2) { find_or_create :recruitment_cycle, year: '2019' }
 
@@ -17,9 +19,7 @@ describe '"mcb providers touch"' do
       rolled_over_provider
 
       Timecop.freeze(Date.today + 1) do
-        with_stubbed_stdout do
-          $mcb.run(%W[provider touch #{rolled_over_provider.provider_code}])
-        end
+        touch.execute(arguments: [rolled_over_provider.provider_code])
 
         # Use to_i compare seconds since epoch and side-step sub-second
         # differences that show up even with Timecop on certain platforms.
@@ -32,9 +32,7 @@ describe '"mcb providers touch"' do
       rolled_over_provider
 
       Timecop.freeze(Date.today + 1) do
-        with_stubbed_stdout do
-          $mcb.run(%W[provider touch #{rolled_over_provider.provider_code}])
-        end
+        touch.execute(arguments: [rolled_over_provider.provider_code])
 
         expect(provider.reload.changed_at.to_i).to eq Time.now.to_i
         expect(rolled_over_provider.reload.changed_at.to_i).not_to eq Time.now.to_i
@@ -45,9 +43,7 @@ describe '"mcb providers touch"' do
       rolled_over_provider
 
       expect {
-        with_stubbed_stdout do
-          $mcb.run(%W[provider touch #{rolled_over_provider.provider_code}])
-        end
+        touch.execute(arguments: [rolled_over_provider.provider_code])
       }.to change { provider.reload.audits.count }
              .from(1).to(2)
     end
@@ -58,9 +54,7 @@ describe '"mcb providers touch"' do
       rolled_over_provider
 
       Timecop.freeze(Date.today + 1) do
-        with_stubbed_stdout do
-          $mcb.run(%W[provider touch #{provider.provider_code} -r 2018])
-        end
+        touch.execute(arguments: [provider.provider_code, '-r', recruitment_year1.year])
 
         # Use to_i compare seconds since epoch and side-step sub-second
         # differences that show up even with Timecop on certain platforms.
@@ -73,9 +67,7 @@ describe '"mcb providers touch"' do
       rolled_over_provider
 
       Timecop.freeze(Date.today + 1) do
-        with_stubbed_stdout do
-          $mcb.run(%W[provider touch #{provider.provider_code} -r 2018])
-        end
+        touch.execute(arguments: [provider.provider_code, '-r', recruitment_year1.year])
 
         expect(provider.reload.changed_at.to_i).to eq Time.now.to_i
         expect(rolled_over_provider.reload.changed_at.to_i).not_to eq Time.now.to_i
@@ -86,9 +78,7 @@ describe '"mcb providers touch"' do
       rolled_over_provider
 
       expect {
-        with_stubbed_stdout do
-          $mcb.run(%W[provider touch #{provider.provider_code} -r 2018])
-        end
+        touch.execute(arguments: [provider.provider_code, '-r', recruitment_year1.year])
       }.to change { provider.reload.audits.count }
              .from(1).to(2)
     end

--- a/spec/support/mcb_command.rb
+++ b/spec/support/mcb_command.rb
@@ -1,0 +1,13 @@
+class MCBCommand
+  def initialize(*command)
+    @command = command
+  end
+
+  def execute(arguments: [], input: [])
+    stderr = nil
+    output = with_stubbed_stdout(stdin: input.join("\n"), stderr: stderr) do
+      $mcb.run(@command + arguments)
+    end
+    { stdout: output, stderr: stderr }
+  end
+end


### PR DESCRIPTION
### Context
A number of MCB commands are not recruitment cycle aware.  

### Changes proposed in this pull request
Make all `mcb course` commands recruitment cycle aware and write any missing tests.  
  
### Guidance to review
`sync_to_find` has been ignored for the time being because this is still in C# land.  

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
