### PR TITLE
[1972] Allow non-admin users to create access requests

### DIFF
--- a/app/policies/access_request_policy.rb
+++ b/app/policies/access_request_policy.rb
@@ -9,7 +9,10 @@ class AccessRequestPolicy
     @user.admin?
   end
 
+  def create?
+    @user.present?
+  end
+
   alias_method :index?, :approve?
-  alias_method :create?, :approve?
   alias_method :show?, :approve?
 end

--- a/spec/policies/access_request_policy_spec.rb
+++ b/spec/policies/access_request_policy_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe AccessRequestPolicy do
   subject { described_class }
 
-  permissions :approve?, :index?, :create?, :show? do
+  permissions :approve?, :index?, :show? do
     let(:access_request) { build(:access_request) }
 
     context 'non-admin user' do
@@ -14,6 +14,14 @@ describe AccessRequestPolicy do
 
     context 'admin user' do
       let(:user) { build(:user, :admin) }
+
+      it { should permit(user) }
+    end
+  end
+
+  permissions :create? do
+    context 'non-admin user' do
+      let(:user) { build(:user) }
 
       it { should permit(user) }
     end

--- a/spec/requests/api/v2/access_request_spec.rb
+++ b/spec/requests/api/v2/access_request_spec.rb
@@ -282,13 +282,15 @@ describe 'Access Request API V2', type: :request do
       it { should have_http_status(:unauthorized) }
     end
 
-    context 'when unauthorized' do
-      let(:unauthorised_user) { create(:user) }
-      let(:payload) { { email: unauthorised_user.email } }
+    context 'authorises non-admin users' do
+      let(:non_admin_user) { create(:user) }
+      let(:payload) { { email: non_admin_user.email } }
 
-      it "should raise an error" do
-        expect { do_post }.to raise_error Pundit::NotAuthorizedError
+      before do
+        do_post
       end
+
+      it { should have_http_status(:ok) }
     end
 
     context 'when authorised' do


### PR DESCRIPTION
### Context
Currently if a non admin user tries to create an access request it throws an error.

### Changes proposed in this pull request

- Tweak the policy to allow any user to create an access request.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
