### PR TITLE
[1932] move send from subject to course

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -24,6 +24,7 @@
 #  discarded_at              :datetime
 #  age_range_in_years        :string
 #  applications_open_from    :date
+#  is_send                   :boolean          default(false)
 #
 
 class Course < ApplicationRecord
@@ -276,10 +277,6 @@ class Course < ApplicationRecord
 
   def level
     Subjects::CourseLevel.new(subjects.map(&:subject_name)).level
-  end
-
-  def is_send?
-    subjects.any?(&:is_send?)
   end
 
   def is_fee_based?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -24,7 +24,7 @@
 #  discarded_at              :datetime
 #  age_range_in_years        :string
 #  applications_open_from    :date
-#  is_send                   :boolean          default(false)
+#  is_send                   :boolean          default(FALSE)
 #
 
 class Course < ApplicationRecord

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -24,6 +24,7 @@
 #  discarded_at              :datetime
 #  age_range_in_years        :string
 #  applications_open_from    :date
+#  is_send                   :boolean          default(FALSE)
 #
 
 class CourseSerializer < ActiveModel::Serializer

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -79,4 +79,15 @@ class CourseSerializer < ActiveModel::Serializer
   def recruitment_cycle
     object.provider.recruitment_cycle.year
   end
+
+  # Course now has a `is_send` attribute so we do not need to model `SEND` courses using the
+  # Subject. However, API V1 is still expecting the Subject so we add it back in.
+  def subjects
+    return object.subjects unless object.is_send?
+
+    subjects_array = object.subjects.to_a
+    subjects_array << Subject.new(subject_code: 'U3', subject_name: 'Special Educational Needs')
+
+    subjects_array
+  end
 end

--- a/db/migrate/20190812153252_add_is_send_to_course.rb
+++ b/db/migrate/20190812153252_add_is_send_to_course.rb
@@ -1,0 +1,9 @@
+class AddIsSendToCourse < ActiveRecord::Migration[5.2]
+  def change
+    add_column :course, :is_send, :boolean, default: false
+
+    say_with_time 'Ensuring Courses have `is_send` set' do
+      Course.joins(:subjects).where(subject: { subject_code: 'U3' }).update_all(is_send: true)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_06_102256) do
+ActiveRecord::Schema.define(version: 2019_08_12_153252) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -89,6 +89,7 @@ ActiveRecord::Schema.define(version: 2019_08_06_102256) do
     t.datetime "discarded_at"
     t.string "age_range_in_years"
     t.date "applications_open_from"
+    t.boolean "is_send", default: false
     t.index ["accrediting_provider_code"], name: "index_course_on_accrediting_provider_code"
     t.index ["accrediting_provider_id"], name: "IX_course_accrediting_provider_id"
     t.index ["changed_at"], name: "index_course_on_changed_at", unique: true

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -24,6 +24,7 @@
 #  discarded_at              :datetime
 #  age_range_in_years        :string
 #  applications_open_from    :date
+#  is_send                   :boolean          default(FALSE)
 #
 
 FactoryBot.define do

--- a/spec/factory_specs/subject_spec.rb
+++ b/spec/factory_specs/subject_spec.rb
@@ -9,13 +9,4 @@ describe "Subject Factory" do
     its(:subject_name) { should eq 'Further Education' }
     it { should be_in(Subject.further_education) }
   end
-
-  describe "Subject 'Send' Factory" do
-    let(:subject) { create(:send_subject) }
-
-    it { should be_instance_of(Subject) }
-    it { should be_valid }
-    its(:subject_name) { should eq 'Special Educational Needs' }
-    its(:subject_code) { should eq 'U3' }
-  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -24,6 +24,7 @@
 #  discarded_at              :datetime
 #  age_range_in_years        :string
 #  applications_open_from    :date
+#  is_send                   :boolean          default(FALSE)
 #
 
 require 'rails_helper'

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -531,7 +531,7 @@ RSpec.describe Course, type: :model do
       its(:is_send?) { should be_falsey }
 
       context "with a SEND subject" do
-        subject { create(:course, subjects: [create(:send_subject)]) }
+        subject { create(:course, is_send: true) }
         its(:is_send?) { should be_truthy }
       end
     end

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -245,7 +245,7 @@ describe "Courses API", type: :request do
                 changed_since: timestamp_of_last_course.utc.strftime('%FT%T.%6NZ'),
                 per_page: 100
               }
-    )
+            )
             expect(response.headers["Link"]).to match "#{url}; rel=\"next\""
           end
         end
@@ -287,7 +287,7 @@ describe "Courses API", type: :request do
                 changed_since: timestamp_of_last_course.utc.strftime('%FT%T.%6NZ'),
                 per_page: 100
               }
-    )
+            )
             expect(response.headers["Link"]).to match "#{url}; rel=\"next\""
           end
         end

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -435,7 +435,7 @@ describe "Courses API", type: :request do
     end
 
     context 'with a SEND course' do
-      let(:course) { create(:course, provider: provider, subjects: [create(:subject), create(:send_subject)]) }
+      let(:course) { create(:course, provider: provider, is_send: true, subjects: [create(:subject)]) }
       let(:site) { create(:site_status, :published, course: course) }
 
       before do
@@ -454,6 +454,10 @@ describe "Courses API", type: :request do
         expect(json['subjects']).to include(
           'subject_code' => 'U3', 'subject_name' => 'Special Educational Needs'
         )
