### PR TITLE
1865 mcb god users

### DIFF
--- a/lib/mcb/commands/users/grant.rb
+++ b/lib/mcb/commands/users/grant.rb
@@ -1,12 +1,18 @@
 summary 'Attach a user to an organisation/provider in the DB. Will prompt to create user if email address is unknown.'
 param :id_or_email_or_sign_in_id
-param :provider_code, transform: ->(code) { code.upcase }
-usage 'grant <user_id/email/sign_in_user_id> <provider_code>'
+option :p, 'provider_code', 'provider code',
+       argument: :optional, transform: ->(code) { code.upcase }
+flag nil, 'admin', 'admin'
+usage 'grant --admin <user_id/email/sign_in_user_id> -p <provider_code>'
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 
   cli = HighLine.new
-  provider = Provider.find_by!(provider_code: args[:provider_code])
-  MCB::GrantAccessWizard.new(cli, args[:id_or_email_or_sign_in_id], provider).run
+  provider = nil
+  admin = opts[:admin]
+  if opts[:provider_code]
+    provider = Provider.find_by!(provider_code: opts[:provider_code])
+  end
+  MCB::GrantAccessWizard.new(cli, args[:id_or_email_or_sign_in_id], provider, admin).run
 end

--- a/lib/mcb/grant_access_wizard.rb
+++ b/lib/mcb/grant_access_wizard.rb
@@ -22,37 +22,37 @@ module MCB
     def setup_user
       return false unless find_or_init_user
 
-      puts MCB::Render::ActiveRecord.user @user
+      puts MCB::Render::ActiveRecord.user @user_to_grant
 
       persist_user_if_new
     end
 
     def find_or_init_user
-      @user = MCB.find_user_by_identifier @id_or_email_or_sign_in_id
-      return @user if @user != nil
+      @user_to_grant = MCB.find_user_by_identifier @id_or_email_or_sign_in_id
+      return @user_to_grant if @user_to_grant != nil
 
       unless @id_or_email_or_sign_in_id.include? '@'
         puts "#{@id_or_email_or_sign_in_id} not found. Specify an email address if you wish to create a user"
         return nil
       end
 
-      @user = User.new(email: @id_or_email_or_sign_in_id)
+      @user_to_grant = User.new(email: @id_or_email_or_sign_in_id)
       puts "#{@id_or_email_or_sign_in_id} appears to be a new user"
-      @user.first_name = @cli.ask("First name?  ").strip
-      @user.last_name = @cli.ask("Last name?  ").strip
-      @user
+      @user_to_grant.first_name = @cli.ask("First name?  ").strip
+      @user_to_grant.last_name = @cli.ask("Last name?  ").strip
+      @user_to_grant
     end
 
     def persist_user_if_new
-      if @user.new_record?
-        if !@user.valid?
+      if @user_to_grant.new_record?
+        if !@user_to_grant.valid?
           puts "Cannot create this user:"
-          @user.errors.full_messages.each do |message|
+          @user_to_grant.errors.full_messages.each do |message|
             puts "- #{message}"
           end
           return false
-        elsif @cli.agree("About to create #{@user}. Continue? ")
-          @user.save!
+        elsif @cli.agree("About to create #{@user_to_grant}. Continue? ")
+          @user_to_grant.save!
           true
         else
           return false
@@ -69,8 +69,8 @@ module MCB
       end
 
       @organisation = @provider.organisations.first # a provider should only ever be associated with one organisation
-      if @user.in?(@organisation.users)
-        puts "#{@user} already belongs to #{@organisation.name}"
+      if @user_to_grant.in?(@organisation.users)
+        puts "#{@user_to_grant} already belongs to #{@organisation.name}"
         return
       end
 
@@ -79,14 +79,14 @@ module MCB
 
     def add_user_to_org
       puts "\n"
-      puts "You're about to give #{@user} access to organisation #{@organisation.name}. They will manage:"
+      puts "You're about to give #{@user_to_grant} access to organisation #{@organisation.name}. They will manage:"
       puts MCB::Render::ActiveRecord.providers_table @organisation.providers, name: "Additional Providers"
-      @organisation.users << @user if @cli.agree("Agree?  ")
+      @organisation.users << @user_to_grant if @cli.agree("Agree?  ")
     end
 
     def confirm_and_add_user_to_all_organisations
-      unless @user.admin?
-        puts "Refusing to give non-admin user #{@user} access to all orgs"
+      unless @user_to_grant.admin?
+        puts "Refusing to give non-admin user #{@user_to_grant} access to all orgs"
         return nil
       end
 
@@ -94,10 +94,10 @@ module MCB
     end
 
     def add_user_to_all_organisations
-      @user.organisations = Organisation.all
+      @user_to_grant.organisations = Organisation.all
 
       puts "\n"
-      puts "#{@user} given access to all orgs"
+      puts "#{@user_to_grant} given access to all orgs"
     end
   end
 end

--- a/lib/mcb/grant_access_wizard.rb
+++ b/lib/mcb/grant_access_wizard.rb
@@ -1,25 +1,30 @@
 module MCB
   class GrantAccessWizard
-    def initialize(cli, id_or_email_or_sign_in_id, provider)
+    def initialize(cli, id_or_email_or_sign_in_id, provider, admin)
       @cli = cli
       @id_or_email_or_sign_in_id = id_or_email_or_sign_in_id
       @provider = provider
+      @admin = admin
     end
 
     def run
-      fetch_organisation
-      return unless find_or_init_user
+      return unless setup_user
 
-      puts MCB::Render::ActiveRecord.user @user
-      return unless persist_user_if_new
-
-      confirm_and_add_user_to_organisation
+      if @admin
+        confirm_and_add_user_to_all_organisations
+      else
+        confirm_and_add_user_to_organisation
+      end
     end
 
   private
 
