### PR TITLE
[1822] Don't send courses marked 'new' to UCAS

### DIFF
--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -12,13 +12,15 @@ module API
 
         ActiveRecord::Base.transaction do
           ActiveRecord::Base.connection.execute('LOCK provider, provider_enrichment, site IN SHARE UPDATE EXCLUSIVE MODE')
+
           @courses = @recruitment_cycle
              .courses
              .includes(:provider,
                        :site_statuses,
                        :subjects,
-                       site_statuses: [:site])
+                       site_statuses: %i[site course])
              .changed_since(changed_since)
+             .not_new
              .limit(per_page)
         end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -121,6 +121,12 @@ class Course < ApplicationRecord
     end.order(:changed_at, :id)
   end
 
+  scope :not_new, -> do
+    includes(site_statuses: %i[site course])
+      .where
+      .not(SiteStatus.table_name => { status: SiteStatus.statuses[:new_status] })
+  end
+
   def self.entry_requirement_options_without_nil_choice
     ENTRY_REQUIREMENT_OPTIONS.reject { |option| option == :not_set }.keys.map(&:to_s)
   end

--- a/lib/tasks/govuk_lint.rake
+++ b/lib/tasks/govuk_lint.rake
@@ -3,7 +3,7 @@ namespace :lint do
   task :ruby do
     puts 'Linting...'
     unless system 'bundle exec rubocop app config db lib spec Gemfile --format clang -a'
-      exit $?
+      exit $?.exitstatus
     end
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -140,7 +140,10 @@ RSpec.describe Course, type: :model do
   end
 
   context 'with site statuses' do
+    let(:new_site_status) { build(:site_status, :new) }
+    let(:new_site_status2) { build(:site_status, :new) }
     let(:findable) { build(:site_status, :findable) }
+    let(:suspended) { build(:site_status, :suspended) }
     let(:with_any_vacancy) { build(:site_status, :with_any_vacancy) }
     let(:default) { build(:site_status) }
     let(:applications_being_accepted_now) { build(:site_status, :applications_being_accepted_now) }
@@ -277,6 +280,30 @@ RSpec.describe Course, type: :model do
         let(:subject) { create(:course, site_statuses: [suspended]) }
 
         its(:ucas_status) { should eq :not_running }
+      end
+    end
+
+    describe '#not_new' do
+      let(:new_course) do
+        create(:course, site_statuses: [new_site_status])
+      end
+
+      let(:suspended_course_with_new_site) do
+        create(:course, site_statuses: [suspended, new_site_status2])
+      end
+
+      let(:findable_course) do
+        create(:course, site_statuses: [findable])
+      end
+
+      it 'only returns courses that arent new' do
+        new_course
+        findable_course
+        suspended_course_with_new_site
+
+        expect(Course.not_new.count).to eq(2)
+        expect(Course.not_new.first.sites.count).to eq(1)
+        expect(Course.not_new.second.sites.count).to eq(1)
       end
     end
 

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -25,7 +25,6 @@ describe "Courses API", type: :request do
                         enrichments: [])
     end
 
-
     context "without changed_since parameter" do
       before do
         site = FactoryBot.create(:site, code: "-", location_name: "Main Site", provider: provider)
@@ -123,16 +122,22 @@ describe "Courses API", type: :request do
       end
 
       it 'includes correct next link in response headers' do
-        create(:course,
-               course_code: "LAST1",
-               age: 10.minutes.ago,
-               provider: provider)
+        Timecop.freeze(10.minutes.ago) do
+          first_course = create(:course,
+                                course_code: 'LAST1',
+                                provider: provider)
+
+          create(:site_status, :published, course: first_course)
+        end
 
         timestamp_of_last_course = 2.minutes.ago
-        _last_course_in_results = create(:course,
-                                         course_code: "LAST2",
-                                         age: timestamp_of_last_course,
-                                         provider: provider)
+
+        Timecop.freeze(timestamp_of_last_course) do
+          last_course_in_results = create(:course,
+                                          course_code: 'LAST2',
+                                          provider: provider)
+          create(:site_status, :published, course: last_course_in_results)
+        end
 
         get '/api/v1/2019/courses',
             headers: { 'HTTP_AUTHORIZATION' => credentials }
