### PR TITLE
[1808] expose accrediting providers

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -99,7 +99,7 @@ class Provider < ApplicationRecord
            primary_key: :provider_code,
            inverse_of: :accrediting_provider
 
-
+  has_many :accrediting_providers, through: :courses
 
   scope :changed_since, ->(timestamp) do
     if timestamp.present?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -99,7 +99,7 @@ class Provider < ApplicationRecord
            primary_key: :provider_code,
            inverse_of: :accrediting_provider
 
-  has_many :accrediting_providers, through: :courses
+  has_many :accrediting_providers, -> { distinct }, :through => :courses
 
   scope :changed_since, ->(timestamp) do
     if timestamp.present?

--- a/app/serializers/api/v2/serializable_accrediting_provider.rb
+++ b/app/serializers/api/v2/serializable_accrediting_provider.rb
@@ -1,0 +1,13 @@
+# This lightweight serializer is to reduce the amount of database
+# hits needed to build this and reduce the amount of data sent
+# over the wire that isn't used in the front-end
+
+module API
+  module V2
+    class SerializableAccreditingProvider < JSONAPI::Serializable::Resource
+      type 'accrediting_providers'
+
+      attributes :provider_code, :provider_name
+    end
+  end
+end

--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -62,7 +62,7 @@ module API
       enrichment_attribute :train_with_disability
 
       has_many :sites
-      has_many :accrediting_providers
+      has_many :accrediting_providers, serializer: API::V2::SerializableAccreditingProvider
       has_one :latest_enrichment, key: :ProviderEnrichment, serializer: API::V2::SerializableProviderEnrichment
 
       has_many :courses do

--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -62,6 +62,7 @@ module API
       enrichment_attribute :train_with_disability
 
       has_many :sites
+      has_many :accrediting_providers
       has_one :latest_enrichment, key: :ProviderEnrichment, serializer: API::V2::SerializableProviderEnrichment
 
       has_many :courses do

--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -63,9 +63,7 @@ module API
 
       has_many :sites
 
-      meta do
-        {
-          accredited_bodies:
+      attribute :accredited_bodies do
             @object.accrediting_providers.map do |ap|
               accrediting_provider_entry = @object.latest_enrichment.accrediting_provider_enrichments.find do |ape|
                 ape['UcasProviderCode'] == ap.provider_code
@@ -77,7 +75,6 @@ module API
                 description: accrediting_provider_entry['Description']
               }
             end
-        }
       end
 
       has_many :accrediting_provider_enrichments

--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -62,7 +62,25 @@ module API
       enrichment_attribute :train_with_disability
 
       has_many :sites
-      has_many :accrediting_providers, serializer: API::V2::SerializableAccreditingProvider
+
+      meta do
+        {
+          accredited_bodies:
+            @object.accrediting_providers.map do |ap|
+              accrediting_provider_entry = @object.latest_enrichment.accrediting_provider_enrichments.find do |ape|
+                ape['UcasProviderCode'] == ap.provider_code
+              end
+
+              {
+                provider_name: ap.provider_name,
+                provider_code: ap.provider_code,
+                description: accrediting_provider_entry['Description']
+              }
+            end
+        }
+      end
+
+      has_many :accrediting_provider_enrichments
       has_one :latest_enrichment, key: :ProviderEnrichment, serializer: API::V2::SerializableProviderEnrichment
 
       has_many :courses do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -278,10 +278,12 @@ describe Provider, type: :model do
     let!(:course1) { create :course, :with_accrediting_provider, provider: provider }
     let!(:course2) { create :course, accrediting_provider: course1.accrediting_provider, provider: provider }
 
-    it "gets the accrediting provider" do
-      expect(provider.accrediting_providers.count).to eq(1)
-      expect(provider.accrediting_providers.first.provider_code).to eq(course1.accrediting_provider.provider_code)
-      expect(provider.accrediting_providers.first.provider_name).to eq(course1.accrediting_provider.provider_name)
+    context 'getting the accrediting provider' do
+      it 'does not duplicate data' do
+        expect(provider.accrediting_providers.count).to eq(1)
+        expect(provider.accrediting_providers.first.provider_code).to eq(course1.accrediting_provider.provider_code)
+        expect(provider.accrediting_providers.first.provider_name).to eq(course1.accrediting_provider.provider_name)
+      end
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -271,6 +271,17 @@ describe Provider, type: :model do
     end
   end
 
