### PR TITLE
[1919] Advance validation for accrediting provider description word

### DIFF
--- a/app/models/accrediting_provider_enrichment.rb
+++ b/app/models/accrediting_provider_enrichment.rb
@@ -1,0 +1,39 @@
+class AccreditingProviderEnrichment
+  include ActiveModel::Validations
+  include ActiveModel::Model
+
+  attr_accessor :UcasProviderCode, :Description
+
+  validates :Description, words_count: { maximum: 100 }
+
+  def initialize(attrs)
+    attrs.each do |attr, value|
+      send("#{attr}=", value) unless attr == "errors"
+    end
+  end
+
+  def attributes
+    %i[UcasProviderCode Description].inject({}) do |hash, attr|
+      hash[attr] = send(attr)
+      hash
+    end
+  end
+
+  class ArraySerializer
+    class << self
+      def load(json)
+        if json.present?
+          arr = JSON.parse json
+
+          arr.map do |item|
+            AccreditingProviderEnrichment.new(item)
+          end
+        end
+      end
+
+      def dump(obj)
+        obj.to_json if obj
+      end
+    end
+  end
+end

--- a/app/models/accrediting_provider_enrichment.rb
+++ b/app/models/accrediting_provider_enrichment.rb
@@ -2,6 +2,7 @@ class AccreditingProviderEnrichment
   include ActiveModel::Validations
   include ActiveModel::Model
 
+  # Pascal cased as the original is store like so.
   attr_accessor :UcasProviderCode, :Description
 
   validates :Description, words_count: { maximum: 100 }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -175,10 +175,10 @@ class Course < ApplicationRecord
 
     accrediting_provider_enrichment = provider_enrichment.accrediting_provider_enrichments
       .find do |provider|
-      provider['UcasProviderCode'] == accrediting_provider.provider_code
+      provider.UcasProviderCode == accrediting_provider.provider_code
     end
 
-    accrediting_provider_enrichment['Description'] if accrediting_provider_enrichment.present?
+    accrediting_provider_enrichment.Description if accrediting_provider_enrichment.present?
   end
 
   def publishable?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -302,8 +302,22 @@ private
       # `full_messages_for` here will remove any `^`s defined in the validator or en.yml.
       # We still need it for later, so re-add it.
       # jsonapi_errors will throw if it's given an array, so we call `.first`.
+
       message = "^" + enrichment.errors.full_messages_for(field).first.to_s
-      errors.add field.to_sym, message
+
+      if field == :accrediting_provider_enrichments
+
+        enrichment.accrediting_provider_enrichments.each_with_index { |accrediting_provider_enrichment, _index|
+          if accrediting_provider_enrichment['Description'].scan(/\S+/).size > 100
+            accrediting_provider = accrediting_providers.find { |ap| ap.provider_code == accrediting_provider_enrichment['UcasProviderCode'] }
+
+            errors.add "accredited_bodies".to_sym, "#{message} for #{accrediting_provider.provider_name}"
+          end
+        }
+      else
+
+        errors.add field.to_sym, message
+      end
     end
   end
 

--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -46,6 +46,8 @@ class ProviderEnrichment < ApplicationRecord
                                                     store_key: 'AccreditingProviderEnrichments']
 
 
+  validate :validate_accrediting_provider_enrichments_descriptions
+
   validates :train_with_us, words_count: { maximum: 250 }
   validates :train_with_disability, words_count: { maximum: 250 }
 
@@ -53,6 +55,16 @@ class ProviderEnrichment < ApplicationRecord
             :address1, :address3, :address4,
             :postcode, :train_with_us, :train_with_disability,
             presence: true, on: :publish
+
+  def validate_accrediting_provider_enrichments_descriptions
+    if accrediting_provider_enrichments.present? && accrediting_provider_enrichments.is_a?(Array)
+
+      if accrediting_provider_enrichments.any? { |enrichment| enrichment['Description'].scan(/\S+/).size > 100 }
+        errors.add(:accrediting_provider_enrichments, "^Reduce the word count")
+      end
+
+    end
+  end
 
   def has_been_published_before?
     last_published_at.present?

