### PR TITLE
[1438] Make the accept transition screen idempotent

### DIFF
--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -24,7 +24,9 @@ module API
       end
 
       def accept_rollover_screen
-        @user.accept_rollover_screen!
+        if @user.state == 'transitioned'
+          @user.accept_rollover_screen!
+        end
       end
 
     private

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -18,7 +18,9 @@ module API
       end
 
       def accept_transition_screen
-        @user.accept_transition_screen!
+        if @user.state == 'new'
+          @user.accept_transition_screen!
+        end
       end
 
       def accept_rollover_screen

--- a/spec/requests/api/v2/users/accept_rollover_screen_spec.rb
+++ b/spec/requests/api/v2/users/accept_rollover_screen_spec.rb
@@ -59,8 +59,8 @@ describe 'PATCH /api/v2/users/:id/accept_rollover_screen', type: :request do
         user.accept_rollover_screen!
       end
 
-      it 'returns error' do
-        expect { perform_request }.to raise_error AASM::InvalidTransition
+      it 'does not return an error' do
+        expect { perform_request }.not_to raise_error
       end
     end
   end

--- a/spec/requests/api/v2/users/accept_transition_screen_spec.rb
+++ b/spec/requests/api/v2/users/accept_transition_screen_spec.rb
@@ -59,7 +59,7 @@ describe 'PATCH /api/v2/users/:id/accept_transition_screen', type: :request do
         user.accept_transition_screen!
       end
 
-      it 'returns error' do
+      it 'does not return an error' do
         expect { perform_request }.not_to raise_error
       end
     end

--- a/spec/requests/api/v2/users/accept_transition_screen_spec.rb
+++ b/spec/requests/api/v2/users/accept_transition_screen_spec.rb
@@ -60,7 +60,7 @@ describe 'PATCH /api/v2/users/:id/accept_transition_screen', type: :request do
       end
 
       it 'returns error' do
-        expect { perform_request }.to raise_error AASM::InvalidTransition
+        expect { perform_request }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
### Context

If a user tries to accept the transition screen while already rolled over, it currently throws a sentry error. This is undesirable behaviour.

### Changes proposed in this pull request

- Make the accept transition screen idempotent

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
