### PR TITLE
1804 Add not null validation error for gcse_requirments

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -58,9 +58,9 @@ module API
       end
 
       def update
+        update_course
         update_enrichment
         update_sites
-        update_course
         has_synced? if site_ids.present?
 
         if @course.errors.empty? && @course.valid?
@@ -81,8 +81,6 @@ module API
       end
 
       def update_course
-        return unless course_params.values.any?
-
         @course.assign_attributes(course_params)
         @course.save
       end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -126,8 +126,7 @@ class Course < ApplicationRecord
   validate :validate_enrichment
   validate :validate_course_syncable, on: :sync
   validates :english, presence: true
-  validates :maths, presence: true
-  validates :science, presence: true
+  validates :maths, presence: true  
 
   after_validation :remove_unnecessary_enrichments_validation_message
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -125,6 +125,9 @@ class Course < ApplicationRecord
   validate :validate_enrichment_publishable, on: :publish
   validate :validate_enrichment
   validate :validate_course_syncable, on: :sync
+  validates :english, presence: true
+  validates :maths, presence: true
+  validates :science, presence: true
 
   after_validation :remove_unnecessary_enrichments_validation_message
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -34,6 +34,9 @@ FactoryBot.define do
 
     study_mode { :full_time }
     resulting_in_pgce_with_qts
+    maths { :must_have_qualification_at_application_time }
+    english { :must_have_qualification_at_application_time }
+    science { :must_have_qualification_at_application_time }
 
     transient do
       age { nil }

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -87,7 +87,7 @@ describe "Courses API", type: :request do
                                 "modular" => "",
                                 "english" => 3,
                                 "maths" => 9,
-                                "science" => nil,
+                                "science" => 1,
                                 "recruitment_cycle" => "2019",
                                 "campus_statuses" => [
                                   {

--- a/spec/requests/api/v2/providers/courses/update_gsce_requirements_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_gsce_requirements_spec.rb
@@ -46,6 +46,11 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
             **gcse_requirements
   }
 
+  before do
+    updated_course.id = course.id
+    perform_request(updated_course)
+  end
+
   let(:credentials) do
     ActionController::HttpAuthentication::Token.encode_credentials(token)
   end
@@ -61,11 +66,6 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
         maths: 'expect_to_achieve_before_training_begins',
         science: 'expect_to_achieve_before_training_begins'
       }
-    end
-
-    before do
-      updated_course.id = course.id
-      perform_request(updated_course)
     end
 
     it "returns http success" do
@@ -93,11 +93,6 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
           maths: 'must_have_qualification_at_application_time',
           science: 'must_have_qualification_at_application_time'
         }
-      end
-
-      before do
-        updated_course.id = course.id
-        perform_request(updated_course)
       end
 
       it "returns http success" do
@@ -143,6 +138,14 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
       it "does not change science attribute" do
         expect(course.reload.science).to eq(@science)
       end
+    end
+  end
+
+  describe 'error messaging' do
+    let(:gcse_requirements) { { english: nil, maths: nil, science: nil } }
+
+    it "returns http success" do
+      expect(response).to have_http_status(:unprocessable_entity)
     end
   end
 end


### PR DESCRIPTION
### Context

**Should not be merged until nil data has been cleansed**   

The backend would currently update gcse_requirements to nil if passed them from the frontend. This is not desirable behaviour

### Changes proposed in this pull request
- Add validations to check to ensure nil cannot be passed in.
- Small refactor of request specs


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