+      end
+
+      it 'does not create a SEND subject' do
+        expect(Subject.where(subject_code: 'U3').count).to eq(0)
       end
     end
   end

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -433,5 +433,28 @@ describe "Courses API", type: :request do
         expect(data.first['campus_statuses'].first['campus_code']).to eq(status3.site.code)
       end
     end
+
+    context 'with a SEND course' do
+      let(:course) { create(:course, provider: provider, subjects: [create(:subject), create(:send_subject)]) }
+      let(:site) { create(:site_status, :published, course: course) }
+
+      before do
+        course
+        site
+
+        get '/api/v1/courses', headers: { 'HTTP_AUTHORIZATION' => credentials }
+      end
+
+      it 'contains a SEND subject' do
+        json = JSON.parse(response.body).first
+
+        expect(json).to_not have_key('is_send') # API v2
+
+        expect(json['subjects'].length).to eq(2)
+        expect(json['subjects']).to include(
+          'subject_code' => 'U3', 'subject_name' => 'Special Educational Needs'
+        )
+      end
+    end
   end
 end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -10,7 +10,6 @@ describe 'Courses API v2', type: :request do
   end
   let(:course_subject_primary) { find_or_create(:subject, :primary) }
   let(:course_subject_mathematics) { find_or_create(:subject, :mathematics) }
-  let(:course_subject_send) { find_or_create(:send_subject) }
 
   let(:findable_open_course) {
     create(:course, :resulting_in_pgce_with_qts, :with_apprenticeship,
@@ -18,7 +17,8 @@ describe 'Courses API v2', type: :request do
            provider: provider,
            start_date: Time.now.utc,
            study_mode: :full_time,
-           subjects: [course_subject_primary, course_subject_mathematics, course_subject_send],
+           subjects: [course_subject_primary, course_subject_mathematics],
+           is_send: true,
            site_statuses: [courses_site_status],
            enrichments: [enrichment],
            maths: :must_have_qualification_at_application_time,

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -143,7 +143,7 @@ describe API::V2::SerializableCourse do
     it { expect(subject["attributes"]).to include("is_send?" => false) }
 
     context "with a SEND subject" do
-      let(:course) { create(:course, subjects: [find_or_create(:send_subject)]) }
+      let(:course) { create(:course, is_send: true) }
       it { expect(subject["attributes"]).to include("is_send?" => true) }
     end
   end

--- a/spec/serializers/course_serializer_spec.rb
+++ b/spec/serializers/course_serializer_spec.rb
@@ -36,4 +36,15 @@ RSpec.describe CourseSerializer do
   it { should include(course_code: course.course_code) }
   it { should include(name: course.name) }
   it { should include(recruitment_cycle: course.provider.recruitment_cycle.year) }
+  it { is_expected.to_not have_key(:is_send) } # Ensure V2 API is not being included.
+
+  context 'when the course is SEND' do
+    let(:course) { create :course, provider: provider, is_send: true }
+
+    it 'includes a SEND subject' do
+      expect(subject[:subjects]).to include(
+        'subject_code' => 'U3', 'subject_name' => 'Special Educational Needs'
+      )
+    end
+  end
 end

--- a/spec/serializers/course_serializer_spec.rb
+++ b/spec/serializers/course_serializer_spec.rb
@@ -24,6 +24,7 @@
 #  discarded_at              :datetime
 #  age_range_in_years        :string
 #  applications_open_from    :date
+#  is_send                   :boolean          default(FALSE)
 #
 
 require "rails_helper"

--- a/spec/serializers/search_and_compare/course_serializer_spec.rb
+++ b/spec/serializers/search_and_compare/course_serializer_spec.rb
@@ -7,14 +7,11 @@ describe SearchAndCompare::CourseSerializer do
     subject { resource }
 
     context 'an existing course' do
-      let(:with_send_subject) { true }
       let(:subject_names) { %w[Primary] }
       let(:subjects) do
         subjects = subject_names.map do |subject_name|
           build(:subject, subject_name: subject_name)
         end
-
-        subjects << build(:send_subject) if with_send_subject
 
         subjects
       end
@@ -35,6 +32,7 @@ describe SearchAndCompare::CourseSerializer do
                site_statuses: [site_status1, site_status2],
                enrichments: course_enrichments,
                subjects: subjects,
+               is_send: true,
                applications_open_from: '2018-10-09T00:00:00').tap do |c|
           # These sites, taken from real prod data, aren't actually valid in
           # that they're missing the following bits of data.


### PR DESCRIPTION
### Context

In able to easily edit a Course's SEND state. We need to remove the legacy implementation of SEND as a subject.

What we use for SEND for the C# App: https://github.com/DFE-Digital/manage-courses-backend/blob/c976d4ab6da8224db2a35b0e5499410c86627661/app/serializers/search_and_compare/course_serializer.rb#L52 

And the Subjects we pass for the C# App: https://github.com/DFE-Digital/manage-courses-backend/blob/c976d4ab6da8224db2a35b0e5499410c86627661/app/serializers/search_and_compare/course_serializer.rb#L226-L238

~~So I don't think there would be any impact to the C# App.~~

### Changes proposed in this pull request

- Add test to API V1 to ensure no regressions
- Add DB Column `is_send` as boolean to Course
- Update tests to reflect this new behaviour 

### Guidance to review

Are microservices effected by this change? 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
