### PR TITLE
[1804] Add validations for GCSE entry requirements

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -85,6 +85,7 @@ module API
 
       def update_course
         return unless course_params.values.any?
+        return unless @course.entry_requirements_assignable(course_params)
 
         @course.assign_attributes(course_params)
         @course.save

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -125,6 +125,9 @@ class Course < ApplicationRecord
     ENTRY_REQUIREMENT_OPTIONS.reject { |option| option == :not_set }.keys.map(&:to_s)
   end
 
+  validates :maths,   inclusion: { in: entry_requirement_options_without_nil_choice }
+  validates :english, inclusion: { in: entry_requirement_options_without_nil_choice }
+  validates :science, inclusion: { in: entry_requirement_options_without_nil_choice }, if: :gcse_science_required?
   validates :enrichments, presence: true, on: :publish
   validate :validate_enrichment_publishable, on: :publish
   validate :validate_enrichment
@@ -283,6 +286,10 @@ class Course < ApplicationRecord
     else
       []
     end
+  end
+
+  def gcse_science_required?
+    gcse_subjects_required.include?('science')
   end
 
   def last_published_at

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -121,6 +121,10 @@ class Course < ApplicationRecord
     end.order(:changed_at, :id)
   end
 
+  def self.entry_requirement_options_without_nil_choice
+    ENTRY_REQUIREMENT_OPTIONS.reject { |option| option == :not_set }.keys.map(&:to_s)
+  end
+
   validates :enrichments, presence: true, on: :publish
   validate :validate_enrichment_publishable, on: :publish
   validate :validate_enrichment

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -381,6 +381,16 @@ class Course < ApplicationRecord
     recruitment_cycle.year > RecruitmentCycle.current_recruitment_cycle.year
   end
 
+  # Ideally this would just use the validation, but:
+  # https://github.com/rails/rails/issues/13971
+  def entry_requirements_assignable(course_params)
+    course_params.slice(:maths, :english, :science)
+      .to_h
+      .select { |_subject, value| value && !ENTRY_REQUIREMENT_OPTIONS.key?(value.to_sym) }
+      .map { |subject, _value| errors.add(subject.to_sym, "is invalid") }
+      .empty?
+  end
+
 private
 
   def add_enrichment_errors(enrichment)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,12 @@ en:
               blank: "is missing"
         course:
           attributes:
+            maths:
+              inclusion: "^Pick an option for Maths"
+            english:
+              inclusion: "^Pick an option for English"
+            science:
+              inclusion: "^Pick an option for Science"
             enrichments:
               blank: "^Complete your course information before publishing"
         course_enrichment:

--- a/db/migrate/20190724112016_fix_nil_entry_requirements.rb
+++ b/db/migrate/20190724112016_fix_nil_entry_requirements.rb
@@ -1,0 +1,15 @@
+class FixNilEntryRequirements < ActiveRecord::Migration[5.2]
+  def up
+    say_with_time 'fixing courses with a nil subject requirement for required subjects' do
+      Course
+        .includes(:subjects)
+        .select { |c| c.maths.nil? || c.english.nil? || (c.gcse_science_required? && c.science.nil?) }
+        .each do |course|
+        course.maths = 'equivalence_test' if course.maths.nil?
+        course.english = 'equivalence_test' if course.english.nil?
+        course.science = 'equivalence_test' if course.science.nil?
+        course.save
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_23_092536) do
+ActiveRecord::Schema.define(version: 2019_07_24_112016) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"

--- a/lib/mcb/courses_editor_cli.rb
+++ b/lib/mcb/courses_editor_cli.rb
@@ -9,16 +9,22 @@ module MCB
       @cli.ask("New course title?  ")
     end
 
-    def ask_english; ask_gcse_subject(:english); end
+    def ask_english
+      ask_gcse_subject(:english, Course::entry_requirement_options_without_nil_choice)
+    end
 
-    def ask_maths; ask_gcse_subject(:maths); end
+    def ask_maths
+      ask_gcse_subject(:maths, Course::entry_requirement_options_without_nil_choice)
+    end
 
-    def ask_science; ask_gcse_subject(:science); end
+    def ask_science
+      ask_gcse_subject(:science, Course::ENTRY_REQUIREMENT_OPTIONS.keys)
+    end
 
-    def ask_gcse_subject(subject)
+    def ask_gcse_subject(subject, choices)
       ask_multiple_choice(
         prompt: "What's the #{subject} entry requirements?",
-        choices: Course::ENTRY_REQUIREMENT_OPTIONS.keys
+        choices: choices
       )
     end
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -33,6 +33,9 @@ FactoryBot.define do
     provider
 
     study_mode { :full_time }
+    maths { :must_have_qualification_at_application_time }
+    english { :must_have_qualification_at_application_time }
+    science { :must_have_qualification_at_application_time }
     resulting_in_pgce_with_qts
 
     transient do

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -41,6 +41,7 @@ describe "Courses API", type: :request do
                                    age_range: 'primary',
                                    english: :equivalence_test,
                                    maths: :not_required,
+                                   science: :not_set,
                                    profpost_flag: :postgraduate,
                                    program_type: :school_direct_training_programme,
                                    modular: "",

--- a/spec/requests/api/v2/providers/courses/update_gsce_requirements_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_gsce_requirements_spec.rb
@@ -30,9 +30,6 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
     create :course,
            provider: provider,
              subjects: [primary_subject],
