### PR TITLE
1740 mcb psql connect to backup

### DIFF
--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -86,9 +86,9 @@ module MCB
     `#{cmd}`
   end
 
-  def self.exec_command(cmd)
-    verbose("Running: #{cmd}")
-    exec(cmd)
+  def self.exec_command(cmd, *command_args)
+    verbose("Running: #{cmd} #{command_args}")
+    exec(cmd, *command_args)
   end
 
   def self.apiv1_token(webapp: nil, rgroup: nil)

--- a/lib/mcb/commands/az/apps/psql.rb
+++ b/lib/mcb/commands/az/apps/psql.rb
@@ -1,7 +1,7 @@
 name 'psql'
 summary 'connect to the psql server for an app'
-# h is used for help so used z instead
-option :z, 'host', 'override hostname of database - useful for connecting to restored copies.'\
+# h is used for help so used H instead
+option :H, 'host', 'override hostname of database - useful for connecting to restored copies.'\
        ' Just the hostname, not the fully qualified name. E.g. bat-mcapi-restore-psql',
        argument: :optional
 option :f, 'source_file', 'source sql file to pass to psql to run',

--- a/lib/mcb/commands/az/apps/psql.rb
+++ b/lib/mcb/commands/az/apps/psql.rb
@@ -16,13 +16,19 @@ run do |opts, _args, _cmd|
   end
 
   ENV['PGPASSWORD'] = ENV['DB_PASSWORD']
-  cmd = "psql -h #{ENV['DB_HOSTNAME']} -U #{ENV['DB_USERNAME']} -d #{ENV['DB_DATABASE']}"
+  psql_args = ["-h", ENV['DB_HOSTNAME'], "-U", ENV['DB_USERNAME'], "-d", ENV['DB_DATABASE']]
 
   source_file = opts[:source_file]
-  cmd = "#{cmd} --file '#{source_file}'" if source_file
+  if source_file
+    psql_args << "--file"
+    psql_args << source_file
+  end
 
   sql_command = opts[:sql_command]
-  cmd = "#{cmd} --command '#{sql_command}'" if sql_command
+  if sql_command
+    psql_args << "--command"
+    psql_args << sql_command
+  end
 
-  MCB::exec_command(cmd)
+  MCB::exec_command("psql", *psql_args)
 end

--- a/spec/lib/mcb/commands/az/apps/psql_spec.rb
+++ b/spec/lib/mcb/commands/az/apps/psql_spec.rb
@@ -4,8 +4,10 @@ require 'mcb_helper'
 describe 'mcb az apps psql' do
   it 'returns the psql of apps' do
     allow(MCB).to receive(:exec_command).with(
-      "psql -h localhost -U manage_courses_backend " \
-      "-d manage_courses_backend_development"
+      "psql",
+      "-h", "localhost",
+      "-U", "manage_courses_backend",
+      "-d", "manage_courses_backend_development"
     )
 
     with_stubbed_stdout do

--- a/spec/lib/mcb/commands/az/apps/psql_spec.rb
+++ b/spec/lib/mcb/commands/az/apps/psql_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'mcb_helper'
 
 describe 'mcb az apps psql' do
-  it 'returns the psql of apps' do
+  it 'runs psql for localhost' do
     allow(MCB).to receive(:exec_command).with(
       "psql",
       "-h", "localhost",
@@ -12,6 +12,45 @@ describe 'mcb az apps psql' do
 
     with_stubbed_stdout do
       $mcb.run(%w[az apps psql])
+    end
+  end
+
+  context 'with qa environment specified' do
+    before do
+      app_config = {
+        'MANAGE_COURSES_POSTGRESQL_SERVICE_HOST' => 'azhost',
+        'PG_DATABASE'                            => 'pgdb',
+        'PG_USERNAME'                            => 'azuser',
+        'PG_PASSWORD'                            => 'azpass',
+        'RAILS_ENV'                              => 'qa',
+      }
+      allow(MCB::Azure).to(receive(:get_config).and_return(app_config))
+    end
+
+    it 'runs psql for azure server' do
+      allow(MCB).to receive(:exec_command).with(
+        "psql",
+        "-h", "azhost",
+        "-U", "azuser",
+        "-d", "pgdb"
+      )
+
+      with_stubbed_stdout(stdin: "qa") do
+        $mcb.run(%w[az apps psql -E qa])
+      end
+    end
+
+    it 'runs psql for azure backup host' do
+      allow(MCB).to receive(:exec_command).with(
+        "psql",
+        "-h", "backup-host.postgres.database.azure.com",
+        "-U", "azuser",
+        "-d", "pgdb"
+      )
+
+      with_stubbed_stdout(stdin: "qa") do
+        $mcb.run(%w[az apps psql -E qa -H backup-host])
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Restoring an azure postgres backup keeps all the settings and passwords but gives a new hostname.

replaces #575 

### Changes proposed in this pull request

Make it easy to use mcb psql to connect to one of the backups.

### Guidance to review

:ship:

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
