### PR TITLE
[1928] Escape peroid in User email regex

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@
 class User < ApplicationRecord
   include AASM
 
-  DFE_EMAIL_PATTERN = '@(digital.){0,1}education.gov.uk$'.freeze
+  DFE_EMAIL_PATTERN = '@(digital\.){0,1}education\.gov\.uk$'.freeze
 
   has_and_belongs_to_many :organisations
   has_many :providers, through: :organisations

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -87,15 +87,15 @@ describe User, type: :model do
       end
     end
 
-    context 'user does not have a digital.education or education.gov.uk email' do
+    context 'user does not have a digital.education.gov.uk or education.gov.uk email' do
       subject { create(:user, email: email) }
 
-      context 'when other doamin' do
+      context 'when other domain' do
         let(:email) { 'test@hrmc.gov.uk' }
 
         its(:admin?) { should be_falsey }
 
-        it "is an non-admin user" do
+        it "is a non-admin user" do
           expect(User.non_admins).to eq([subject])
         end
 
@@ -109,7 +109,7 @@ describe User, type: :model do
 
         its(:admin?) { should be_falsey }
 
-        it "is an non-admin user" do
+        it "is a non-admin user" do
           expect(User.non_admins).to eq([subject])
         end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -95,8 +95,12 @@ describe User, type: :model do
 
         its(:admin?) { should be_falsey }
 
-        it "does shows up in User.non_admins" do
+        it "is an non-admin user" do
           expect(User.non_admins).to eq([subject])
+        end
+
+        it "is not an admin" do
+          expect(User.admins).to be_empty
         end
       end
 
@@ -105,13 +109,13 @@ describe User, type: :model do
 
         its(:admin?) { should be_falsey }
 
-        it "does shows up in User.non_admins" do
+        it "is an non-admin user" do
           expect(User.non_admins).to eq([subject])
         end
-      end
 
-      it "doesn't show up in User.admins" do
-        expect(User.admins).to be_empty
+        it "is not an admin" do
+          expect(User.admins).to be_empty
+        end
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -88,12 +88,26 @@ describe User, type: :model do
     end
 
     context 'user does not have a digital.education or education.gov.uk email' do
-      subject { create(:user, email: 'test@hrmc.gov.uk') }
+      subject { create(:user, email: email) }
 
-      its(:admin?) { should be_falsey }
+      context 'when other doamin' do
+        let(:email) { 'test@hrmc.gov.uk' }
 
-      it "does shows up in User.non_admins" do
-        expect(User.non_admins).to eq([subject])
+        its(:admin?) { should be_falsey }
+
+        it "does shows up in User.non_admins" do
+          expect(User.non_admins).to eq([subject])
+        end
+      end
+
+      context 'when an email has a domain similar but not identical to "digital.education.gov.uk"' do
+        let(:email) { 'test@digitalaeducationagov.uk' }
+
+        its(:admin?) { should be_falsey }
+
+        it "does shows up in User.non_admins" do
+          expect(User.non_admins).to eq([subject])
+        end
       end
 
       it "doesn't show up in User.admins" do


### PR DESCRIPTION
### Context

Noticed Regex did not escape any character `.`

### Changes proposed in this pull request

Escape any character regex 

### Guidance to review

Edge case spec added

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
