### PR TITLE
[1798] Make sure an Org Name has been entered via MCB providers create

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,8 +64,6 @@ gem 'terminal-table'
 #   tabulo is even more flexible than terminal-table, used for the audit
 #   stuff for now, probably worth switching other commands to it later
 gem 'tabulo'
-#   terminfo allows us to get terminal info like width, etc.
-gem 'tty-screen'
 
 # For querying third party APIs
 gem 'faraday'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -449,7 +449,6 @@ DEPENDENCIES
   tabulo
   terminal-table
   timecop
-  tty-screen
   tzinfo-data
   uk_postcode
   webmock

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -10,4 +10,6 @@
 class Organisation < ApplicationRecord
   has_and_belongs_to_many :users
   has_and_belongs_to_many :providers
+
+  validates :name, presence: true
 end

--- a/lib/mcb/commands/courses/list.rb
+++ b/lib/mcb/commands/courses/list.rb
@@ -11,8 +11,6 @@ run do |opts, args, _cmd|
 
   tp.set :capitalize_headers, false
 
-  puts "Your terminal is --> TTY::Screen.cols <-- wide"
-
   output = [
     '',
     'Course:',

--- a/lib/mcb/provider_cli.rb
+++ b/lib/mcb/provider_cli.rb
@@ -40,7 +40,7 @@ module MCB
     end
 
     def ask_organisation_name
-      @cli.ask("What organisation should the new provider be added to?  ")
+      @cli.ask("What Organisation should the new provider be added to? (Enter Org Name)  ")
     end
 
     def ask_name_of_first_location

--- a/lib/mcb/provider_editor.rb
+++ b/lib/mcb/provider_editor.rb
@@ -88,22 +88,22 @@ module MCB
 
     def find_or_create_organisation
       finished_picking_organisation = false
-      org_name_input = nil
 
-      until finished_picking_organisation && org_name_input.present?
-        org_name_input = @cli.ask_organisation_name
+      until finished_picking_organisation
+        organisation_name = @cli.ask_organisation_name
 
-        if org_name_input.present?
-          organisation = Organisation.find_or_initialize_by(name: org_name_input)
-
-          if organisation.persisted?
-            finished_picking_organisation = true
-          elsif organisation.new_record? && @cli.confirm_new_organisation_needed?
-            organisation.save!
-            finished_picking_organisation = true
-          end
-        else
+        if organisation_name.blank?
           puts "Organisation name cannot be blank."
+          next
+        end
+
+        organisation = Organisation.find_or_initialize_by(name: organisation_name)
+
+        if organisation.persisted?
+          finished_picking_organisation = true
+        elsif organisation.new_record? && @cli.confirm_new_organisation_needed?
+          organisation.save!
+          finished_picking_organisation = true
         end
       end
 

--- a/lib/mcb/provider_editor.rb
+++ b/lib/mcb/provider_editor.rb
@@ -88,13 +88,22 @@ module MCB
 
     def find_or_create_organisation
       finished_picking_organisation = false
-      until finished_picking_organisation
-        organisation = Organisation.find_or_initialize_by(name: @cli.ask_organisation_name)
-        if organisation.persisted?
-          finished_picking_organisation = true
-        elsif organisation.new_record? && @cli.confirm_new_organisation_needed?
-          organisation.save!
-          finished_picking_organisation = true
+      org_name_input = nil
+
+      until finished_picking_organisation && org_name_input.present?
+        org_name_input = @cli.ask_organisation_name
+
+        if org_name_input.present?
+          organisation = Organisation.find_or_initialize_by(name: org_name_input)
+
+          if organisation.persisted?
+            finished_picking_organisation = true
+          elsif organisation.new_record? && @cli.confirm_new_organisation_needed?
+            organisation.save!
+            finished_picking_organisation = true
+          end
+        else
+          puts "Organisation name cannot be blank."
         end
       end
 

--- a/lib/mcb/provider_editor.rb
+++ b/lib/mcb/provider_editor.rb
@@ -36,7 +36,7 @@ module MCB
 
       puts "\nAbout to create the Provider"
       if @cli.confirm_creation? && try_saving_provider
-        organisation = find_or_create_organisation
+        organisation = ask_and_set_organisation
 
         update_organisation_with_admins(organisation)
 
@@ -86,10 +86,10 @@ module MCB
       end
     end
 
-    def find_or_create_organisation
-      finished_picking_organisation = false
+    def ask_and_set_organisation
+      organisation = nil
 
-      until finished_picking_organisation
+      until organisation.present?
         organisation_name = @cli.ask_organisation_name
 
         if organisation_name.blank?
@@ -97,18 +97,25 @@ module MCB
           next
         end
 
-        organisation = Organisation.find_or_initialize_by(name: organisation_name)
-
-        if organisation.persisted?
-          finished_picking_organisation = true
-        elsif organisation.new_record? && @cli.confirm_new_organisation_needed?
-          organisation.save!
-          finished_picking_organisation = true
-        end
+        organisation = find_or_create_organisation(organisation_name)
       end
 
       # connect provider to org
       provider.organisations << organisation
+
+      organisation
+    end
+
+    def find_or_create_organisation(organisation_name)
+      organisation = Organisation.find_or_initialize_by(name: organisation_name)
+
+      if organisation.new_record?
+        if @cli.confirm_new_organisation_needed?
+          organisation.save!
+        else
+          organisation = nil
+        end
+      end
 
       organisation
     end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -29,7 +29,7 @@
 FactoryBot.define do
   factory :course do
     sequence(:course_code) { |n| "C#{n}D3" }
-    name { Faker::ProgrammingLanguage.name }
+    name { Faker::Lorem.word }
     qualification { :pgce_with_qts }
     with_higher_education
 

--- a/spec/lib/mcb/provider_editor_spec.rb
+++ b/spec/lib/mcb/provider_editor_spec.rb
@@ -210,6 +210,47 @@ describe MCB::ProviderEditor do
         end
       end
 
+      context "when adding a new provider into an organisation" do
+        it "does not accept zero input" do
+          output, = run_new_provider_wizard(
+            *valid_answers,
+            'y', # confirm creation
+            '', # Empty Org Name
+            # adding the provider into a new organisation
+            desired_attributes[:organisation_name],
+            "y" # confirm creation of a new org
+          )
+
+          expect(output).to include('Organisation name cannot be blank.')
+        end
+
+        it "does not accept new line" do
+          output, = run_new_provider_wizard(
+            *valid_answers,
+            'y', # confirm creation
+            "\n", # Empty Org Name
+            # adding the provider into a new organisation
+            desired_attributes[:organisation_name],
+            "y" # confirm creation of a new org
+          )
+
+          expect(output).to include('Organisation name cannot be blank.')
+        end
+
+        it "does not accept only whitespace" do
+          output, = run_new_provider_wizard(
+            *valid_answers,
+            'y', # confirm creation
+            "   ", # Empty Org Name
+            # adding the provider into a new organisation
+            desired_attributes[:organisation_name],
+            "y" # confirm creation of a new org
+          )
+
+          expect(output).to include('Organisation name cannot be blank.')
+        end
+      end
+
       context "when adding a new provider into an existing organisation" do
         let!(:existing_organisation) { create(:organisation, name: desired_attributes[:organisation_name]) }
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -16,4 +16,26 @@ RSpec.describe Organisation, type: :model do
     it { should have_and_belong_to_many(:users) }
     it { should have_and_belong_to_many(:providers) }
   end
+
+  describe 'validations' do
+    subject { build(:organisation, name: name) }
+
+    context 'when name is empty string' do
+      let(:name) { '  ' }
+
+      it { should_not be_valid }
+    end
+
+    context 'when name is nil' do
+      let(:name) { nil }
+
+      it { should_not be_valid }
+    end
+
+    context 'when name is a school' do
+      let(:name) { 'High School' }
+
+      it { should be_valid }
+    end
+  end
 end


### PR DESCRIPTION
### Context

Providers were created with an Organisation without a name.

### Changes proposed in this pull request

Before: Was able to create/assign Providers to organisation with an empty name
After: Must provide an Organisation name to create a new Provider

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
