### PR TITLE
[1880] Edit SEND on course via API

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -139,7 +139,8 @@ module API
                   :age_range_in_years,
                   :start_date,
                   :applications_open_from,
-                  :study_mode,)
+                  :study_mode,
+                  :is_send)
           .permit(
             :about_course,
             :course_length,
@@ -185,6 +186,7 @@ module API
             :start_date,
             :applications_open_from,
             :study_mode,
+            :is_send
           )
       end
 

--- a/app/deserializers/api/v2/deserializable_course.rb
+++ b/app/deserializers/api/v2/deserializable_course.rb
@@ -26,6 +26,7 @@ module API
         start_date
         applications_open_from
         study_mode
+        is_send
       ].freeze
 
       attributes(*COURSE_ATTRIBUTES)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -147,6 +147,7 @@ class Course < ApplicationRecord
   validates :english, inclusion: { in: entry_requirement_options_without_nil_choice }
   validates :science, inclusion: { in: entry_requirement_options_without_nil_choice }, if: :gcse_science_required?
   validates :enrichments, presence: true, on: :publish
+  validates :is_send, inclusion: { in: [true, false] }
   validate :validate_enrichment_publishable, on: :publish
   validate :validate_enrichment
   validate :validate_course_syncable, on: :sync
@@ -161,6 +162,16 @@ class Course < ApplicationRecord
     RecruitmentCycle.find_by(year: year)
       .providers.find_by(provider_code: provider_code)
       .courses.find_by(course_code: course_code)
+  end
+
+  # To stop the API sending not valid values we have to write our own setter to ensure we get
+  # correct booleans stored.
+  def is_send=(value)
+    if value.to_s.in?(%w[true false 0 1])
+      super(value)
+    else
+      super(nil)
+    end
   end
 
   def recruitment_cycle

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1055,4 +1055,55 @@ RSpec.describe Course, type: :model do
       its(:applications_open_from) { should eq recruitment_cycle.application_start_date }
     end
   end
+
+  describe "#is_send=" do
+    let(:subject) { build(:course) }
+
+    before do
+      subject.is_send = value
+    end
+
+    context 'when value is `true`' do
+      let(:value) { true }
+
+      its(:is_send) { is_expected.to be(true) }
+    end
+
+    context 'when value is `"true"`' do
+      let(:value) { "true" }
+
+      its(:is_send) { is_expected.to be(true) }
+    end
+
+    context 'when value is `1`' do
+      let(:value) { 1 }
+
+      its(:is_send) { is_expected.to be(true) }
+    end
+
+    context 'when value is `0`' do
+      let(:value) { 0 }
+
+      its(:is_send) { is_expected.to be(false) }
+    end
+
+    context 'when value is `false`' do
+      let(:value) { false }
+
+      its(:is_send) { is_expected.to be(false) }
+    end
+
+    context 'when value is `"false"`' do
+      let(:value) { "false" }
+
+      its(:is_send) { is_expected.to be(false) }
+    end
+
+    context 'when value is a string that is not like a boolean' do
+      let(:value) { "blah-blah" }
+
+      its(:is_send) { is_expected.to be_nil }
+      it { is_expected.to_not be_valid }
+    end
+  end
 end

--- a/spec/requests/api/v2/providers/courses/update_send_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_send_spec.rb
@@ -1,0 +1,103 @@
+require "rails_helper"
+
+describe 'PATCH /providers/:provider_code/courses/:course_code' do
+  let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+
+  def perform_request(updated_is_send)
+    jsonapi_data = jsonapi_renderer.render(
+      course,
+      class: {
+        Course: API::V2::SerializableCourse
+      }
+    )
+
+    jsonapi_data[:data][:attributes] = updated_is_send
+
+    patch "/api/v2/providers/#{course.provider.provider_code}" \
+            "/courses/#{course.course_code}",
+          headers: { 'HTTP_AUTHORIZATION' => credentials },
+          params: {
+            _jsonapi: jsonapi_data
+          }
+  end
+  let(:organisation)      { create :organisation }
+  let(:provider)          { create :provider, organisations: [organisation] }
+  let(:user)              { create :user, organisations: [organisation] }
+  let(:payload)           { { email: user.email } }
+  let(:token)             { build_jwt :apiv2, payload: payload }
+
+  let(:course)            {
+    create :course,
+           provider: provider,
+           subjects: [build(:subject, :primary)],
+           is_send: false
+  }
+
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+
+  let(:permitted_params) do
+    %i[updated_is_send]
+  end
+
+  before do
+    perform_request(updated_is_send)
+  end
+
+  context "course has an updated is_send attribute" do
+    let(:updated_is_send) { { is_send: true } }
+
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it "updates the `is_send` attribute to the correct value" do
+      expect(course.reload.is_send).to eq(updated_is_send[:is_send])
+    end
+  end
+
+  context "course has the same SEND value" do
+    context "with values passed into the params" do
+      let(:updated_is_send) { { is_send: true } }
+
+      it "returns http success" do
+        expect(response).to have_http_status(:success)
+      end
+
+      it "does not change `is_send` attribute" do
+        expect(course.reload.is_send).to eq(updated_is_send[:is_send])
+      end
+    end
+  end
+
+  context "with no values passed into the params" do
+    let(:updated_is_send) { {} }
+
+    before do
+      @is_send = course.is_send
+      perform_request(updated_is_send)
+    end
+
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it "does not change `is_send` attribute" do
+      expect(course.reload.is_send).to eq(@is_send)
+    end
+  end
+
+  context "for any course" do
+    context "when a bad `is_send` is submitted" do
+      let(:json_data) { JSON.parse(response.body)['errors'] }
+      let(:updated_is_send) { { is_send: 'blah_blah' } }
+
+      it "returns an error" do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_data.count).to eq 1
+        expect(response.body).to include("Invalid is_send")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Uses #704 as a base. Need to allow the Front End to set the `is_send` attribute on a Course.

### Changes proposed in this pull request

- Add Validation to `Course#is_send` attribute to only allow explicit variables
- Add V2 Course Controller to accept `is_send` param

### Guidance to review

Do we trust the the information sent to the API will always be valid? If so, do we need to be so restrictive about settings `is_send`? 

For example, without the `#is_send=(value)` override then:
```ruby
$ course.is_send? 
=> true
$ course.is_send = 'something'
$ course.is_send?
=> false 
```

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
