### PR TITLE
[1852] Add provider publish logic

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -43,7 +43,6 @@ module API
               'error received when syncing with search and compare'
             )
           end
-
         else
           render jsonapi_errors: @course.errors, status: :unprocessable_entity
         end

--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -42,7 +42,14 @@ module API
 
         if @provider.publishable?
           @provider.publish_enrichment(@current_user)
-          head :ok
+
+          if courses_synced?(@provider.syncable_courses)
+            head :ok
+          else
+            raise RuntimeError.new(
+              "#{@provider} failed to sync these courses #{@provider.syncable_courses.pluck(:course_code)}"
+            )
+          end
         else
           render jsonapi_errors: @provider.errors, status: :unprocessable_entity
         end

--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -41,6 +41,7 @@ module API
         authorize @provider, :publish?
 
         if @provider.publishable?
+          @provider.publish_enrichment(@current_user)
           head :ok
         else
           render jsonapi_errors: @provider.errors, status: :unprocessable_entity

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -149,6 +149,12 @@ class Provider < ApplicationRecord
     ).select("provider.*, COALESCE(a.courses_count, 0) AS included_courses_count")
   end
 
+  def publish_enrichment(current_user)
+    enrichments.draft.each do |enrichment|
+      enrichment.publish(current_user)
+    end
+  end
+
   def courses_count
     self.respond_to?("included_courses_count") ? included_courses_count : courses.size
   end

--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -54,4 +54,8 @@ class ProviderEnrichment < ApplicationRecord
   def has_been_published_before?
     last_published_at.present?
   end
+
+  def publish(current_user)
+    update(status: 'published', last_published_at: Time.now.utc, updated_by_user_id: current_user.id)
+  end
 end

--- a/spec/models/provider_enrichment_spec.rb
+++ b/spec/models/provider_enrichment_spec.rb
@@ -49,4 +49,20 @@ describe ProviderEnrichment, type: :model do
       expect(ProviderEnrichment.latest_created_at.last).to eq old_enrichment
     end
   end
+
+  fdescribe '#publish' do
+    let(:user) { create :user }
+    let!(:provider_enrichment) { create(:provider_enrichment, :initial_draft) }
+
+    it 'sets the status to published' do
+      publish_time = Time.parse("2019-07-30")
+      Timecop.freeze(publish_time) do
+        provider_enrichment.publish(user)
+        provider_enrichment.reload
+        expect(provider_enrichment.status).to eq('published')
+        expect(provider_enrichment.last_published_at).to eq(publish_time.utc)
+        expect(provider_enrichment.updated_by_user_id).to eq(user.id)
+      end
+    end
+  end
 end

--- a/spec/models/provider_enrichment_spec.rb
+++ b/spec/models/provider_enrichment_spec.rb
@@ -50,7 +50,7 @@ describe ProviderEnrichment, type: :model do
     end
   end
 
-  fdescribe '#publish' do
+  describe '#publish' do
     let(:user) { create :user }
     let!(:provider_enrichment) { create(:provider_enrichment, :initial_draft) }
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -481,4 +481,16 @@ describe Provider, type: :model do
       end
     end
   end
+
+  describe '#publish_enrichment' do
+    let(:user) { create :user }
+    let(:provider) { create :provider }
+    let!(:provider_enrichment1) { create :provider_enrichment, provider: provider }
+    let!(:provider_enrichment2) { create :provider_enrichment, provider: provider }
+
+    it 'sets the status of all draft enrichments to published' do
+      provider.publish_enrichment(user)
+      expect(provider.reload.enrichments.draft.size).to eq(0)
+    end
+  end
 end

--- a/spec/requests/api/v2/providers/publish_spec.rb
+++ b/spec/requests/api/v2/providers/publish_spec.rb
@@ -36,7 +36,7 @@ describe 'Provider Publish API v2', type: :request do
 
     context 'unpublished provider with draft enrichment' do
       let(:enrichment) { build(:provider_enrichment, :initial_draft) }
-      let(:provider) {
+      let!(:provider) {
         create(
           :provider,
           organisations: [organisation],
@@ -44,8 +44,11 @@ describe 'Provider Publish API v2', type: :request do
         )
       }
 
-      xit 'publishes a provider' do
-        # TODO
+      fit 'publishes a provider' do
+        subject
+        enrichment.reload
+        expect(enrichment.status).to eq('published')
+        expect(enrichment.updated_by_user_id).to eq(user.id)
       end
     end
 

--- a/spec/requests/api/v2/providers/sync_courses_with_search_and_compare_spec.rb
+++ b/spec/requests/api/v2/providers/sync_courses_with_search_and_compare_spec.rb
@@ -92,7 +92,7 @@ describe 'Courses API v2', type: :request do
           let(:status) { 451 }
 
           it 'should throw an error' do
-            expect { subject }.to raise_error("#{provider} failed to sync these courses #{provider.syncable_courses.pluck(:course_code)}")
+            expect { subject }.to raise_error("#{provider} failed to sync these courses #{[syncable_course.course_code]}")
           end
         end
       end


### PR DESCRIPTION
### Context
As it stands the provider publish endpoints are just stubs.  
  
### Changes proposed in this pull request
 - Publish the enrichments for a provider    
 - Sync SearchAndCompare  
  
### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