-    def fetch_organisation
-      @organisation = @provider.organisations.first # a provider should only ever be associated with one organisation
+    def setup_user
+      return false unless find_or_init_user
+
+      puts MCB::Render::ActiveRecord.user @user
+
+      persist_user_if_new
     end
 
     def find_or_init_user
@@ -57,14 +62,42 @@ module MCB
     end
 
     def confirm_and_add_user_to_organisation
+      unless @provider
+        puts "\n"
+        puts "Error: specify a provider code"
+        return
+      end
+
+      @organisation = @provider.organisations.first # a provider should only ever be associated with one organisation
       if @user.in?(@organisation.users)
         puts "#{@user} already belongs to #{@organisation.name}"
-      else
-        puts "\n"
-        puts "You're about to give #{@user} access to organisation #{@organisation.name}. They will manage:"
-        puts MCB::Render::ActiveRecord.providers_table @organisation.providers, name: "Additional Providers"
-        @organisation.users << @user if @cli.agree("Agree?  ")
+        return
       end
+
+      add_user_to_org
+    end
+
+    def add_user_to_org
+      puts "\n"
+      puts "You're about to give #{@user} access to organisation #{@organisation.name}. They will manage:"
+      puts MCB::Render::ActiveRecord.providers_table @organisation.providers, name: "Additional Providers"
+      @organisation.users << @user if @cli.agree("Agree?  ")
+    end
+
+    def confirm_and_add_user_to_all_organisations
+      unless @user.admin?
+        puts "Refusing to give non-admin user #{@user} access to all orgs"
+        return nil
+      end
+
+      add_user_to_all_organisations
+    end
+
+    def add_user_to_all_organisations
+      @user.organisations = Organisation.all
+
+      puts "\n"
+      puts "#{@user} given access to all orgs"
     end
   end
 end

--- a/spec/lib/mcb/commands/users/grant_admin_spec.rb
+++ b/spec/lib/mcb/commands/users/grant_admin_spec.rb
@@ -1,0 +1,76 @@
+require 'mcb_helper'
+
+describe 'mcb users grant --admin' do
+  def grant(id_or_email_or_sign_in_id, commands)
+    stderr = ""
+    output = with_stubbed_stdout(stdin: commands, stderr: stderr) do
+      cmd.run([id_or_email_or_sign_in_id, "--admin"])
+    end
+    [output, stderr]
+  end
+
+  let(:lib_dir) { Rails.root.join('lib') }
+  let(:cmd) do
+    Cri::Command.load_file(
+      "#{lib_dir}/mcb/commands/users/grant.rb"
+    )
+  end
+  let!(:organisation1) { create(:organisation) }
+  let!(:organisation2) { create(:organisation) }
+  let!(:organisation3) { create(:organisation) } # no provider in this one
+  let!(:provider) { create(:provider, organisations: [organisation1]) }
+  let!(:provider) { create(:provider, organisations: [organisation2]) }
+
+  let(:output) do
+    combined_input = input_commands.map { |c| "#{c}\n" }.join
+    grant(id_or_email_or_sign_in_id, combined_input).first
+  end
+
+  context 'admin email' do
+    context 'when the user exists but is not a member of any orgs' do
+      let(:user) { create(:user, :admin, organisations: []) }
+      let(:id_or_email_or_sign_in_id) { user.email }
+      let(:input_commands) { %w[y] }
+
+      before do
+        output
+      end
+
+      it 'grants membership of all organisations to that user' do
+        expect(user.reload.organisations).to eq([organisation1, organisation2, organisation3])
+      end
+    end
+
+    context 'when the user exists and is not a member of all orgs' do
+      let(:user) { create(:user, :admin, organisations: [organisation2]) }
+      let(:id_or_email_or_sign_in_id) { user.email }
+      let(:input_commands) { %w[y] }
+
+      before do
+        output
+      end
+
+      it 'grants membership of all organisations to that user' do
+        expect(user.reload.organisations).to eq([organisation1, organisation2, organisation3])
+      end
+    end
+  end
+
+  context 'non-admin email' do
+    let(:user) { create(:user, organisations: [organisation2]) }
+    let(:id_or_email_or_sign_in_id) { user.email }
+    let(:input_commands) { %w[y] }
+
+    before do
+      output
+    end
+
+    it 'shows a message about refusing to act' do
+      expect(output).to include("Refusing to give non-admin user #{user} access to all orgs")
+    end
+
+    it 'doesn\'t change the organisation membership of the user' do
+      expect(user.reload.organisations).to eq([organisation2])
+    end
+  end
+end

--- a/spec/lib/mcb/commands/users/grant_spec.rb
+++ b/spec/lib/mcb/commands/users/grant_spec.rb
@@ -4,7 +4,7 @@ describe 'mcb users grant' do
   def grant(id_or_email_or_sign_in_id, provider_code, commands)
     stderr = ""
     output = with_stubbed_stdout(stdin: commands, stderr: stderr) do
-      cmd.run([id_or_email_or_sign_in_id, provider_code])
+      cmd.run([id_or_email_or_sign_in_id, '-p', provider_code])
     end
     [output, stderr]
   end


### PR DESCRIPTION
### Context

Interim measure - give DfE people access to all orgs for support / research etc.

### Changes proposed in this pull request

* Add `--admin` flag - `bin/mcb users grant --admin someone@digital.education.gov.uk`
* Move provider into `-p` flag (because of the way the cli lib works) - `bin/mcb users grant  someone@example.org -P AA1`

### Guidance to review

:ship: ?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