+  describe "accredited_providers" do
+    let(:provider) { create :provider, accrediting_provider: 'N' }
+    let!(:course) { create :course, :with_accrediting_provider, provider: provider }
+
+    it "gets the accrediting provider" do
+      expect(provider.accrediting_providers.count).to eq(1)
+      expect(provider.accrediting_providers.first.provider_code).to eq(course.accrediting_provider.provider_code)
+      expect(provider.accrediting_providers.first.provider_name).to eq(course.accrediting_provider.provider_name)
+    end
+  end
+
   describe '#copy_to_recruitment_cycle' do
     let(:site)   { build :site }
     let(:course) { build :course }

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -273,12 +273,15 @@ describe Provider, type: :model do
 
   describe "accredited_providers" do
     let(:provider) { create :provider, accrediting_provider: 'N' }
-    let!(:course) { create :course, :with_accrediting_provider, provider: provider }
+
+    # two courses with same accrediting provider to ensure returned data is not duplicated
+    let!(:course1) { create :course, :with_accrediting_provider, provider: provider }
+    let!(:course2) { create :course, accrediting_provider: course1.accrediting_provider, provider: provider }
 
     it "gets the accrediting provider" do
       expect(provider.accrediting_providers.count).to eq(1)
-      expect(provider.accrediting_providers.first.provider_code).to eq(course.accrediting_provider.provider_code)
-      expect(provider.accrediting_providers.first.provider_name).to eq(course.accrediting_provider.provider_name)
+      expect(provider.accrediting_providers.first.provider_code).to eq(course1.accrediting_provider.provider_code)
+      expect(provider.accrediting_providers.first.provider_name).to eq(course1.accrediting_provider.provider_name)
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -271,19 +271,19 @@ describe Provider, type: :model do
     end
   end
 
-  describe "accredited_providers" do
+  describe "accrediting_providers" do
     let(:provider) { create :provider, accrediting_provider: 'N' }
 
-    # two courses with same accrediting provider to ensure returned data is not duplicated
-    let!(:course1) { create :course, :with_accrediting_provider, provider: provider }
-    let!(:course2) { create :course, accrediting_provider: course1.accrediting_provider, provider: provider }
+    let(:accrediting_provider) { create :provider, accrediting_provider: 'Y' }
+    let!(:course1) { create :course, accrediting_provider: accrediting_provider, provider: provider }
+    let!(:course2) { create :course, accrediting_provider: accrediting_provider, provider: provider }
 
-    context 'getting the accrediting provider' do
-      it 'does not duplicate data' do
-        expect(provider.accrediting_providers.count).to eq(1)
-        expect(provider.accrediting_providers.first.provider_code).to eq(course1.accrediting_provider.provider_code)
-        expect(provider.accrediting_providers.first.provider_name).to eq(course1.accrediting_provider.provider_name)
-      end
+    it "returns the course's accrediting provider" do
+      expect(provider.accrediting_providers.first).to eq(accrediting_provider)
+    end
+
+    it 'does not duplicate data' do
+      expect(provider.accrediting_providers.count).to eq(1)
     end
   end
 

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -320,11 +320,9 @@ describe 'Providers API v2', type: :request do
       it 'includes the accrediting_provider in the included data' do
         perform_request
 
-        # assumes nothing else is included so we can use zero index
-
+        expect(json_response["included"].count).to eq(1)
         expect(json_response.dig("included", 0, "type")).to eq("providers")
         expect(json_response.dig("included", 0, "id")).to eq(accrediting_provider.id.to_s)
-
         expect(json_response.dig("included", 0, "attributes", "provider_code")).to eq(accrediting_provider.provider_code)
         expect(json_response.dig("included", 0, "attributes", "provider_name")).to eq(accrediting_provider.provider_name)
       end

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -275,70 +275,32 @@ describe 'Providers API v2', type: :request do
       it 'has a data section with the correct attributes' do
         perform_request
 
