### PR TITLE
Expose edit options for entry requirements

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -260,6 +260,10 @@ class Course < ApplicationRecord
     end
   end
 
+  def edit_options
+    @edit_options ||= EditCourseOptions.new(self)
+  end
+
   def dfe_subjects
     SubjectMapperService.get_subject_list(name, subjects.map(&:subject_name))
   end

--- a/app/models/edit_course_options.rb
+++ b/app/models/edit_course_options.rb
@@ -1,0 +1,11 @@
+class EditCourseOptions
+  def initialize(course)
+    @course = course
+  end
+
+  def entry_requirements
+    Course::ENTRY_REQUIREMENT_OPTIONS
+      .reject { |k, _v| %i[not_set not_required].include?(k) }
+      .keys
+  end
+end

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -60,6 +60,14 @@ module API
       enrichment_attribute :personal_qualities
       enrichment_attribute :required_qualifications
       enrichment_attribute :salary_details
+
+      meta do
+        {
+          edit_options: {
+            entry_requirements: @object.edit_options.entry_requirements
+          }
+        }
+      end
     end
   end
 end

--- a/spec/models/edit_course_options_spec.rb
+++ b/spec/models/edit_course_options_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe EditCourseOptions, type: :model do
+  let(:course) { create(:course, name: 'Biology', course_code: '3X9F') }
+  let(:edit_course_options) { EditCourseOptions.new(course) }
+
+  context 'entry_requirements' do
+    it 'returns the entry requirements that users can choose between' do
+      expect(edit_course_options.entry_requirements).to eq(%i[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test])
+    end
+  end
+end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -146,6 +146,11 @@ describe 'Courses API v2', type: :request do
               "sites" => { "meta" => { "included" => false } },
               "site_statuses" => { "data" => [{ "type" => "site_statuses", "id" => site_status.id.to_s }] },
             },
+            "meta" => {
+              "edit_options" => {
+                "entry_requirements" => %w[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test]
+              }
+            }
           },
           "jsonapi" => {
             "version" => "1.0"
@@ -283,6 +288,11 @@ describe 'Courses API v2', type: :request do
               "provider" => { "meta" => { "included" => false } },
               "site_statuses" => { "meta" => { "included" => false } },
               "sites" => { "meta" => { "included" => false } },
+            },
+            "meta" => {
+              "edit_options" => {
+                "entry_requirements" => %w[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test]
+              }
             },
           }],
           "jsonapi" => {


### PR DESCRIPTION
### Context

Backend should be responsible for the business logic which determines which options are available for each course. Eg which course outcomes should be listed when editing the outcome.

We need a place for these and we need to share them with the frontend.

### Changes proposed in this pull request

Add an EditOptions class and use it pass through the options for editing entry requirements.

### Guidance to review

Goes alongside https://github.com/DFE-Digital/manage-courses-frontend/pull/481