### PR TITLE
Add a year to the start-dates of rolled-over courses.

### DIFF
--- a/db/migrate/20190730133727_update_start_date_for_rolled_over_courses.rb
+++ b/db/migrate/20190730133727_update_start_date_for_rolled_over_courses.rb
@@ -1,0 +1,21 @@
+class UpdateStartDateForRolledOverCourses < ActiveRecord::Migration[5.2]
+  def up
+    Course.connection.update <<~EOSQL
+      UPDATE course c SET start_date = start_date + INTERVAL '1 year'
+             FROM provider p, recruitment_cycle rc
+             WHERE c.provider_id = p.id
+                   AND p.recruitment_cycle_id = rc.id
+                   AND rc.year = '2020'
+    EOSQL
+  end
+
+  def down
+    Course.connection.update <<~EOSQL
+      UPDATE course c SET start_date = start_date - INTERVAL '1 year'
+             FROM provider p, recruitment_cycle rc
+             WHERE c.provider_id = p.id
+                   AND p.recruitment_cycle_id = rc.id
+                   AND rc.year = '2020'
+    EOSQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_26_104939) do
+ActiveRecord::Schema.define(version: 2019_07_30_133727) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"


### PR DESCRIPTION
### Context

Start dates for the next cycle's courses were still set to the same value as last cycle's courses.

### Changes proposed in this pull request

Add a migration to update courses in the next cycle to have a start date one year after their existing date.

### Guidance to review

Example courses from before this migration is run:

```
[10] pry(main)> Course.get_by_codes('2020', '2JF', '39SS').start_date
=> Sun, 01 Sep 2019 00:00:00 UTC +00:00
[19] pry(main)> Course.get_by_codes('2020', '2BN', '2YVF').start_date
=> Thu, 01 Aug 2019 00:00:00 UTC +00:00

# Migration is run

[11] pry(main)> Course.get_by_codes('2020', '2JF', '39SS').start_date
=> Tue, 01 Sep 2020 00:00:00 UTC +00:00
[20] pry(main)> Course.get_by_codes('2020', '2BN', '2YVF').start_date
=> Sat, 01 Aug 2020 00:00:00 UTC +00:00
```

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
