### PR TITLE
1837 add background job arm template

### DIFF
--- a/azure/backgroundJobTemplate.json
+++ b/azure/backgroundJobTemplate.json
@@ -8,6 +8,12 @@
         "description": "The name of the Azure Container Instances resource. This will be its identifier in Azure and can be different from the image name."
       }
     },
+    "containerGroupName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Azure Container Instances resource. This will be its identifier in Azure and can be different from the image name."
+      }
+    },
     "authenticationToken": {
       "type": "string",
       "metadata": {
@@ -92,7 +98,6 @@
     "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/130-create-a-release-pipeline-for-background-web-app/templates/"
   },
   "resources": [
-
     {
       "name": "container-instances",
       "type": "Microsoft.Resources/deployments",
@@ -105,6 +110,9 @@
         },
         "parameters": {
           "containerName": {
+            "value": "[parameters('containerName')]"
+          },
+          "containerGroupName": {
             "value": "[parameters('containerName')]"
           },
           "imageName": {

--- a/azure/backgroundJobTemplate.json
+++ b/azure/backgroundJobTemplate.json
@@ -89,7 +89,7 @@
     }
   },
   "variables": {
-    "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/ARM-Template-for-Azure-Container-Instances/templates/"
+    "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/130-create-a-release-pipeline-for-background-web-app/templates/"
   },
   "resources": [
 

--- a/azure/backgroundJobTemplate.json
+++ b/azure/backgroundJobTemplate.json
@@ -81,12 +81,6 @@
         "description": "Auth secret for manage back-end."
       }
     },
-    "settingsManageApiSecret": {
-      "type": "string",
-      "metadata": {
-        "description": "The secret shared between manage courses backend and manage courses API to authorize requests."
-      }
-    },
     "settingsSearchApiSecret": {
       "type": "string",
       "metadata": {
@@ -159,10 +153,6 @@
               {
                 "name": "SETTINGS__AUTHENTICATION__SECRET",
                 "secureValue": "[parameters('settingsAuthenticationSecret')]"
-              },
-              {
-                "name": "SETTINGS__MANAGE_API__SECRET",
-                "secureValue": "[parameters('settingsManageApiSecret')]"
               },
               {
                 "name": "SETTINGS__SEARCH_API__SECRET",

--- a/azure/backgroundJobTemplate.json
+++ b/azure/backgroundJobTemplate.json
@@ -87,7 +87,7 @@
     }
   },
   "variables": {
-    "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/ARM-Template-for-Azure-Container-Instances/templates/",
+    "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/ARM-Template-for-Azure-Container-Instances/templates/"
   },
   "resources": [
 

--- a/azure/backgroundJobTemplate.json
+++ b/azure/backgroundJobTemplate.json
@@ -4,7 +4,9 @@
   "parameters": {
     "containerName": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "The name of the Azure Container Instances resource. This will be its identifier in Azure and can be different from the image name."
+      }
     },
     "authenticationToken": {
       "type": "string",

--- a/azure/backgroundJobTemplate.json
+++ b/azure/backgroundJobTemplate.json
@@ -113,7 +113,7 @@
             "value": "[parameters('containerName')]"
           },
           "containerGroupName": {
-            "value": "[parameters('containerName')]"
+            "value": "[parameters('containerGroupName')]"
           },
           "imageName": {
             "value": "[parameters('imageName')]"

--- a/azure/backgroundJobTemplate.json
+++ b/azure/backgroundJobTemplate.json
@@ -111,10 +111,6 @@
           "environmentVariables": {
             "value": [
               {
-                "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
-                "value": "[reference('app-insights').outputs.instrumentationKey.value]"
-              },
-              {
                 "name": "RAILS_ENV",
                 "value": "[parameters('railsEnv')]"
               },

--- a/azure/backgroundJobTemplate.json
+++ b/azure/backgroundJobTemplate.json
@@ -2,28 +2,28 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "containerInstanceName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Azure Container Instances resource. This will be its identifier in Azure and can be different from the image name."
+      }
+    },
     "containerName": {
       "type": "string",
       "metadata": {
-        "description": "The name of the Azure Container Instances resource. This will be its identifier in Azure and can be different from the image name."
-      }
-    },
-    "containerGroupName": {
-      "type": "string",
-      "metadata": {
-        "description": "The name of the Azure Container Instances resource. This will be its identifier in Azure and can be different from the image name."
-      }
-    },
-    "authenticationToken": {
-      "type": "string",
-      "metadata": {
-        "description": "Authentication token for api access."
+        "description": "The name or role of the container to identify individual containers in multi-container setup."
       }
     },
     "imageName": {
       "type": "string",
       "metadata": {
         "description": "The container image to pull from the server. Should be in image:tag format."
+      }
+    },
+    "authenticationToken": {
+      "type": "string",
+      "metadata": {
+        "description": "Authentication token for api access."
       }
     },
     "railsEnv": {
@@ -95,7 +95,7 @@
     }
   },
   "variables": {
-    "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/130-create-a-release-pipeline-for-background-web-app/templates/"
+    "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/templates/"
   },
   "resources": [
     {
@@ -109,11 +109,11 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
+          "containerInstanceName": {
+            "value": "[parameters('containerInstanceName')]"
+          },
           "containerName": {
             "value": "[parameters('containerName')]"
-          },
-          "containerGroupName": {
-            "value": "[parameters('containerGroupName')]"
           },
           "imageName": {
             "value": "[parameters('imageName')]"

--- a/azure/backgroundJobTemplate.json
+++ b/azure/backgroundJobTemplate.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "containerName": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "authenticationToken": {
+      "type": "string",
+      "metadata": {
+        "description": "Authentication token for api access."
+      }
+    },
+    "imageName": {
+      "type": "string",
+      "metadata": {
+        "description": "The container image to pull from the server. Should be in image:tag format."
+      }
+    },
+    "railsEnv": {
+      "type": "string",
+      "defaultValue": "production",
+      "metadata": {
+        "description": "Environment for the rails app."
+      }
+    },
+    "databaseName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the database that the app will connect to."
+      }
+    },
+    "databaseServerHostName": {
+      "type": "string",
+      "metadata": {
+        "description": "The fqdn of the psql server hosting the database."
+      }
+    },
+    "databasePort": {
+      "type": "string",
+      "metadata": {
+        "description": "The default port for the psql server."
+      }
+    },
+    "databaseUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "The username used to connect to the database."
+      }
+    },
+    "databasePassword": {
+      "type": "string",
+      "metadata": {
+        "description": "The password used to connect to the database."
+      }
+    },
+    "secretKeyBase": {
+      "type": "string",
+      "metadata": {
+        "description": "Secret Key Base."
+      }
+    },
+    "sentryDSN": {
+      "type": "string",
+      "metadata": {
+        "description": "Connection string for Sentry monitoring."
+      }
+    },
+    "settingsAuthenticationSecret": {
+      "type": "string",
+      "metadata": {
+        "description": "Auth secret for manage back-end."
+      }
+    },
+    "settingsManageApiSecret": {
+      "type": "string",
+      "metadata": {
+        "description": "The secret shared between manage courses backend and manage courses API to authorize requests."
+      }
+    },
+    "settingsSearchApiSecret": {
+      "type": "string",
+      "metadata": {
+        "description": "The secret shared between manage courses backend and search and compare API to authorize requests."
+      }
+    }
+  },
+  "variables": {
+    "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/ARM-Template-for-Azure-Container-Instances/templates/",
+  },
+  "resources": [
+
+    {
+      "name": "container-instances",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2017-05-10",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'), 'container-instances.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "containerName": {
+            "value": "[parameters('containerName')]"
+          },
+          "imageName": {
+            "value": "[parameters('imageName')]"
+          },
+          "environmentVariables": {
+            "value": [
+              {
+                "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
+                "value": "[reference('app-insights').outputs.instrumentationKey.value]"
+              },
+              {
+                "name": "RAILS_ENV",
+                "value": "[parameters('railsEnv')]"
+              },
+              {
+                "name": "AUTHENTICATION_TOKEN",
+                "value": "[parameters('authenticationToken')]"
+              },
+              {
+                "name": "DB_DATABASE",
+                "value": "[parameters('databaseName')]"
+              },
+              {
+                "name": "DB_HOSTNAME",
+                "value": "[parameters('databaseServerHostName')]"
+              },
+              {
+                "name": "DB_PASSWORD",
+                "value": "[parameters('databasePassword')]"
+              },
+              {
+                "name": "DB_USERNAME",
+                "value": "[parameters('databaseUsername')]"
+              },
+              {
+                "name": "DB_PORT",
+                "value": "[parameters('databasePort')]"
+              },
+              {
+                "name": "SECRET_KEY_BASE",
+                "value": "[parameters('secretKeyBase')]"
+              },
+              {
+                "name": "SENTRY_DSN",
+                "value": "[parameters('sentryDSN')]"
+              },
+              {
+                "name": "SETTINGS__AUTHENTICATION__SECRET",
+                "value": "[parameters('settingsAuthenticationSecret')]"
+              },
+              {
+                "name": "SETTINGS__MANAGE_API__SECRET",
+                "value": "[parameters('settingsManageApiSecret')]"
+              },
+              {
+                "name": "SETTINGS__SEARCH_API__SECRET",
+                "value": "[parameters('settingsSearchApiSecret')]"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/azure/backgroundJobTemplate.json
+++ b/azure/backgroundJobTemplate.json
@@ -116,7 +116,7 @@
               },
               {
                 "name": "AUTHENTICATION_TOKEN",
-                "value": "[parameters('authenticationToken')]"
+                "secureValue": "[parameters('authenticationToken')]"
               },
               {
                 "name": "DB_DATABASE",
@@ -128,7 +128,7 @@
               },
               {
                 "name": "DB_PASSWORD",
-                "value": "[parameters('databasePassword')]"
+                "secureValue": "[parameters('databasePassword')]"
               },
               {
                 "name": "DB_USERNAME",
@@ -140,23 +140,23 @@
               },
               {
                 "name": "SECRET_KEY_BASE",
-                "value": "[parameters('secretKeyBase')]"
+                "secureValue": "[parameters('secretKeyBase')]"
               },
               {
                 "name": "SENTRY_DSN",
-                "value": "[parameters('sentryDSN')]"
+                "secureValue": "[parameters('sentryDSN')]"
               },
               {
                 "name": "SETTINGS__AUTHENTICATION__SECRET",
-                "value": "[parameters('settingsAuthenticationSecret')]"
+                "secureValue": "[parameters('settingsAuthenticationSecret')]"
               },
               {
                 "name": "SETTINGS__MANAGE_API__SECRET",
-                "value": "[parameters('settingsManageApiSecret')]"
+                "secureValue": "[parameters('settingsManageApiSecret')]"
               },
               {
                 "name": "SETTINGS__SEARCH_API__SECRET",
-                "value": "[parameters('settingsSearchApiSecret')]"
+                "secureValue": "[parameters('settingsSearchApiSecret')]"
               }
             ]
           }


### PR DESCRIPTION
### Context
Automate deployment of background jobs docker images onto an Azure Container Instance (ACI). ARM template has been created to deploy the ACI infrastructure using Azure Devops Release pipeline. 

### Changes proposed in this pull request
New additional ARM template for for background job creation. This ARM template has no dependency and does not replace existing template for Backend app services (template.json). 

### Guidance to review
New file created under Azure folder


