### PR TITLE
[1900] update study mode

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -128,7 +128,8 @@ module API
                   :qualification,
                   :age_range_in_years,
                   :start_date,
-                  :applications_open_from)
+                  :applications_open_from,
+                  :study_mode,)
           .permit(
             :about_course,
             :course_length,
@@ -173,6 +174,7 @@ module API
             :age_range_in_years,
             :start_date,
             :applications_open_from,
+            :study_mode,
           )
       end
 

--- a/app/controllers/concerns/study_mode_vacancy_mapper.rb
+++ b/app/controllers/concerns/study_mode_vacancy_mapper.rb
@@ -1,0 +1,16 @@
+module StudyModeVacancyMapper
+  extend ActiveSupport::Concern
+
+  def update_vac_status(study_mode, site_status)
+    case study_mode
+    when "full_time"
+      site_status.update(vac_status: :full_time_vacancies)
+    when "part_time"
+      site_status.update(vac_status: :part_time_vacancies)
+    when "full_time_or_part_time"
+      site_status.update(vac_status: :both_full_time_and_part_time_vacancies)
+    else
+      raise "Unexpected study mode #{study_mode}"
+    end
+  end
+end

--- a/app/deserializers/api/v2/deserializable_course.rb
+++ b/app/deserializers/api/v2/deserializable_course.rb
@@ -25,6 +25,7 @@ module API
         age_range_in_years
         start_date
         applications_open_from
+        study_mode
       ].freeze
 
       attributes(*COURSE_ATTRIBUTES)

--- a/spec/requests/api/v2/providers/courses/update_study_mode_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_study_mode_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+describe 'PATCH /providers/:provider_code/courses/:course_code' do
+  let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+
+  def perform_request(updated_study_mode)
+    jsonapi_data = jsonapi_renderer.render(
+      course,
+      class: {
+        Course: API::V2::SerializableCourse
+      }
+    )
+
+    jsonapi_data[:data][:attributes] = updated_study_mode
+
+    patch "/api/v2/providers/#{course.provider.provider_code}" \
+            "/courses/#{course.course_code}",
+          headers: { 'HTTP_AUTHORIZATION' => credentials },
+          params: {
+            _jsonapi: jsonapi_data
+          }
+  end
+  let(:organisation)      { create :organisation }
+  let(:provider)          { create :provider, organisations: [organisation] }
+  let(:user)              { create :user, organisations: [organisation] }
+  let(:payload)           { { email: user.email } }
+  let(:token)             { build_jwt :apiv2, payload: payload }
+
+  let(:course)            {
+    create :course,
+           provider: provider,
+           study_mode: study_mode
+  }
+  let(:study_mode) { :full_time }
+
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+
+  let(:permitted_params) do
+    %i[study_mode]
+  end
+
+  before do
+    perform_request(updated_study_mode)
+  end
+
+  context "course has an updated age range in years" do
+    let(:updated_study_mode) { { study_mode: :part_time } }
+
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it "updates the study_mode attribute to the correct value" do
+      expect(course.reload.study_mode).to eq(updated_study_mode[:study_mode].to_s)
+    end
+  end
+
+  context "with no values passed into the params" do
+    let!(:courses_study_mode) { course.study_mode }
+    let(:updated_study_mode) { {} }
+
+    before do
+      perform_request(updated_study_mode)
+    end
+
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it "does not change age_range_in_years attribute" do
+      expect(course.reload.study_mode).to eq(courses_study_mode)
+    end
+  end
+end

--- a/spec/requests/api/v2/providers/courses/update_study_mode_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_study_mode_spec.rb
@@ -51,7 +51,7 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
     perform_request(updated_study_mode)
   end
 
-  context "course has is updated to full time" do
+  context "when  a course is updated to full time" do
     let(:updated_study_mode) { { study_mode: :full_time } }
 
     it "returns http success" do


### PR DESCRIPTION
### Context

Users need to be able to update their course to full time or part time

### Changes proposed in this pull request
- Allow study mode to be updated
- Update site statuses to the correct vac_status.

### Guidance to review

If updated to full time all site statuses except those with no vacancies should have full time vacancies.

Same with part time except part time vacancies.

There is currently no logic to deal with full time and part time courses. This will be dealt with through support until users have the functionality to select both full time and part time vacancies on each site attached to a course.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