-        expect(json_response).to eq(
-          "data" => {
-            "id" => provider.id.to_s,
-            "type" => "providers",
-            "attributes" => {
-              "provider_code" => provider.provider_code,
-              "provider_name" => provider.provider_name,
-              "accredited_body?" => false,
-              "can_add_more_sites?" => true,
-              "train_with_us" => enrichment.train_with_us,
-              "train_with_disability" => enrichment.train_with_disability,
-              "address1" => provider.address1,
-              "address2" => provider.address2,
-              "address3" => provider.address3,
-              "address4" => provider.address4,
-              "postcode" => provider.postcode,
-              "region_code" => provider.region_code,
-              "telephone" => provider.telephone,
-              "email" => provider.email,
-              "website" => provider.url,
-              "recruitment_cycle_year" => provider.recruitment_cycle.year,
-              "content_status" => provider.content_status.to_s,
-              "last_published_at" => provider.last_published_at,
-            },
-            "relationships" => {
-              "sites" => {
-                "data" => [
-                  {
-                    "type" => "sites",
-                    "id" => site.id.to_s,
-                  }
-                ]
-              },
-              "courses" => {
-                "meta" => {
-                  "count" => provider.courses.count
-                }
-              },
-              "latest_enrichment" => {
-                "meta" => { "included" => false }
-              }
-            }
-          },
-          "included" => [
+        expect(json_response.dig("data", "relationships", "sites", "data")).to eq(
+          [
             {
-              "id" => site.id.to_s,
               "type" => "sites",
-              "attributes" => {
-                "code" => site.code,
-                "location_name" => site.location_name,
-                "address1" => site.address1,
-                "address2" => site.address2,
-                "address3" => site.address3,
-                "address4" => site.address4,
-                "postcode" => site.postcode,
-                "region_code" => site.region_code,
-                "recruitment_cycle_year" => site.recruitment_cycle.year
-              }
+              "id" => site.id.to_s,
             }
-          ],
-          "jsonapi" => {
-            "version" => "1.0"
-          }
-        )
+          ]
+)
+
+        expect(json_response["included"]).to eq(
+          [{
+           "id" => site.id.to_s,
+           "type" => "sites",
+           "attributes" => {
+             "code" => site.code,
+             "location_name" => site.location_name,
+             "address1" => site.address1,
+             "address2" => site.address2,
+             "address3" => site.address3,
+             "address4" => site.address4,
+             "postcode" => site.postcode,
+             "region_code" => site.region_code,
+             "recruitment_cycle_year" => site.recruitment_cycle.year
+ }
+ }]
+)
       end
     end
 

--- a/spec/serializers/api/v2/serializable_accrediting_provider_spec.rb
+++ b/spec/serializers/api/v2/serializable_accrediting_provider_spec.rb
@@ -1,19 +1,16 @@
 require 'rails_helper'
 
-describe API::V2::SerializableProvider do
+describe API::V2::SerializableAccreditingProvider do
   let(:provider) { create :provider, accrediting_provider: 'Y' }
   let(:resource) { described_class.new object: provider }
 
   it 'sets type to providers' do
-    expect(resource.jsonapi_type).to eq :providers
+    expect(resource.jsonapi_type).to eq :accrediting_providers
   end
 
   subject { JSON.parse(resource.as_jsonapi.to_json) }
 
-  it { should have_type 'providers' }
+  it { should have_type 'accrediting_providers' }
   it { should have_attribute(:provider_code).with_value(provider.provider_code) }
   it { should have_attribute(:provider_name).with_value(provider.provider_name) }
-  it { should have_attribute(:accredited_body?).with_value(true) }
-  it { should have_attribute(:can_add_more_sites?).with_value(true) }
-  it { should have_attribute(:recruitment_cycle_year).with_value(provider.recruitment_cycle.year) }
 end


### PR DESCRIPTION
### Context

Frontend needs the list of codes and provider names to build the form for users to add more information about the accredited providers for their courses.

### Changes proposed in this pull request

* Update provider model to get access to the list of accrediting providers for their courses
* Expose that list through jsonapi via the serializer
* Test all the things
* Update related tests that failed because they test the entire json returned

### Guidance to review

* The individual commits should be easier to follow than the overall diff
* :ship: 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
