### PR TITLE
[1792] Add provider publish and publishable actions

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -6,7 +6,7 @@ module API
       before_action :build_provider, except: :index
 
       deserializable_resource :provider,
-                              only: :update,
+                              only: %i[update publish publishable],
                               class: API::V2::DeserializableProvider
 
       def index
@@ -34,6 +34,26 @@ module API
           render jsonapi: @provider.reload, include: params[:include]
         else
           render jsonapi_errors: @provider.errors, status: :unprocessable_entity, include: params[:include]
+        end
+      end
+
+      def publish
+        authorize @provider, :publish?
+
+        if @provider.publishable?
+          head :ok
+        else
+          render jsonapi_errors: @provider.errors, status: :unprocessable_entity
+        end
+      end
+
+      def publishable
+        authorize @provider, :publishable?
+
+        if @provider.publishable?
+          head :ok
+        else
+          render jsonapi_errors: @provider.errors, status: :unprocessable_entity
         end
       end
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -111,6 +111,7 @@ class Provider < ApplicationRecord
 
   scope :in_order, -> { order(:provider_name) }
 
+  validate :validate_enrichment_publishable, on: :publish
   validate :validate_enrichment
 
   after_validation :remove_unnecessary_enrichments_validation_message
@@ -256,6 +257,10 @@ class Provider < ApplicationRecord
     sites_count
   end
 
+  def publishable?
+    valid? :publish
+  end
+
 private
 
   def add_enrichment_errors(enrichment)
@@ -274,6 +279,10 @@ private
 
     latest_enrichment.valid? validation_scope
     add_enrichment_errors(latest_enrichment)
+  end
+
+  def validate_enrichment_publishable
+    validate_enrichment :publish
   end
 
   def remove_unnecessary_enrichments_validation_message

--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -46,6 +46,11 @@ class ProviderEnrichment < ApplicationRecord
   validates :train_with_us, words_count: { maximum: 250 }
   validates :train_with_disability, words_count: { maximum: 250 }
 
+  validates :email, :website, :telephone,
+            :address1, :address2, :address3, :address4,
+            :postcode, :train_with_us, :train_with_disability,
+            presence: true, on: :publish
+
   def has_been_published_before?
     last_published_at.present?
   end

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -30,4 +30,6 @@ class ProviderPolicy
   alias_method :can_list_courses?, :show?
   alias_method :can_list_sites?, :show?
   alias_method :update?, :show?
+  alias_method :publish?, :show?
+  alias_method :publishable?, :show?
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,3 +52,23 @@ en:
               blank: "^Enter details about the qualifications needed"
             course_length:
               blank: "^Enter a course length"
+        provider_enrichment:
+          attributes:
+            email:
+              blank: "^Enter email address"
+            website:
+              blank: "^Enter website"
+            telephone:
+              blank: "^Enter telephone"
+            address1:
+              blank: "^Enter building or street"
+            address3:
+              blank: "^Enter town or city"
+            address4:
+              blank: "^Enter county"
+            postcode:
+              blank: "^Enter a postcode in the format ‘SW10 1AA’"
+            train_with_us:
+              blank: "^Enter details about training with you"
+            train_with_disability:
+              blank: "^Enter details about training with a disability"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,7 +124,10 @@ Rails.application.routes.draw do
         resources :providers,
                   only: %i[index show update],
                   param: :code,
-                  concerns: :provider_routes
+                  concerns: :provider_routes do
+          post :publish, on: :member
+          post :publishable, on: :member
+        end
       end
 
 

--- a/spec/factories/provider_enrichments.rb
+++ b/spec/factories/provider_enrichments.rb
@@ -61,5 +61,18 @@ FactoryBot.define do
       status { :draft }
       last_published_at { 5.days.ago }
     end
+
+    trait :without_content do
+      email { nil }
+      website { nil }
+      telephone { nil }
+
+      address1 { nil }
+      address3 { nil }
+      address4 { nil }
+      postcode { nil }
+      train_with_us { nil }
+      train_with_disability { nil }
+    end
   end
 end

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -49,27 +49,7 @@ describe 'Publish API v2', type: :request do
       response
     end
 
-    context 'when unauthenticated' do
-      let(:payload) { { email: 'foo@bar' } }
-
-      it { should have_http_status(:unauthorized) }
-    end
-
-    context 'when user has not accepted terms' do
-      let(:user)         { create(:user, accept_terms_date_utc: nil) }
-      let(:organisation) { create(:organisation, users: [user]) }
-
-      it { should have_http_status(:forbidden) }
-    end
-
-    context 'when unauthorised' do
-      let(:unauthorised_user) { create(:user) }
-      let(:payload)           { { email: unauthorised_user.email } }
-
-      it "raises an error" do
-        expect { subject }.to raise_error Pundit::NotAuthorizedError
-      end
-    end
+    include_examples "Unauthenticated, unauthorised, or not accepted T&Cs"
 
     context 'when course and provider is not related' do
       let(:course) { create(:course) }

--- a/spec/requests/api/v2/providers/courses/publishable_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publishable_spec.rb
@@ -40,27 +40,7 @@ describe 'Publishable API v2', type: :request do
       response
     end
 
-    context 'when unauthenticated' do
-      let(:payload) { { email: 'foo@bar' } }
-
-      it { should have_http_status(:unauthorized) }
-    end
-
-    context 'when user has not accepted terms' do
-      let(:user)         { create(:user, accept_terms_date_utc: nil) }
-      let(:organisation) { create(:organisation, users: [user]) }
-
-      it { should have_http_status(:forbidden) }
-    end
-
-    context 'when unauthorised' do
-      let(:unauthorised_user) { create(:user) }
-      let(:payload)           { { email: unauthorised_user.email } }
-
-      it "raises an error" do
-        expect { subject }.to raise_error Pundit::NotAuthorizedError
-      end
-    end
+    include_examples "Unauthenticated, unauthorised, or not accepted T&Cs"
 
     context 'when course and provider is not related' do
       let(:course) { create(:course) }

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -56,27 +56,7 @@ describe 'Courses API v2', type: :request do
     context 'with a findable_open_course' do
       let(:course) { findable_open_course }
 
-      context 'when unauthenticated' do
-        let(:payload) { { email: 'foo@bar' } }
-
-        it { should have_http_status(:unauthorized) }
-      end
-
-      context 'when user has not accepted terms' do
-        let(:user)         { create(:user, accept_terms_date_utc: nil) }
-        let(:organisation) { create(:organisation, users: [user]) }
-
-        it { should have_http_status(:forbidden) }
-      end
-
-      context 'when unauthorised' do
-        let(:unauthorised_user) { create(:user) }
-        let(:payload)           { { email: unauthorised_user.email } }
-
-        it "raises an error" do
-          expect { subject }.to raise_error Pundit::NotAuthorizedError
-        end
-      end
+      include_examples "Unauthenticated, unauthorised, or not accepted T&Cs"
 
       describe 'JSON generated for courses' do
         before do
@@ -399,27 +379,7 @@ describe 'Courses API v2', type: :request do
       response
     end
 
-    context 'when unauthenticated' do
-      let(:payload) { { email: 'foo@bar' } }
-
-      it { should have_http_status(:unauthorized) }
-    end
-
-    context 'when user has not accepted terms' do
-      let(:user)         { create(:user, accept_terms_date_utc: nil) }
-      let(:organisation) { create(:organisation, users: [user]) }
-
-      it { should have_http_status(:forbidden) }
-    end
-
-    context 'when unauthorised' do
-      let(:unauthorised_user) { create(:user) }
-      let(:payload)           { { email: unauthorised_user.email } }
-
-      it "raises an error" do
-        expect { subject }.to raise_error Pundit::NotAuthorizedError
-      end
-    end
+    include_examples "Unauthenticated, unauthorised, or not accepted T&Cs"
 
     context 'when course and provider is not related' do
       let(:course) { create(:course) }

