### PR TITLE
[1734] Add completions for MCB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --update --no-cache tzdata && \
     echo "Europe/London" > /etc/timezone
 
 RUN apk add --update --no-cache --virtual runtime-dependances \
- postgresql-dev git
+ postgresql-dev git ncurses
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME

--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -361,6 +361,10 @@ module MCB
     def start_mcb_repl(start_argv)
       $mcb_repl_mode = true
 
+      command_names = $mcb.commands.map(&:name)
+      Readline.completion_proc = proc do |s|
+        command_names.grep(/^#{Regexp.escape(s)}/)
+      end
       trap("INT", "SIG_IGN")
 
       env = start_argv[1]
@@ -375,6 +379,7 @@ module MCB
                when nil          then Rainbow('local').green
                else                   env
                end
+
       while (input = Readline.readline("#{prompt}> ", true))
         argv = input.split
 

--- a/spec/bin/mcb_spec.rb
+++ b/spec/bin/mcb_spec.rb
@@ -16,4 +16,36 @@ describe 'running the mcb script' do
       expect(result).to eq config.to_yaml
     end
   end
+
+  describe 'REPL' do
+    it 'provides completions for empty prompt' do
+      output = with_stubbed_stdout(stdin: "\t\t") do
+        MCB.start_mcb_repl([])
+      end
+
+      expect(output).to include("providers")
+      expect(output).to include("console")
+      expect(output).to include("courses")
+      expect(output).to include("config")
+      expect(output).to include("apiv1")
+      expect(output).to include("apiv2")
+      expect(output).to include("users")
+      expect(output).to include("az")
+    end
+
+    it 'provides relevant completions for a main command' do
+      output = with_stubbed_stdout(stdin: "co\t\t") do
+        MCB.start_mcb_repl([])
+      end
+
+      expect(output).not_to include("providers")
+      expect(output).to include("console")
+      expect(output).to include("courses")
+      expect(output).to include("config")
+      expect(output).not_to include("apiv1")
+      expect(output).not_to include("apiv2")
+      expect(output).not_to include("users")
+      expect(output)
+    end
+  end
 end


### PR DESCRIPTION
### Context
For the convenience of users, especially those new to MCB, we should provide a way for commands to be completed.  

### Changes proposed in this pull request
Add tab autocomplete for main commands.  

### Guidance to review  
Currently stderr spills into the terminal during tests, I'm not sure how to disable it in `with_stubbed_stdout`. This also only performs completions for main commands as Readline is not context-aware.  

### Checklist

- [X] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
