### PR TITLE
[1798] mcb providers create

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -217,6 +217,11 @@ class Provider < ApplicationRecord
     organisations.first
   end
 
+  def provider_type=(new_value)
+    super
+    self.scitt = scitt? ? 'Y' : 'N'
+  end
+
   def to_s
     "#{provider_name} (#{provider_code})"
   end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -31,6 +31,8 @@ class Provider < ApplicationRecord
   include RegionCode
   include ChangedAt
 
+  before_create :set_defaults
+
   has_associated_audits
   audited except: :changed_at
 
@@ -307,5 +309,10 @@ private
 
   def remove_unnecessary_enrichments_validation_message
     self.errors.delete :enrichments if self.errors[:enrichments] == ['is invalid']
+  end
+
+  def set_defaults
+    self.scheme_member ||= 'Y'
+    self.year_code ||= recruitment_cycle.year
   end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -220,6 +220,11 @@ class Provider < ApplicationRecord
   def provider_type=(new_value)
     super
     self.scitt = scitt? ? 'Y' : 'N'
+    self.accrediting_provider = if scitt? || university?
+                                  :accredited_body
+                                else
+                                  :not_an_accredited_body
+                                end
   end
 
   def to_s

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -28,6 +28,10 @@ class RecruitmentCycle < ApplicationRecord
     all.order(:year).second
   end
 
+  def next
+    RecruitmentCycle.find_by(year: year.to_i + 1)
+  end
+
   def current?
     RecruitmentCycle.current_recruitment_cycle == self
   end

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -25,7 +25,7 @@ class RecruitmentCycle < ApplicationRecord
   end
 
   def self.next_recruitment_cycle
-    all.order(:year).second
+    current_recruitment_cycle.next
   end
 
   def next

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,7 @@ class User < ApplicationRecord
            primary_key: :id,
            inverse_of: 'requester'
 
+  scope :admins, -> { where('email ~ ?', DFE_EMAIL_PATTERN) }
   scope :non_admins, -> { where.not('email ~ ?', DFE_EMAIL_PATTERN) }
   scope :active, -> { where.not(accept_terms_date_utc: nil) }
 

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -27,6 +27,10 @@ class ProviderPolicy
     user.providers.include?(provider)
   end
 
+  def create?
+    user.admin?
+  end
+
   alias_method :can_list_courses?, :show?
   alias_method :can_list_sites?, :show?
   alias_method :update?, :show?

--- a/lib/mcb/commands/providers/create.rb
+++ b/lib/mcb/commands/providers/create.rb
@@ -1,0 +1,15 @@
+summary 'Create a new provider via the DB'
+
+run do |opts, _args, _cmd|
+  MCB.init_rails(opts)
+
+  Provider.connection.transaction do
+    provider = MCB.get_recruitment_cycle(opts).providers.build
+    requester = User.find_by!(email: MCB.config[:email])
+
+    MCB::ProviderEditor.new(
+      provider: provider,
+      requester: requester
+    ).new_provider_wizard
+  end
+end

--- a/lib/mcb/provider_cli.rb
+++ b/lib/mcb/provider_cli.rb
@@ -27,9 +27,9 @@ module MCB
 
     def ask_contact
       {
-        name: @cli.ask('Contact name: '),
-        email: @cli.ask('Internal contact email (for sharing with UCAS): '),
-        telephone: @cli.ask('Internal contact phone number (for sharing with UCAS): '),
+        name: @cli.ask('UCAS admin account - name: '),
+        email: @cli.ask('UCAS admin account - email: '),
+        telephone: @cli.ask('UCAS admin account - phone number: '),
       }
     end
 
@@ -38,10 +38,6 @@ module MCB
         prompt: "Region code?",
         choices: Provider.region_codes.keys
       )
-    end
-
-    def ask_url
-      @cli.ask('Provider URL? ')
     end
 
     def ask_organisation_name

--- a/lib/mcb/provider_cli.rb
+++ b/lib/mcb/provider_cli.rb
@@ -1,17 +1,7 @@
 module MCB
   class ProviderCLI < BaseCLI
