### PR TITLE
make a better effort to not create duplicate site codes in factories

### DIFF
--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -25,6 +25,19 @@ FactoryBot.define do
     address4 { Faker::Address.state }
     postcode { Faker::Address.postcode }
     region_code { 'london' }
+
+    # When we retrieve a random code (as Site#pick_next_available_code does),
+    # there is the possibility we'll end up with this code duplicated when
+    # creating Sites that aren't persisted (e.g. running build(:site) twice).
+    # Using a sequence significantly reduces the chances of this happening in
+    # the tests, and starting at a random number ensures we don't start to test
+    # site codes in a deterministic way by accident (they should only be
+    # deterministic when set explicitly by the test).
+    sequence(:code, Random.rand(1000)) do |n|
+      max_codes = Site::POSSIBLE_CODES.count
+      Site::POSSIBLE_CODES[n % max_codes]
+    end
+
     provider
 
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -56,7 +56,7 @@ describe Site, type: :model do
   end
 
   describe 'after running validation' do
-    let(:site) { build(:site, provider: provider) }
+    let(:site) { build(:site, provider: provider, code: nil) }
     let(:provider) { build(:provider) }
     subject { site }
 


### PR DESCRIPTION
### Context

Every now and then some tests fail because duplicate site codes can be generated when building multiple sites that aren't persisted.

### Changes proposed in this pull request

Use a sequence when generating a site's code instead of relying on randomness. Also, use randomness to try to ensure we don't accidentally start to rely on deterministic site codes (always expecting the site code to be 'A') unless explicitly set.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
