### PR TITLE
[1813] delete a course

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,9 @@ gem 'aasm'
 # Allows writing of error full_messages for validations that don't start with the attribute name
 gem 'custom_error_message', git: 'https://github.com/nanamkim/custom-err-msg.git', ref: 'd72fb18'
 
+# Soft delete
+gem 'discard'
+
 group :development, :test do
   # add info about db structure to models and other files
   gem 'annotate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
     database_cleaner (1.7.0)
     deep_merge (1.2.1)
     diff-lcs (1.3)
+    discard (1.1.0)
+      activerecord (>= 4.2, < 7)
     docile (1.3.2)
     dry-configurable (0.8.3)
       concurrent-ruby (~> 1.0)
@@ -402,6 +404,7 @@ DEPENDENCIES
   cri
   custom_error_message!
   database_cleaner
+  discard
   factory_bot_rails (~> 5.0)
   fakefs
   faker

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -72,6 +72,10 @@ module API
         end
       end
 
+      def destroy
+        @course.discard
+      end
+
     private
 
       def update_enrichment

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -24,6 +24,7 @@
 #
 
 class Course < ApplicationRecord
+  include Discard::Model
   include WithQualifications
   include ChangedAt
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -31,6 +31,10 @@ class Course < ApplicationRecord
 
   after_initialize :set_defaults
 
+  before_discard do
+    raise "You cannot delete a running course (Course: #{self}, Provider: #{provider_id})" if ucas_status != :new
+  end
+
   has_associated_audits
   audited
   validates :course_code, uniqueness: { scope: :provider_id }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -11,6 +11,7 @@
 #  qualification             :integer          not null
 #  start_date                :datetime
 #  study_mode                :text
+#  accrediting_provider_id   :integer
 #  provider_id               :integer          default(0), not null
 #  modular                   :text
 #  english                   :integer
@@ -20,7 +21,7 @@
 #  updated_at                :datetime         not null
 #  changed_at                :datetime         not null
 #  accrediting_provider_code :text
-#  accrediting_provider_id   :integer
+#  discarded_at              :datetime
 #
 
 class Course < ApplicationRecord

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -60,7 +60,7 @@ class Provider < ApplicationRecord
           -> { published.latest_published_at },
           class_name: "ProviderEnrichment",
           inverse_of: 'provider'
-  has_many :courses
+  has_many :courses, -> { kept }
   has_one :ucas_preferences, class_name: 'ProviderUCASPreference'
   has_many :contacts
   has_many :accredited_courses,

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -15,6 +15,7 @@ class CoursePolicy
   end
 
   alias_method :update?, :show?
+  alias_method :destroy?, :show?
   alias_method :sync_with_search_and_compare?, :update?
   alias_method :publish?, :update?
   alias_method :publishable?, :update?

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -11,6 +11,7 @@
 #  qualification             :integer          not null
 #  start_date                :datetime
 #  study_mode                :text
+#  accrediting_provider_id   :integer
 #  provider_id               :integer          default(0), not null
 #  modular                   :text
 #  english                   :integer
@@ -20,7 +21,7 @@
 #  updated_at                :datetime         not null
 #  changed_at                :datetime         not null
 #  accrediting_provider_code :text
-#  accrediting_provider_id   :integer
+#  discarded_at              :datetime
 #
 
 class CourseSerializer < ActiveModel::Serializer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,7 +103,7 @@ Rails.application.routes.draw do
       end
 
       concern :provider_routes do
-        resources :courses, param: :code, only: %i[index create show update] do
+        resources :courses, param: :code do
           post :sync_with_search_and_compare, on: :member
           post :publish, on: :member
           post :publishable, on: :member

--- a/db/migrate/20190718142118_add_discarded_at_to_course.rb
+++ b/db/migrate/20190718142118_add_discarded_at_to_course.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToCourse < ActiveRecord::Migration[5.2]
+  def change
+    add_column :course, :discarded_at, :datetime
+    add_index :course, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -86,9 +86,11 @@ ActiveRecord::Schema.define(version: 2019_07_24_112016) do
     t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.datetime "changed_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.text "accrediting_provider_code"
