### PR TITLE
[1952] edit course send via mcb cli

### DIFF
--- a/lib/mcb/courses_editor.rb
+++ b/lib/mcb/courses_editor.rb
@@ -7,6 +7,7 @@ module MCB
       accredited_body: :accrediting_provider,
       start_date: :start_date,
       application_opening_date: :applications_open_from,
+      is_send: :is_send
     }.freeze
 
     def initialize(provider:, requester:, course_codes: [], courses: nil)
@@ -37,7 +38,7 @@ module MCB
 
     def new_course_wizard
       %i[title qualifications study_mode accredited_body start_date route maths
-         english science age_range course_code].each do |attribute|
+         english science age_range course_code is_send].each do |attribute|
         edit(attribute)
       end
 
@@ -70,6 +71,7 @@ module MCB
         "edit application opening date",
         "edit age range",
         "edit subjects",
+        "edit is SEND",
         "edit training locations",
         "sync course(s) to Find"
       ]
@@ -87,7 +89,7 @@ module MCB
       elsif choice == 'edit training locations'
         edit_sites
       elsif choice.start_with?("edit")
-        attribute = choice.gsub("edit ", "").gsub(" ", "_").to_sym
+        attribute = choice.gsub("edit ", "").gsub(" ", "_").downcase.to_sym
         edit(attribute)
       elsif choice =~ /sync .* to Find/
         sync_courses_to_find

--- a/lib/mcb/courses_editor_cli.rb
+++ b/lib/mcb/courses_editor_cli.rb
@@ -58,6 +58,10 @@ module MCB
       )
     end
 
+    def ask_is_send
+      @cli.agree("Is the course SEND?   ")
+    end
+
     def ask_accredited_body
       new_accredited_body = nil
       until new_accredited_body.present?


### PR DESCRIPTION
### Context

Based on https://trello.com/c/1HMd3Qmk/1932-remove-send-u3-subject-and-add-it-as-attribute-to-course and #704. 

~Cannot merge until #704 has been merged in.~

### Changes proposed in this pull request

- Add ability to Edit a Course to be SEND
- Add ability to Create a Course as SEND

### Guidance to review

- ~Uses #704 as base branch so only look at `lib/mcb` changes~

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
