### PR TITLE
[1843] Command output spec rewrite

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -72,6 +72,10 @@ module API
         end
       end
 
+      def destroy
+        @course.discard
+      end
+
     private
 
       def update_enrichment

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -31,6 +31,10 @@ class Course < ApplicationRecord
 
   after_initialize :set_defaults
 
+  before_discard do
+    raise "You cannot delete a running course (Course: #{self}, Provider: #{provider_id})" if ucas_status != :new
+  end
+
   has_associated_audits
   audited
   validates :course_code, uniqueness: { scope: :provider_id }

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -15,6 +15,7 @@ class CoursePolicy
   end
 
   alias_method :update?, :show?
+  alias_method :destroy?, :show?
   alias_method :sync_with_search_and_compare?, :update?
   alias_method :publish?, :update?
   alias_method :publishable?, :update?

--- a/bin/mcb
+++ b/bin/mcb
@@ -49,7 +49,7 @@ $mcb = Cri::Command.define do
   flag :h, :help, 'show help for this command' do |_value, cmd|
     puts cmd.help
 
-    prefix = "    #{cmd.name == "mcb" ? "bin/mcb" : cmd.name} "
+    prefix = "    #{cmd.name == 'mcb' ? 'bin/mcb' : cmd.name} "
     puts_command_index(cmd, prefix, 1)
 
     # Don't exit if we're in repl-mode.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,7 +103,7 @@ Rails.application.routes.draw do
       end
 
       concern :provider_routes do
-        resources :courses, param: :code, only: %i[index create show update] do
+        resources :courses, param: :code do
           post :sync_with_search_and_compare, on: :member
           post :publish, on: :member
           post :publishable, on: :member

--- a/spec/lib/mcb/commands/courses/list_spec.rb
+++ b/spec/lib/mcb/commands/courses/list_spec.rb
@@ -11,75 +11,71 @@ describe 'mcb providers list' do
     let(:provider2) { create(:provider, recruitment_cycle: current_cycle) }
     let(:provider3) { create(:provider, recruitment_cycle: additional_cycle) }
 
-    let(:course1) { create(:course, provider: provider1) }
-    let(:course2) { create(:course, provider: provider2) }
-    let(:course3) { create(:course, provider: provider3) }
+    let(:course_present) { create(:course, provider: provider1, name: 'First present course') }
+    let(:course_present2) { create(:course, provider: provider2, name: 'Second present course') }
+    let(:course_not_present) { create(:course, provider: provider3, name: 'Non-present course') }
 
     it 'lists all courses for the default recruitment cycle' do
-      course1
-      course2
-      course3
+      course_present
+      course_not_present
 
       command_output = list.execute[:stdout]
 
-      expect(command_output).to include(course1.course_code)
-      expect(command_output).to include(course1.name)
+      expect(command_output).to include(course_present.course_code)
+      expect(command_output).to include(course_present.name)
 
-      expect(command_output).to include(course2.course_code)
-      expect(command_output).to include(course2.name)
-
-      expect(command_output).not_to include(course3.course_code)
-      expect(command_output).not_to include(course3.name)
+      expect(command_output).not_to include(course_not_present.course_code)
+      expect(command_output).not_to include(course_not_present.name)
     end
 
     context 'when course is specified' do
       it 'displays the provider information' do
-        course1
-        course2
+        course_present
+        course_present2
 
-        command_output = list.execute(arguments: [course1.course_code])[:stdout]
+        command_output = list.execute(arguments: [course_present.course_code])[:stdout]
 
-        expect(command_output).to include(course1.course_code)
-        expect(command_output).to include(course1.name)
+        expect(command_output).to include(course_present.course_code)
+        expect(command_output).to include(course_present.name)
 
-        expect(command_output).not_to include(course2.course_code)
-        expect(command_output).not_to include(course2.name)
+        expect(command_output).not_to include(course_present2.course_code)
+        expect(command_output).not_to include(course_present2.name)
       end
 
       it 'displays multiple specified courses' do
-        course1
-        course2
+        course_present
+        course_present2
 
-        command_output = list.execute(arguments: [course1.course_code, course2.course_code])[:stdout]
+        command_output = list.execute(arguments: [course_present.course_code, course_present2.course_code])[:stdout]
 
-        expect(command_output).to include(course1.course_code)
-        expect(command_output).to include(course1.name)
+        expect(command_output).to include(course_present.course_code)
+        expect(command_output).to include(course_present.name)
 
-        expect(command_output).to include(course2.course_code)
-        expect(command_output).to include(course2.name)
+        expect(command_output).to include(course_present2.course_code)
+        expect(command_output).to include(course_present2.name)
       end
 
       it 'is case insensitive' do
-        course1
-        course2
+        course_present
+        course_present2
 
-        command_output = list.execute(arguments: [course2.course_code.downcase])[:stdout]
-        expect(command_output).to include(course2.course_code)
+        command_output = list.execute(arguments: [course_present2.course_code.downcase])[:stdout]
+        expect(command_output).to include(course_present2.course_code)
       end
     end
 
     context 'when provider is unspecified' do
       it 'displays information about courses for the current recruitment cycle' do
-        course1
-        course2
+        course_present
+        course_present2
 
         command_output = list.execute[:stdout]
 
-        expect(command_output).to include(course1.course_code)
-        expect(command_output).to include(course1.name)
+        expect(command_output).to include(course_present.course_code)
+        expect(command_output).to include(course_present.name)
 
-        expect(command_output).to include(course2.course_code)
-        expect(command_output).to include(course2.name)
+        expect(command_output).to include(course_present2.course_code)
+        expect(command_output).to include(course_present2.name)
       end
     end
   end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -974,4 +974,58 @@ RSpec.describe Course, type: :model do
       it { should be_truthy }
     end
   end
+
+  describe '#discard' do
+    context 'new course' do
+      let!(:subject) do
+        course = create(:course)
+
+        site = create(:site)
+        create(:site_status, :new, site: site, course: course)
+
+        course
+      end
+
+      context 'before discarding' do
+        its(:discarded?) { should be false }
+
+        it 'is in kept' do
+          expect(described_class.kept.size).to eq(1)
+        end
+
+        it 'is not in discarded' do
+          expect(described_class.discarded.size).to eq(0)
+        end
+      end
+
+      context 'after discarding' do
+        before do
+          subject.discard
+        end
+
+        its(:discarded?) { should be true }
+
+        it 'is not in kept' do
+          expect(described_class.kept.size).to eq(0)
+        end
+
+        it 'is in discarded' do
+          expect(described_class.discarded.size).to eq(1)
+        end
+      end
+
+      context 'incorrect actions' do
+        it 'raises error when deleted and course status is running' do
+          course = subject
+
+          site = create(:site)
+          create(:site_status, :running, :published, site: site, course: course)
+
+          expect { course.discard }.to raise_error(
+            "You cannot delete a running course (Course: #{course}, Provider: #{course.provider_id})"
+          )
+        end
+      end
+    end
+  end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -268,14 +268,6 @@ describe Provider, type: :model do
           expect { course.discard }.to change { provider.courses.size }.by(-1)
         end
       end
-
-      context 'when course is discarded' do
-        it 'does not show up in kept' do
-          course.discard
-
-          expect(provider.courses.size).to be(0)
-        end
-      end
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -261,6 +261,22 @@ describe Provider, type: :model do
         expect(first_provider.courses_count).to eq(1)
       end
     end
+
+    describe '#courses' do
+      describe 'discard' do
+        it 'reduces courses when one is discarded' do
+          expect { course.discard }.to change { provider.courses.size }.by(-1)
+        end
+      end
+
+      context 'when course is discarded' do
+        it 'does not show up in kept' do
+          course.discard
+
+          expect(provider.courses.size).to be(0)
+        end
+      end
+    end
   end
 
   describe '#copy_to_recruitment_cycle' do

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -89,96 +89,97 @@ describe 'Courses API v2', type: :request do
         it 'has a data section with the correct attributes' do
           json_response = JSON.parse response.body
           expect(json_response).to eq(
-            "data" => {
+          "data" => {
             "id" => provider.courses[0].id.to_s,
             "type" => "courses",
             "attributes" => {
-            "findable?" => true,
-            "open_for_applications?" => true,
-            "has_vacancies?" => true,
-            "name" => provider.courses[0].name,
-            "course_code" => provider.courses[0].course_code,
-            "start_date" => provider.courses[0].start_date.iso8601,
-            "study_mode" => "full_time",
-            "qualifications" => %w[qts pgce],
-            "description" => "PGCE with QTS full time teaching apprenticeship",
-            "content_status" => "published",
-            "ucas_status" => "running",
-            "funding" => "apprenticeship",
-            "is_send?" => true,
-            "subjects" => ["Primary", "Primary with mathematics"],
-            "level" => "primary",
-            "applications_open_from" => "2019-01-01T00:00:00Z",
-            "about_course" => enrichment.about_course,
-            "course_length" => enrichment.course_length,
-            "fee_details" => enrichment.fee_details,
-            "fee_international" => enrichment.fee_international,
-            "fee_uk_eu" => enrichment.fee_uk_eu,
-            "financial_support" => enrichment.financial_support,
-            "how_school_placements_work" => enrichment.how_school_placements_work,
-            "interview_process" => enrichment.interview_process,
-            "other_requirements" => enrichment.other_requirements,
-            "personal_qualities" => enrichment.personal_qualities,
-            "required_qualifications" => enrichment.required_qualifications,
-            "salary_details" => enrichment.salary_details,
-            "last_published_at" => enrichment.last_published_timestamp_utc.iso8601,
-            "has_bursary?" => true,
-            "has_scholarship_and_bursary?" => false,
-            "has_early_career_payments?" => false,
-            "bursary_amount" => nil,
-            "scholarship_amount" => nil,
-            "about_accrediting_body" => nil,
-            "english" => 'must_have_qualification_at_application_time',
-            "maths" => 'must_have_qualification_at_application_time',
-            "science" => 'must_have_qualification_at_application_time',
-            "provider_code" => provider.provider_code,
-            "recruitment_cycle_year" => "2019",
-            "gcse_subjects_required" => %w[maths english science],
+              "findable?" => true,
+              "open_for_applications?" => true,
+              "has_vacancies?" => true,
+              "name" => provider.courses[0].name,
+              "course_code" => provider.courses[0].course_code,
+              "start_date" => provider.courses[0].start_date.iso8601,
+              "study_mode" => "full_time",
+              "qualifications" => %w[qts pgce],
+              "description" => "PGCE with QTS full time teaching apprenticeship",
+              "content_status" => "published",
+              "ucas_status" => "running",
+              "funding" => "apprenticeship",
+              "is_send?" => true,
+              "subjects" => ["Primary",
+                             "Primary with mathematics"],
+              "level" => "primary",
+              "applications_open_from" => "2019-01-01T00:00:00Z",
+              "about_course" => enrichment.about_course,
+              "course_length" => enrichment.course_length,
+              "fee_details" => enrichment.fee_details,
+              "fee_international" => enrichment.fee_international,
+              "fee_uk_eu" => enrichment.fee_uk_eu,
+              "financial_support" => enrichment.financial_support,
+              "how_school_placements_work" => enrichment.how_school_placements_work,
+              "interview_process" => enrichment.interview_process,
+              "other_requirements" => enrichment.other_requirements,
+              "personal_qualities" => enrichment.personal_qualities,
+              "required_qualifications" => enrichment.required_qualifications,
+              "salary_details" => enrichment.salary_details,
+              "last_published_at" => enrichment.last_published_timestamp_utc.iso8601,
+              "has_bursary?" => true,
+              "has_scholarship_and_bursary?" => false,
+              "has_early_career_payments?" => false,
+              "bursary_amount" => nil,
+              "scholarship_amount" => nil,
+              "about_accrediting_body" => nil,
+              "english" => 'must_have_qualification_at_application_time',
+              "maths" => 'must_have_qualification_at_application_time',
+              "science" => 'must_have_qualification_at_application_time',
+              "provider_code" => provider.provider_code,
+              "recruitment_cycle_year" => "2019",
+              "gcse_subjects_required" => %w[maths english science],
             },
             "relationships" => {
-            "accrediting_provider" => { "meta" => { "included" => false } },
-            "provider" => { "meta" => { "included" => false } },
-            "sites" => { "meta" => { "included" => false } },
-            "site_statuses" => { "data" => [{ "type" => "site_statuses", "id" => site_status.id.to_s }] },
+              "accrediting_provider" => { "meta" => { "included" => false } },
+              "provider" => { "meta" => { "included" => false } },
+              "sites" => { "meta" => { "included" => false } },
+              "site_statuses" => { "data" => [{ "type" => "site_statuses", "id" => site_status.id.to_s }] },
             },
-            },
-            "jsonapi" => {
+          },
+          "jsonapi" => {
             "version" => "1.0"
-            },
-            "included" => [{
+          },
+          "included" => [{
             "id" => site_status.id.to_s,
             "type" => "site_statuses",
             "attributes" => {
-            "vac_status" => site_status.vac_status,
-            "publish" => site_status.publish,
-            "status" => site_status.status,
-            "applications_accepted_from" => site_status.applications_accepted_from.strftime("%Y-%m-%d"),
-            "has_vacancies?" => true
+              "vac_status" => site_status.vac_status,
+              "publish" => site_status.publish,
+              "status" => site_status.status,
+              "applications_accepted_from" => site_status.applications_accepted_from.strftime("%Y-%m-%d"),
+              "has_vacancies?" => true
             },
             "relationships" => {
-            "site" => {
-            "data" => {
-            "type" => "sites",
-            "id" => site.id.to_s
+              "site" => {
+                "data" => {
+                  "type" => "sites",
+                    "id" => site.id.to_s
+                }
+              }
             }
-            }
-            }
-            }, {
+          }, {
             "id" => site.id.to_s,
             "type" => "sites",
             "attributes" => {
-            "code" => site.code,
-            "location_name" => site.location_name,
-            "address1" => site.address1,
-            "address2" => site.address2,
-            "address3" => site.address3,
-            "address4" => site.address4,
-            "postcode" => site.postcode,
-            "region_code" => site.region_code,
-            "recruitment_cycle_year" => "2019",
+              "code" => site.code,
+              "location_name" => site.location_name,
+              "address1" => site.address1,
+              "address2" => site.address2,
+              "address3" => site.address3,
+              "address4" => site.address4,
+              "postcode" => site.postcode,
+              "region_code" => site.region_code,
+              "recruitment_cycle_year" => "2019",
             }
-            }]
-          )
+          }]
+        )
         end
       end
     end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -46,34 +46,143 @@ describe 'Courses API v2', type: :request do
       "/api/v2/providers/#{provider.provider_code}" +
         "/courses/#{course.course_code}"
     end