-             english: 1,
-             maths: 1,
-             science: 1
   }
   let(:updated_course) {
     build :course,

--- a/spec/requests/api/v2/providers/courses/update_gsce_requirements_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_gsce_requirements_spec.rb
@@ -21,17 +21,14 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
           }
   end
   let(:organisation)      { create :organisation }
-  let(:provider)          { create :provider, organisations: [organisation], sites: [site] }
+  let(:provider)          { create :provider, organisations: [organisation] }
   let(:user)              { create :user, organisations: [organisation] }
   let(:payload)           { { email: user.email } }
   let(:token)             { build_jwt :apiv2, payload: payload }
-  let(:site_status)       { build(:site_status, :findable, site: site) }
-  let(:site)              { build(:site) }
   let(:primary_subject)   { build(:subject, :primary) }
   let(:course)            {
     create :course,
            provider: provider,
-             site_statuses: [site_status],
              subjects: [primary_subject],
              english: 1,
              maths: 1,
@@ -41,7 +38,6 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
     build :course,
           course_code: course.course_code,
             provider: provider,
-            site_statuses: [site_status],
             subjects: [primary_subject],
             **gcse_requirements
   }

--- a/spec/requests/api/v2/providers/courses/update_gsce_requirements_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_gsce_requirements_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe 'PATCH /providers/:provider_code/courses/:course_code' do
   let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
 
-  def perform_request(course)
+  def perform_request(gcse_requirements)
     jsonapi_data = jsonapi_renderer.render(
       course,
       class: {
@@ -11,7 +11,7 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
       }
     )
 
-    jsonapi_data.dig(:data, :attributes).slice!(*permitted_params)
+    jsonapi_data[:data][:attributes] = gcse_requirements
 
     patch "/api/v2/providers/#{course.provider.provider_code}" \
             "/courses/#{course.course_code}",
@@ -25,18 +25,11 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
   let(:user)              { create :user, organisations: [organisation] }
   let(:payload)           { { email: user.email } }
   let(:token)             { build_jwt :apiv2, payload: payload }
-  let(:primary_subject)   { build(:subject, :primary) }
+
   let(:course)            {
     create :course,
            provider: provider,
-             subjects: [primary_subject],
-  }
-  let(:updated_course) {
-    build :course,
-          course_code: course.course_code,
-            provider: provider,
-            subjects: [primary_subject],
-            **gcse_requirements
+           subjects: [build(:subject, :primary)]
   }
 
   let(:credentials) do
@@ -45,6 +38,10 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
 
   let(:permitted_params) do
     %i[english maths science]
+  end
+
+  before do
+    perform_request(gcse_requirements)
   end
 
   context "course has updated gcse requirements" do
@@ -56,25 +53,20 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
       }
     end
 
-    before do
-      updated_course.id = course.id
-      perform_request(updated_course)
-    end
-
     it "returns http success" do
       expect(response).to have_http_status(:success)
     end
 
     it "updates the english attribute to the correct value" do
-      expect(course.reload.english).to eq(updated_course.english)
+      expect(course.reload.english).to eq(gcse_requirements[:english])
     end
 
     it "updates the maths attribute to the correct value" do
-      expect(course.reload.maths).to eq(updated_course.maths)
+      expect(course.reload.maths).to eq(gcse_requirements[:maths])
     end
 
     it "updates the science attribute to the correct value" do
-      expect(course.reload.science).to eq(updated_course.science)
+      expect(course.reload.science).to eq(gcse_requirements[:science])
     end
   end
 
@@ -86,11 +78,6 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
           maths: 'must_have_qualification_at_application_time',
           science: 'must_have_qualification_at_application_time'
         }
-      end
-
-      before do
-        updated_course.id = course.id
-        perform_request(updated_course)
       end
 
       it "returns http success" do
@@ -114,8 +101,6 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
       let(:gcse_requirements) { {} }
 
       before do
-        updated_course.id = course.id
-        perform_request(updated_course)
         @english = course.english
         @maths = course.maths
         @science = course.science

--- a/spec/requests/api/v2/providers/courses/update_gsce_requirements_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_gsce_requirements_spec.rb
@@ -168,4 +168,18 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
       expect(course.reload.science).to eq('must_have_qualification_at_application_time')
     end
   end
+
+  context "when unknown values are provided on a course" do
+    let(:json_data) { JSON.parse(response.body)['errors'] }
+    let(:gcse_requirements) { { english: 'must_have_qualification_at_application_time', maths: nil, science: 'blah' } }
+
+    it "returns an error" do
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "has validation errors" do
+      expect(json_data.count).to eq 1
+      expect(response.body).to include('Science is invalid')
+    end
+  end
 end


### PR DESCRIPTION
### Context

A follow up to #631.

### Changes proposed in this pull request

- Add validations to maths, english and science
  - Maths and english must always be set, science only on Primary courses
- New validations make some existing courses invalid, include a data migration to correct those courses (22 per cycle)
- Don't include "not_set" option for Maths and English when creating courses in MCB (this can't use the gcse_subjects_required method as the course level is determined by subjects which are only added after creation)
- DRY up the existing spec

There's a few gotchas found while working on this, which led to some frustrating rabbit holes:
- When a enum is assigned to nil, (not_set: nil), a `presence` validation won't work as expected – 'not_set' gets passed through and becomes nil after validations run
- When creating a course in MCB we do so before assigning subjects, subjects determine the course level, which in turn determine if science is required or not
- When trying to assign an invalid option not in the requirements enum, Rails throws an ArgumentError rather than using validations if present

### Guidance to review

- Review commit by commit
- Double check the data migration

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
