### PR TITLE
[1811] Add command to delete site

### DIFF
--- a/lib/mcb/base_cli.rb
+++ b/lib/mcb/base_cli.rb
@@ -35,6 +35,10 @@ module MCB
       @cli.agree("Continue? ")
     end
 
+    def confirm_deletion?(subject)
+      @cli.agree("Are you sure you want to delete #{subject}? ")
+    end
+
     def enter_to_continue
       @cli.ask("Press Enter to continue")
     end

--- a/lib/mcb/commands/sites.rb
+++ b/lib/mcb/commands/sites.rb
@@ -1,0 +1,6 @@
+name 'sites'
+summary 'Operate on courses directly in db'
+
+instance_eval(&MCB.remote_connect_options)
+
+default_subcommand :list

--- a/lib/mcb/commands/sites/delete.rb
+++ b/lib/mcb/commands/sites/delete.rb
@@ -1,0 +1,23 @@
+name 'delete'
+summary 'delete sites in db'
+usage 'delete [options] <site code>'
+param :site_code
+
+run do |opts, args, _cmd|
+  cli = MCB::BaseCLI.new
+  site_code = args[:site_code]
+  site = MCB.get_recruitment_cycle(opts).sites.find_by(code: site_code)
+
+  if site.nil?
+    puts "The site #{site_code} does not exist"
+  elsif cli.confirm_deletion?("site #{site_code}")
+    site.destroy
+    if site.destroyed?
+      puts "\nSite deleted"
+    else
+      puts "\nFailed to delete site"
+    end
+  else
+    puts "\nSite not deleted"
+  end
+end

--- a/spec/lib/mcb/commands/sites/delete_spec.rb
+++ b/spec/lib/mcb/commands/sites/delete_spec.rb
@@ -1,0 +1,63 @@
+require 'mcb_helper'
+
+describe 'mcb sites delete' do
+  def delete(arguments: [], input: [])
+    output = with_stubbed_stdout(stdin: input.join("\n"), stderr: nil) do
+      $mcb.run(%w[sites delete] + arguments)
+    end
+
+    { stdout: output }
+  end
+
+  let(:current_recruitment_cycle) { RecruitmentCycle.current_recruitment_cycle }
+  let(:rolled_over_recruitment_cycle) { find_or_create :recruitment_cycle, :next }
+
+  let(:current_provider) { create :provider, recruitment_cycle: current_recruitment_cycle }
+  let(:rolled_over_provider) do
+    new_provider = current_provider.dup
+    new_provider.update(recruitment_cycle: rolled_over_recruitment_cycle)
+    new_provider.save
+    new_provider
+  end
+
+  let(:current_site) { create :site, provider: current_provider }
+  let(:rolled_over_site) do
+    new_site = current_site.dup
+    new_site.update(provider: rolled_over_provider)
+    new_site.save
+    new_site
+  end
+
+  context 'with recruitment year unspecified' do
+    it 'aborts if confirmation denied' do
+      rolled_over_site
+      expect(delete(arguments: [current_site.code], input: %w[No])[:stdout]).to eq("Are you sure you want to delete site #{current_site.code}? \nSite not deleted\n")
+
+      expect(Site.exists?(id: current_site.id)).to eq(true)
+      expect(Site.exists?(id: rolled_over_site.id)).to eq(true)
+    end
+
+    it 'deletes the site' do
+      rolled_over_site
+      expect(delete(arguments: [current_site.code], input: %w[Yes])[:stdout]).to eq("Are you sure you want to delete site #{current_site.code}? \nSite deleted\n")
+
+      expect(Site.exists?(id: current_site.id)).to eq(false)
+      expect(Site.exists?(id: rolled_over_site.id)).to eq(true)
+    end
+
+    it 'errors if the site does not exist' do
+      rolled_over_site
+      expect(delete(arguments: %w[E], input: %w[Yes])[:stdout]).to eq("The site E does not exist\n")
+    end
+  end
+
+  context 'with recruitment year specified' do
+    it 'deletes the site' do
+      rolled_over_site
+      delete(arguments: [current_site.code, '-r', rolled_over_recruitment_cycle.year], input: %w[Yes])
+
+      expect(Site.exists?(id: rolled_over_site.id)).to eq(false)
+      expect(Site.exists?(id: current_site.id)).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
### Context
Support needed the ability to delete a site. This implements it, also 

### Changes proposed in this pull request
Adds `sites delete`.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
