### PR TITLE
[1916] Add Audits to Provider Enrichments

### DIFF
--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -23,7 +23,9 @@ class ProviderEnrichment < ApplicationRecord
 
   belongs_to :provider,
              inverse_of: 'enrichments'
-  audited associated_with: :provider
+
+  audited except: :json_data,
+          associated_with: :provider
 
   scope :latest_created_at, -> { order(created_at: :desc) }
   scope :latest_published_at, -> { order(last_published_at: :desc) }


### PR DESCRIPTION
### Context

Attribute `accrediting_provider_enrichments` was being added to the audits twice. Once at the top level and once within the `json data`

### Changes proposed in this pull request

Do not duplicate attribute in audit

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
