### PR TITLE
[1826] Fix mismatch between api v1 docs and api v1 implementation

### DIFF
--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -95,13 +95,17 @@ private
 
   def generate_provider_contacts
     provider_contacts = object.contacts.map do |c|
-      c.attributes.slice('type', 'name', 'email', 'telephone')
+      contact = c.attributes.slice('type', 'name', 'email', 'telephone')
+      if c.type == 'admin'
+        contact['type'] = 'admin_contact'
+      end
+      contact
     end
 
-    has_admin_contact = provider_contacts.any? { |c| c['type'] == 'admin' }
+    has_admin_contact = provider_contacts.any? { |c| c['type'] == 'admin_contact' }
     unless has_admin_contact
       provider_contacts.prepend(
-        type: 'admin',
+        type: 'admin_contact',
         name: object.contact_name,
         email: object.email,
         telephone: object.telephone

--- a/spec/lib/mcb/commands/apiv1/providers/find_spec.rb
+++ b/spec/lib/mcb/commands/apiv1/providers/find_spec.rb
@@ -60,7 +60,7 @@ describe '"mcb apiv1 providers find"' do
                         '%02d' % site2.region_code_before_type_cast
                       ))
     expect(output).to(have_text_table_row(
-                        contact2.type,
+                        'admin_contact',
                         contact2.name,
                         contact2.email,
                         contact2.telephone

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -182,7 +182,7 @@ describe 'Providers API', type: :request do
               'utt_application_alerts' => 'Yes, required',
               'contacts' => [
                 {
-                  'type' => 'admin',
+                  'type' => 'admin_contact',
                   'name' => 'Admin Contact A123',
                   'email' => 'admin@acmescitt.education.uk',
                   'telephone' => '020 812 345 678'
@@ -243,7 +243,7 @@ describe 'Providers API', type: :request do
               'utt_application_alerts' => 'No, not required',
               'contacts' => [
                 {
-                  'type' => 'admin',
+                  'type' => 'admin_contact',
                   'name' => 'Admin Contact B123',
                   'email' => 'admin@acmeuniversity.education.uk',
                   'telephone' => '01273 345 678'

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -115,7 +115,7 @@ describe ProviderSerializer do
 
     describe 'admin contact' do
       context 'exists on provider record and not in contacts table' do
-        subject { serialize(provider)['contacts'].find { |c| c[:type] == 'admin' } }
+        subject { serialize(provider)['contacts'].find { |c| c[:type] == 'admin_contact' } }
 
         its([:name]) { should eq provider.contact_name }
         its([:email]) { should eq provider.email }
@@ -126,9 +126,10 @@ describe ProviderSerializer do
         let(:contact)  { create :contact, type: 'admin' }
         let(:provider) { create :provider, contacts: [contact] }
 
-        subject { serialize(provider)['contacts'].find { |c| c[:type] == 'admin' } }
+        subject { serialize(provider)['contacts'].find { |c| c[:type] == 'admin_contact' } }
 
         its([:name]) { should eq contact.name }
+        its([:type]) { should eq 'admin_contact' }
         its([:email]) { should eq contact.email }
         its([:telephone]) { should eq contact.telephone }
       end


### PR DESCRIPTION
### Context
https://github.com/DFE-Digital/manage-courses-backend/blob/master/docs/api.md#example-response-body-2  
This document specifies 'admin_contact' be the admin type however we are producing 'admin'.  
Originally #635  
  
### Changes proposed in this pull request
This pull request serialises the 'admin' type as 'admin_contact'.  

### Guidance to review
Because MCB's displayed types are coupled to the serialiser this has had he knock-on effect of changing the type displayed for MCB but I believe this is minor.  

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally