### PR TITLE
[1858]  Update a courses subjects 

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -60,6 +60,7 @@ module API
         update_course
         update_enrichment
         update_sites
+        update_subjects
         should_sync = site_ids.present? && @course.recruitment_cycle.current?
         has_synced? if should_sync
 
@@ -105,6 +106,12 @@ module API
         @course.errors[:sites] << "^You must choose at least one location" if site_ids.empty?
       end
 
+      def update_subjects
+        return if subject_params.nil?
+
+        @course.subjects = Subject.where(subject_name: subject_params)
+      end
+
       def build_provider
         @provider = @recruitment_cycle.providers.find_by!(
           provider_code: params[:provider_code].upcase
@@ -134,7 +141,8 @@ module API
                   :maths,
                   :science,
                   :qualification,
-                  :age_range_in_years)
+                  :age_range_in_years,
+                  :subjects)
           .permit(
             :about_course,
             :course_length,
@@ -170,7 +178,8 @@ module API
                   :id,
                   :type,
                   :sites_ids,
-                  :sites_types)
+                  :sites_types,
+                  :subjects)
           .permit(
             :english,
             :maths,
@@ -178,6 +187,10 @@ module API
             :qualification,
             :age_range_in_years,
           )
+      end
+
+      def subject_params
+        params.fetch(:course, {})[:subjects]
       end
 
       def site_ids

--- a/app/deserializers/api/v2/deserializable_course.rb
+++ b/app/deserializers/api/v2/deserializable_course.rb
@@ -23,6 +23,7 @@ module API
         science
         qualification
         age_range_in_years
+        subjects
       ].freeze
 
       attributes(*COURSE_ATTRIBUTES)

--- a/spec/requests/api/v2/providers/courses/update_subject_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_subject_spec.rb
@@ -1,0 +1,96 @@
+describe 'PATCH /providers/:provider_code/courses/:course_code' do
+  let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+
+  def perform_request(subjects)
+    jsonapi_data = jsonapi_renderer.render(
+      course,
+      class: {
+        Course: API::V2::SerializableCourse
+      }
+    )
+
+    jsonapi_data[:data][:attributes] = subjects
+
+    patch "/api/v2/providers/#{course.provider.provider_code}" \
+            "/courses/#{course.course_code}",
+          headers: { 'HTTP_AUTHORIZATION' => credentials },
+          params: {
+            _jsonapi: jsonapi_data
+          }
+  end
+  let(:organisation)      { create :organisation }
+  let(:provider)          { create :provider, organisations: [organisation] }
+  let(:user)              { create :user, organisations: [organisation] }
+  let(:payload)           { { email: user.email } }
+  let(:token)             { build_jwt :apiv2, payload: payload }
+
+  let(:course)            {
+    create :course,
+           provider: provider,
+           subjects: [english, secondary]
+  }
+  let(:secondary) { create(:subject, :secondary) }
+  let(:english) { create(:subject, :english) }
+
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+
+  let(:permitted_params) do
+    %i[subjects]
+  end
+
+  before do
+    perform_request(subjects)
+  end
+
+  context "course has an updated subject" do
+    let(:mathematics) { create(:subject, :mathematics) }
+    let(:subjects) do
+      {
+        subjects: [mathematics, secondary]
+      }
+    end
+
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it "updates subjects to the correct value" do
+      expect(course.reload.subjects).to eq(subjects[:subjects])
+    end
+  end
+
+  context "course has not updated its subjects" do
+    context "with values passed into the params" do
+      let(:subjects) do
+        {
+          subjects: [english, secondary]
+        }
+      end
+
+      it "returns http success" do
+        expect(response).to have_http_status(:success)
+      end
+
+      it "does not change the subjects" do
+        expect(course.reload.subjects).to eq(subjects[:subjects])
+      end
+    end
+    context "with no values passed into the params" do
+      let(:subjects) { {} }
+
+      before do
+        @subjects = course.subjects
+      end
+
+      it "returns http success" do
+        expect(response).to have_http_status(:success)
+      end
+
+      it "does not change english attribute" do
+        expect(course.reload.subjects).to eq(@subjects)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

A provider needs the ability to edit  a courses subject. 

### Changes proposed in this pull request

- Allow the course update endpoint to update subjects. 

### Guidance to review

After speaking to Misha it seems like this may not need updates as the drop down logic should sit on the front end. Am open to suggestions.


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