--- a/spec/requests/api/v2/providers/publish_spec.rb
+++ b/spec/requests/api/v2/providers/publish_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+describe 'Provider Publish API v2', type: :request do
+  let(:user)         { create(:user) }
+  let(:organisation) { create(:organisation, users: [user]) }
+  let(:provider)     { create :provider, organisations: [organisation] }
+  let(:payload)      { { email: user.email } }
+  let(:token)        { build_jwt :apiv2, payload: payload }
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+
+  describe 'POST publish' do
+    let(:publish_path) do
+      "/api/v2/recruitment_cycles/#{provider.recruitment_cycle.year}" +
+        "/providers/#{provider.provider_code}/publish"
+    end
+
+    let(:enrichment) { build(:provider_enrichment, :initial_draft) }
+
+    subject do
+      post publish_path,
+           headers: { 'HTTP_AUTHORIZATION' => credentials },
+           params: {
+             _jsonapi: {
+               data: {
+                 attributes: {},
+                 type: "provider"
+               }
+             }
+           }
+      response
+    end
+
+    context 'when unauthenticated' do
+      let(:payload) { { email: 'foo@bar' } }
+
+      it { should have_http_status(:unauthorized) }
+    end
+
+    context 'when user has not accepted terms' do
+      let(:user)         { create(:user, accept_terms_date_utc: nil) }
+      let(:organisation) { create(:organisation, users: [user]) }
+
+      it { should have_http_status(:forbidden) }
+    end
+
+    context 'when unauthorised' do
+      let(:unauthorised_user) { create(:user) }
+      let(:payload)           { { email: unauthorised_user.email } }
+
+      it "raises an error" do
+        expect { subject }.to raise_error Pundit::NotAuthorizedError
+      end
+    end
+
+    context 'unpublished provider with draft enrichment' do
+      let(:enrichment) { build(:provider_enrichment, :initial_draft) }
+      let(:provider) {
+        create(
+          :provider,
+          organisations: [organisation],
+          enrichments: [enrichment]
+        )
+      }
+
+      xit 'publishes a provider' do
+        # TODO
+      end
+    end
+
+    describe 'failed validation' do
+      let(:json_data) { JSON.parse(subject.body)['errors'] }
+
+      context 'invalid enrichment with invalid content lack_presence fields' do
+        let(:invalid_enrichment) { build(:provider_enrichment, :without_content) }
+        let(:provider) {
+          create(
+            :provider,
+            organisations: [organisation],
+            enrichments: [invalid_enrichment]
+          )
+        }
+
+        it { should have_http_status(:unprocessable_entity) }
+
+        it 'has validation error details' do
+          expect(json_data.count).to eq 9
+          expect(json_data[0]["detail"]).to eq("Enter email address")
+          expect(json_data[1]["detail"]).to eq("Enter website")
+          expect(json_data[2]["detail"]).to eq("Enter telephone")
+          expect(json_data[3]["detail"]).to eq("Enter building or street")
+          expect(json_data[4]["detail"]).to eq("Enter town or city")
+          expect(json_data[5]["detail"]).to eq("Enter county")
+          expect(json_data[6]["detail"]).to eq("Enter a postcode in the format ‘SW10 1AA’")
+          expect(json_data[7]["detail"]).to eq("Enter details about training with you")
+          expect(json_data[8]["detail"]).to eq("Enter details about training with a disability")
+        end
+
+        it 'has validation error pointers' do
+          expect(json_data[0]["source"]["pointer"]).to eq("/data/attributes/email")
+          expect(json_data[1]["source"]["pointer"]).to eq("/data/attributes/website")
+          expect(json_data[2]["source"]["pointer"]).to eq("/data/attributes/telephone")
+          expect(json_data[3]["source"]["pointer"]).to eq("/data/attributes/address1")
+          expect(json_data[4]["source"]["pointer"]).to eq("/data/attributes/address3")
+          expect(json_data[5]["source"]["pointer"]).to eq("/data/attributes/address4")
+          expect(json_data[6]["source"]["pointer"]).to eq("/data/attributes/postcode")
+          expect(json_data[7]["source"]["pointer"]).to eq("/data/attributes/train_with_us")
+          expect(json_data[8]["source"]["pointer"]).to eq("/data/attributes/train_with_disability")
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/providers/publish_spec.rb
+++ b/spec/requests/api/v2/providers/publish_spec.rb
@@ -32,27 +32,7 @@ describe 'Provider Publish API v2', type: :request do
       response
     end
 
