### PR TITLE
[1805] rolled over course status

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -76,6 +76,7 @@ module API
 
         enrichment = @course.enrichments.find_or_initialize_draft
         enrichment.assign_attributes(enrichment_params)
+        enrichment.status = :draft if enrichment.rolled_over?
         enrichment.save
       end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -225,6 +225,8 @@ class Course < ApplicationRecord
       :published
     elsif newest_enrichment.has_been_published_before?
       :published_with_unpublished_changes
+    elsif newest_enrichment.rolled_over?
+      :rolled_over
     else
       :draft
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -220,7 +220,11 @@ class Course < ApplicationRecord
     newest_enrichment = enrichments.latest_first.first
 
     if newest_enrichment.nil?
-      :empty
+      if next_recruitment_cycle?
+        :rolled_over
+      else
+        :empty
+      end
     elsif newest_enrichment.published?
       :published
     elsif newest_enrichment.has_been_published_before?
@@ -348,6 +352,10 @@ class Course < ApplicationRecord
         new_site&.copy_to_course(new_course)
       end
     end
+  end
+
+  def next_recruitment_cycle?
+    recruitment_cycle.year > RecruitmentCycle.current_recruitment_cycle.year
   end
 
 private

--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -38,6 +38,11 @@ class CourseEnrichment < ApplicationRecord
   belongs_to :course
 
   scope :latest_first, -> { order(created_at: :desc, id: :desc) }
+  scope :draft, -> { where(status: 'draft').or(CourseEnrichment.rolled_over) }
+
+  def draft?
+    status.in? %w[draft rolled_over]
+  end
 
   validates :course, presence: true
 

--- a/spec/factories/course_enrichments.rb
+++ b/spec/factories/course_enrichments.rb
@@ -85,6 +85,10 @@ FactoryBot.define do
         "Using the unqualified teachers scale"
       ].sample
     end
+
+    trait :rolled_over do
+      status { :rolled_over }
+    end
   end
 
   trait :initial_draft do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -416,6 +416,24 @@ RSpec.describe Course, type: :model do
 
       it { should eq :rolled_over }
     end
+
+    context 'when there are no enrichments' do
+      let(:course) { create :course, enrichments: [] }
+
+      subject { course.content_status }
+
+      it { should eq :empty }
+    end
+
+    context 'when there are no enrichments and the course is rolled-over' do
+      let(:next_recruitment_cycle) { create :recruitment_cycle, :next }
+      let(:next_provider) { create :provider, recruitment_cycle: next_recruitment_cycle }
+      let(:course) { create :course, provider: next_provider, enrichments: [] }
+
+      subject { course.content_status }
+
+      it { should eq :rolled_over }
+    end
   end
 
   describe 'qualifications' do
@@ -812,7 +830,7 @@ RSpec.describe Course, type: :model do
       expect(new_course.accrediting_provider_code)
         .to eq course.accrediting_provider_code
       expect(new_course.subjects).to eq course.subjects
-      expect(new_course.content_status).to eq :empty
+      expect(new_course.content_status).to eq :rolled_over
       expect(new_course.ucas_status).to eq :new
       expect(new_course.open_for_applications?).to be_falsey
     end
@@ -837,7 +855,7 @@ RSpec.describe Course, type: :model do
       describe 'the new course' do
         subject { new_course }
 
-        its(:content_status) { should eq :draft }
+        its(:content_status) { should eq :rolled_over }
       end
 
       describe 'the copied enrichment' do
@@ -866,7 +884,7 @@ RSpec.describe Course, type: :model do
       describe 'the new course' do
         subject { new_course }
 
-        its(:content_status) { should eq :draft }
+        its(:content_status) { should eq :rolled_over }
       end
 
       describe 'the copied enrichment' do
@@ -934,6 +952,22 @@ RSpec.describe Course, type: :model do
         it { should be_status_new_status }
         its(:applications_accepted_from) { should eq new_recruitment_cycle.application_start_date }
       end
+    end
+  end
+
+  describe 'next_recruitment_cycle?' do
+    subject { course.next_recruitment_cycle? }
+
+    context 'course is in current recruitment cycle' do
+      it { should be_falsey }
+    end
+
+    context 'course is in the next recruitment cycle' do
+      let(:recruitment_cycle) { create :recruitment_cycle, :next }
+      let(:provider)          { create :provider, recruitment_cycle: recruitment_cycle }
+      let(:course) { create :course, provider: provider }
+
+      it { should be_truthy }
     end
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -398,6 +398,26 @@ RSpec.describe Course, type: :model do
     end
   end
 
+  describe 'content_status' do
+    let(:course) { create :course, enrichments: [enrichment] }
+
+    context 'when enrichment is published' do
+      let(:enrichment) { create :course_enrichment, status: :published }
+
+      subject { course.content_status }
+
+      it { should eq :published }
+    end
+
+    context 'when enrichment is rolled-over' do
+      let(:enrichment) { create :course_enrichment, status: :rolled_over }
+
+      subject { course.content_status }
+
+      it { should eq :rolled_over }
+    end
+  end
+
   describe 'qualifications' do
     context "course with qts qualication" do
       let(:subject) { create(:course, :resulting_in_qts) }


### PR DESCRIPTION
### Context

Rolled-over courses should have their content-status of "Rolled-Over".

### Changes proposed in this pull request

Change the content-status on courses to display "Rolled-Over" if their enrichments have the status "rolled-over".

### Guidance to review

#589 needs to be merged and this rebased before this can be merged.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
