### PR TITLE
updated base_url in config/settings/qa.yml

### DIFF
--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -2,5 +2,5 @@ manage_api:
   base_url: https://api.qa.publish-teacher-training-courses.service.gov.uk
   secret: please_change_me
 search_api:
-  base_url: https://api.qa.find-poqaraduate-teacher-training.service.gov.uk
+  base_url: https://api.qa.find-postgraduate-teacher-training.service.gov.uk
   secret: please_change_me

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,6 +1,6 @@
 manage_api:
-  base_url: https://bat-qa-mcapi-as.azurewebsites.net
+  base_url: https://api.qa.publish-teacher-training-courses.service.gov.uk
   secret: please_change_me
 search_api:
-  base_url: https://bat-qa-sacapi-as.azurewebsites.net
+  base_url: https://api.qa.find-poqaraduate-teacher-training.service.gov.uk
   secret: please_change_me


### PR DESCRIPTION
### Context
Update qa environment to use non-Azure domains

### Changes proposed in this pull request
Change base_url value in qa.yml file from default azure web app .azurewebsites.net urls to service domains

### Guidance to review
base_url updated in qa.yml file only. New staging service domain urls are as follows:
mcapi: https://api.qa.publish-teacher-training-courses.service.gov.uk
mcbe: https://api2.qa.publish-teacher-training-courses.service.gov.uk
mcfe: https://www2.qa.publish-teacher-training-courses.service.gov.uk
mcspt: https://support.qa.publish-teacher-training-courses.service.gov.uk
mcui: https://www.qa.publish-teacher-training-courses.service.gov.uk
sacapi: https://api.qa.find-postgraduate-teacher-training.service.gov.uk
sacui: https://www.qa.find-postgraduate-teacher-training.service.gov.uk