+    t.datetime "discarded_at"
     t.index ["accrediting_provider_code"], name: "index_course_on_accrediting_provider_code"
     t.index ["accrediting_provider_id"], name: "IX_course_accrediting_provider_id"
     t.index ["changed_at"], name: "index_course_on_changed_at", unique: true
+    t.index ["discarded_at"], name: "index_course_on_discarded_at"
     t.index ["provider_id", "course_code"], name: "IX_course_provider_id_course_code", unique: true
   end
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -11,6 +11,7 @@
 #  qualification             :integer          not null
 #  start_date                :datetime
 #  study_mode                :text
+#  accrediting_provider_id   :integer
 #  provider_id               :integer          default(0), not null
 #  modular                   :text
 #  english                   :integer
@@ -20,7 +21,7 @@
 #  updated_at                :datetime         not null
 #  changed_at                :datetime         not null
 #  accrediting_provider_code :text
-#  accrediting_provider_id   :integer
+#  discarded_at              :datetime
 #
 
 FactoryBot.define do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -11,6 +11,7 @@
 #  qualification             :integer          not null
 #  start_date                :datetime
 #  study_mode                :text
+#  accrediting_provider_id   :integer
 #  provider_id               :integer          default(0), not null
 #  modular                   :text
 #  english                   :integer
@@ -20,7 +21,7 @@
 #  updated_at                :datetime         not null
 #  changed_at                :datetime         not null
 #  accrediting_provider_code :text
-#  accrediting_provider_id   :integer
+#  discarded_at              :datetime
 #
 
 require 'rails_helper'

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -974,4 +974,58 @@ RSpec.describe Course, type: :model do
       it { should be_truthy }
     end
   end
+
+  describe '#discard' do
+    context 'new course' do
+      let!(:subject) do
+        course = create(:course)
+
+        site = create(:site)
+        create(:site_status, :new, site: site, course: course)
+
+        course
+      end
+
+      context 'before discarding' do
+        its(:discarded?) { should be false }
+
+        it 'is in kept' do
+          expect(described_class.kept.size).to eq(1)
+        end
+
+        it 'is not in discarded' do
+          expect(described_class.discarded.size).to eq(0)
+        end
+      end
+
+      context 'after discarding' do
+        before do
+          subject.discard
+        end
+
+        its(:discarded?) { should be true }
+
+        it 'is not in kept' do
+          expect(described_class.kept.size).to eq(0)
+        end
+
+        it 'is in discarded' do
+          expect(described_class.discarded.size).to eq(1)
+        end
+      end
+
+      context 'incorrect actions' do
+        it 'raises error when deleted and course status is running' do
+          course = subject
+
+          site = create(:site)
+          create(:site_status, :running, :published, site: site, course: course)
+
+          expect { course.discard }.to raise_error(
+            "You cannot delete a running course (Course: #{course}, Provider: #{course.provider_id})"
+          )
+        end
+      end
+    end
+  end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -261,6 +261,14 @@ describe Provider, type: :model do
         expect(first_provider.courses_count).to eq(1)
       end
     end
+
+    describe '#courses' do
+      describe 'discard' do
+        it 'reduces courses when one is discarded' do
+          expect { course.discard }.to change { provider.courses.size }.by(-1)
+        end
+      end
+    end
   end
 
   describe '#copy_to_recruitment_cycle' do

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -46,32 +46,141 @@ describe 'Courses API v2', type: :request do
       "/api/v2/providers/#{provider.provider_code}" +
         "/courses/#{course.course_code}"
     end
-    let(:course) { findable_open_course }
 
     subject do
       get show_path, headers: { 'HTTP_AUTHORIZATION' => credentials }
       response
     end
 
-    context 'when unauthenticated' do
-      let(:payload) { { email: 'foo@bar' } }
+    context 'with a findable_open_course' do
+      let(:course) { findable_open_course }
 
-      it { should have_http_status(:unauthorized) }
-    end
+      context 'when unauthenticated' do
+        let(:payload) { { email: 'foo@bar' } }
 
-    context 'when user has not accepted terms' do
-      let(:user)         { create(:user, accept_terms_date_utc: nil) }
-      let(:organisation) { create(:organisation, users: [user]) }
+        it { should have_http_status(:unauthorized) }
+      end
 
-      it { should have_http_status(:forbidden) }
-    end
+      context 'when user has not accepted terms' do
+        let(:user)         { create(:user, accept_terms_date_utc: nil) }
+        let(:organisation) { create(:organisation, users: [user]) }
 
-    context 'when unauthorised' do
-      let(:unauthorised_user) { create(:user) }
-      let(:payload)           { { email: unauthorised_user.email } }
+        it { should have_http_status(:forbidden) }
+      end
 
-      it "raises an error" do
-        expect { subject }.to raise_error Pundit::NotAuthorizedError
+      context 'when unauthorised' do
+        let(:unauthorised_user) { create(:user) }
+        let(:payload)           { { email: unauthorised_user.email } }
+
+        it "raises an error" do
+          expect { subject }.to raise_error Pundit::NotAuthorizedError
+        end
+      end
+
+      describe 'JSON generated for courses' do
+        before do
+          get "/api/v2/providers/#{provider.provider_code.downcase}/courses/#{findable_open_course.course_code.downcase}",
+              headers: { 'HTTP_AUTHORIZATION' => credentials },
+              params: { include: 'subjects,site_statuses.site' }
+        end
+
+        it { should have_http_status(:success) }
+
+        it 'has a data section with the correct attributes' do
+          json_response = JSON.parse response.body
+          expect(json_response).to eq(
+            "data" => {
+              "id" => provider.courses[0].id.to_s,
+              "type" => "courses",
+              "attributes" => {
+                "findable?" => true,
+                "open_for_applications?" => true,
+                "has_vacancies?" => true,
+                "name" => provider.courses[0].name,
+                "course_code" => provider.courses[0].course_code,
+                "start_date" => provider.courses[0].start_date.iso8601,
+                "study_mode" => "full_time",
+                "qualifications" => %w[qts pgce],
+                "description" => "PGCE with QTS full time teaching apprenticeship",
+                "content_status" => "published",
+                "ucas_status" => "running",
+                "funding" => "apprenticeship",
+                "is_send?" => true,
+                "subjects" => ["Primary",
+                               "Primary with mathematics"],
+                "level" => "primary",
+                "applications_open_from" => "2019-01-01T00:00:00Z",
+                "about_course" => enrichment.about_course,
+                "course_length" => enrichment.course_length,
+                "fee_details" => enrichment.fee_details,
+                "fee_international" => enrichment.fee_international,
+                "fee_uk_eu" => enrichment.fee_uk_eu,
+                "financial_support" => enrichment.financial_support,
+                "how_school_placements_work" => enrichment.how_school_placements_work,
+                "interview_process" => enrichment.interview_process,
+                "other_requirements" => enrichment.other_requirements,
+                "personal_qualities" => enrichment.personal_qualities,
+                "required_qualifications" => enrichment.required_qualifications,
+                "salary_details" => enrichment.salary_details,
+                "last_published_at" => enrichment.last_published_timestamp_utc.iso8601,
+                "has_bursary?" => true,
+                "has_scholarship_and_bursary?" => false,
+                "has_early_career_payments?" => false,
+                "bursary_amount" => nil,
+                "scholarship_amount" => nil,
+                "about_accrediting_body" => nil,
+                "english" => 'must_have_qualification_at_application_time',
+                "maths" => 'must_have_qualification_at_application_time',
+                "science" => 'must_have_qualification_at_application_time',
+                "provider_code" => provider.provider_code,
+                "recruitment_cycle_year" => "2019",
+                "gcse_subjects_required" => %w[maths english science],
+              },
+              "relationships" => {
+                "accrediting_provider" => { "meta" => { "included" => false } },
+                "provider" => { "meta" => { "included" => false } },
+                "sites" => { "meta" => { "included" => false } },
+                "site_statuses" => { "data" => [{ "type" => "site_statuses", "id" => site_status.id.to_s }] },
+              },
+            },
+            "jsonapi" => {
+              "version" => "1.0"
+            },
+            "included" => [{
+              "id" => site_status.id.to_s,
+              "type" => "site_statuses",
+              "attributes" => {
+                "vac_status" => site_status.vac_status,
+                "publish" => site_status.publish,
+                "status" => site_status.status,
+                "applications_accepted_from" => site_status.applications_accepted_from.strftime("%Y-%m-%d"),
+                "has_vacancies?" => true
+              },
+              "relationships" => {
+                "site" => {
+                  "data" => {
+                    "type" => "sites",
+                      "id" => site.id.to_s
+                  }
+                }
+              }
+            }, {
+              "id" => site.id.to_s,
+              "type" => "sites",
+              "attributes" => {
+                "code" => site.code,
+                "location_name" => site.location_name,
+                "address1" => site.address1,
+                "address2" => site.address2,
+                "address3" => site.address3,
+                "address4" => site.address4,
+                "postcode" => site.postcode,
+                "region_code" => site.region_code,
+                "recruitment_cycle_year" => "2019",
+              }
+            }]
+          )
+        end
       end
     end
 
@@ -81,110 +190,15 @@ describe 'Courses API v2', type: :request do
       it { should have_http_status(:not_found) }
     end
 
-    describe 'JSON generated for courses' do
-      before do
-        get "/api/v2/providers/#{provider.provider_code.downcase}/courses/#{findable_open_course.course_code.downcase}",
-            headers: { 'HTTP_AUTHORIZATION' => credentials },
-            params: { include: 'subjects,site_statuses.site' }
+    context 'when a course is discarded' do
+      let(:course) do
+        course = create(:course, provider: provider)
+        create(:site_status, :new, site: create(:site), course: course)
+        course.discard
+        course
       end
 
-      it { should have_http_status(:success) }
-
-      it 'has a data section with the correct attributes' do
-        json_response = JSON.parse response.body
-        expect(json_response).to eq(
-          "data" => {
-            "id" => provider.courses[0].id.to_s,
-            "type" => "courses",
-            "attributes" => {
-              "findable?" => true,
-              "open_for_applications?" => true,
-              "has_vacancies?" => true,
-              "name" => provider.courses[0].name,
-              "course_code" => provider.courses[0].course_code,
-              "start_date" => provider.courses[0].start_date.iso8601,
-              "study_mode" => "full_time",
-              "qualifications" => %w[qts pgce],
-              "description" => "PGCE with QTS full time teaching apprenticeship",
-              "content_status" => "published",
-              "ucas_status" => "running",
-              "funding" => "apprenticeship",
-              "is_send?" => true,
-              "subjects" => ["Primary",
-                             "Primary with mathematics"],
-              "level" => "primary",
-              "applications_open_from" => "2019-01-01T00:00:00Z",
-              "about_course" => enrichment.about_course,
-              "course_length" => enrichment.course_length,
-              "fee_details" => enrichment.fee_details,
-              "fee_international" => enrichment.fee_international,
-              "fee_uk_eu" => enrichment.fee_uk_eu,
-              "financial_support" => enrichment.financial_support,
-              "how_school_placements_work" => enrichment.how_school_placements_work,
-              "interview_process" => enrichment.interview_process,
-              "other_requirements" => enrichment.other_requirements,
-              "personal_qualities" => enrichment.personal_qualities,
-              "required_qualifications" => enrichment.required_qualifications,
-              "salary_details" => enrichment.salary_details,
-              "last_published_at" => enrichment.last_published_timestamp_utc.iso8601,
-              "has_bursary?" => true,
-              "has_scholarship_and_bursary?" => false,
-              "has_early_career_payments?" => false,
-              "bursary_amount" => nil,
-              "scholarship_amount" => nil,
-              "about_accrediting_body" => nil,
-              "english" => 'must_have_qualification_at_application_time',
-              "maths" => 'must_have_qualification_at_application_time',
-              "science" => 'must_have_qualification_at_application_time',
-              "provider_code" => provider.provider_code,
-              "recruitment_cycle_year" => "2019",
-              "gcse_subjects_required" => %w[maths english science],
-            },
-            "relationships" => {
-              "accrediting_provider" => { "meta" => { "included" => false } },
-              "provider" => { "meta" => { "included" => false } },
-              "sites" => { "meta" => { "included" => false } },
-              "site_statuses" => { "data" => [{ "type" => "site_statuses", "id" => site_status.id.to_s }] },
-            },
-          },
-          "jsonapi" => {
-            "version" => "1.0"
-          },
-          "included" => [{
-            "id" => site_status.id.to_s,
-            "type" => "site_statuses",
-            "attributes" => {
-              "vac_status" => site_status.vac_status,
-              "publish" => site_status.publish,
-              "status" => site_status.status,
-              "applications_accepted_from" => site_status.applications_accepted_from.strftime("%Y-%m-%d"),
-              "has_vacancies?" => true
-            },
-            "relationships" => {
-              "site" => {
-                "data" => {
-                  "type" => "sites",
-                    "id" => site.id.to_s
-                }
-              }
-            }
-          }, {
-            "id" => site.id.to_s,
-            "type" => "sites",
-            "attributes" => {
-              "code" => site.code,
-              "location_name" => site.location_name,
-              "address1" => site.address1,
-              "address2" => site.address2,
-              "address3" => site.address3,
-              "address4" => site.address4,
-              "postcode" => site.postcode,
-              "region_code" => site.region_code,
-              "recruitment_cycle_year" => "2019",
-            }
-          }]
-        )
-      end
+      it { should have_http_status(:not_found) }
     end
   end
 
@@ -349,6 +363,57 @@ describe 'Courses API v2', type: :request do
             .to have_attribute('recruitment_cycle_year').with_value('2020')
         end
       end
+    end
+  end
+
+  describe 'DELETE destroy' do
+    let(:path) do
+      "/api/v2/providers/#{provider.provider_code}" +
+        "/courses/#{course.course_code}"
+    end
+
+    let(:course) { create(:course, provider: provider, site_statuses: [site_status]) }
+    let(:site_status) { build(:site_status, :new) }
+
+    before do
+      course
+    end
+
+    subject do
+      delete path, headers: { 'HTTP_AUTHORIZATION' => credentials }
+      response
+    end
+
+    context 'when unauthenticated' do
+      let(:payload) { { email: 'foo@bar' } }
+
+      it { should have_http_status(:unauthorized) }
+    end
+
+    context 'when user has not accepted terms' do
+      let(:user)         { create(:user, accept_terms_date_utc: nil) }
+      let(:organisation) { create(:organisation, users: [user]) }
+
+      it { should have_http_status(:forbidden) }
+    end
+
+    context 'when unauthorised' do
+      let(:unauthorised_user) { create(:user) }
+      let(:payload)           { { email: unauthorised_user.email } }
+
+      it "raises an error" do
+        expect { subject }.to raise_error Pundit::NotAuthorizedError
+      end
+    end
+
+    context 'when course and provider is not related' do
+      let(:course) { create(:course) }
+
+      it { should have_http_status(:not_found) }
+    end
+
+    describe 'when authorized' do
+      it { should have_http_status(:success) }
     end
   end
 end

--- a/spec/serializers/course_serializer_spec.rb
+++ b/spec/serializers/course_serializer_spec.rb
@@ -11,6 +11,7 @@
 #  qualification             :integer          not null
 #  start_date                :datetime
 #  study_mode                :text
+#  accrediting_provider_id   :integer
 #  provider_id               :integer          default(0), not null
 #  modular                   :text
 #  english                   :integer
@@ -20,7 +21,7 @@
 #  updated_at                :datetime         not null
 #  changed_at                :datetime         not null
 #  accrediting_provider_code :text
-#  accrediting_provider_id   :integer
+#  discarded_at              :datetime
 #
 
 require "rails_helper"


### PR DESCRIPTION
### Context

* Allowing deletion of courses through the Ruby gem discard.
* :sweat_smile: damn hot https://www.youtube.com/watch?v=DpktBGInl60
* Scorchio :hot_pepper: https://www.youtube.com/watch?v=kZMUAd7OJc8

Pairing @timabell & @NyWeb 

### Changes proposed in this pull request
- Include gem
- Used the gems callbacks for throwing error when a course can't be deleted
- Forced kept as a scope for provider
- Minor clean-up of test
- Added tests

### Guidance to review

* Simplest implementation of if `discard is allowed` was to throw an exception in `before_discard`
* Feedback on the test setup always welcomed.
* Turn off whitespace to see the change to `spec/requests/api/v2/providers/courses_spec.rb` more clearly (indented large json block because it's wrapped in a new block)


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master x10
- [x] Cleaned commit history x100
- [x] Tested by running locally x20