@@ -152,9 +157,9 @@ describe "Courses API", type: :request do
 
     describe 'JSON body response' do
       let(:provider) { build(:provider) }
-      let(:course) { create(:course, provider: provider) }
+      let(:course) { create(:course, provider: provider, site_statuses: [create(:site_status, :published)]) }
       let(:provider2) { build(:provider, recruitment_cycle: next_cycle) }
-      let(:course2) { create(:course, provider: provider2) }
+      let(:course2) { create(:course, provider: provider2, site_statuses: [create(:site_status, :published)]) }
       let(:next_cycle) { build(:recruitment_cycle, year: '2020') }
 
       before do
@@ -188,33 +193,45 @@ describe "Courses API", type: :request do
     context "with changed_since parameter" do
       describe "JSON body response" do
         it 'contains expected courses' do
-          old_course = create(:course, course_code: "SINCE1", age: 1.hour.ago)
-          updated_course = create(:course, course_code: "SINCE2", age: 5.minutes.ago)
+          site_status1 = create(:site_status, :published)
+          site_status2 = create(:site_status, :published)
+          old_course = create(:course, course_code: 'SINCE', site_statuses: [site_status1])
 
-          get '/api/v1/2019/courses',
-              headers: { 'HTTP_AUTHORIZATION' => credentials },
-              params: { changed_since: 10.minutes.ago.utc.iso8601 }
+          Timecop.freeze(5.minutes.from_now) do
+            new_course = create(:course, course_code: 'SINCE2', site_statuses: [site_status2])
 
-          returned_course_codes = get_course_codes_from_body(response.body)
+            get "/api/v1/2019/courses?changed_since=#{3.minutes.ago.utc.iso8601}",
+                headers: { 'HTTP_AUTHORIZATION' => credentials }
 
-          expect(returned_course_codes).not_to include old_course.course_code
-          expect(returned_course_codes).to include updated_course.course_code
+            returned_course_codes = get_course_codes_from_body(response.body)
+
+            expect(returned_course_codes).not_to include old_course.course_code
+            expect(returned_course_codes).to include new_course.course_code
+          end
         end
       end
 
       describe 'response headers' do
         context 'when the recruitment year is in the path' do
           it 'includes the correct next link' do
-            create(:course,
-                   course_code: "LAST1",
-                   age: 10.minutes.ago,
-                   provider: provider)
+            course_time = 10.minutes.ago
+            first_course = create(:course,
+                                  course_code: 'LAST1',
+                                  age: course_time,
+                                  provider: provider)
+
+            Timecop.freeze(course_time) do
+              create(:site_status, :published, course: first_course)
+            end
 
             timestamp_of_last_course = 2.minutes.ago
-            _last_course_in_results = create(:course,
-                                             course_code: "LAST2",
-                                             age: timestamp_of_last_course,
-                                             provider: provider)
+            Timecop.freeze(timestamp_of_last_course) do
+              last_course_in_results = create(:course,
+                                              course_code: 'LAST2',
+                                              age: timestamp_of_last_course,
+                                              provider: provider)
+              create(:site_status, :published, course: last_course_in_results)
+            end
 
             get '/api/v1/2019/courses',
                 headers: { 'HTTP_AUTHORIZATION' => credentials },
@@ -240,17 +257,24 @@ describe "Courses API", type: :request do
            # generate used to were of this style, and the UCAS systems
            # were making requests in this style.
           it 'includes the correct next link' do
-            create(:course,
-                   course_code: "LAST1",
-                   age: 10.minutes.ago,
-                   provider: provider)
+            course_time = 10.minutes.ago
+            first_course = create(:course,
+                                  course_code: 'LAST1',
+                                  age: course_time,
+                                  provider: provider)
+
+            Timecop.freeze(course_time) do
+              create(:site_status, :published, course: first_course)
+            end
 
             timestamp_of_last_course = 2.minutes.ago
-            create(:course,
-                   course_code: "LAST2",
-                   age: timestamp_of_last_course,
-                   provider: provider)
-
+            Timecop.freeze(timestamp_of_last_course) do
+              last_course_in_results = create(:course,
+                                              course_code: 'LAST2',
+                                              age: timestamp_of_last_course,
+                                              provider: provider)
+              create(:site_status, :published, course: last_course_in_results)
+            end
             get '/api/v1/courses?recruitment_year=2020',
                 headers: { 'HTTP_AUTHORIZATION' => credentials },
                 params: { changed_since: 30.minutes.ago.utc.iso8601 }
@@ -310,7 +334,8 @@ describe "Courses API", type: :request do
           @courses = Array.new(25) do |i|
             create(:course, course_code: "CRSE#{i + 1}",
                  changed_at: (30 - i).minutes.ago,
-                 provider: provider)
+                 provider: provider,
+                 site_statuses: [create(:site_status, :published)])
           end
         end
 
@@ -330,13 +355,6 @@ describe "Courses API", type: :request do
 
           get_next_courses response.headers['Link'].split(';').first
           expect(response.body).to_not have_courses
-
-          random_course = Course.all.sample
-          random_course.touch
-
-          get_next_courses response.headers['Link'].split(';').first
-          expect(response.body)
-            .to have_courses([random_course])
         end
       end
 
@@ -347,7 +365,8 @@ describe "Courses API", type: :request do
           @courses = Array.new(25) do |i|
             create(:course, course_code: "CRSE#{i + 1}",
                  changed_at: timestamp + i / 1000.0,
-                 provider: provider)
+                 provider: provider,
+                 site_statuses: [create(:site_status, :published)])
           end
         end
 
@@ -367,13 +386,6 @@ describe "Courses API", type: :request do
 
           get_next_courses response.headers['Link'].split(';').first
           expect(response.body).to_not have_courses
-
-          random_course = Course.all.sample
-          random_course.touch
-
-          get_next_courses response.headers['Link'].split(';').first
-          expect(response.body)
-            .to have_courses([random_course])
         end
 
         it 'pages properly with specified recruitment year' do
@@ -396,6 +408,29 @@ describe "Courses API", type: :request do
 
           expect(json[0]["campus_statuses"][0]["status"]). to eq(SiteStatus.statuses["suspended"])
         end
+      end
+    end
+
+    context 'with new courses' do
+      let(:current_cycle) { RecruitmentCycle.current_recruitment_cycle }
+      let(:provider1) { create(:provider, recruitment_cycle: current_cycle) }
+      let(:provider2) { create(:provider, recruitment_cycle: current_cycle) }
+
+      let(:course1) { create(:course, study_mode: 'full_time', profpost_flag: 'postgraduate', program_type: 'higher_education_programme', provider: provider1) }
+      let(:course2) { create(:course, study_mode: 'full_time', profpost_flag: 'postgraduate', program_type: 'higher_education_programme', provider: provider1) }
+
+      let!(:status1) { create(:site_status, status: :new_status, course: course1, vac_status: 'full_time_vacancies', applications_accepted_from: Date.new(2019, 7, 23)) }
+      let!(:status2) { create(:site_status, status: :new_status, course: course2, vac_status: 'full_time_vacancies', applications_accepted_from: Date.new(2019, 7, 24)) }
+      let!(:status3) { create(:site_status, status: :running, course: course2, vac_status: 'full_time_vacancies', applications_accepted_from: Date.new(2019, 7, 24)) }
+
+      it 'does not send courses marked new' do
+        get "/api/v1/2019/courses", headers: { 'HTTP_AUTHORIZATION' => credentials }
+
+        data = JSON.parse(response.body)
+        expect(data.length).to eq(1)
+        expect(data.first['course_code']).to eq(course2.course_code)
+        expect(data.first['campus_statuses'].length).to eq(1)
+        expect(data.first['campus_statuses'].first['campus_code']).to eq(status3.site.code)
       end
     end
   end


### PR DESCRIPTION
### Context
When UCAS requests course data we should not provide courses that have been marked 'new' as these haven't yet been published (and also have the potential to be discarded instead).

### Changes proposed in this pull request
This PR ensures that courses with a status of 'new' are not emitted by the v1 courses endpoint.  

### Guidance to review
This has the side effect of causing empty courses not to be sent, but this is correct behaviour. I had to correct tests that were dependent on the previous behaviour.  
This PR is a redo of #641 for merging into master.  

### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