--- a/spec/models/provider_enrichment_spec.rb
+++ b/spec/models/provider_enrichment_spec.rb
@@ -94,4 +94,83 @@ describe ProviderEnrichment, type: :model do
       its(:provider_code) { should eq(existing_provider_code) }
     end
   end
+
+  describe 'validation' do
+    describe 'on publish' do
+      it { should validate_presence_of(:email).on(:publish) }
+      it { should validate_presence_of(:website).on(:publish) }
+      it { should validate_presence_of(:telephone).on(:publish) }
+
+      it { should validate_presence_of(:address1).on(:publish) }
+      it { should validate_presence_of(:address3).on(:publish) }
+      it { should validate_presence_of(:address4).on(:publish) }
+
+      it { should validate_presence_of(:postcode).on(:publish) }
+      it { should validate_presence_of(:train_with_us).on(:publish) }
+      it { should validate_presence_of(:train_with_disability).on(:publish) }
+    end
+
+    describe '#train_with_us' do
+      let(:word_count) { 250 }
+      let(:train_with_us) { Faker::Lorem.sentence(word_count: word_count) }
+
+      subject { build :provider_enrichment, train_with_us: train_with_us }
+
+      context 'word count within limit' do
+        it { should be_valid }
+      end
+
+      context 'word count exceed limit' do
+        let(:word_count) { 250 + 1 }
+        it { should_not be_valid }
+      end
+    end
+
+    describe '#train_with_disability' do
+      let(:word_count) { 250 }
+      let(:train_with_disability) { Faker::Lorem.sentence(word_count: word_count) }
+
+      subject { build :provider_enrichment, train_with_disability: train_with_disability }
+
+      context 'word count within limit' do
+        it { should be_valid }
+      end
+
+      context 'word count exceed limit' do
+        let(:word_count) { 250 + 1 }
+        it { should_not be_valid }
+      end
+    end
+
+    describe '#accrediting_provider_enrichments' do
+      let(:word_count) { 100 }
+
+      let(:accrediting_provider_enrichments) {
+        result = []
+        10.times do |index|
+          result <<
+            {
+              "Description" => Faker::Lorem.sentence(word_count: word_count),
+              "UcasProviderCode" => "UPC#{index}"
+            }
+        end
+        result
+      }
+
+      let(:provider_enrichment) do
+        build :provider_enrichment, accrediting_provider_enrichments: accrediting_provider_enrichments
+      end
+
+      subject { provider_enrichment }
+
+      context 'word count within limit' do
+        it { should be_valid }
+      end
+
+      context 'word count exceed limit' do
+        let(:word_count) { 100 + 1 }
+        it { should_not be_valid }
+      end
+    end
+  end
 end

--- a/spec/requests/api/v2/providers/update_accrediting_providers_spec.rb
+++ b/spec/requests/api/v2/providers/update_accrediting_providers_spec.rb
@@ -72,6 +72,33 @@ describe 'PATCH /providers/:provider_code' do
         expect(accredited_body.dig("provider_name")).to eq(accrediting_provider.provider_name)
         expect(accredited_body.dig("description")).to eq(new_description)
       end
+
+      context 'failed validation' do
+        let(:new_description) {
+          Faker::Lorem.sentence(word_count: 101)
+        }
+        it "creates a draft enrichment for the provider with the accredited body enrichment" do
+          expect {
+            patch_request(enrichment_payload)
+          }.to_not(change { provider.reload.enrichments.count })
+        end
+        let(:json_data) { JSON.parse(subject.body)['errors'] }
+        subject do
+          patch_request(enrichment_payload)
+          response
+        end
+
+        it { should have_http_status(:unprocessable_entity) }
+
+        it 'has validation error details' do
+          expect(json_data.count).to eq 1
+          expect(json_data[0]["detail"]).to eq("Reduce the word count for #{accrediting_provider.provider_name}")
+        end
+
+        it 'has validation error pointers' do
+          expect(json_data[0]["source"]["pointer"]).to eq("/data/attributes/accredited_bodies")
+        end
+      end
     end
 
     context 'provider has only a single draft enrichments' do

--- a/spec/requests/api/v2/providers/update_accrediting_providers_spec.rb
+++ b/spec/requests/api/v2/providers/update_accrediting_providers_spec.rb
@@ -61,9 +61,10 @@ describe 'PATCH /providers/:provider_code' do
         }.to(change { provider.reload.enrichments.count }.from(0).to(1))
 
         expect(provider.enrichments.draft.first.accrediting_provider_enrichments.count).to eq(courses.size)
-        expect(provider.enrichments.draft.first.accrediting_provider_enrichments.first).to eq(
-          "Description" => new_description, "UcasProviderCode" => accrediting_provider.provider_code
-        )
+
+        accrediting_provider_enrichment = provider.enrichments.draft.first.accrediting_provider_enrichments.first
+        expect(accrediting_provider_enrichment.Description).to eq(new_description)
+        expect(accrediting_provider_enrichment.UcasProviderCode).to eq(accrediting_provider.provider_code)
 
         expect(response).to have_http_status(:ok)
         accredited_body = JSON.parse(response.body).dig("data", "attributes", "accredited_bodies").first
@@ -140,9 +141,10 @@ describe 'PATCH /providers/:provider_code' do
         }.to_not(change { provider.reload.enrichments.count })
 
         expect(provider.enrichments.draft.first.accrediting_provider_enrichments.count).to eq(courses.size)
-        expect(provider.enrichments.draft.first.accrediting_provider_enrichments.first).to eq(
-          "Description" => new_description, "UcasProviderCode" => accrediting_provider.provider_code
-        )
+
+        accrediting_provider_enrichment = provider.enrichments.draft.first.accrediting_provider_enrichments.first
+        expect(accrediting_provider_enrichment.Description).to eq(new_description)
+        expect(accrediting_provider_enrichment.UcasProviderCode).to eq(accrediting_provider.provider_code)
 
         expect(response).to have_http_status(:ok)
         accredited_body = JSON.parse(response.body).dig("data", "attributes", "accredited_bodies").first
@@ -170,9 +172,10 @@ describe 'PATCH /providers/:provider_code' do
         }.to(change { provider.reload.enrichments.count }.from(0).to(1))
 
         expect(provider.enrichments.draft.first.accrediting_provider_enrichments.count).to eq(courses.size)
-        expect(provider.enrichments.draft.first.accrediting_provider_enrichments.first).to eq(
-          "Description" => new_description, "UcasProviderCode" => accrediting_provider.provider_code
-        )
+        accrediting_provider_enrichment = provider.enrichments.draft.first.accrediting_provider_enrichments.first
+
+        expect(accrediting_provider_enrichment.Description).to eq(new_description)
+        expect(accrediting_provider_enrichment.UcasProviderCode).to eq(accrediting_provider.provider_code)
 
         expect(response).to have_http_status(:ok)
         accredited_body = JSON.parse(response.body).dig("data", "attributes", "accredited_bodies").first
@@ -195,9 +198,10 @@ describe 'PATCH /providers/:provider_code' do
         }.to_not(change { provider.reload.enrichments.count })
 
         expect(provider.enrichments.draft.first.accrediting_provider_enrichments.count).to eq(courses.size)
-        expect(provider.enrichments.draft.first.accrediting_provider_enrichments.first).to eq(
-          "Description" => new_description, "UcasProviderCode" => accrediting_provider.provider_code
-        )
+
+        accrediting_provider_enrichment = provider.enrichments.draft.first.accrediting_provider_enrichments.first
+        expect(accrediting_provider_enrichment.Description).to eq(new_description)
+        expect(accrediting_provider_enrichment.UcasProviderCode).to eq(accrediting_provider.provider_code)
 
         expect(response).to have_http_status(:ok)
         accredited_body = JSON.parse(response.body).dig("data", "attributes", "accredited_bodies").first


### PR DESCRIPTION
### Context
Main different between this PR and the #695 

word count validation is done per accrediting provider enrichments' description
 via the introduction of said class

### Changes proposed in this pull request
Added word count validation for the description of an accrediting provider enrichment

### Guidance to review


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
