### PR TITLE
[1641] Added additional tests to illustrate manage-courses-api integration

### DIFF
--- a/spec/controllers/api/v2/application_controller_spec.rb
+++ b/spec/controllers/api/v2/application_controller_spec.rb
@@ -2,10 +2,11 @@ require 'rails_helper'
 
 describe API::V2::ApplicationController, type: :controller do
   describe '#authenticate' do
+    let(:secret) { Settings.authentication.secret }
     let(:encoded_token) do
       JWT.encode(
         payload,
-        Settings.authentication.secret,
+        secret,
         Settings.authentication.algorithm
       )
     end
@@ -39,6 +40,34 @@ describe API::V2::ApplicationController, type: :controller do
 
         expect(response.headers['WWW-Authenticate'])
           .to eq('Token realm="Application"')
+      end
+    end
+
+    context 'manage course api integration' do
+      let(:email) { "manage_courses@api.com" }
+      let(:sign_in_user_id) { "manage_courses_api" }
+      let(:existing_user) { create(:user, email: email, sign_in_user_id: sign_in_user_id) }
+      let(:secret) { Settings.authentication.secret = "SETTINGS:MANAGE_BACKEND:SECRET" }
+
+      before do
+        existing_user
+        Settings.authentication.secret = "SETTINGS:MANAGE_BACKEND:SECRET"
+      end
+
+      # NOTES:
+      # This is hardcode as the ruby version of JWT encoding is not asymmetrical with csharp and does not applies
+      #
+      # RECOMMENDED (Notational Conventions) for the "typ" (Type) Header Parameter see (https://tools.ietf.org/html/rfc7519#section-5.1)
+      # as default.
+      # In any case as long as it can be verified it is fine.
+      let(:encoded_token) do
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzaWduX2luX3VzZXJfaWQiOiJtYW5hZ2VfY291cnNlc19hcGkiLCJlbWFpbCI6Im1hbmFnZV9jb3Vyc2VzQGFwaS5jb20ifQ.fs0tM5Lc_5vA2w94PhlDMnq50NUn2K5SMxggdAApp_w"
+      end
+
+      it 'assigns the user' do
+        controller.authenticate
+
+        expect(assigns(:current_user)).to eq existing_user
       end
     end
   end

--- a/spec/controllers/api/v2/application_controller_spec.rb
+++ b/spec/controllers/api/v2/application_controller_spec.rb
@@ -43,7 +43,7 @@ describe API::V2::ApplicationController, type: :controller do
       end
     end
 
-    context 'manage course api integration' do
+    describe 'manage course api integration' do
       let(:email) { "manage_courses@api.com" }
       let(:sign_in_user_id) { "manage_courses_api" }
       let(:existing_user) { create(:user, email: email, sign_in_user_id: sign_in_user_id) }
@@ -55,7 +55,7 @@ describe API::V2::ApplicationController, type: :controller do
       end
 
       # NOTES:
-      # This is hardcode as the ruby version of JWT encoding is not asymmetrical with csharp and does not applies
+      # This is hardcode as the ruby version of JWT encoding is not symmetrical with csharp and does not applies
       #
       # RECOMMENDED (Notational Conventions) for the "typ" (Type) Header Parameter see (https://tools.ietf.org/html/rfc7519#section-5.1)
       # as default.


### PR DESCRIPTION
### Context
Manage course api calling manage courses backend

### Changes proposed in this pull request
Pass thro user info in order to allow for authenticated calls to backend.

Api will be proxying an authenticated user to backend similar aspect as to the frontend.

### Guidance to review

Api user is already authenticated the test is to illustrate the expected behaviour of api generating a token that can be consumed by backend. 

Related to 
https://github.com/DFE-Digital/manage-courses-api/pull/325

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
