### PR TITLE
[1944] Add provider enrichment details validations

### DIFF
--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -52,7 +52,10 @@ class ProviderEnrichment < ApplicationRecord
   validates :train_with_us, words_count: { maximum: 250, message: "^Reduce the word count for training with you" }
   validates :train_with_disability, words_count: { maximum: 250, message: "^Reduce the word count for training with disabilities and other needs" }
 
-  validates :email, :website, :telephone,
+  validates :email, email: true, on: :update, if: Proc.new { |enrichment| enrichment.email_changed? }
+  validates :email, email: true, on: :publish
+
+  validates :website, :telephone,
             :address1, :address3, :address4,
             :postcode, :train_with_us, :train_with_disability,
             presence: true, on: :publish

--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -52,8 +52,10 @@ class ProviderEnrichment < ApplicationRecord
   validates :train_with_us, words_count: { maximum: 250, message: "^Reduce the word count for training with you" }
   validates :train_with_disability, words_count: { maximum: 250, message: "^Reduce the word count for training with disabilities and other needs" }
 
-  validates :email, email: true, on: :update, if: Proc.new { |enrichment| enrichment.email_changed? }
+  validates :email, email: true, on: :update, allow_nil: true
   validates :email, email: true, on: :publish
+
+  validates :telephone, phone: { message: '^Enter a valid telephone number' }, on: :update, allow_nil: true
 
   validates :website, :telephone,
             :address1, :address3, :address4,

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -1,0 +1,9 @@
+class EmailValidator < ActiveModel::Validator
+  EMAIL_VALIDATION_ERROR_MESSAGE = "^Enter an email address in the correct format, like name@example.com".freeze
+
+  def validate(record)
+    if record.email.nil? || record.email.empty? || !record.email.match?(/@/)
+      record.errors[:email] << EMAIL_VALIDATION_ERROR_MESSAGE
+    end
+  end
+end

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -1,9 +1,9 @@
-class EmailValidator < ActiveModel::Validator
+class EmailValidator < ActiveModel::EachValidator
   EMAIL_VALIDATION_ERROR_MESSAGE = "^Enter an email address in the correct format, like name@example.com".freeze
 
-  def validate(record)
-    if record.email.nil? || record.email.empty? || !record.email.match?(/@/)
-      record.errors[:email] << EMAIL_VALIDATION_ERROR_MESSAGE
+  def validate_each(record, attribute, value)
+    if value.blank? || !value.match?(/@/)
+      record.errors[attribute] << EMAIL_VALIDATION_ERROR_MESSAGE
     end
   end
 end

--- a/app/validators/phone_validator.rb
+++ b/app/validators/phone_validator.rb
@@ -1,0 +1,15 @@
+class PhoneValidator < ActiveModel::EachValidator
+  PHONE_VALIDATION_ERROR_MESSAGE = "^Enter a valid telephone number".freeze
+
+  def validate_each(record, attribute, value)
+    if value.blank? || is_invalid_phone_number_format?(value)
+      record.errors[attribute] << PHONE_VALIDATION_ERROR_MESSAGE
+    end
+  end
+
+private
+
+  def is_invalid_phone_number_format?(value)
+    value.match?(/[^ext()+\. 0-9]/)
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,7 +59,7 @@ en:
             website:
               blank: "^Enter website"
             telephone:
-              blank: "^Enter telephone"
+              blank: "^Enter a valid telephone number"
             address1:
               blank: "^Enter building or street"
             address3:

--- a/spec/factories/provider_enrichments.rb
+++ b/spec/factories/provider_enrichments.rb
@@ -33,7 +33,7 @@ FactoryBot.define do
     address3 { Faker::Address.city }
     address4 { Faker::Address.state }
     postcode { Faker::Address.postcode }
-    telephone { Faker::PhoneNumber.phone_number }
+    telephone { '01234 123 123 ext 123' }
     region_code { 'eastern' }
     train_with_us { Faker::Lorem.sentence.to_s }
     train_with_disability { Faker::Lorem.sentence.to_s }

--- a/spec/models/provider_enrichment_spec.rb
+++ b/spec/models/provider_enrichment_spec.rb
@@ -103,21 +103,48 @@ describe ProviderEnrichment, type: :model do
 
       describe 'email' do
         it 'validates email is present' do
-          enrichment.email = ""
+          enrichment.email = ''
           enrichment.valid?
 
           expect(enrichment.errors[:email]).to include("^Enter an email address in the correct format, like name@example.com")
         end
 
         it 'validates email contains an @ symbol' do
