### PR TITLE
[1945] Update error message for provider enrichments

### DIFF
--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -49,8 +49,8 @@ class ProviderEnrichment < ApplicationRecord
                  accrediting_provider_enrichments: [:json,
                                                     store_key: 'AccreditingProviderEnrichments']
 
-  validates :train_with_us, words_count: { maximum: 250 }
-  validates :train_with_disability, words_count: { maximum: 250 }
+  validates :train_with_us, words_count: { maximum: 250, message: "^Reduce the word count for training with you" }
+  validates :train_with_disability, words_count: { maximum: 250, message: "^Reduce the word count for training with disabilities and other needs" }
 
   validates :email, :website, :telephone,
             :address1, :address3, :address4,


### PR DESCRIPTION
### Context

Two tweaks to error messages:

> Reduce the word count for train with us

"Reduce the word count for training with you"

> Reduce the word count for train with disability

"Reduce the word count for training with disabilities and other needs"

### Changes proposed in this pull request

Adds a message to the word count validation to display the correct error messages

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