-    def initialize(provider)
-      super()
-
-      @provider = provider
-    end
-
     def ask_name
       @cli.ask("Enter new name").strip
-    end
-
-    def ask_new_course_code
-      @cli.ask("New course code?  ")
     end
   end
 end

--- a/lib/mcb/provider_cli.rb
+++ b/lib/mcb/provider_cli.rb
@@ -48,6 +48,10 @@ module MCB
       @cli.ask("What organisation should the new provider be added to?  ")
     end
 
+    def ask_name_of_first_location
+      @cli.ask("What's the name of the first location?  ")
+    end
+
     def confirm_new_organisation_needed?
       @cli.agree("This organisation doesn't exist. Do you want to create a new one?  ")
     end

--- a/lib/mcb/provider_cli.rb
+++ b/lib/mcb/provider_cli.rb
@@ -1,7 +1,55 @@
 module MCB
   class ProviderCLI < BaseCLI
     def ask_name
-      @cli.ask("Enter new name").strip
+      @cli.ask("Enter new name?  ").strip
+    end
+
+    def ask_provider_type
+      ask_multiple_choice(
+        prompt: "What kind of provider is it?",
+        choices: Provider.provider_types.keys
+      )
+    end
+
+    def ask_new_provider_code
+      @cli.ask("What's the new provider code?  ")
+    end
+
+    def ask_address
+      {
+        address1: @cli.ask('Building and street: '),
+        address2: @cli.ask('Building and street (2nd line): '),
+        town_or_city: @cli.ask('Town and city: '),
+        county: @cli.ask('County: '),
+        postcode: @cli.ask('Postcode: '),
+      }
+    end
+
+    def ask_contact
+      {
+        name: @cli.ask('Contact name: '),
+        email: @cli.ask('Internal contact email (for sharing with UCAS): '),
+        telephone: @cli.ask('Internal contact phone number (for sharing with UCAS): '),
+      }
+    end
+
+    def ask_region_code
+      ask_multiple_choice(
+        prompt: "Region code?",
+        choices: Provider.region_codes.keys
+      )
+    end
+
+    def ask_url
+      @cli.ask('Provider URL? ')
+    end
+
+    def ask_organisation_name
+      @cli.ask("What organisation should the new provider be added to?  ")
+    end
+
+    def confirm_new_organisation_needed?
+      @cli.agree("This organisation doesn't exist. Do you want to create a new one?  ")
     end
   end
 end

--- a/lib/mcb/provider_cli.rb
+++ b/lib/mcb/provider_cli.rb
@@ -18,7 +18,6 @@ module MCB
     def ask_address
       {
         address1: @cli.ask('Building and street: '),
-        address2: @cli.ask('Building and street (2nd line): '),
         town_or_city: @cli.ask('Town and city: '),
         county: @cli.ask('County: '),
         postcode: @cli.ask('Postcode: '),

--- a/lib/mcb/provider_editor.rb
+++ b/lib/mcb/provider_editor.rb
@@ -78,6 +78,16 @@ module MCB
       # add god users to the org, for any that aren't already in it
       organisation.users << (User.admins - organisation.users)
 
+      provider.sites.create(
+        location_name: @cli.ask_name_of_first_location,
+        address1: provider.address1,
+        address2: provider.address2,
+        address3: provider.address3,
+        address4: provider.address4,
+        postcode: provider.postcode,
+        region_code: provider.region_code
+      )
+
       next_recruitment_cycle = provider.recruitment_cycle.next
       while next_recruitment_cycle
         provider.copy_to_recruitment_cycle(next_recruitment_cycle)

--- a/lib/mcb/provider_editor.rb
+++ b/lib/mcb/provider_editor.rb
@@ -42,8 +42,6 @@ module MCB
       provider.email = contact[:email]
       provider.telephone = contact[:telephone]
 
-      provider.url = @cli.ask_url
-
       location_name = @cli.ask_name_of_first_location
 
       address = @cli.ask_address

--- a/lib/mcb/provider_editor.rb
+++ b/lib/mcb/provider_editor.rb
@@ -77,6 +77,12 @@ module MCB
 
       # add god users to the org, for any that aren't already in it
       organisation.users << (User.admins - organisation.users)
+
+      next_recruitment_cycle = provider.recruitment_cycle.next
+      while next_recruitment_cycle
+        provider.copy_to_recruitment_cycle(next_recruitment_cycle)
+        next_recruitment_cycle = next_recruitment_cycle.next
+      end
     end
 
   private

--- a/lib/mcb/provider_editor.rb
+++ b/lib/mcb/provider_editor.rb
@@ -27,9 +27,9 @@ module MCB
     end
 
     def new_provider_wizard
+      # TODO: this should live in Provider
       provider.scheme_member = 'Y'
       provider.year_code = provider.recruitment_cycle.year
-      provider.last_published_at = Time.zone.now
       provider.changed_at = Time.zone.now
 
       name = @cli.ask_name
@@ -37,12 +37,14 @@ module MCB
       provider.provider_code = @cli.ask_new_provider_code
       provider.provider_type = @cli.ask_provider_type
 
-      provider.scitt = provider.scitt? ? 'Y' : 'N'
-      provider.accrediting_provider = if provider.scitt? || provider.university?
-                                        :accredited_body
-                                      else
-                                        :not_an_accredited_body
-                                      end
+      contact = @cli.ask_contact
+      provider.contact_name = contact[:name]
+      provider.email = contact[:email]
+      provider.telephone = contact[:telephone]
+
+      provider.url = @cli.ask_url
+
+      location_name = @cli.ask_name_of_first_location
 
       address = @cli.ask_address
       provider.address1 = address[:address1]
@@ -52,14 +54,9 @@ module MCB
       provider.postcode = address[:postcode]
       provider.region_code = @cli.ask_region_code
 
-      contact = @cli.ask_contact
-      provider.contact_name = contact[:name]
-      provider.email = contact[:email]
-      provider.telephone = contact[:telephone]
-
-      provider.url = @cli.ask_url
-
+      # TODO: confirm creation if valid
       provider.save!
+      puts "New provider has been created: #{provider}"
 
       finished_picking_organisation = false
       until finished_picking_organisation
@@ -79,7 +76,7 @@ module MCB
       organisation.users << (User.admins - organisation.users)
 
       provider.sites.create(
-        location_name: @cli.ask_name_of_first_location,
+        location_name: location_name,
         address1: provider.address1,
         address2: provider.address2,
         address3: provider.address3,

--- a/lib/mcb/provider_editor.rb
+++ b/lib/mcb/provider_editor.rb
@@ -3,7 +3,7 @@ module MCB
     attr_reader :provider
 
     def initialize(provider:, requester:, environment: nil)
-      @cli = ProviderCLI.new(provider)
+      @cli = ProviderCLI.new
       @provider = provider
       @requester = requester
       @environment = environment

--- a/lib/mcb/provider_editor.rb
+++ b/lib/mcb/provider_editor.rb
@@ -27,19 +27,12 @@ module MCB
     end
 
     def new_provider_wizard
-      # QUESTION: Should live in Provider?
-      provider.scheme_member = 'Y'
-      provider.year_code = provider.recruitment_cycle.year
-
       ask_and_set_provider_details
       ask_and_set_contact_info
 
       location_name = @cli.ask_name_of_first_location
 
       ask_and_set_address_info
-
-      # Not using `Provider#update_changed_at` as we have not created a Provider at this point.
-      provider.changed_at = Time.now.utc
 
       puts "\nAbout to create the Provider"
       if @cli.confirm_creation? && try_saving_provider

--- a/spec/lib/mcb/commands/providers/create_spec.rb
+++ b/spec/lib/mcb/commands/providers/create_spec.rb
@@ -1,6 +1,6 @@
 require 'mcb_helper'
 
-fdescribe 'mcb providers create' do
+describe 'mcb providers create' do
   let(:cmd) { MCBCommand.new('providers', 'create') }
 
   let(:email) { 'user@education.gov.uk' }

--- a/spec/lib/mcb/commands/providers/create_spec.rb
+++ b/spec/lib/mcb/commands/providers/create_spec.rb
@@ -1,0 +1,43 @@
+require 'mcb_helper'
+
+fdescribe 'mcb providers create' do
+  let(:cmd) { MCBCommand.new('providers', 'create') }
+
+  let(:email) { 'user@education.gov.uk' }
+  let(:organisation) { create(:organisation) }
+  let(:provider_code) { 'X01' }
+  let!(:next_recruitment_cycle) { find_or_create(:recruitment_cycle, :next) }
+  before do
+    allow(MCB).to receive(:config).and_return(email: email)
+  end
+
+  context 'for an authorised user' do
+    let!(:requester) { create(:user, email: email, organisations: [organisation]) }
+
+    before do
+      allow(MCB::ProviderEditor).to receive(:new).and_return(instance_double(MCB::ProviderEditor, new_provider_wizard: nil))
+    end
+
+    it 'starts the new provider creation in the current cycle by default' do
+      cmd.execute
+
+      expect(MCB::ProviderEditor).to have_received(:new) do |args|
+        expect(args[:provider].recruitment_cycle).to eq(RecruitmentCycle.current_recruitment_cycle)
+        expect(args[:provider]).to be_new_record
+      end
+    end
+
+    context 'when a recruitment cycle is explicitly specified' do
+      let(:cmd) { MCBCommand.new('providers', 'create', '-r', next_recruitment_cycle.year) }
+
+      it 'starts the new provider creation in the specified cycle' do
+        cmd.execute
+
+        expect(MCB::ProviderEditor).to have_received(:new) do |args|
+          expect(args[:provider].recruitment_cycle).to eq(next_recruitment_cycle)
+          expect(args[:provider]).to be_new_record
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/mcb/provider_editor_spec.rb
+++ b/spec/lib/mcb/provider_editor_spec.rb
@@ -112,7 +112,6 @@ describe MCB::ProviderEditor do
           type: 'scitt',
           first_location_name: "ACME Primary School",
           address1: '123 Acme Lane',
-          address2: '',
           town_or_city: 'Acmeton',
           county: '',
           postcode: 'SW13 9AA',
@@ -134,7 +133,6 @@ describe MCB::ProviderEditor do
           desired_attributes[:telephone],
           desired_attributes[:first_location_name],
           desired_attributes[:address1],
-          desired_attributes[:address2],
           desired_attributes[:town_or_city],
           desired_attributes[:county],
           desired_attributes[:postcode],
@@ -151,7 +149,6 @@ describe MCB::ProviderEditor do
           "email" => desired_attributes[:email],
           "telephone" => desired_attributes[:telephone],
           "address1" => desired_attributes[:address1],
-          "address2" => desired_attributes[:address2],
           "address3" => desired_attributes[:town_or_city],
           "address4" => desired_attributes[:county],
           "postcode" => desired_attributes[:postcode],
@@ -193,7 +190,7 @@ describe MCB::ProviderEditor do
 
           site = created_provider.sites.first
           expect(site.address1).to eq(desired_attributes[:address1])
-          expect(site.address2).to eq(desired_attributes[:address2])
+          expect(site.address2).to be_nil
           expect(site.address3).to eq(desired_attributes[:town_or_city])
           expect(site.address4).to eq(desired_attributes[:county])
           expect(site.postcode).to eq(desired_attributes[:postcode])

--- a/spec/lib/mcb/provider_editor_spec.rb
+++ b/spec/lib/mcb/provider_editor_spec.rb
@@ -94,6 +94,171 @@ describe MCB::ProviderEditor do
           from("Original name")
       end
     end
+
+    describe 'runs the provider creation wizard' do
+      def run_new_provider_wizard(*input_cmds)
+        stderr = nil
+        output = with_stubbed_stdout(stdin: input_cmds.join("\n"), stderr: stderr) do
+          subject.new_provider_wizard
+        end
+        [output, stderr]
+      end
+      let(:provider) { RecruitmentCycle.current_recruitment_cycle.providers.build }
+
+      let(:desired_attributes) {
+        {
+          name: "ACME SCITT",
+          code: 'X01',
+          type: 'scitt',
+          first_location_name: "ACME Primary School",
+          address1: '123 Acme Lane',
+          address2: '',
+          town_or_city: 'Acmeton',
+          county: '',
+          postcode: 'SW13 9AA',
+          region_code: 'london',
+          contact_name: 'Jane Smith',
+          email: 'jsmith@acme-scitt.org.uk',
+          telephone: "0123456",
+          url: 'https://www.acme-scitt.org.uk/default.htm',
+          organisation_name: 'ACME SCITT',
+        }
+      }
+
+      let(:valid_answers) {
+        [
+          desired_attributes[:name],
+          desired_attributes[:code],
+          desired_attributes[:type],
+          desired_attributes[:contact_name],
+          desired_attributes[:email],
+          desired_attributes[:telephone],
+          desired_attributes[:url],
+          desired_attributes[:first_location_name],
+          desired_attributes[:address1],
+          desired_attributes[:address2],
+          desired_attributes[:town_or_city],
+          desired_attributes[:county],
+          desired_attributes[:postcode],
+          desired_attributes[:region_code],
+        ]
+      }
+
+      let(:expected_provider_attributes) {
+        {
+          "provider_name" => desired_attributes[:name],
+          "provider_code" => desired_attributes[:code],
+          "provider_type" => desired_attributes[:type],
+          "contact_name" => desired_attributes[:contact_name],
+          "email" => desired_attributes[:email],
+          "telephone" => desired_attributes[:telephone],
+          "url" => desired_attributes[:url],
+          "address1" => desired_attributes[:address1],
+          "address2" => desired_attributes[:address2],
+          "address3" => desired_attributes[:town_or_city],
+          "address4" => desired_attributes[:county],
+          "postcode" => desired_attributes[:postcode],
+          "region_code" => desired_attributes[:region_code],
+          "scitt" => 'Y',
+          "accrediting_provider" => "accredited_body",
+        }
+      }
+
+      context "when adding a new provider into a completely new organisation" do
+        before do
+          @output, = run_new_provider_wizard(
+            *valid_answers,
+            # adding the provider into a new organisation
+            desired_attributes[:organisation_name],
+            "y" # confirm creation of a new org
+          )
+        end
+
+        let(:created_provider) { RecruitmentCycle.current_recruitment_cycle.providers.find_by!(provider_code: desired_attributes[:code]) }
+
+        it "creates a new provider with the passed parameters" do
+          expect(@output).to include("New provider has been created")
+
+          expect(created_provider.attributes).to include(expected_provider_attributes)
+
+          expect(created_provider.changed_at).to be_present
+          expect(created_provider.scheme_member).to eq('Y')
+          expect(created_provider.year_code).to eq(RecruitmentCycle.current_recruitment_cycle.year)
+        end
+
+        it "creates a new organisation with the passed parameters" do
+          expect(created_provider.organisations.count).to eq(1)
+          expect(created_provider.organisation.name).to eq(desired_attributes[:organisation_name])
+        end
+
+        it "creates the first training location with the passed parameters" do
+          expect(created_provider.sites.count).to eq(1)
+
+          site = created_provider.sites.first
+          expect(site.address1).to eq(desired_attributes[:address1])
+          expect(site.address2).to eq(desired_attributes[:address2])
+          expect(site.address3).to eq(desired_attributes[:town_or_city])
+          expect(site.address4).to eq(desired_attributes[:county])
+          expect(site.postcode).to eq(desired_attributes[:postcode])
+          expect(site.region_code).to eq(desired_attributes[:region_code])
+        end
+      end
+
+      context "when adding a new provider into an existing organisation" do
+        let!(:existing_organisation) { create(:organisation, name: desired_attributes[:organisation_name]) }
+
+        it "creates a new provider into the existing organisation with the passed parameters" do
+          output, = run_new_provider_wizard(
+            *valid_answers,
+            desired_attributes[:organisation_name], # adding the provider into an existing organisation
+          )
+
+          expect(output).to include("New provider has been created")
+
+          provider = RecruitmentCycle.current_recruitment_cycle.providers.find_by!(provider_code: desired_attributes[:code])
+          expect(provider.organisation).to eq(existing_organisation)
+
+          # no other orgs should have been created
+          expect(Organisation.count).to eq(1)
+        end
+
+        it "creates a new provider into the existing organisation, even if the user makes and then corrects a typo in the org name" do
+          output, = run_new_provider_wizard(
+            *valid_answers,
+            "ACCCCME SCITT", # mistyped organisation name
+            "no", # don't create the mistyped org
+            desired_attributes[:organisation_name], # try typing in the org name again
+          )
+
+          expect(output).to include("New provider has been created")
+
+          provider = RecruitmentCycle.current_recruitment_cycle.providers.find_by!(provider_code: desired_attributes[:code])
+          expect(provider.organisation).to eq(existing_organisation)
+
+          # no other orgs should have been created
+          expect(Organisation.count).to eq(1)
+        end
+      end
+
+      context "when there are later recruitment cycles after the one that's been added to" do
+        let!(:next_recruitment_cycle) { create :recruitment_cycle, :next }
+        let!(:one_after_next_recruitment_cycle) { create :recruitment_cycle, year: next_recruitment_cycle.year.to_i + 1 }
+
+        it "clones the provider into all subsequent recruitment cycles" do
+          run_new_provider_wizard(
+            *valid_answers,
+            desired_attributes[:organisation_name],
+            "yes"
+          )
+
+          expect(next_recruitment_cycle.providers.count).to eq(1)
+          expect(next_recruitment_cycle.providers.first.attributes).to include(expected_provider_attributes)
+
+          expect(one_after_next_recruitment_cycle.providers.count).to eq(1)
+          expect(one_after_next_recruitment_cycle.providers.first.attributes).to include(expected_provider_attributes)
+        end
+      end
+    end
   end
 
   context 'for an unauthorised user' do

--- a/spec/lib/mcb/provider_editor_spec.rb
+++ b/spec/lib/mcb/provider_editor_spec.rb
@@ -120,7 +120,6 @@ describe MCB::ProviderEditor do
           contact_name: 'Jane Smith',
           email: 'jsmith@acme-scitt.org.uk',
           telephone: "0123456",
-          url: 'https://www.acme-scitt.org.uk/default.htm',
           organisation_name: 'ACME SCITT',
         }
       }
@@ -133,7 +132,6 @@ describe MCB::ProviderEditor do
           desired_attributes[:contact_name],
           desired_attributes[:email],
           desired_attributes[:telephone],
-          desired_attributes[:url],
           desired_attributes[:first_location_name],
           desired_attributes[:address1],
           desired_attributes[:address2],
@@ -152,7 +150,6 @@ describe MCB::ProviderEditor do
           "contact_name" => desired_attributes[:contact_name],
           "email" => desired_attributes[:email],
           "telephone" => desired_attributes[:telephone],
-          "url" => desired_attributes[:url],
           "address1" => desired_attributes[:address1],
           "address2" => desired_attributes[:address2],
           "address3" => desired_attributes[:town_or_city],

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -191,6 +191,8 @@ describe Provider, type: :model do
   end
 
   describe "#provider_type=" do
+    subject { build(:provider, accrediting_provider: nil) }
+
     it "sets the provider type" do
       expect { subject.provider_type = "scitt" }
         .to change { subject.provider_type }
@@ -207,6 +209,24 @@ describe Provider, type: :model do
       expect { subject.provider_type = "university" }
         .to change { subject.scitt }
         .from(nil).to('N')
+    end
+
+    it "sets 'accrediting_provider' correctly for SCITTs" do
+      expect { subject.provider_type = "scitt" }
+        .to change { subject.accrediting_provider }
+        .from(nil).to('accredited_body')
+    end
+
+    it "sets 'accrediting_provider' correctly for universities" do
+      expect { subject.provider_type = "university" }
+        .to change { subject.accrediting_provider }
+        .from(nil).to('accredited_body')
+    end
+
+    it "sets 'accrediting_provider' correctly for universities" do
+      expect { subject.provider_type = "lead_school" }
+        .to change { subject.accrediting_provider }
+        .from(nil).to('not_an_accredited_body')
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -533,4 +533,42 @@ describe Provider, type: :model do
       expect(provider.reload.enrichments.draft.size).to eq(0)
     end
   end
+
+  describe '#before_create' do
+    describe '#set_defaults' do
+      let(:provider) { build :provider }
+
+      it 'sets scheme_member to "Y"' do
+        expect(provider.scheme_member).to be_nil
+
+        provider.save!
+
+        expect(provider.scheme_member).to eq('Y')
+      end
+
+      it 'sets the year_code from the recruitment_cycle' do
+        expect(provider.year_code).to be_nil
+
+        provider.save!
+
+        expect(provider.year_code).to eq(provider.recruitment_cycle.year)
+      end
+
+      it 'does not override a given value for scheme_member' do
+        provider.scheme_member = 'A'
+
+        provider.save!
+
+        expect(provider.scheme_member).to eq('A')
+      end
+
+      it 'does not override a given value for recruitment_cycle' do
+        provider.scheme_member = 2020
+
+        provider.save!
+
+        expect(provider.scheme_member).to eq("2020")
+      end
+    end
+  end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -190,6 +190,26 @@ describe Provider, type: :model do
     end
   end
 
+  describe "#provider_type=" do
+    it "sets the provider type" do
+      expect { subject.provider_type = "scitt" }
+        .to change { subject.provider_type }
+        .from(nil).to('scitt')
+    end
+
+    it "sets 'scitt=Y' when the provider type is set to scitt" do
+      expect { subject.provider_type = "scitt" }
+        .to change { subject.scitt }
+        .from(nil).to('Y')
+    end
+
+    it "sets 'scitt=N' when the provider type is not a scitt" do
+      expect { subject.provider_type = "university" }
+        .to change { subject.scitt }
+        .from(nil).to('N')
+    end
+  end
+
   its(:recruitment_cycle) { should eq find(:recruitment_cycle) }
 
   describe '#unassigned_site_codes' do

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -41,19 +41,33 @@ describe RecruitmentCycle, type: :model do
     end
   end
 
-  describe "#next" do
+  context 'when there are multiple cycles' do
     let(:current_cycle) { subject }
     let!(:second_cycle) { create(:recruitment_cycle, year: "2020") }
     let!(:third_cycle) { create(:recruitment_cycle, year: "2021") }
 
-    its(:next) { should eq(second_cycle) }
-
-    it "is nil for the newest cycle" do
-      expect(third_cycle.next).to be_nil
+    describe '.current_recruitment_cycle' do
+      it 'returns the first cycle, ordered by year' do
+        expect(RecruitmentCycle.current_recruitment_cycle).to eq(current_cycle)
+      end
     end
 
-    it "returns the next cycle along when there is one" do
-      expect(second_cycle.next).to eq(third_cycle)
+    describe '.next_recruitment_cycle' do
+      it 'returns the next cycle after the current one' do
+        expect(RecruitmentCycle.next_recruitment_cycle).to eq(second_cycle)
+      end
+    end
+
+    describe "#next" do
+      its(:next) { should eq(second_cycle) }
+
+      it "is nil for the newest cycle" do
+        expect(third_cycle.next).to be_nil
+      end
+
+      it "returns the next cycle along when there is one" do
+        expect(second_cycle.next).to eq(third_cycle)
+      end
     end
   end
 end

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -40,4 +40,20 @@ describe RecruitmentCycle, type: :model do
       expect(second_cycle.current?).to be(false)
     end
   end