-    let(:course) { findable_open_course }
 
     subject do
       get show_path, headers: { 'HTTP_AUTHORIZATION' => credentials }
       response
     end
 
-    context 'when unauthenticated' do
-      let(:payload) { { email: 'foo@bar' } }
+    context 'with a findable_open_course' do
+      let(:course) { findable_open_course }
 
-      it { should have_http_status(:unauthorized) }
-    end
+      context 'when unauthenticated' do
+        let(:payload) { { email: 'foo@bar' } }
 
-    context 'when user has not accepted terms' do
-      let(:user)         { create(:user, accept_terms_date_utc: nil) }
-      let(:organisation) { create(:organisation, users: [user]) }
+        it { should have_http_status(:unauthorized) }
+      end
 
-      it { should have_http_status(:forbidden) }
-    end
+      context 'when user has not accepted terms' do
+        let(:user)         { create(:user, accept_terms_date_utc: nil) }
+        let(:organisation) { create(:organisation, users: [user]) }
 
-    context 'when unauthorised' do
-      let(:unauthorised_user) { create(:user) }
-      let(:payload)           { { email: unauthorised_user.email } }
+        it { should have_http_status(:forbidden) }
+      end
 
-      it "raises an error" do
-        expect { subject }.to raise_error Pundit::NotAuthorizedError
+      context 'when unauthorised' do
+        let(:unauthorised_user) { create(:user) }
+        let(:payload)           { { email: unauthorised_user.email } }
+
+        it "raises an error" do
+          expect { subject }.to raise_error Pundit::NotAuthorizedError
+        end
+      end
+
+      describe 'JSON generated for courses' do
+        before do
+          get "/api/v2/providers/#{provider.provider_code.downcase}/courses/#{findable_open_course.course_code.downcase}",
+              headers: { 'HTTP_AUTHORIZATION' => credentials },
+              params: { include: 'subjects,site_statuses.site' }
+        end
+
+        it { should have_http_status(:success) }
+
+        it 'has a data section with the correct attributes' do
+          json_response = JSON.parse response.body
+          expect(json_response).to eq(
+            "data" => {
+            "id" => provider.courses[0].id.to_s,
+            "type" => "courses",
+            "attributes" => {
+            "findable?" => true,
+            "open_for_applications?" => true,
+            "has_vacancies?" => true,
+            "name" => provider.courses[0].name,
+            "course_code" => provider.courses[0].course_code,
+            "start_date" => provider.courses[0].start_date.iso8601,
+            "study_mode" => "full_time",
+            "qualifications" => %w[qts pgce],
+            "description" => "PGCE with QTS full time teaching apprenticeship",
+            "content_status" => "published",
+            "ucas_status" => "running",
+            "funding" => "apprenticeship",
+            "is_send?" => true,
+            "subjects" => ["Primary", "Primary with mathematics"],
+            "level" => "primary",
+            "applications_open_from" => "2019-01-01T00:00:00Z",
+            "about_course" => enrichment.about_course,
+            "course_length" => enrichment.course_length,
+            "fee_details" => enrichment.fee_details,
+            "fee_international" => enrichment.fee_international,
+            "fee_uk_eu" => enrichment.fee_uk_eu,
+            "financial_support" => enrichment.financial_support,
+            "how_school_placements_work" => enrichment.how_school_placements_work,
+            "interview_process" => enrichment.interview_process,
+            "other_requirements" => enrichment.other_requirements,
+            "personal_qualities" => enrichment.personal_qualities,
+            "required_qualifications" => enrichment.required_qualifications,
+            "salary_details" => enrichment.salary_details,
+            "last_published_at" => enrichment.last_published_timestamp_utc.iso8601,
+            "has_bursary?" => true,
+            "has_scholarship_and_bursary?" => false,
+            "has_early_career_payments?" => false,
+            "bursary_amount" => nil,
+            "scholarship_amount" => nil,
+            "about_accrediting_body" => nil,
+            "english" => 'must_have_qualification_at_application_time',
+            "maths" => 'must_have_qualification_at_application_time',
+            "science" => 'must_have_qualification_at_application_time',
+            "provider_code" => provider.provider_code,
+            "recruitment_cycle_year" => "2019",
+            "gcse_subjects_required" => %w[maths english science],
+            },
+            "relationships" => {
+            "accrediting_provider" => { "meta" => { "included" => false } },
+            "provider" => { "meta" => { "included" => false } },
+            "sites" => { "meta" => { "included" => false } },
+            "site_statuses" => { "data" => [{ "type" => "site_statuses", "id" => site_status.id.to_s }] },
+            },
+            },
+            "jsonapi" => {
+            "version" => "1.0"
+            },
+            "included" => [{
+            "id" => site_status.id.to_s,
+            "type" => "site_statuses",
+            "attributes" => {
+            "vac_status" => site_status.vac_status,
+            "publish" => site_status.publish,
+            "status" => site_status.status,
+            "applications_accepted_from" => site_status.applications_accepted_from.strftime("%Y-%m-%d"),
+            "has_vacancies?" => true
+            },
+            "relationships" => {
+            "site" => {
+            "data" => {
+            "type" => "sites",
+            "id" => site.id.to_s
+            }
+            }
+            }
+            }, {
+            "id" => site.id.to_s,
+            "type" => "sites",
+            "attributes" => {
+            "code" => site.code,
+            "location_name" => site.location_name,
+            "address1" => site.address1,
+            "address2" => site.address2,
+            "address3" => site.address3,
+            "address4" => site.address4,
+            "postcode" => site.postcode,
+            "region_code" => site.region_code,
+            "recruitment_cycle_year" => "2019",
+            }
+            }]
+          )
+        end
       end
     end