-          enrichment.email = "meow"
+          enrichment.email = 'meow'
           enrichment.valid?
 
           expect(enrichment.errors[:email]).to include("^Enter an email address in the correct format, like name@example.com")
         end
 
-        it 'does not validate if the email was not updated' do
-          enrichment.website = "cats4lyf.cat"
+        it 'Does not validate the email if it is not present'do
+          enrichment.website = 'cats4lyf.cat'
+
+          expect(enrichment.valid?).to be true
+        end
+      end
+
+      describe 'telephone' do
+        it 'validates telephone is present' do
+          enrichment.telephone = ""
+          enrichment.valid?
+
+          expect(enrichment.errors[:telephone]).to include("^Enter a valid telephone number")
+        end
+
+        it 'Correctly validates valid phone numbers' do
+          enrichment.telephone = "+447 123 123 123"
+          expect(enrichment.valid?).to be true
+        end
+
+        it 'Correctly invalidates invalid phone numbers' do
+          enrichment.telephone = "123cat456"
+          expect(enrichment.valid?).to be false
+          expect(enrichment.errors[:telephone]).to include("^Enter a valid telephone number")
+        end
+
+        it 'Does not validate the telephone if it is not present'do
+          enrichment.website = 'cats4lyf.cat'
+
           expect(enrichment.valid?).to be true
         end
       end
@@ -126,7 +153,7 @@ describe ProviderEnrichment, type: :model do
     describe 'on publish' do
       it { should validate_presence_of(:email).on(:publish).with_message("^Enter an email address in the correct format, like name@example.com") }
       it { should validate_presence_of(:website).on(:publish) }
-      it { should validate_presence_of(:telephone).on(:publish) }
+      it { should validate_presence_of(:telephone).on(:publish).with_message("^Enter a valid telephone number") }
 
       it { should validate_presence_of(:address1).on(:publish) }
       it { should validate_presence_of(:address3).on(:publish) }

--- a/spec/models/provider_enrichment_spec.rb
+++ b/spec/models/provider_enrichment_spec.rb
@@ -96,8 +96,35 @@ describe ProviderEnrichment, type: :model do
   end
 
   describe 'validation' do
+    describe 'on update' do
+      let(:provider) { build(:provider) }
+      let(:existing_provider_code) { nil }
+      let(:enrichment) { create(:provider_enrichment, provider: provider, provider_code: existing_provider_code) }
+
+      describe 'email' do
+        it 'validates email is present' do
+          enrichment.email = ""
+          enrichment.valid?
+
+          expect(enrichment.errors[:email]).to include("^Enter an email address in the correct format, like name@example.com")
+        end
+
+        it 'validates email contains an @ symbol' do
+          enrichment.email = "meow"
+          enrichment.valid?
+
+          expect(enrichment.errors[:email]).to include("^Enter an email address in the correct format, like name@example.com")
+        end
+
+        it 'does not validate if the email was not updated' do
+          enrichment.website = "cats4lyf.cat"
+          expect(enrichment.valid?).to be true
+        end
+      end
+    end
+
     describe 'on publish' do
-      it { should validate_presence_of(:email).on(:publish) }
+      it { should validate_presence_of(:email).on(:publish).with_message("^Enter an email address in the correct format, like name@example.com") }
       it { should validate_presence_of(:website).on(:publish) }
       it { should validate_presence_of(:telephone).on(:publish) }
 

--- a/spec/requests/api/v2/providers/publish_spec.rb
+++ b/spec/requests/api/v2/providers/publish_spec.rb
@@ -100,7 +100,7 @@ describe 'Provider Publish API v2', type: :request do
           expect(json_data.count).to eq 9
           expect(json_data[0]["detail"]).to eq("Enter an email address in the correct format, like name@example.com")
           expect(json_data[1]["detail"]).to eq("Enter website")
-          expect(json_data[2]["detail"]).to eq("Enter telephone")
+          expect(json_data[2]["detail"]).to eq("Enter a valid telephone number")
           expect(json_data[3]["detail"]).to eq("Enter building or street")
           expect(json_data[4]["detail"]).to eq("Enter town or city")
           expect(json_data[5]["detail"]).to eq("Enter county")

--- a/spec/requests/api/v2/providers/publish_spec.rb
+++ b/spec/requests/api/v2/providers/publish_spec.rb
@@ -98,7 +98,7 @@ describe 'Provider Publish API v2', type: :request do
 
         it 'has validation error details' do
           expect(json_data.count).to eq 9
