### PR TITLE
[1808] accrediting provider enrichments

### DIFF
--- a/app/deserializers/api/v2/deserializable_provider.rb
+++ b/app/deserializers/api/v2/deserializable_provider.rb
@@ -13,6 +13,7 @@ module API
         address4
         postcode
         region_code
+        accredited_bodies
       ].freeze
 
       attributes(*PROVIDER_ATTRIBUTES)

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -273,10 +273,9 @@ class Provider < ApplicationRecord
 
   def accredited_bodies
     accrediting_providers.map do |ap|
-      accrediting_provider_entry = latest_enrichment&.accrediting_provider_enrichments&.find do |ape|
-        ape['UcasProviderCode'] == ap.provider_code
-      end
+      accrediting_provider_entry = latest_enrichment&.accrediting_provider_enrichment(ap.provider_code)
 
+      # map() to this hash:
       {
         provider_name: ap.provider_name,
         provider_code: ap.provider_code,

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -99,7 +99,7 @@ class Provider < ApplicationRecord
            primary_key: :provider_code,
            inverse_of: :accrediting_provider
 
-
+  has_many :accrediting_providers, -> { distinct }, through: :courses
 
   scope :changed_since, ->(timestamp) do
     if timestamp.present?
@@ -269,6 +269,20 @@ class Provider < ApplicationRecord
 
   def publishable?
     valid? :publish
+  end
+
+  def accredited_bodies
+    accrediting_providers.map do |ap|
+      accrediting_provider_entry = latest_enrichment&.accrediting_provider_enrichments&.find do |ape|
+        ape['UcasProviderCode'] == ap.provider_code
+      end
+
+      {
+        provider_name: ap.provider_name,
+        provider_code: ap.provider_code,
+        description: accrediting_provider_entry.present? ? accrediting_provider_entry['Description'] : ""
+      }
+    end
   end
 
 private

--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -58,4 +58,10 @@ class ProviderEnrichment < ApplicationRecord
   def publish(current_user)
     update(status: 'published', last_published_at: Time.now.utc, updated_by_user_id: current_user.id)
   end
+
+  def accrediting_provider_enrichment(provider_code)
+    accrediting_provider_enrichments&.find do |enrichment|
+      enrichment['UcasProviderCode'] == provider_code
+    end
+  end
 end

--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -11,8 +11,7 @@ module API
 
       type 'providers'
 
-      attributes :provider_code, :provider_name, :accredited_body?, :can_add_more_sites?, :content_status
-
+      attributes :provider_code, :provider_name, :accredited_body?, :can_add_more_sites?, :content_status, :accredited_bodies
 
       attribute :address1 do
         @object.external_contact_info['address1']
@@ -62,6 +61,7 @@ module API
       enrichment_attribute :train_with_disability
 
       has_many :sites
+
       has_one :latest_enrichment, key: :ProviderEnrichment, serializer: API::V2::SerializableProviderEnrichment
 
       has_many :courses do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -30,7 +30,17 @@
 require 'rails_helper'
 
 describe Provider, type: :model do
-  subject { create(:provider, provider_name: 'ACME SCITT', provider_code: 'A01') }
+  let(:courses) { [] }
+  let(:enrichments) { [] }
+  let(:provider) do
+    create(:provider,
+           provider_name: 'ACME SCITT',
+           provider_code: 'A01',
+           enrichments: enrichments,
+           courses: courses)
+  end
+
+  subject { provider }
 
   its(:to_s) { should eq('ACME SCITT (A01)') }
 
@@ -307,6 +317,85 @@ describe Provider, type: :model do
 
     it 'does not duplicate data' do
       expect(provider.accrediting_providers.count).to eq(1)
+    end
+  end
+
+  describe "#accredited_bodies" do
+    let(:accrediting_provider_enrichments) { [] }
+    let(:description) { "Ye olde establishmente" }
+    let(:enrichments) do
+      [build(:provider_enrichment, accrediting_provider_enrichments: accrediting_provider_enrichments)]
+    end
+
+    subject { provider.accredited_bodies }
+
+    context "with no accrediting provider (via courses)" do
+      it { should be_empty }
+
+      context "with an old accredited body enrichment" do
+        let(:accrediting_provider_enrichments) do
+          [{
+             "Description" => description,
+             # XX4 might have previously been an accrediting provider for this provider, and the data is still in the database
+             "UcasProviderCode" => "XX4",
+           }]
+        end
+
+        it { should be_empty }
+      end
+    end
+
+    context "with an accrediting provider (via courses)" do
+      let(:accrediting_provider) { build :provider }
+      let(:courses) { [build(:course, accrediting_provider: accrediting_provider)] }
+
+      its(:length) { should be(1) }
+
+      describe "the returned accredited body" do
+        subject { provider.accredited_bodies.first }
+
+        its([:description]) { should eq("") }
+        its([:provider_code]) { should eq(accrediting_provider.provider_code) }
+        its([:provider_name]) { should eq(accrediting_provider.provider_name) }
+      end
+
+      context "with an accredited body enrichment" do
+        let(:accrediting_provider_enrichments) do
+          [{
+             "Description" => description,
+             "UcasProviderCode" => accrediting_provider.provider_code,
+           }]
+        end
+
+        its(:length) { should be(1) }
+
+        describe "the returned accredited body" do
+          subject { provider.accredited_bodies.first }
+
+          its([:description]) { should eq(description) }
+          its([:provider_code]) { should eq(accrediting_provider.provider_code) }
+          its([:provider_name]) { should eq(accrediting_provider.provider_name) }
+        end
+      end
+
+      context "with a corrupt accredited body enrichment" do
+        let(:accrediting_provider_enrichments) do
+          [{
+             "Description" => description,
+             # UcasProviderCode missing. We found data like this in our database so need to handle it.
+           }]
+        end
+
+        its(:length) { should be(1) }
+
+        describe "the returned accredited body" do
+          subject { provider.accredited_bodies.first }
+
+          its([:description]) { should eq("") }
+          its([:provider_code]) { should eq(accrediting_provider.provider_code) }
+          its([:provider_name]) { should eq(accrediting_provider.provider_name) }
+        end
+      end
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -294,6 +294,22 @@ describe Provider, type: :model do
     end
   end
 
+  describe "accrediting_providers" do
+    let(:provider) { create :provider, accrediting_provider: 'N' }
+
+    let(:accrediting_provider) { create :provider, accrediting_provider: 'Y' }
+    let!(:course1) { create :course, accrediting_provider: accrediting_provider, provider: provider }
+    let!(:course2) { create :course, accrediting_provider: accrediting_provider, provider: provider }
+
+    it "returns the course's accrediting provider" do
+      expect(provider.accrediting_providers.first).to eq(accrediting_provider)
+    end
+
+    it 'does not duplicate data' do
+      expect(provider.accrediting_providers.count).to eq(1)
+    end
+  end
+
   describe '#copy_to_recruitment_cycle' do
     let(:site)   { build :site }
     let(:course) { build :course }

--- a/spec/requests/api/v2/providers/update_accrediting_providers_spec.rb
+++ b/spec/requests/api/v2/providers/update_accrediting_providers_spec.rb
@@ -1,0 +1,129 @@
+require "rails_helper"
+
+describe 'PATCH /providers/:provider_code' do
+  let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+  let(:request_path) do
+    "/api/v2/recruitment_cycles/#{recruitment_cycle.year}" +
+      "/providers/#{provider.provider_code}"
+  end
+  let(:permitted_params) { %i[accredited_bodies] }
+  let(:recruitment_cycle) { find_or_create :recruitment_cycle }
+  let(:organisation) { create :organisation }
+  let(:accrediting_provider) { create :provider }
+  let(:course) { create :course, accrediting_provider: accrediting_provider }
+  let(:courses) { [course] }
+  let(:provider) do
+    create :provider,
+           organisations: [organisation],
+           recruitment_cycle: recruitment_cycle,
+           enrichments: enrichments,
+           courses: courses
+  end
+  let(:user)         { create :user, organisations: [organisation] }
+  let(:payload)      { { email: user.email } }
+  let(:token)        { build_jwt :apiv2, payload: payload }
+  let(:enrichments) { [] }
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+  let(:new_description) { "new description" }
+
+  def json_payload(provider)
+    jsonapi_data = jsonapi_renderer.render(
+      provider,
+      class: {
+        Provider: API::V2::SerializableProvider
+      }
+    )
+    jsonapi_data.dig(:data, :attributes).slice!(*permitted_params)
+    jsonapi_data
+  end
+
+  def patch_request(jsonapi_data)
+    patch request_path,
+          headers: { 'HTTP_AUTHORIZATION' => credentials },
+          params: {
+            _jsonapi: jsonapi_data
+          }
+  end
+
+  let(:enrichment_payload) do
+    jsonapi_data = json_payload(provider)
+    jsonapi_data.dig(:data, :attributes, :accredited_bodies, 0)[:description] = new_description
+    jsonapi_data
+  end
+
+  context 'provider with a single accrediting provider' do
+    context 'provider has no enrichments' do
+      it "creates a draft enrichment for the provider with the accredited body enrichment" do
+        expect {
+          patch_request(enrichment_payload)
+        }.to(change { provider.reload.enrichments.count }.from(0).to(1))
+
+        expect(provider.enrichments.draft.first.accrediting_provider_enrichments.count).to eq(courses.size)
+        expect(provider.enrichments.draft.first.accrediting_provider_enrichments.first).to eq(
+          "Description" => new_description, "UcasProviderCode" => accrediting_provider.provider_code
+        )
+      end
+    end
+
+    context 'provider has only a single draft enrichments' do
+      let(:enrichments) do
+        [create(:provider_enrichment,
+                accrediting_provider_enrichments: [{ "Description" => "old stuff", "UcasProviderCode" => accrediting_provider.provider_code }])]
+      end
+
+      it "updates an existing draft enrichment for the provider with the accredited body enrichment" do
+        expect {
+          patch_request(enrichment_payload)
+        }.to_not(change { provider.reload.enrichments.count })
+
+        expect(provider.enrichments.draft.first.accrediting_provider_enrichments.count).to eq(courses.size)
+        expect(provider.enrichments.draft.first.accrediting_provider_enrichments.first).to eq(
+          "Description" => new_description, "UcasProviderCode" => accrediting_provider.provider_code
+        )
+      end
+    end
+  end
+
+  context 'provider with multiple accrediting providers' do
+    let(:additional_acrediting_courses) {
+      result = []
+      10.times { result << create(:course, accrediting_provider: create(:provider)) }
+      result
+    }
+
+    let(:courses) { [course] + additional_acrediting_courses }
+
+    context 'provider has no enrichments' do
+      it "creates a draft enrichment for the provider with the accredited body enrichment" do
+        expect {
+          patch_request(enrichment_payload)
+        }.to(change { provider.reload.enrichments.count }.from(0).to(1))
+
+        expect(provider.enrichments.draft.first.accrediting_provider_enrichments.count).to eq(courses.size)
+        expect(provider.enrichments.draft.first.accrediting_provider_enrichments.first).to eq(
+          "Description" => new_description, "UcasProviderCode" => accrediting_provider.provider_code
+        )
+      end
+    end
+
+    context 'provider has only a single draft enrichments' do
+      let(:enrichments) do
+        [create(:provider_enrichment,
+                accrediting_provider_enrichments: [{ "Description" => "old stuff", "UcasProviderCode" => accrediting_provider.provider_code }])]
+      end
+
+      it "updates an existing draft enrichment for the provider with the accredited body enrichment" do
+        expect {
+          patch_request(enrichment_payload)
+        }.to_not(change { provider.reload.enrichments.count })
+
+        expect(provider.enrichments.draft.first.accrediting_provider_enrichments.count).to eq(courses.size)
+        expect(provider.enrichments.draft.first.accrediting_provider_enrichments.first).to eq(
+          "Description" => new_description, "UcasProviderCode" => accrediting_provider.provider_code
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -194,8 +194,23 @@ describe 'Providers API v2', type: :request do
     let(:payload) { { email: user.email } }
 
     let(:site) { build(:site) }
-    let(:enrichment) { build(:provider_enrichment) }
-    let!(:provider) { create(:provider, sites: [site], organisations: [organisation], enrichments: [enrichment]) }
+    let(:description) { "An accredited body description" }
+    let(:enrichment) do
+      create(:provider_enrichment, accrediting_provider_enrichments: [{
+        "UcasProviderCode" => accrediting_provider.provider_code,
+        "Description" => description,
+      }])
+    end
+    let(:accrediting_provider) { create :provider }
+    let(:course) { create :course, accrediting_provider: accrediting_provider }
+    let(:courses) { [course] }
+    let!(:provider) do
+      create(:provider,
+             sites: [site],
+             organisations: [organisation],
+             enrichments: [enrichment],
+             courses: courses)
+    end
 
     let(:token) do
       JWT.encode payload,
@@ -230,7 +245,12 @@ describe 'Providers API v2', type: :request do
             "website" => enrichment.website,
             "recruitment_cycle_year" => provider.recruitment_cycle.year,
             "content_status" => provider.content_status.to_s,
-            "last_published_at" => provider.last_published_at
+            "last_published_at" => provider.last_published_at,
+            "accredited_bodies" => [{
+              "provider_code" => accrediting_provider.provider_code,
+              "provider_name" => accrediting_provider.provider_name,
+              "description" => description,
+            }],
           },
           "relationships" => {
             "sites" => {
@@ -298,6 +318,11 @@ describe 'Providers API v2', type: :request do
               "recruitment_cycle_year" => provider.recruitment_cycle.year,
               "content_status" => provider.content_status.to_s,
               "last_published_at" => provider.last_published_at,
+              "accredited_bodies" => [{
+                "provider_code" => accrediting_provider.provider_code,
+                "provider_name" => accrediting_provider.provider_name,
+                "description" => description,
+              }],
             },
             "relationships" => {
               "sites" => {

--- a/spec/serializers/api/v2/serializable_provider_spec.rb
+++ b/spec/serializers/api/v2/serializable_provider_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe API::V2::SerializableProvider do
   let(:provider) { create :provider, accrediting_provider: 'Y' }
-  let(:resource) { API::V2::SerializableProvider.new object: provider }
+  let(:resource) { described_class.new object: provider }
 
   it 'sets type to providers' do
     expect(resource.jsonapi_type).to eq :providers


### PR DESCRIPTION
### Context

Full read/create/update for accrediting provider enrichments.

Because of all the questions about feasibility & shape of update when working on just the list of names/codes we gave up on splitting the card in three and this PR is for the whole feature.

This is api work is to support re-implement https://bat-qa-mcui-as.azurewebsites.net/organisation/1dq/about in rails

### Changes proposed in this pull request

* `providers#show`: Include code/name, & enrichment if available, of accrediting bodies for a provider.
* `providers#update`: Update enrichments in database when accredited body info is posted as part of provider#update

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Tested by running locally
- [x] Cleaned commit history
- [x] Test coverage for read
- [x] Test coverage updating existing enrichment


