### PR TITLE
[1843] mcb specs fails intermittently due to pseudo-random test-data

### DIFF
--- a/spec/lib/mcb/commands/courses/list_spec.rb
+++ b/spec/lib/mcb/commands/courses/list_spec.rb
@@ -11,75 +11,76 @@ describe 'mcb providers list' do
     let(:provider2) { create(:provider, recruitment_cycle: current_cycle) }
     let(:provider3) { create(:provider, recruitment_cycle: additional_cycle) }
 
-    let(:course1) { create(:course, provider: provider1) }
-    let(:course2) { create(:course, provider: provider2) }
-    let(:course3) { create(:course, provider: provider3) }
+    # Explicitly setting the course names, Course Factory isn't random enough
+    let(:course_present) { create(:course, provider: provider1, name: 'English') }
+    let(:course_present2) { create(:course, provider: provider2, name: 'Maths') }
+    let(:course_not_present) { create(:course, provider: provider3, name: 'Swedish') }
 
     it 'lists all courses for the default recruitment cycle' do
-      course1
-      course2
-      course3
+      course_present
+      course_present2
+      course_not_present
 
       command_output = list.execute[:stdout]
 
-      expect(command_output).to include(course1.course_code)
-      expect(command_output).to include(course1.name)
+      expect(command_output).to include(course_present.course_code)
+      expect(command_output).to include(course_present.name)
 
-      expect(command_output).to include(course2.course_code)
-      expect(command_output).to include(course2.name)
+      expect(command_output).to include(course_present2.course_code)
+      expect(command_output).to include(course_present2.name)
 
-      expect(command_output).not_to include(course3.course_code)
-      expect(command_output).not_to include(course3.name)
+      expect(command_output).not_to include(course_not_present.course_code)
+      expect(command_output).not_to include(course_not_present.name)
     end
 
     context 'when course is specified' do
       it 'displays the provider information' do
-        course1
-        course2
+        course_present
+        course_present2
 
-        command_output = list.execute(arguments: [course1.course_code])[:stdout]
+        command_output = list.execute(arguments: [course_present.course_code])[:stdout]
 
-        expect(command_output).to include(course1.course_code)
-        expect(command_output).to include(course1.name)
+        expect(command_output).to include(course_present.course_code)
+        expect(command_output).to include(course_present.name)
 
-        expect(command_output).not_to include(course2.course_code)
-        expect(command_output).not_to include(course2.name)
+        expect(command_output).not_to include(course_present2.course_code)
+        expect(command_output).not_to include(course_present2.name)
       end
 
       it 'displays multiple specified courses' do
-        course1
-        course2
+        course_present
+        course_present2
 
-        command_output = list.execute(arguments: [course1.course_code, course2.course_code])[:stdout]
+        command_output = list.execute(arguments: [course_present.course_code, course_present2.course_code])[:stdout]
 
-        expect(command_output).to include(course1.course_code)
-        expect(command_output).to include(course1.name)
+        expect(command_output).to include(course_present.course_code)
+        expect(command_output).to include(course_present.name)
 
-        expect(command_output).to include(course2.course_code)
-        expect(command_output).to include(course2.name)
+        expect(command_output).to include(course_present2.course_code)
+        expect(command_output).to include(course_present2.name)
       end
 
       it 'is case insensitive' do
-        course1
-        course2
+        course_present
+        course_present2
 
-        command_output = list.execute(arguments: [course2.course_code.downcase])[:stdout]
-        expect(command_output).to include(course2.course_code)
+        command_output = list.execute(arguments: [course_present2.course_code.downcase])[:stdout]
+        expect(command_output).to include(course_present2.course_code)
       end
     end
 
     context 'when provider is unspecified' do
       it 'displays information about courses for the current recruitment cycle' do
-        course1
-        course2
+        course_present
+        course_present2
 
         command_output = list.execute[:stdout]
 
-        expect(command_output).to include(course1.course_code)
-        expect(command_output).to include(course1.name)
+        expect(command_output).to include(course_present.course_code)
+        expect(command_output).to include(course_present.name)
 
-        expect(command_output).to include(course2.course_code)
-        expect(command_output).to include(course2.name)
+        expect(command_output).to include(course_present2.course_code)
+        expect(command_output).to include(course_present2.name)
       end
     end
   end


### PR DESCRIPTION
### Context
MCB spec randomly fails as string checks where a bit wobbly. We're using Faker for generating strings (programming languages). D & C gives false positives, and there are only so many languages.

This got me and @timabell many times when we were trying to push forward the Delete Courses Backend work, and left us rerunning TravisCI over and over, delaying the eventual merge. 

### Changes proposed in this pull request
Gave explicit names to courses to give fewer false positives, making us

### Guidance to review
I could've created more randomness in the factory too, but that seemed like the wrong way.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally