### PR TITLE
[1905] expose applications accepted from

### DIFF
--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -13,13 +13,17 @@ module API
 
       attributes :findable?, :open_for_applications?, :has_vacancies?,
                  :course_code, :name, :study_mode, :qualification, :description,
-                 :content_status, :ucas_status, :funding, :applications_open_from,
+                 :content_status, :ucas_status, :funding,
                  :level, :is_send?, :has_bursary?, :has_scholarship_and_bursary?,
                  :has_early_career_payments?, :bursary_amount, :scholarship_amount,
                  :english, :maths, :science, :gcse_subjects_required, :age_range_in_years
 
       attribute :start_date do
         @object.start_date&.iso8601
+      end
+
+      attribute :applications_open_from do
+        @object.applications_open_from&.iso8601
       end
 
       attribute :last_published_at do

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -23,6 +23,7 @@
 #  accrediting_provider_code :text
 #  discarded_at              :datetime
 #  age_range_in_years        :string
+#  applications_open_from    :date
 #
 
 class CourseSerializer < ActiveModel::Serializer

--- a/db/migrate/20190806102256_add_applications_open_from_to_courses.rb
+++ b/db/migrate/20190806102256_add_applications_open_from_to_courses.rb
@@ -1,0 +1,16 @@
+class AddApplicationsOpenFromToCourses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :course, :applications_open_from, :date
+
+    say_with_time 'Setting applications_open_from to one held within sites' do
+      Course.all.each do |course|
+        if course.recruitment_cycle.current?
+          applications_open_from = course.site_statuses.order("applications_accepted_from ASC").first.applications_accepted_from
+          course.update!(applications_open_from: applications_open_from)
+        else
+          course.update!(applications_open_from: course.recruitment_cycle.application_start_date)
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_30_133727) do
+ActiveRecord::Schema.define(version: 2019_08_06_102256) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -88,6 +88,7 @@ ActiveRecord::Schema.define(version: 2019_07_30_133727) do
     t.text "accrediting_provider_code"
     t.datetime "discarded_at"
     t.string "age_range_in_years"
+    t.date "applications_open_from"
     t.index ["accrediting_provider_code"], name: "index_course_on_accrediting_provider_code"
     t.index ["accrediting_provider_id"], name: "IX_course_accrediting_provider_id"
     t.index ["changed_at"], name: "index_course_on_changed_at", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,7 +12,7 @@ AccessRequest.destroy_all
 RecruitmentCycle.destroy_all
 
 current_recruitment_cycle = RecruitmentCycle.create(year: '2019', application_start_date: Date.new(2018, 10, 9))
-next_recruitment_cycle = RecruitmentCycle.create(year: '2020')
+next_recruitment_cycle = RecruitmentCycle.create(year: '2020', application_start_date: Date.new(2019, 10, 8))
 
 {
   "Primary" => "00",
@@ -75,7 +75,7 @@ def create_standard_provider_and_courses_for_cycle(recruitment_cycle, superuser)
       Subject.find_by(subject_name: "Secondary"),
       Subject.find_by(subject_name: "Mathematics")
     ],
-    study_mode: "F",
+    study_mode: "F"
   )
 
   SiteStatus.create!(
@@ -98,13 +98,13 @@ def create_standard_provider_and_courses_for_cycle(recruitment_cycle, superuser)
     english: 9,
     science: nil,
     modular: "",
-    qualification: :pgce_with_qts,
+    qualification: :pgce,
     subjects: [
       Subject.find_by(subject_name: "Secondary"),
       Subject.find_by(subject_name: "Biology"),
       Subject.find_by(subject_name: "Further Education"),
     ],
-    study_mode: "B",
+    study_mode: "B"
   )
 
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -23,6 +23,7 @@
 #  accrediting_provider_code :text
 #  discarded_at              :datetime
 #  age_range_in_years        :string
+#  applications_open_from    :date
 #
 
 FactoryBot.define do

--- a/spec/lib/mcb/courses_editor_spec.rb
+++ b/spec/lib/mcb/courses_editor_spec.rb
@@ -34,7 +34,8 @@ describe MCB::CoursesEditor do
            study_mode: 'part_time',
            start_date: Date.new(2019, 8, 1),
            age_range: 'secondary',
-           subjects: [secondary, biology])
+           subjects: [secondary, biology],
+           applications_open_from: Date.new(2018, 10, 9))
   }
   subject { described_class.new(provider: provider, course_codes: course_codes, requester: requester) }
 
@@ -172,14 +173,14 @@ describe MCB::CoursesEditor do
 
         it 'updates the "applications open from" when that is valid' do
           expect { run_editor("edit application opening date", "1 October 2018", "exit") }.
-            to change { Date.parse(course.reload.applications_open_from) }.
+            to change { Date.parse(course.reload.applications_open_from.to_s) }.
             from(Date.new(2018, 10, 9)).to(Date.new(2018, 10, 1))
         end
 
         it 'updates the application opening date to today by default' do
           Timecop.freeze(Time.utc(2019, 6, 1, 12, 0, 0)) do
             expect { run_editor("edit application opening date", "", "exit") }.
-              to change { Date.parse(course.reload.applications_open_from) }.
+              to change { Date.parse(course.reload.applications_open_from.to_s) }.
               from(Date.new(2018, 10, 9)).to(Date.new(2019, 6, 1))
           end
         end
@@ -451,7 +452,7 @@ describe MCB::CoursesEditor do
         expect(created_course.accrediting_provider).to eq(accredited_body)
         expect(created_course.recruitment_cycle).to eq(current_cycle)
         expect(created_course.sites).to include(site_1, site_3)
-        expect(created_course.site_statuses.map(&:applications_accepted_from).uniq).to eq([Date.new(2018, 10, 18)])
+        expect(created_course.applications_open_from).to eq(Date.new(2018, 10, 18))
         expect(created_course.ucas_status).to eq(:new)
       end
 

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -24,7 +24,8 @@ describe 'Courses API v2', type: :request do
            maths: :must_have_qualification_at_application_time,
            english: :must_have_qualification_at_application_time,
            science: :must_have_qualification_at_application_time,
-           age_range_in_years: '3_to_7')
+           age_range_in_years: '3_to_7',
+           applications_open_from: Date.new(2019, 1, 1))
   }
 
   let(:courses_site_status) {
@@ -90,7 +91,7 @@ describe 'Courses API v2', type: :request do
                 "subjects" => ["Primary",
                                "Primary with mathematics"],
                 "level" => "primary",
-                "applications_open_from" => "2019-01-01T00:00:00Z",
+                "applications_open_from" => "2019-01-01",
                 "about_course" => enrichment.about_course,
                 "course_length" => enrichment.course_length,
                 "fee_details" => enrichment.fee_details,
@@ -254,7 +255,7 @@ describe 'Courses API v2', type: :request do
               "subjects" => ["Primary",
                              "Primary with mathematics"],
               "level" => "primary",
-              "applications_open_from" => "2019-01-01T00:00:00Z",
+              "applications_open_from" => "2019-01-01",
               "about_course" => enrichment.about_course,
               "course_length" => enrichment.course_length,
               "fee_details" => enrichment.fee_details,

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -3,8 +3,10 @@ require "rails_helper"
 describe API::V2::SerializableCourse do
   let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
   let(:enrichment)       { build :course_enrichment }
-  let(:course)           do
-    create(:course, enrichments: [enrichment], start_date: Time.now.utc)
+  let(:date_today) { Date.today }
+  let(:time_now) { Time.now.utc }
+  let(:course) do
+    create(:course, enrichments: [enrichment], start_date: time_now, applications_open_from: date_today)
   end
   let(:course_json) do
     jsonapi_renderer.render(
@@ -19,12 +21,12 @@ describe API::V2::SerializableCourse do
   subject { parsed_json['data'] }
 
   it { should have_type('courses') }
-  it { should have_attributes :start_date }
+  it { should have_attribute(:start_date).with_value(time_now.iso8601) }
   it { should have_attribute :content_status }
   it { should have_attribute :ucas_status }
   it { should have_attribute :funding }
   it { should have_attribute :subjects }
-  it { should have_attribute :applications_open_from }
+  it { should have_attribute(:applications_open_from).with_value(date_today.to_s) }
   it { should have_attribute :is_send? }
   it { should have_attribute :level }
   it { should have_attribute :english }

--- a/spec/serializers/course_serializer_spec.rb
+++ b/spec/serializers/course_serializer_spec.rb
@@ -23,6 +23,7 @@
 #  accrediting_provider_code :text
 #  discarded_at              :datetime
 #  age_range_in_years        :string
+#  applications_open_from    :date
 #
 
 require "rails_helper"

--- a/spec/serializers/search_and_compare/course_serializer_spec.rb
+++ b/spec/serializers/search_and_compare/course_serializer_spec.rb
@@ -34,7 +34,8 @@ describe SearchAndCompare::CourseSerializer do
                study_mode:  :full_time,
                site_statuses: [site_status1, site_status2],
                enrichments: course_enrichments,
-               subjects: subjects).tap do |c|
+               subjects: subjects,
+               applications_open_from: '2018-10-09T00:00:00').tap do |c|
           # These sites, taken from real prod data, aren't actually valid in
           # that they're missing the following bits of data.
           c.site_statuses.each do |site_status|


### PR DESCRIPTION
## Context

Courses have a date that applications are accepted from. This date is currently modelled onto the `SiteStatus` instead of the course, so it's duplicated a lot.

### Changes proposed in this pull request

- Add new attribute `applications_open_from`, replacing the current method which pulls from the site statuses
- Default to next recruitment cycle
- Update current references to `applications_open_from`

### Guidance to review

Am open to suggestions on any changes/incorrect assumptions I have made given I'm still getting my head around the data model :tada:

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
