### PR TITLE
[1856] Migration to set application end date

### DIFF
--- a/db/migrate/20190815091422_set_application_end_dates_on_recruitment_cycles.rb
+++ b/db/migrate/20190815091422_set_application_end_dates_on_recruitment_cycles.rb
@@ -1,0 +1,9 @@
+class SetApplicationEndDatesOnRecruitmentCycles < ActiveRecord::Migration[5.2]
+  def up
+    say_with_time 'fixing recruitment cycles with a nil application end dates' do
+      RecruitmentCycle.all.each do |recruitment_cycle|
+        recruitment_cycle.update(application_end_date: DateTime.new(recruitment_cycle.year.to_i, 9, 30)) if recruitment_cycle.application_end_date.nil?
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_12_153252) do
+ActiveRecord::Schema.define(version: 2019_08_15_091422) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"


### PR DESCRIPTION
### Context

Currently recruitment cycles application_end_date is set to nil. Some code is reliant on this being set for validations.

### Changes proposed in this pull request
- Creates a migration that sets the application_end_date 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