+
+  describe "#next" do
+    let(:current_cycle) { subject }
+    let!(:second_cycle) { create(:recruitment_cycle, year: "2020") }
+    let!(:third_cycle) { create(:recruitment_cycle, year: "2021") }
+
+    its(:next) { should eq(second_cycle) }
+
+    it "is nil for the newest cycle" do
+      expect(third_cycle.next).to be_nil
+    end
+
+    it "returns the next cycle along when there is one" do
+      expect(second_cycle.next).to eq(third_cycle)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -64,6 +64,10 @@ describe User, type: :model do
 
       its(:admin?) { should be_truthy }
 
+      it "shows up in User.admins" do
+        expect(User.admins).to eq([subject])
+      end
+
       it "doesn't show up in User.non_admins" do
         expect(User.non_admins).to be_empty
       end
@@ -73,6 +77,10 @@ describe User, type: :model do
       subject! { create(:user, email: 'test@digital.education.gov.uk') }
 
       its(:admin?) { should be_truthy }
+
+      it "shows up in User.admins" do
+        expect(User.admins).to eq([subject])
+      end
 
       it "doesn't show up in User.non_admins" do
         expect(User.non_admins).to be_empty
@@ -86,6 +94,10 @@ describe User, type: :model do
 
       it "does shows up in User.non_admins" do
         expect(User.non_admins).to eq([subject])
+      end
+
+      it "doesn't show up in User.admins" do
+        expect(User.admins).to be_empty
       end
     end
   end

--- a/spec/policies/provider_policy_spec.rb
+++ b/spec/policies/provider_policy_spec.rb
@@ -29,4 +29,15 @@ describe ProviderPolicy do
   permissions :index? do
     it { should permit user }
   end
+
+  permissions :create? do
+    let(:user_outside_org) { create(:user) }
+    let(:admin) { create(:user, :admin) }
+    let(:provider) { create(:provider) }
+    let!(:organisation) { create(:organisation, providers: [provider], users: [user]) }
+
+    it { should_not permit(user, provider) }
+    it { should_not permit(user_outside_org, provider) }
+    it { should permit(admin, provider) }
+  end
 end

--- a/spec/policies/provider_policy_spec.rb
+++ b/spec/policies/provider_policy_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 describe ProviderPolicy do
+  let(:user) { create(:user) }
+
   describe 'scope' do
-    let(:user) { create(:user) }
     let(:organisation) { create(:organisation, users: [user]) }
 
     it 'limits the providers to those the user is assigned to' do
@@ -26,8 +27,6 @@ describe ProviderPolicy do
   end
 
   permissions :index? do
-    let(:user) { create(:user) }
-
     it { should permit user }
   end
 end

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -113,7 +113,7 @@ describe "Courses API", type: :request do
                                   "institution_code" => "2LD",
                                   "institution_name" => "ACME SCITT",
                                   "institution_type" => "B",
-                                  "accrediting_provider" => 'N',
+                                  "accrediting_provider" => 'Y',
                                   "scheme_member" => "Y"
                                 },
                                 "accrediting_provider" => nil

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -220,7 +220,7 @@ describe 'Providers API', type: :request do
               ]
             },
             {
-              'accrediting_provider' => 'N',
+              'accrediting_provider' => 'Y',
               'campuses' => [
                 {
                   'campus_code' => '-',


### PR DESCRIPTION
### Context

Need to provide a command via `mcb` to create a Provider (and organisation).

### Changes proposed in this pull request

- Add create command for Providers 
- Automatically set `accrediting_provider` and `scitt` based on Provider Type
- `User.admins` scope

### Guidance to review

- ~~Should this belong here: https://github.com/DFE-Digital/manage-courses-backend/pull/683/files#diff-5c08de53fa6bea147e31fe1d5930422aR30-R32~~

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
