### PR TITLE
[1797] Don't sync courses not in current recycle

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -60,7 +60,8 @@ module API
       def update
         update_enrichment
         update_sites
-        has_synced? if site_ids.present?
+        should_sync = site_ids.present? && @course.recruitment_cycle.current?
+        has_synced? if should_sync
 
         if @course.errors.empty? && @course.valid?
           render jsonapi: @course.reload

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -24,6 +24,10 @@ class RecruitmentCycle < ApplicationRecord
     all.first
   end
 
+  def current?
+    RecruitmentCycle.current_recruitment_cycle == self
+  end
+
   def to_s
     following_year = Date.new(year.to_i, 1, 1) + 1.year
     "#{year}/#{following_year.strftime('%y')}"

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -13,7 +13,7 @@
 require 'rails_helper'
 
 describe RecruitmentCycle, type: :model do
-  subject { create(:recruitment_cycle, year: "2019") }
+  subject { RecruitmentCycle.find_by(year: "2019") }
 
   its(:to_s) { should eq("2019/20") }
 
@@ -26,5 +26,18 @@ describe RecruitmentCycle, type: :model do
   describe 'associations' do
     it { should have_many(:courses).through(:providers) }
     it { should have_many(:sites).through(:providers) }
+  end
+
+  describe "current?" do
+    let(:current_cycle) { subject }
+    let(:second_cycle) { create(:recruitment_cycle, year: "2020") }
+
+    it "should return true when it's the current cycle" do
+      expect(current_cycle.current?).to be(true)
+    end
+
+    it "should return true false it's not the current cycle" do
+      expect(second_cycle.current?).to be(false)
+    end
   end
 end


### PR DESCRIPTION
### Context

This is to allow users to manage their course sites without seeing an error due to the sync currently failing.

### Changes proposed in this pull request

Checks for the recruitment cycle in the controller. Adds a helper method to the model to check if it's current.

### Guidance to review

I fruitlessly attempted to write a request spec for this but could not figure out why the request would result in a 404 when I would set the provider to the 2020 cycle.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally