### PR TITLE
[1844] Add new age ranges to course

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -22,6 +22,7 @@
 #  changed_at                :datetime         not null
 #  accrediting_provider_code :text
 #  discarded_at              :datetime
+#  age_range_in_years        :string
 #
 
 class Course < ApplicationRecord

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -16,7 +16,7 @@ module API
                  :content_status, :ucas_status, :funding, :applications_open_from,
                  :level, :is_send?, :has_bursary?, :has_scholarship_and_bursary?,
                  :has_early_career_payments?, :bursary_amount, :scholarship_amount,
-                 :english, :maths, :science, :gcse_subjects_required
+                 :english, :maths, :science, :gcse_subjects_required, :age_range_in_years
 
       attribute :start_date do
         @object.start_date&.iso8601

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -22,6 +22,7 @@
 #  changed_at                :datetime         not null
 #  accrediting_provider_code :text
 #  discarded_at              :datetime
+#  age_range_in_years        :string
 #
 
 class CourseSerializer < ActiveModel::Serializer

--- a/db/migrate/20190726104939_add_age_range_in_years_to_course.rb
+++ b/db/migrate/20190726104939_add_age_range_in_years_to_course.rb
@@ -1,0 +1,5 @@
+class AddAgeRangeInYearsToCourse < ActiveRecord::Migration[5.2]
+  def change
+    add_column :course, :age_range_in_years, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_24_112016) do
+ActiveRecord::Schema.define(version: 2019_07_26_104939) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -87,6 +87,7 @@ ActiveRecord::Schema.define(version: 2019_07_24_112016) do
     t.datetime "changed_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.text "accrediting_provider_code"
     t.datetime "discarded_at"
+    t.string "age_range_in_years"
     t.index ["accrediting_provider_code"], name: "index_course_on_accrediting_provider_code"
     t.index ["accrediting_provider_id"], name: "IX_course_accrediting_provider_id"
     t.index ["changed_at"], name: "index_course_on_changed_at", unique: true

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -22,6 +22,7 @@
 #  changed_at                :datetime         not null
 #  accrediting_provider_code :text
 #  discarded_at              :datetime
+#  age_range_in_years        :string
 #
 
 FactoryBot.define do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -22,6 +22,7 @@
 #  changed_at                :datetime         not null
 #  accrediting_provider_code :text
 #  discarded_at              :datetime
+#  age_range_in_years        :string
 #
 
 require 'rails_helper'

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -23,7 +23,8 @@ describe 'Courses API v2', type: :request do
            enrichments: [enrichment],
            maths: :must_have_qualification_at_application_time,
            english: :must_have_qualification_at_application_time,
-           science: :must_have_qualification_at_application_time)
+           science: :must_have_qualification_at_application_time,
+           age_range_in_years: '3 to 7')
   }
 
   let(:courses_site_status) {
@@ -135,6 +136,7 @@ describe 'Courses API v2', type: :request do
                 "provider_code" => provider.provider_code,
                 "recruitment_cycle_year" => "2019",
                 "gcse_subjects_required" => %w[maths english science],
+                "age_range_in_years" => provider.courses[0].age_range_in_years,
               },
               "relationships" => {
                 "accrediting_provider" => { "meta" => { "included" => false } },
@@ -297,6 +299,7 @@ describe 'Courses API v2', type: :request do
               "provider_code" => provider.provider_code,
               "recruitment_cycle_year" => "2019",
               "gcse_subjects_required" => %w[maths english science],
+              "age_range_in_years" => provider.courses[0].age_range_in_years,
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -32,6 +32,7 @@ describe API::V2::SerializableCourse do
   it { should have_attribute :science }
   it { should have_attribute :gcse_subjects_required }
   it { should have_attribute :provider_code }
+  it { should have_attribute :age_range_in_years }
   it { should have_attribute(:recruitment_cycle_year).with_value(course.recruitment_cycle.year) }
 
   context 'with a provider' do

--- a/spec/serializers/course_serializer_spec.rb
+++ b/spec/serializers/course_serializer_spec.rb
@@ -22,6 +22,7 @@
 #  changed_at                :datetime         not null
 #  accrediting_provider_code :text
 #  discarded_at              :datetime
+#  age_range_in_years        :string
 #
 
 require "rails_helper"


### PR DESCRIPTION
### Context
Better age range for courses

### Changes proposed in this pull request
Add new age range course for V2 so that we don't impact V1(UCAS)

### Guidance to review
I see us handling this in the same way we do for course length, have several hardcoded radion buttons on the frontend and just send a string value to the backend. An ENUM would have been nicer but the "other" makes this difficult.

🚢 

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
