### PR TITLE
Spike: Share edit options with frontend

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -260,6 +260,10 @@ class Course < ApplicationRecord
     end
   end
 
+  def edit_options
+    @edit_options ||= EditCourseOptions.new(self)
+  end
+
   def dfe_subjects
     SubjectMapperService.get_subject_list(name, subjects.map(&:subject_name))
   end

--- a/app/models/edit_course_options.rb
+++ b/app/models/edit_course_options.rb
@@ -1,0 +1,27 @@
+class EditCourseOptions
+  def initialize(course)
+    @course = course
+  end
+
+  def entry_requirements
+    Course::ENTRY_REQUIREMENT_OPTIONS
+      .reject { |a| a.include? %i[not_set not_required] }
+      .map do |choice|
+      option = { value: choice }
+
+      case choice
+      when :must_have_qualification_at_application_time
+        option[:text] = '1. Must have (least flexible)'
+        option[:help] = 'UCAS will block applications from candidates who haven’t gained their GCSE yet or who need to take an equivalency test.'
+      when :expect_to_achieve_before_training_begins
+        option[:text] = '2: Taking'
+        option[:help] = 'You will consider candidates with a pending GCSE. But UCAS will block applications from someone who needs to take an equivalency test.'
+      when :equivalence_test
+        option[:text] = '3: Equivalence test'
+        option[:help] = 'You will consider candidates who need to take an equivalency test as well as those with a pending GCSE.'
+      end
+
+      option
+    end
+  end
+end

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -60,6 +60,14 @@ module API
       enrichment_attribute :personal_qualities
       enrichment_attribute :required_qualifications
       enrichment_attribute :salary_details
+
+      meta do
+        {
+          edit_options: {
+            entry_requirements: @object.edit_options.entry_requirements
+          }
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Backend should be responsible for the business logic which determines which options are available for each course. Eg which course outcomes should be listed when editing the outcome.

We need a place for these and we need to share them with the frontend.

### Changes proposed in this pull request

- Create an EditCourseOptions class
- Send values from that class through in the `:meta` part of a serialised course for the frontend
- Use UCAS eligibility as an example (would replace list in https://github.com/DFE-Digital/manage-courses-frontend/blob/master/app/views/courses/entry_requirements/_subject_choices.html.erb)

```json
"meta": {
      "edit_options": {
        "entry_requirements": [
          {
            "key": "must_have_qualification_at_application_time",
            "text": "1. Must have (least flexible)",
            "help": "UCAS will block applications from candidates who haven’t gained their GCSE yet or who need to take an equivalency test."
          },
          {
            "key": "expect_to_achieve_before_training_begins",
            "text": "2: Taking",
            "help": "You will consider candidates with a pending GCSE. But UCAS will block applications from someone who needs to take an equivalency test."
          },
          {
            "key": "equivalence_test",
            "text": "3: Equivalence test",
            "help": "You will consider candidates who need to take an equivalency test as well as those with a pending GCSE."
          }
        ]
      }
```