### PR TITLE
[1804] Set further education requirements to not_required

### DIFF
--- a/db/migrate/20190723092536_fix_fe_course_requirements.rb
+++ b/db/migrate/20190723092536_fix_fe_course_requirements.rb
@@ -1,0 +1,9 @@
+class FixFeCourseRequirements < ActiveRecord::Migration[5.2]
+  def up
+    say_with_time 'setting further education course requirements to not_required' do
+      Course.includes(:subjects).select { |course| course.level == :further_education }.each do |course|
+        course.update(maths: :not_required, english: :not_required, science: :not_required)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_11_074433) do
+ActiveRecord::Schema.define(version: 2019_07_23_092536) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"


### PR DESCRIPTION
### Context

There are no minimum GCSE requirements for further education courses. UCAS advises providers to set these to code 9 (not_required).

We're going to remove the ability to edit these codes for FE, but need to make the data consistent first.

### Changes proposed in this pull request

```
== 20190723092536 FixFeCourseRequirements: migrating ==========================
-- setting further education course requirements to not_required
   -> 9.5594s
== 20190723092536 FixFeCourseRequirements: migrated (9.5596s) =================
```

Before:
```
["equivalence_test", "equivalence_test", nil, 22],
["expect_to_achieve_before_training_begins", "expect_to_achieve_before_training_begins", nil, 20],
["not_required", "expect_to_achieve_before_training_begins", nil, 20],
["not_required", "not_required", nil, 16],
["must_have_qualification_at_application_time", "must_have_qualification_at_application_time", nil, 4]
```

After:
```["not_required", "not_required", "not_required", 82]```

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