+
 
     context 'when course and provider is not related' do
       let(:course) { create(:course) }
@@ -81,110 +190,15 @@ describe 'Courses API v2', type: :request do
       it { should have_http_status(:not_found) }
     end
 
-    describe 'JSON generated for courses' do
-      before do
-        get "/api/v2/providers/#{provider.provider_code.downcase}/courses/#{findable_open_course.course_code.downcase}",
-            headers: { 'HTTP_AUTHORIZATION' => credentials },
-            params: { include: 'subjects,site_statuses.site' }
+    context 'when a course is discarded' do
+      let(:course) do
+        course = create(:course, provider: provider)
+        create(:site_status, :new, site: create(:site), course: course)
+        course.discard
+        course
       end
 
-      it { should have_http_status(:success) }
-
-      it 'has a data section with the correct attributes' do
-        json_response = JSON.parse response.body
-        expect(json_response).to eq(
-          "data" => {
-            "id" => provider.courses[0].id.to_s,
-            "type" => "courses",
-            "attributes" => {
-              "findable?" => true,
-              "open_for_applications?" => true,
-              "has_vacancies?" => true,
-              "name" => provider.courses[0].name,
-              "course_code" => provider.courses[0].course_code,
-              "start_date" => provider.courses[0].start_date.iso8601,
-              "study_mode" => "full_time",
-              "qualifications" => %w[qts pgce],
-              "description" => "PGCE with QTS full time teaching apprenticeship",
-              "content_status" => "published",
-              "ucas_status" => "running",
-              "funding" => "apprenticeship",
-              "is_send?" => true,
-              "subjects" => ["Primary",
-                             "Primary with mathematics"],
-              "level" => "primary",
-              "applications_open_from" => "2019-01-01T00:00:00Z",
-              "about_course" => enrichment.about_course,
-              "course_length" => enrichment.course_length,
-              "fee_details" => enrichment.fee_details,
-              "fee_international" => enrichment.fee_international,
-              "fee_uk_eu" => enrichment.fee_uk_eu,
-              "financial_support" => enrichment.financial_support,
-              "how_school_placements_work" => enrichment.how_school_placements_work,
-              "interview_process" => enrichment.interview_process,
-              "other_requirements" => enrichment.other_requirements,
-              "personal_qualities" => enrichment.personal_qualities,
-              "required_qualifications" => enrichment.required_qualifications,
-              "salary_details" => enrichment.salary_details,
-              "last_published_at" => enrichment.last_published_timestamp_utc.iso8601,
-              "has_bursary?" => true,
-              "has_scholarship_and_bursary?" => false,
-              "has_early_career_payments?" => false,
-              "bursary_amount" => nil,
-              "scholarship_amount" => nil,
-              "about_accrediting_body" => nil,
-              "english" => 'must_have_qualification_at_application_time',
-              "maths" => 'must_have_qualification_at_application_time',
-              "science" => 'must_have_qualification_at_application_time',
-              "provider_code" => provider.provider_code,
-              "recruitment_cycle_year" => "2019",
-              "gcse_subjects_required" => %w[maths english science],
-            },
-            "relationships" => {
-              "accrediting_provider" => { "meta" => { "included" => false } },
-              "provider" => { "meta" => { "included" => false } },
-              "sites" => { "meta" => { "included" => false } },
-              "site_statuses" => { "data" => [{ "type" => "site_statuses", "id" => site_status.id.to_s }] },
-            },
-          },
-          "jsonapi" => {
-            "version" => "1.0"
-          },
-          "included" => [{
-            "id" => site_status.id.to_s,
-            "type" => "site_statuses",
-            "attributes" => {
-              "vac_status" => site_status.vac_status,
-              "publish" => site_status.publish,
-              "status" => site_status.status,
-              "applications_accepted_from" => site_status.applications_accepted_from.strftime("%Y-%m-%d"),
-              "has_vacancies?" => true
-            },
-            "relationships" => {
-              "site" => {
-                "data" => {
-                  "type" => "sites",
-                    "id" => site.id.to_s
-                }
-              }
-            }
-          }, {
-            "id" => site.id.to_s,
-            "type" => "sites",
-            "attributes" => {
-              "code" => site.code,
-              "location_name" => site.location_name,
-              "address1" => site.address1,
-              "address2" => site.address2,
-              "address3" => site.address3,
-              "address4" => site.address4,
-              "postcode" => site.postcode,
-              "region_code" => site.region_code,
-              "recruitment_cycle_year" => "2019",
-            }
-          }]
-        )
-      end
+      it { should have_http_status(:not_found) }
     end
   end
 
@@ -349,6 +363,57 @@ describe 'Courses API v2', type: :request do
             .to have_attribute('recruitment_cycle_year').with_value('2020')
         end
       end
+    end
+  end
+
+  describe 'DELETE destroy' do
+    let(:path) do
+      "/api/v2/providers/#{provider.provider_code}" +
+        "/courses/#{course.course_code}"
+    end
+
+    let(:course) { create(:course, provider: provider, site_statuses: [site_status]) }
+    let(:site_status) { build(:site_status, :new) }
+
+    before do
+      course
+    end
+
+    subject do
+      delete path, headers: { 'HTTP_AUTHORIZATION' => credentials }
+      response
+    end
+
+    context 'when unauthenticated' do
+      let(:payload) { { email: 'foo@bar' } }
+
+      it { should have_http_status(:unauthorized) }
+    end
+
+    context 'when user has not accepted terms' do
+      let(:user)         { create(:user, accept_terms_date_utc: nil) }
+      let(:organisation) { create(:organisation, users: [user]) }
+
+      it { should have_http_status(:forbidden) }
+    end
+
+    context 'when unauthorised' do
+      let(:unauthorised_user) { create(:user) }
+      let(:payload)           { { email: unauthorised_user.email } }
+
+      it "raises an error" do
+        expect { subject }.to raise_error Pundit::NotAuthorizedError
+      end
+    end
+
+    context 'when course and provider is not related' do
+      let(:course) { create(:course) }
+
+      it { should have_http_status(:not_found) }
+    end
+
+    describe 'when authorized' do
+      it { should have_http_status(:success) }
     end
   end
 end


### PR DESCRIPTION
### Context
MCB spec randomly fails as string checks where a bit wobbly. We're using faker for generating strings (programming languages). D & C gives false positives, and it's a very limited entropy.

Got us many times when we were trying to push the Delete Courses Backend work, and left us rerunning TravisCI, delaying the eventual merge. 

### Changes proposed in this pull request
Gave explicit names to courses to give fewer false positives, making us

### Guidance to review
I could've created more randomness in the factory too, but that seemed like the wrong way.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