-          expect(json_data[0]["detail"]).to eq("Enter email address")
+          expect(json_data[0]["detail"]).to eq("Enter an email address in the correct format, like name@example.com")
           expect(json_data[1]["detail"]).to eq("Enter website")
           expect(json_data[2]["detail"]).to eq("Enter telephone")
           expect(json_data[3]["detail"]).to eq("Enter building or street")

--- a/spec/requests/api/v2/providers/publishable_spec.rb
+++ b/spec/requests/api/v2/providers/publishable_spec.rb
@@ -66,7 +66,7 @@ describe 'Provider Publishable API v2', type: :request do
 
         it 'has validation error details' do
           expect(json_data.count).to eq 9
-          expect(json_data[0]["detail"]).to eq("Enter email address")
+          expect(json_data[0]["detail"]).to eq("Enter an email address in the correct format, like name@example.com")
           expect(json_data[1]["detail"]).to eq("Enter website")
           expect(json_data[2]["detail"]).to eq("Enter telephone")
           expect(json_data[3]["detail"]).to eq("Enter building or street")

--- a/spec/requests/api/v2/providers/publishable_spec.rb
+++ b/spec/requests/api/v2/providers/publishable_spec.rb
@@ -68,7 +68,7 @@ describe 'Provider Publishable API v2', type: :request do
           expect(json_data.count).to eq 9
           expect(json_data[0]["detail"]).to eq("Enter an email address in the correct format, like name@example.com")
           expect(json_data[1]["detail"]).to eq("Enter website")
-          expect(json_data[2]["detail"]).to eq("Enter telephone")
+          expect(json_data[2]["detail"]).to eq("Enter a valid telephone number")
           expect(json_data[3]["detail"]).to eq("Enter building or street")
           expect(json_data[4]["detail"]).to eq("Enter town or city")
           expect(json_data[5]["detail"]).to eq("Enter county")

--- a/spec/requests/api/v2/providers/update_spec.rb
+++ b/spec/requests/api/v2/providers/update_spec.rb
@@ -53,7 +53,7 @@ describe 'PATCH /providers/:provider_code' do
 
   let(:updated_attributes) do
     {
-      email: 'email_address',
+      email: 'cats@cats4lyf.cat',
       website: 'url',
       address1: 'number',
       address2: 'street',
@@ -202,7 +202,7 @@ describe 'PATCH /providers/:provider_code' do
 
       expect(json_response).to have_id(provider.reload.enrichments.first.id.to_s)
       expect(json_response).to have_type('provider_enrichment')
-      expect(json_response).to have_attribute(:email).with_value('email_address')
+      expect(json_response).to have_attribute(:email).with_value('cats@cats4lyf.cat')
       expect(json_response).to have_attribute(:website).with_value('url')
       expect(json_response).to have_attribute(:address1).with_value('number')
       expect(json_response).to have_attribute(:address2).with_value('street')

--- a/spec/validators/email_validator_spec.rb
+++ b/spec/validators/email_validator_spec.rb
@@ -1,5 +1,15 @@
 describe EmailValidator do
-  let(:model) { ExampleModel.new }
+  let(:model) do
+    cls = Class.new do
+      include ActiveRecord::Validations
+
+      attr_accessor :email
+
+      validates :email, email: true
+    end
+
+    cls.new
+  end
 
   describe 'With nil email address' do
     before do
@@ -53,15 +63,5 @@ describe EmailValidator do
 
       expect(model.valid?(:no_context)).to be true
     end
-  end
-
-private
-
-  class ExampleModel
-    include ActiveRecord::Validations
-
-    attr_accessor :email
-
-    validates :email, email: true
   end
 end

--- a/spec/validators/email_validator_spec.rb
+++ b/spec/validators/email_validator_spec.rb
@@ -1,0 +1,67 @@
+describe EmailValidator do
+  let(:model) { ExampleModel.new }
+
+  describe 'With nil email address' do
+    before do
+      model.email = nil
+      model.validate(:no_context)
+    end
+
+    it 'Returns invalid' do
+      expect(model.valid?(:no_context)).to be false
+    end
+
+    it 'Returns the correct error message' do
+      expect(model.errors[:email]).to include("^Enter an email address in the correct format, like name@example.com")
+    end
+  end
+
+  describe 'With empty email address supplied' do
+    before do
+      model.email = ""
+      model.validate(:no_context)
+    end
+
+    it 'Returns invalid' do
+      expect(model.valid?(:no_context)).to be false
+    end
+
+    it 'Returns the correct error message' do
+      expect(model.errors[:email]).to include("^Enter an email address in the correct format, like name@example.com")
+    end
+  end
+
+  describe 'With an email address in an invalid format' do
+    before do
+      model.email = "cats4lyf"
+      model.validate(:no_context)
+    end
+
+    it 'Returns invalid' do
+      expect(model.valid?(:no_context)).to be false
+    end
+
+    it 'Returns the correct error message' do
+      expect(model.errors[:email]).to include("^Enter an email address in the correct format, like name@example.com")
+    end
+  end
+
+  describe 'With a valid email address' do
+    it 'Returns valid' do
+      model.email = "cats@meow.cat"
+      model.validate(:no_context)
+
+      expect(model.valid?(:no_context)).to be true
+    end
+  end
+
+private
+
+  class ExampleModel
+    include ActiveRecord::Validations
+
+    attr_accessor :email
+
+    validates :email, email: true
+  end
+end

--- a/spec/validators/phone_validator_spec.rb
+++ b/spec/validators/phone_validator_spec.rb
@@ -1,0 +1,96 @@
+describe PhoneValidator do
+  let(:model) do
+    cls = Class.new do
+      include ActiveRecord::Validations
+
+      attr_accessor :phone_number
+
+      validates :phone_number, phone: true
+    end
+
+    cls.new
+  end
+
+  describe 'With nil phone number address' do
+    before do
+      model.phone_number = nil
+      model.validate(:no_context)
+    end
+
+    it 'Returns invalid' do
+      expect(model.valid?(:no_context)).to be false
+    end
+
+    it 'Returns the correct error message' do
+      expect(model.errors[:phone_number]).to include("^Enter a valid telephone number")
+    end
+  end
+
+  describe 'With empty phone number address supplied' do
+    before do
+      model.phone_number = ""
+      model.validate(:no_context)
+    end
+
+    it 'Returns invalid' do
+      expect(model.valid?(:no_context)).to be false
+    end
+
+    it 'Returns the correct error message' do
+      expect(model.errors[:phone_number]).to include("^Enter a valid telephone number")
+    end
+  end
+
+  describe 'With an phone number address in an invalid format' do
+    let(:invalid_telephone_numbers) do
+      [
+        "12 3 4 cat",
+        "12dog34",
+      ]
+    end
+
+    it 'Correctly invalidates invalid phone numbers' do
+      invalid_telephone_numbers.each do |number|
+        model.phone_number = number
+        expect(model.valid?(:no_context)).to(be(false), "Expected phone number #{number} to be invalid")
+      end
+    end
+  end
+
+  describe 'With a valid phone number address' do
+    let(:valid_telephone_numbers) do
+      [
+        "+447123 123 123",
+        "+447123123123",
+        "07123123123",
+        "01234 123 123 ext123",
+        "01234 123 123 ext 123",
+        "01234 123 123 x123",
+        "(01234) 123123",
+        "(12345) 123123",
+        "(+44) (0)1234 123456",
+        "+44 (0) 123 4567 123",
+        "123 1234 1234 ext 123",
+        "12345 123456 ext 123",
+        "12345 123456 ext. 123",
+        "12345 123456 ext123",
+        "01234123456 ext 123",
+        "123 1234 1234 x123",
+        "12345 123456 x123",
+        "12345123456 x123",
+        "(1234) 123 1234",
+        "1234 123 1234 x123",
+        "1234 123 1234 ext 1234",
+        "1234 123 1234  ext 123",
+        "+44(0)123 12 12345",
+      ]
+    end
+
+    it 'Correctly validates valid phone numbers' do
+      valid_telephone_numbers.each do |number|
+        model.phone_number = number
+        expect(model.valid?(:no_context)).to(be(true), "Expected phone number #{number} to be valid")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

C# has validations for the email and telephone numbers for provider enrichments - we need to add these to the ruby application.

### Changes proposed in this pull request
![image](https://user-images.githubusercontent.com/976254/62950979-09219d80-bde1-11e9-9b38-ad2ef761873c.png)

- Validate email address and telephone formats when they are updated by the user
  - These are not updated on create/all updates as they'd be triggered by updating values that are not on the details page, e.g. About your organisation
  - The error messages have been taken from [The GOV.UK Design System](https://design-system.service.gov.uk/patterns/email-addresses/)

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
