### PR TITLE
[1835] sync courses to find active job

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,5 @@
+class ApplicationJob < ActiveJob::Base
+  retry_on ActiveRecord::Deadlocked
+
+  discard_on ActiveJob::DeserializationError
+end

--- a/app/jobs/sync_courses_to_find_job.rb
+++ b/app/jobs/sync_courses_to_find_job.rb
@@ -1,0 +1,7 @@
+class SyncCoursesToFindJob < ApplicationJob
+  queue_as :find_sync
+
+  def perform(*courses)
+    SearchAndCompareAPIService::Request.sync(courses)
+  end
+end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -7,5 +7,5 @@ Rails.application.initialize!
 Rails.application.configure do
   config.action_controller.action_on_unpermitted_parameters = :raise
 
-  config.active_job.queue_adapter = :async
+  config.active_job.queue_adapter = :inline
 end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -6,4 +6,6 @@ Rails.application.initialize!
 
 Rails.application.configure do
   config.action_controller.action_on_unpermitted_parameters = :raise
+
+  config.active_job.queue_adapter = :async
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,4 +45,6 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.authentication_token = ENV.fetch("AUTHENTICATION_TOKEN", "bats")
+
+  config.active_job.queue_adapter = :inline
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,4 +42,6 @@ Rails.application.configure do
     Bullet.bullet_logger = true
     Bullet.raise = false # don't raise an error if an n+1 query occurs
   end
+
+  config.active_job.queue_adapter = :test
 end

--- a/spec/jobs/sync_courses_to_find_job_spec.rb
+++ b/spec/jobs/sync_courses_to_find_job_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe SyncCoursesToFindJob, type: :job do
+  let(:course) { create :course }
+
+  before do
+    allow(SearchAndCompareAPIService::Request).to receive(:sync)
+  end
+
+  it 'queues the expected job' do
+    described_class.perform_later(course)
+
+    expect(SyncCoursesToFindJob)
+      .to have_been_enqueued.with(course).on_queue('find_sync')
+  end
+
+  it 'syncs using the SearchAndCompareAPIService' do
+    described_class.perform_now(course)
+
+    expect(SearchAndCompareAPIService::Request)
+      .to have_received(:sync).with([course])
+  end
+end

--- a/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
+++ b/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
@@ -33,6 +33,19 @@ describe 'Courses API v2', type: :request do
       response
     end
 
+    it { should have_http_status(:success) }
+
+    its(:body) { should be_empty }
+
+    it 'makes syncs to search and compare' do
+      perform_enqueued_jobs do
+        subject
+      end
+
+      expect(WebMock)
+        .to have_requested(:put, "#{Settings.search_api.base_url}/api/courses/")
+    end
+
     context 'when unauthenticated' do
       let(:payload) { { email: 'foo@bar' } }
       let(:credentials) do
@@ -62,21 +75,6 @@ describe 'Courses API v2', type: :request do
       let(:course) { create(:course) }
 
       it { should have_http_status(:not_found) }
-    end
-
-    context 'when the api responds with a success' do
-      it { should have_http_status(:success) }
-    end
-
-    context 'when the api was unsuccessful' do
-      let(:search_api_status) { 400 }
-
-      it 'raises an error' do
-        expect {
-          subject
-        }.to raise_error RuntimeError,
-                         'error received when syncing with search and compare'
-      end
     end
   end
 end

--- a/spec/requests/api/v2/providers/courses/update_sites_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_sites_spec.rb
@@ -45,7 +45,6 @@ describe 'PATCH /providers/:provider_code/courses/:course_code with sites' do
     }
   end
 
-
   let!(:sync_courses_request_stub) do
     stub_request(:put, %r{#{Settings.search_api.base_url}/api/courses/})
       .to_return(
@@ -67,7 +66,9 @@ describe 'PATCH /providers/:provider_code/courses/:course_code with sites' do
   context "course has some sites" do
     context "course is new" do
       before do
-        perform_request
+        perform_enqueued_jobs do
+          perform_request
+        end
       end
 
       it "returns http success" do
@@ -108,7 +109,9 @@ describe 'PATCH /providers/:provider_code/courses/:course_code with sites' do
       let(:sites_payload) { [] }
 
       before do
-        perform_request
+        perform_enqueued_jobs do
+          perform_request
+        end
       end
 
       it "returns http 422" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -122,4 +122,6 @@ RSpec.configure do |config|
   end
 
   config.include ActiveJob::TestHelper, type: :request
+
+  ActiveJob::Base.queue_adapter = :test
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -120,4 +120,6 @@ RSpec.configure do |config|
     config.before(:each) { Bullet.start_request }
     config.after(:each)  { Bullet.end_request }
   end
+
+  config.include ActiveJob::TestHelper, type: :request
 end


### PR DESCRIPTION
### Context

We need to background this task.

### Changes proposed in this pull request

Use ActiveJob to sync a course to find. This will allow us to plugin a background job processor when ready.

### Guidance to review

This doesn't include a proper background job processor, but it's a step above what we have (it'll background the task to sync the course), even if it suffers from the flaw that it could lose jobs when the app is restarted. The next PR should add a background job processor, so we may want to couple the two PRs together for release.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
