### PR TITLE
🗡 fix dev role creation for db:create (and dropping for db:drop) 

### DIFF
--- a/lib/tasks/prepare_postgres.rake
+++ b/lib/tasks/prepare_postgres.rake
@@ -1,34 +1,41 @@
 desc "Prepare db for dev environments"
 namespace :db do
-  task create: [:prepare_postgres]
+  task create: [:create_dev_role]
 
-  task :prepare_postgres do
-    if package_missing? 'postgres'
-      case RUBY_PLATFORM
-      when /darwin/
-        darwin_install_package 'postgres'
+  task :create_dev_role do
+    if exec_present? 'createuser'
+      system "createuser -d -s -w #{username}"
+      puts "Created user '#{username}'"
+    else
+      puts <<~EOTEXT
+        No 'createuser' command. Please ensure postgres is installed:
 
-      else
-        puts <<~EOTEXT
-          Don't know how to install postgres on your platform. Please do so yourself \
-          before you proceed
-        EOTEXT
-      end
+        For OSX, use brew:
+
+          brew install postgresql
+
+        For Linux, use your package manager. e.x. for Debian/Ubunte:
+
+          apt-get install postgresql
+
+      EOTEXT
     end
+  end
 
+  task :add_password_to_dev_role do
     run_sql <<~EOSQL.strip
-      CREATE USER manage_courses_backend WITH SUPERUSER CREATEDB PASSWORD 'manage_courses_backend';
+      ALTER USER #{username} WITH PASSWORD '#{password}';
     EOSQL
+    puts "Changed password for user '#{username}'"
   end
 
   task :drop do
-    Rake::Task['db:drop_dev_user'].execute
+    Rake::Task['db:drop_dev_role'].execute
   end
 
-  task :drop_dev_user do
-    run_sql <<~EOSQL.strip
-      DROP ROLE IF EXISTS manage_courses_backend;
-    EOSQL
+  task :drop_dev_role do
+    system("dropuser #{username}")
+    puts "Dropped user '#{username}'"
   end
 
 private
@@ -36,9 +43,9 @@ private
   def run_sql(query)
     case RUBY_PLATFORM
     when /darwin/
-      system('psql', '-c', query)
+      system('psql', '-c', query, dbname)
     when /linux/
-      system('sudo', '-u', 'postgres', 'psql', '-c', query)
+      system('sudo', '-u', 'postgres', 'psql', '-c', query, dbname)
     else
       puts <<~EOTEXT
         Don't know how to support this platform, sorry. Please run this SQL in psql by hand:
@@ -48,13 +55,27 @@ private
     end
   end
 
-  def package_missing?(package)
-    command = 'which ' + package
-
-    `#{command}`[0] != '/'
+  def exec_present? name
+    system("which #{name} 2>&1 >/dev/null")
   end
 
   def darwin_install_package(package)
     system('brew', 'install', package)
   end
+
+  def dbname
+    Rails.application.config.database_configuration.fetch(Rails.env).fetch('database')
+  end
+
+  def username
+    Rails.application.config.database_configuration.fetch(Rails.env).fetch('username')
+  end
+
+  def password
+    Rails.application.config.database_configuration.fetch(Rails.env).fetch('password')
+  end
+end
+
+Rake::Task['db:create'].enhance do
+  Rake::Task['db:add_password_to_dev_role'].invoke
 end

--- a/lib/tasks/prepare_postgres.rake
+++ b/lib/tasks/prepare_postgres.rake
@@ -59,10 +59,6 @@ private
     system("which #{name} 2>&1 >/dev/null")
   end
 
-  def darwin_install_package(package)
-    system('brew', 'install', package)
-  end
-
   def dbname
     Rails.application.config.database_configuration.fetch(Rails.env).fetch('database')
   end


### PR DESCRIPTION
### Context

We've taken a couple stabs :hocho: at fixing how we create the use role when we create the db, esp on dev. :imp: 

### Changes proposed in this pull request

* Create the user before the dbs are created, and then set the user's password afterwards. This sequence seems to be the right way to get things done.
* Unholy deeds :latin_cross: 

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [x] ![Bug squashed](https://user-images.githubusercontent.com/15608/62134619-bd4b0080-b2d8-11e9-9e02-4365688b1319.jpg)
