### PR TITLE
[1732] Make 'mcb courses create' cycle-aware

### DIFF
--- a/lib/mcb/commands/courses/create.rb
+++ b/lib/mcb/commands/courses/create.rb
@@ -6,7 +6,7 @@ run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
   Course.connection.transaction do
-    provider = RecruitmentCycle.current_recruitment_cycle.providers.find_by!(provider_code: args[:provider_code])
+    provider = MCB.get_recruitment_cycle(opts).providers.find_by!(provider_code: args[:provider_code])
     requester = User.find_by!(email: MCB.config[:email])
 
     MCB::CoursesEditor.new(


### PR DESCRIPTION
### Context
We will be seeing course creation requests from current and next recruitment cycles from now on.

### Changes proposed in this pull request
Make `mcb courses create` cycle-aware.

### Guidance to review
Inspired by #614

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
