### PR TITLE
[1691]  Codify required GCSE subjects

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -269,6 +269,18 @@ class Course < ApplicationRecord
     funding == 'fee'
   end
 
+  # https://www.gov.uk/government/publications/initial-teacher-training-criteria/initial-teacher-training-itt-criteria-and-supporting-advice#c11-gcse-standard-equivalent
+  def gcse_subjects_required
+    case level
+    when :primary
+      %w[maths english science]
+    when :secondary
+      %w[maths english]
+    else
+      []
+    end
+  end
+
   def last_published_at
     newest_enrichment = enrichments.latest_first.first
     newest_enrichment&.last_published_timestamp_utc

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -16,7 +16,7 @@ module API
                  :content_status, :ucas_status, :funding, :applications_open_from,
                  :level, :is_send?, :has_bursary?, :has_scholarship_and_bursary?,
                  :has_early_career_payments?, :bursary_amount, :scholarship_amount,
-                 :english, :maths, :science
+                 :english, :maths, :science, :gcse_subjects_required
 
       attribute :start_date do
         @object.start_date&.iso8601

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -478,18 +478,21 @@ RSpec.describe Course, type: :model do
     context 'with primary subjects' do
       subject { create(:course, subjects: [find_or_create(:subject, :primary)]) }
       its(:level) { should eq(:primary) }
+      its(:gcse_subjects_required) { should eq(%w[maths english science]) }
       its(:dfe_subjects) { should eq([DFESubject.new("Primary")]) }
     end
 
     context 'with secondary subjects' do
       subject { create(:course, subjects: [find_or_create(:subject, subject_name: "physical education")]) }
       its(:level) { should eq(:secondary) }
+      its(:gcse_subjects_required) { should eq(%w[maths english]) }
       its(:dfe_subjects) { should eq([DFESubject.new("Physical education")]) }
     end
 
     context 'with further education subjects' do
       subject { create(:course, subjects: [create(:further_education_subject)]) }
       its(:level) { should eq(:further_education) }
+      its(:gcse_subjects_required) { should eq([]) }
       its(:dfe_subjects) { should eq([DFESubject.new("Further education")]) }
     end
 

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -138,6 +138,7 @@ describe 'Courses API v2', type: :request do
               "science" => 'must_have_qualification_at_application_time',
               "provider_code" => provider.provider_code,
               "recruitment_cycle_year" => "2019",
+              "gcse_subjects_required" => %w[maths english science],
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },
@@ -275,6 +276,7 @@ describe 'Courses API v2', type: :request do
               "science" => 'must_have_qualification_at_application_time',
               "provider_code" => provider.provider_code,
               "recruitment_cycle_year" => "2019",
+              "gcse_subjects_required" => %w[maths english science],
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -27,6 +27,10 @@ describe API::V2::SerializableCourse do
   it { should have_attribute :applications_open_from }
   it { should have_attribute :is_send? }
   it { should have_attribute :level }
+  it { should have_attribute :english }
+  it { should have_attribute :maths }
+  it { should have_attribute :science }
+  it { should have_attribute :gcse_subjects_required }
   it { should have_attribute :provider_code }
   it { should have_attribute(:recruitment_cycle_year).with_value(course.recruitment_cycle.year) }
 


### PR DESCRIPTION
### Context

Standards are defined in the ITT criteria:
https://www.gov.uk/government/publications/initial-teacher-training-criteria/initial-teacher-training-itt-criteria-and-supporting-advice#c11-gcse-standard-equivalent

Further education has no minimum requirements (they don't award QTS)
Secondary requires Maths and English
Primary requires Maths, English and Science

All are to a grade 4 level (or C)

| Level | Maths | English | Science
|--|--|--|--|
| Secondary | 1-3 | 1-3 | Not set, or not required |
| Primary | 1-3 | 1-3 | 1-3 |
| Further education | Not required | Not required | Not required |

## Changes in this PR

Codify this logic and expose for frontend.

Follow-up to https://github.com/DFE-Digital/manage-courses-frontend/pull/473

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
