### PR TITLE
[1933] Fix latest_enrichment scope on provider model 

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -56,9 +56,8 @@ class Provider < ApplicationRecord
 
   has_many :sites
   has_one :latest_enrichment,
-          class_name: "ProviderEnrichment" do
-    enrichments.latest_created_at
-  end
+          -> { latest_created_at },
+          class_name: "ProviderEnrichment"
 
   has_many :enrichments,
            class_name: "ProviderEnrichment",

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -676,4 +676,14 @@ describe Provider, type: :model do
       end
     end
   end
+
+  describe "#latest_enrichment" do
+    let(:old_enrichment) { create(:provider_enrichment, created_at: 1.day.ago) }
+    let(:new_enrichment) { create(:provider_enrichment, created_at: 1.second.ago) }
+    let(:enrichments) { [new_enrichment, old_enrichment] }
+
+    it 'returns correct enrichment' do
+      expect(provider.latest_enrichment).to eq(new_enrichment)
+    end
+  end
 end


### PR DESCRIPTION
### Context

Updating provider enrichments doesn't work for some providers.

### Changes proposed in this pull request

The previously provided block was a no-op.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally