### PR TITLE
1982 bad phone

### DIFF
--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -57,7 +57,7 @@ class ProviderEnrichment < ApplicationRecord
   validates :email, email: true, on: :update, allow_nil: true
   validates :email, email: true, on: :publish
 
-  validates :telephone, phone: { message: '^Enter a valid telephone number' }, on: :update, allow_nil: true
+  validates :telephone, phone: { message: '^Enter a valid telephone number' }, allow_nil: true
 
   validates :website, :telephone,
             :address1, :address3, :address4,


### PR DESCRIPTION
### Context
Telephone number was not triggering validation on creation of an enrichment from the `enrichment` (`enrichment.save`)
Leading to the enrichment being saved then triggering validation from the provider (`@provider.valid?`) 

On the controller

### Changes proposed in this pull request
Making phone calls again 


### Guidance to review
First commit to flush it out
Second commit to clean it up

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