-    context 'when unauthenticated' do
-      let(:payload) { { email: 'foo@bar' } }
-
-      it { should have_http_status(:unauthorized) }
-    end
-
-    context 'when user has not accepted terms' do
-      let(:user)         { create(:user, accept_terms_date_utc: nil) }
-      let(:organisation) { create(:organisation, users: [user]) }
-
-      it { should have_http_status(:forbidden) }
-    end
-
-    context 'when unauthorised' do
-      let(:unauthorised_user) { create(:user) }
-      let(:payload)           { { email: unauthorised_user.email } }
-
-      it "raises an error" do
-        expect { subject }.to raise_error Pundit::NotAuthorizedError
-      end
-    end
+    include_examples "Unauthenticated, unauthorised, or not accepted T&Cs"
 
     context 'unpublished provider with draft enrichment' do
       let(:enrichment) { build(:provider_enrichment, :initial_draft) }

--- a/spec/requests/api/v2/providers/publishable_spec.rb
+++ b/spec/requests/api/v2/providers/publishable_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+describe 'Provider Publishable API v2', type: :request do
+  let(:user)         { create(:user) }
+  let(:organisation) { create(:organisation, users: [user]) }
+  let(:provider)     { create :provider, organisations: [organisation] }
+  let(:payload)      { { email: user.email } }
+  let(:token)        { build_jwt :apiv2, payload: payload }
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+
+  describe 'POST publishable' do
+    let(:publishable_path) do
+      "/api/v2/recruitment_cycles/#{provider.recruitment_cycle.year}" +
+        "/providers/#{provider.provider_code}/publishable"
+    end
+
+    let(:enrichment) { build(:provider_enrichment, :initial_draft) }
+
+    subject do
+      post publishable_path,
+           headers: { 'HTTP_AUTHORIZATION' => credentials },
+           params: {
+             _jsonapi: {
+               data: {
+                 attributes: {},
+                 type: "provider"
+               }
+             }
+           }
+      response
+    end
+
+    context 'when unauthenticated' do
+      let(:payload) { { email: 'foo@bar' } }
+
+      it { should have_http_status(:unauthorized) }
+    end
+
+    context 'when user has not accepted terms' do
+      let(:user)         { create(:user, accept_terms_date_utc: nil) }
+      let(:organisation) { create(:organisation, users: [user]) }
+
+      it { should have_http_status(:forbidden) }
+    end
+
+    context 'when unauthorised' do
+      let(:unauthorised_user) { create(:user) }
+      let(:payload)           { { email: unauthorised_user.email } }
+
+      it "raises an error" do
+        expect { subject }.to raise_error Pundit::NotAuthorizedError
+      end
+    end
+
+    context 'unpublished provider with draft enrichment' do
+      let(:enrichment) { build(:provider_enrichment, :initial_draft) }
+      let(:provider) {
+        create(
+          :provider,
+          organisations: [organisation],
+          enrichments: [enrichment]
+        )
+      }
+
+      it 'returns ok' do
+        expect(subject).to have_http_status(:success)
+      end
+    end
+
+    describe 'failed validation' do
+      let(:json_data) { JSON.parse(subject.body)['errors'] }
+
+      context 'invalid enrichment with invalid content lack_presence fields' do
+        let(:invalid_enrichment) { build(:provider_enrichment, :without_content) }
+        let(:provider) {
+          create(
+            :provider,
+            organisations: [organisation],
+            enrichments: [invalid_enrichment]
+          )
+        }
+
+        it { should have_http_status(:unprocessable_entity) }
+
+        it 'has validation error details' do
+          expect(json_data.count).to eq 9
+          expect(json_data[0]["detail"]).to eq("Enter email address")
+          expect(json_data[1]["detail"]).to eq("Enter website")
+          expect(json_data[2]["detail"]).to eq("Enter telephone")
+          expect(json_data[3]["detail"]).to eq("Enter building or street")
+          expect(json_data[4]["detail"]).to eq("Enter town or city")
+          expect(json_data[5]["detail"]).to eq("Enter county")
+          expect(json_data[6]["detail"]).to eq("Enter a postcode in the format ‘SW10 1AA’")
+          expect(json_data[7]["detail"]).to eq("Enter details about training with you")
+          expect(json_data[8]["detail"]).to eq("Enter details about training with a disability")
+        end
+
+        it 'has validation error pointers' do
+          expect(json_data[0]["source"]["pointer"]).to eq("/data/attributes/email")
+          expect(json_data[1]["source"]["pointer"]).to eq("/data/attributes/website")
+          expect(json_data[2]["source"]["pointer"]).to eq("/data/attributes/telephone")
+          expect(json_data[3]["source"]["pointer"]).to eq("/data/attributes/address1")
+          expect(json_data[4]["source"]["pointer"]).to eq("/data/attributes/address3")
+          expect(json_data[5]["source"]["pointer"]).to eq("/data/attributes/address4")
+          expect(json_data[6]["source"]["pointer"]).to eq("/data/attributes/postcode")
+          expect(json_data[7]["source"]["pointer"]).to eq("/data/attributes/train_with_us")
+          expect(json_data[8]["source"]["pointer"]).to eq("/data/attributes/train_with_disability")
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/providers/publishable_spec.rb
+++ b/spec/requests/api/v2/providers/publishable_spec.rb
@@ -32,27 +32,7 @@ describe 'Provider Publishable API v2', type: :request do
       response
     end
 
