### PR TITLE
[1822] Don't send courses marked 'new' to UCAS

### DIFF
--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -12,13 +12,15 @@ module API
 
         ActiveRecord::Base.transaction do
           ActiveRecord::Base.connection.execute('LOCK provider, provider_enrichment, site IN SHARE UPDATE EXCLUSIVE MODE')
+
           @courses = @recruitment_cycle
              .courses
              .includes(:provider,
                        :site_statuses,
                        :subjects,
-                       site_statuses: [:site])
+                       site_statuses: %i[site course])
              .changed_since(changed_since)
+             .not_new
              .limit(per_page)
         end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -127,6 +127,10 @@ class Course < ApplicationRecord
     end.order(:changed_at, :id)
   end
 
+  scope :not_new, -> do
+    includes(site_statuses: %i[site course]).where.not(SiteStatus.table_name => { status: 'N' })
+  end
+
   def self.entry_requirement_options_without_nil_choice
     ENTRY_REQUIREMENT_OPTIONS.reject { |option| option == :not_set }.keys.map(&:to_s)
   end

--- a/lib/tasks/govuk_lint.rake
+++ b/lib/tasks/govuk_lint.rake
@@ -3,7 +3,7 @@ namespace :lint do
   task :ruby do
     puts 'Linting...'
     unless system 'bundle exec rubocop app config db lib spec Gemfile --format clang -a'
-      exit $?
+      exit $?.exitstatus
     end
   end
 end

--- a/spec/factories/site_statuses.rb
+++ b/spec/factories/site_statuses.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
     transient do
       any_vancancy { false }
       provider { build :provider }
+      age { nil }
     end
 
     trait :published do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -141,7 +141,10 @@ RSpec.describe Course, type: :model do
   end
 
   context 'with site statuses' do
+    let(:new_site_status) { build(:site_status, :new) }
+    let(:new_site_status2) { build(:site_status, :new) }
     let(:findable) { build(:site_status, :findable) }
+    let(:suspended) { build(:site_status, :suspended) }
     let(:with_any_vacancy) { build(:site_status, :with_any_vacancy) }
     let(:default) { build(:site_status) }
     let(:applications_being_accepted_now) { build(:site_status, :applications_being_accepted_now) }
@@ -278,6 +281,30 @@ RSpec.describe Course, type: :model do
         let(:subject) { create(:course, site_statuses: [suspended]) }
 
         its(:ucas_status) { should eq :not_running }
+      end
+    end
+
+    describe '#not_new' do
+      let(:new_course) do
+        create(:course, site_statuses: [new_site_status])
+      end
+
+      let(:findable_course_with_new_site) do
+        create(:course, site_statuses: [suspended, new_site_status2])
+      end
+
+      let(:findable_course) do
+        create(:course, site_statuses: [findable])
+      end
+
+      it 'only returns courses that arent new' do
+        new_course
+        findable_course
+        findable_course_with_new_site
+
+        expect(Course.not_new.count).to eq(2)
+        expect(Course.not_new.first.sites.count).to eq(1)
+        expect(Course.not_new.second.sites.count).to eq(1)
       end
     end
 


### PR DESCRIPTION
### Context
When UCAS requests course data we should not provide courses that have been marked 'new' as these haven't yet been published (and also have the potential to be discarded instead).

### Changes proposed in this pull request
This PR ensures that courses with a status of 'new' are not emitted by the v1 courses endpoint.  

### Guidance to review
This has the side effect of causing empty courses not to be sent, but this is correct behaviour. I had to correct tests that were dependent on the previous behaviour.

### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [X] Rebased parent
- [X] Cleaned commit history
- [X] Tested by running locally
