### PR TITLE
[1836] Use background process to sync

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -44,13 +44,9 @@ module API
         if @provider.publishable?
           @provider.publish_enrichment(@current_user)
 
-          if courses_synced?(@provider.syncable_courses)
-            head :ok
-          else
-            raise RuntimeError.new(
-              "#{@provider} failed to sync these courses #{@provider.syncable_courses.pluck(:course_code)}"
-            )
-          end
+          courses_synced?(@provider.syncable_courses)
+
+          head :ok
         else
           render jsonapi_errors: @provider.errors, status: :unprocessable_entity
         end
@@ -74,13 +70,10 @@ module API
             "#{@provider} is not from the current recruitment cycle"
           )
         end
-        if courses_synced?(@provider.syncable_courses)
-          head :ok
-        else
-          raise RuntimeError.new(
-            "#{@provider} failed to sync these courses #{@provider.syncable_courses.pluck(:course_code)}"
-          )
-        end
+
+        courses_synced?(@provider.syncable_courses)
+
+        head :ok
       end
 
     private
@@ -168,9 +161,7 @@ module API
       end
 
       def courses_synced?(syncable_courses)
-        SearchAndCompareAPIService::Request.sync(
-          syncable_courses
-        )
+        SyncCoursesToFindJob.perform_later(*syncable_courses)
       end
     end
   end

--- a/spec/requests/api/v2/providers/publish_spec.rb
+++ b/spec/requests/api/v2/providers/publish_spec.rb
@@ -73,15 +73,10 @@ describe 'Provider Publish API v2', type: :request do
       context 'when the sync API is available' do
         let(:sync_body) { include("\"ProgrammeCode\":\"#{course1.course_code}\"", "\"ProgrammeCode\":\"#{course2.course_code}\"") }
         it 'syncs a providers courses' do
-          subject
+          perform_enqueued_jobs do
+            subject
+          end
           expect(sync_stub).to have_been_requested
-        end
-      end
-
-      context 'when the sync API is unavailable' do
-        let(:search_api_status) { 409 }
-        it 'raises an error' do
-          expect { subject }.to raise_error(RuntimeError, "#{provider} failed to sync these courses #{[course1.course_code, course2.course_code]}")
         end
       end
     end

--- a/spec/requests/api/v2/providers/sync_courses_with_search_and_compare_spec.rb
+++ b/spec/requests/api/v2/providers/sync_courses_with_search_and_compare_spec.rb
@@ -83,16 +83,10 @@ describe 'Courses API v2', type: :request do
           end
 
           it 'should make the appropriate request' do
-            subject
+            perform_enqueued_jobs do
+              subject
+            end
             expect(stubbed_request).to have_been_requested
-          end
-        end
-
-        context 'when an unsuccessful external call to search has been made' do
-          let(:status) { 451 }
-
-          it 'should throw an error' do
-            expect { subject }.to raise_error("#{provider} failed to sync these courses #{[syncable_course.course_code]}")
           end
         end
       end

--- a/spec/requests/api/v2/providers/sync_courses_with_search_and_compare_spec.rb
+++ b/spec/requests/api/v2/providers/sync_courses_with_search_and_compare_spec.rb
@@ -86,7 +86,9 @@ describe 'Courses API v2', type: :request do
             perform_enqueued_jobs do
               subject
             end
-            expect(stubbed_request).to have_been_requested
+
+            expect(WebMock)
+              .to have_requested(:put, "#{Settings.search_api.base_url}/api/courses/")
           end
         end
       end


### PR DESCRIPTION
### Context

Add job to publish a single provider's courses to find.

### Changes proposed in this pull request

Use ActiveJob to sync

### Guidance to review

I do not have the whole stack running to test this but it is based heavily from https://github.com/DFE-Digital/manage-courses-backend/pull/643

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
