### PR TITLE
[1914] Ensure that JSON Data stores/retrieves RegionCode as Integer

### DIFF
--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -17,6 +17,7 @@
 class ProviderEnrichment < ApplicationRecord
   include RegionCode
 
+  before_save :ensure_region_code_is_an_integer_in_json_data
   before_create :set_provider_code
 
   enum status: { draft: 0, published: 1 }
@@ -79,6 +80,13 @@ class ProviderEnrichment < ApplicationRecord
   end
 
 private
+
+  def ensure_region_code_is_an_integer_in_json_data
+    return if json_data['RegionCode'].blank?
+    return if json_data['RegionCode'].is_a?(Integer)
+
+    json_data['RegionCode'] = ProviderEnrichment.region_codes[json_data['RegionCode']]
+  end
 
   def set_provider_code
     # Note: provider_code is only here to support c# counterpart, until provide_code is removed from database

--- a/spec/models/provider_enrichment_spec.rb
+++ b/spec/models/provider_enrichment_spec.rb
@@ -251,4 +251,76 @@ describe ProviderEnrichment, type: :model do
       end
     end
   end
+
+  describe "#before_save" do
+    describe "#ensure_region_code_is_an_integer_in_json_data" do
+      let(:subject) { build(:provider_enrichment, region_code: nil) }
+      let(:wanted_region_code_string) { ProviderEnrichment.region_codes.keys.sample }
+      let(:wanted_region_code_int) {  ProviderEnrichment.region_codes[wanted_region_code_string] }
+
+      it 'is called when saved' do
+        allow(subject).to receive(:ensure_region_code_is_an_integer_in_json_data)
+
+        subject.save
+
+        expect(subject).to have_received(:ensure_region_code_is_an_integer_in_json_data)
+      end
+
+      context 'when region code is set via accessor as number' do
+        before do
+          subject.region_code = wanted_region_code_int
+        end
+
+        it 'converts the string into an Integer' do
+          expect(subject.json_data['RegionCode']).to eq(wanted_region_code_string)
+
+          subject.send(:ensure_region_code_is_an_integer_in_json_data)
+
+          expect(subject.json_data['RegionCode']).to eq(wanted_region_code_int)
+        end
+      end
+
+      context 'when region code is set via accessor as string' do
+        before do
+          subject.region_code = wanted_region_code_string
+        end
+
+        it 'keeps the integer as an integer' do
+          expect(subject.json_data['RegionCode']).to eq(wanted_region_code_string)
+
+          subject.send(:ensure_region_code_is_an_integer_in_json_data)
+
+          expect(subject.json_data['RegionCode']).to eq(wanted_region_code_int)
+        end
+      end
+
+      context 'when region code has been set in `json_data` as String' do
+        before do
+          subject.json_data = { region_code: wanted_region_code_string }
+        end
+
+        it 'converts the string into an Integer' do
+          expect(subject.json_data['RegionCode']).to eq(wanted_region_code_string)
+
+          subject.send(:ensure_region_code_is_an_integer_in_json_data)
+
+          expect(subject.json_data['RegionCode']).to eq(wanted_region_code_int)
+        end
+      end
+
+      context 'when region code has been set in `json_data` as Integer' do
+        before do
+          subject.json_data = { region_code: wanted_region_code_int }
+        end
+
+        it 'keeps the region code as an Integer' do
+          expect(subject.json_data['RegionCode']).to eq(wanted_region_code_int)
+
+          subject.send(:ensure_region_code_is_an_integer_in_json_data)
+
+          expect(subject.json_data['RegionCode']).to eq(wanted_region_code_int)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

`jsonb_accessor` and `ActiveRecord#enums` does not play nice. Rails can use Int/String and be fine. However, we want to store the data as Integers so the C# App can read them.

`jsonb_accessor` stores the enum as a string.

This comment is explaining the order of events. https://trello.com/c/YyfUArP7/1914-investigation-regioncode-being-saved-to-provider-enrichments-as-a-string-causing-manage-api-c-to-fail#comment-5d5669a350c3475785ca1be6

### Changes proposed in this pull request

- Include a before save that will always set the `RegionCode` to be an integer

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