-    context 'when unauthenticated' do
-      let(:payload) { { email: 'foo@bar' } }
-
-      it { should have_http_status(:unauthorized) }
-    end
-
-    context 'when user has not accepted terms' do
-      let(:user)         { create(:user, accept_terms_date_utc: nil) }
-      let(:organisation) { create(:organisation, users: [user]) }
-
-      it { should have_http_status(:forbidden) }
-    end
-
-    context 'when unauthorised' do
-      let(:unauthorised_user) { create(:user) }
-      let(:payload)           { { email: unauthorised_user.email } }
-
-      it "raises an error" do
-        expect { subject }.to raise_error Pundit::NotAuthorizedError
-      end
-    end
+    include_examples "Unauthenticated, unauthorised, or not accepted T&Cs"
 
     context 'unpublished provider with draft enrichment' do
       let(:enrichment) { build(:provider_enrichment, :initial_draft) }

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -32,27 +32,7 @@ describe 'Sites API v2', type: :request do
       response
     end
 
-    context 'when unauthenticated' do
-      let(:payload) { { email: 'foo@bar' } }
-
-      it { should have_http_status(:unauthorized) }
-    end
-
-    context 'when user has not accepted terms' do
-      let(:user)         { create(:user, accept_terms_date_utc: nil) }
-      let(:organisation) { create(:organisation, users: [user]) }
-
-      it { should have_http_status(:forbidden) }
-    end
-
-    context 'when unauthorised' do
-      let(:unauthorised_user) { create(:user) }
-      let(:payload)           { { email: unauthorised_user.email } }
-
-      it "raises an error" do
-        expect { subject }.to raise_error Pundit::NotAuthorizedError
-      end
-    end
+    include_examples "Unauthenticated, unauthorised, or not accepted T&Cs"
   end
 
   describe 'GET index' do

--- a/spec/support/shared_examples/unauth.rb
+++ b/spec/support/shared_examples/unauth.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+shared_examples 'Unauthenticated, unauthorised, or not accepted T&Cs' do
+  context 'when unauthenticated' do
+    let(:payload) { { email: 'foo@bar' } }
+
+    it { should have_http_status(:unauthorized) }
+  end
+
+  context 'when user has not accepted terms' do
+    let(:user)         { create(:user, accept_terms_date_utc: nil) }
+    let(:organisation) { create(:organisation, users: [user]) }
+
+    it { should have_http_status(:forbidden) }
+  end
+
+  context 'when unauthorised' do
+    let(:unauthorised_user) { create(:user) }
+    let(:payload)           { { email: unauthorised_user.email } }
+
+    it "raises an error" do
+      expect { subject }.to raise_error Pundit::NotAuthorizedError
+    end
+  end
+end


### PR DESCRIPTION
### Context

These will be called by the frontend to publish the latest provider enrichment.

### Changes proposed in this pull request

Adds `#publish` and `#publishable` actions to the provider controller. `#publish` is a no-op.

### Guidance to review

Does not actually implement the publish logic, that will be done as a separate PR; this is just to facilitate the frontend validations work.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally