### PR TITLE
[1987] Ensure that Sub Commands contain Provider Recruitment Cycle year

### DIFF
--- a/lib/mcb/provider_editor.rb
+++ b/lib/mcb/provider_editor.rb
@@ -164,7 +164,7 @@ module MCB
 
     def edit_provider_name
       puts "Current name: #{provider.provider_name}"
-      update(provider_name: @cli.ask_name)
+      provider.update(provider_name: @cli.ask_name)
     end
 
     def select_courses_to_edit_and_launch_editor
@@ -180,10 +180,6 @@ module MCB
     def mcb_courses_edit(course_codes)
       command_params = ['courses', 'edit', provider.provider_code] + course_codes + environment_options + recruitment_cycle_year_options
       $mcb.run(command_params)
-    end
-
-    def update(attrs)
-      @provider.update(attrs)
     end
 
     def check_authorisation

--- a/lib/mcb/provider_editor.rb
+++ b/lib/mcb/provider_editor.rb
@@ -178,7 +178,7 @@ module MCB
     end
 
     def mcb_courses_edit(course_codes)
-      command_params = ['courses', 'edit', provider.provider_code] + course_codes + environment_options
+      command_params = ['courses', 'edit', provider.provider_code] + course_codes + environment_options + recruitment_cycle_year_options
       $mcb.run(command_params)
     end
 
@@ -189,6 +189,10 @@ module MCB
     def check_authorisation
       action = @provider.persisted? ? :update? : :create?
       raise Pundit::NotAuthorizedError unless Pundit.policy(@requester, @provider).send(action)
+    end
+
+    def recruitment_cycle_year_options
+      ["-r", provider.recruitment_cycle.year]
     end
 
     def environment_options

--- a/spec/lib/mcb/provider_editor_spec.rb
+++ b/spec/lib/mcb/provider_editor_spec.rb
@@ -33,6 +33,7 @@ describe MCB::ProviderEditor do
         let!(:courses) { create(:course, course_code: 'A01X', name: 'Biology', provider: provider) }
         let!(:course2) { create(:course, course_code: 'A02X', name: 'History', provider: provider) }
         let!(:course3) { create(:course, course_code: 'A03X', name: 'Economics', provider: provider) }
+        let(:recruitment_cycle_year) { ["-r", provider.recruitment_cycle.year] }
 
         it 'lists the courses for the given provider' do
           output, = run_editor("edit courses", "continue", "exit")
@@ -50,7 +51,9 @@ describe MCB::ProviderEditor do
             "exit" # from the command
           )
 
-          expect($mcb).to have_received(:run).with(%w[courses edit X12 A01X A03X])
+          expect($mcb).to have_received(:run).with(
+            %w[courses edit X12 A01X A03X] + recruitment_cycle_year
+          )
         end
 
         it 'invokes course editing on courses selected by their course code' do
@@ -64,7 +67,9 @@ describe MCB::ProviderEditor do
             "exit" # from the command
           )
 
-          expect($mcb).to have_received(:run).with(%w[courses edit X12 A01X A03X])
+          expect($mcb).to have_received(:run).with(
+            %w[courses edit X12 A01X A03X] + recruitment_cycle_year
+          )
         end
 
         it 'allows to easily select all courses' do
@@ -72,7 +77,9 @@ describe MCB::ProviderEditor do
 
           run_editor("edit courses", "select all", "continue", "exit")
 
-          expect($mcb).to have_received(:run).with(%w[courses edit X12 A01X A02X A03X])
+          expect($mcb).to have_received(:run).with(
+            %w[courses edit X12 A01X A02X A03X] + recruitment_cycle_year
+          )
         end
 
         context "(run against an Azure environment)" do
@@ -84,7 +91,9 @@ describe MCB::ProviderEditor do
 
             run_editor("edit courses", "[ ] Biology (A01X)", "continue", "exit")
 
-            expect($mcb).to have_received(:run).with(%w[courses edit X12 A01X -E qa])
+            expect($mcb).to have_received(:run).with(
+              %w[courses edit X12 A01X -E qa] + recruitment_cycle_year
+            )
           end
         end
       end


### PR DESCRIPTION
### Context

When using `bin/mcb provider edit ABC -r 2020` argument to specify a Recruitment Cycle year and then editing a course from within that Provider. The Courses loaded are for the Current Recruitment Cycle.

### Changes proposed in this pull request

- Always specify the Recruitment Cycle

### Guidance to review

Is there a better way to test this?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
