### PR TITLE
[1905] Improve performance of applications accepted from migration

### DIFF
--- a/db/migrate/20190806102256_add_applications_open_from_to_courses.rb
+++ b/db/migrate/20190806102256_add_applications_open_from_to_courses.rb
@@ -1,16 +1,28 @@
 class AddApplicationsOpenFromToCourses < ActiveRecord::Migration[5.2]
-  def change
+  def up
     add_column :course, :applications_open_from, :date
 
+    say_with_time 'Ensuring next recruitment cycle has the correct application start date' do
+      RecruitmentCycle.next_recruitment_cycle.update!(application_start_date: Date.new(2019, 10, 8))
+    end
+
     say_with_time 'Setting applications_open_from to one held within sites' do
-      Course.all.each do |course|
-        if course.recruitment_cycle.current?
-          applications_open_from = course.site_statuses.order("applications_accepted_from ASC").first.applications_accepted_from
-          course.update!(applications_open_from: applications_open_from)
+      current_recruitment_cycle = RecruitmentCycle.current_recruitment_cycle
+      current_recruitment_cycle.courses.includes(:site_statuses).includes(provider: :recruitment_cycle).all.each do |course|
+        if !course.site_statuses.empty?
+          applications_open_from = course.site_statuses.min_by(&:applications_accepted_from).applications_accepted_from
+          course.update_column(:applications_open_from, applications_open_from)
         else
-          course.update!(applications_open_from: course.recruitment_cycle.application_start_date)
+          course.update_column(:applications_open_from, current_recruitment_cycle.application_start_date)
         end
       end
+
+      next_recruitment_cycle = RecruitmentCycle.next_recruitment_cycle
+      next_recruitment_cycle.courses.update_all(applications_open_from: next_recruitment_cycle.application_start_date)
     end
+  end
+
+  def down
+    remove_column :course, :applications_open_from
   end
 end


### PR DESCRIPTION
### Context

Following the migrations added in #684 it was discovered that they ran poorly on production data (300-400 seconds on my laptop). Indicating that it would be good to improve performance.

![image](https://user-images.githubusercontent.com/976254/62696243-e9990800-b9cf-11e9-9d3e-fed6c117634e.png)

### Changes proposed in this pull request

- Update the migration to use `includes` to pre-load several of the relations
- Sort `site_statuses` in memory
- Skip validations when updating
- Update all courses for the next recruitment cycle in one batch

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
