### PR TITLE
[1997] add endoint for new course

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -7,11 +7,20 @@ module API
 
       before_action :build_recruitment_cycle
       before_action :build_provider
-      before_action :build_course, except: :index
+      before_action :build_course, except: %i[index new]
 
       deserializable_resource :course,
                               only: %i[update publish publishable],
                               class: API::V2::DeserializableCourse
+
+      def new
+        authorize Course
+
+        @course = @provider.courses.new
+        @course.valid?
+
+        render jsonapi: @course, include: params[:include]
+      end
 
       def index
         authorize @provider, :can_list_courses?

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -17,7 +17,6 @@ module API
         authorize Course
 
         @course = @provider.courses.new
-        @course.valid?
 
         render jsonapi: @course, include: params[:include]
       end

--- a/app/models/concerns/courses/edit_options.rb
+++ b/app/models/concerns/courses/edit_options.rb
@@ -6,7 +6,12 @@ module Courses
     include QualificationConcern
     include StartDateConcern
     include StudyModeConcern
+
     included do
+      # When changing edit options here be sure to update the edit_options in the
+      # courses factory in manage-courses-frontend:
+      #
+      # https://github.com/DFE-Digital/manage-courses-frontend/blob/master/spec/factories/courses.rb
       def edit_course_options
         {
           entry_requirements: entry_requirements,

--- a/app/models/concerns/courses/edit_options/age_range_concern.rb
+++ b/app/models/concerns/courses/edit_options/age_range_concern.rb
@@ -3,6 +3,10 @@ module Courses
     module AgeRangeConcern
       extend ActiveSupport::Concern
       included do
+        # When changing anything here be sure to update the edit_options in the
+        # courses factory in manage-courses-frontend:
+        #
+        # https://github.com/DFE-Digital/manage-courses-frontend/blob/master/spec/factories/courses.rb
         def age_range_options
           case level
           when :primary

--- a/app/models/concerns/courses/edit_options/entry_requirements_concern.rb
+++ b/app/models/concerns/courses/edit_options/entry_requirements_concern.rb
@@ -3,6 +3,10 @@ module Courses
     module EntryRequirementsConcern
       extend ActiveSupport::Concern
       included do
+        # When changing anything here be sure to update the edit_options in the
+        # courses factory in manage-courses-frontend:
+        #
+        # https://github.com/DFE-Digital/manage-courses-frontend/blob/master/spec/factories/courses.rb
         def entry_requirements
           Course::ENTRY_REQUIREMENT_OPTIONS
             .reject { |k, _v| %i[not_set not_required].include?(k) }

--- a/app/models/concerns/courses/edit_options/qualification_concern.rb
+++ b/app/models/concerns/courses/edit_options/qualification_concern.rb
@@ -3,6 +3,10 @@ module Courses
     module QualificationConcern
       extend ActiveSupport::Concern
       included do
+        # When changing anything here be sure to update the edit_options in the
+        # courses factory in manage-courses-frontend:
+        #
+        # https://github.com/DFE-Digital/manage-courses-frontend/blob/master/spec/factories/courses.rb
         def qualification_options
           qualifications_with_qts, qualifications_without_qts = Course::qualifications.keys.partition { |q| q.include?('qts') }
           level == :further_education ? qualifications_without_qts : qualifications_with_qts

--- a/app/models/concerns/courses/edit_options/start_date_concern.rb
+++ b/app/models/concerns/courses/edit_options/start_date_concern.rb
@@ -3,6 +3,10 @@ module Courses
     module StartDateConcern
       extend ActiveSupport::Concern
       included do
+        # When changing anything here be sure to update the edit_options in the
+        # courses factory in manage-courses-frontend:
+        #
+        # https://github.com/DFE-Digital/manage-courses-frontend/blob/master/spec/factories/courses.rb
         def start_date_options
           recruitment_year = provider.recruitment_cycle.year.to_i
 

--- a/app/models/concerns/courses/edit_options/study_mode_concern.rb
+++ b/app/models/concerns/courses/edit_options/study_mode_concern.rb
@@ -3,6 +3,10 @@ module Courses
     module StudyModeConcern
       extend ActiveSupport::Concern
       included do
+        # When changing anything here be sure to update the edit_options in the
+        # courses factory in manage-courses-frontend:
+        #
+        # https://github.com/DFE-Digital/manage-courses-frontend/blob/master/spec/factories/courses.rb
         def study_mode_options
           Course.study_modes.keys
         end

--- a/app/models/concerns/with_qualifications.rb
+++ b/app/models/concerns/with_qualifications.rb
@@ -1,7 +1,7 @@
 module WithQualifications
   extend ActiveSupport::Concern
 
-  included do
+  included do # rubocop: disable Metrics/BlockLength
     # The training programme outcome that originated in the UCAS NetUpdate system.
     #
     # See [UCAS Teacher Training Set-up Guide](https://www.ucas.com/file/115581/download?token=mv-G6P53),
@@ -16,19 +16,19 @@ module WithQualifications
       # Professional: the student will receive a Professional Graduate
       # Certificate of Education (offered at Level 6) or Professional
       # Graduate Diploma in Education (PGDE), with no credits or
-      # modules at postgraduate (master’s) Level 7 on successful
+      # modules at postgraduate (master's) Level 7 on successful
       # completion of the programme.
       professional: "PF",
 
       # Postgraduate: the student will receive a Postgraduate Certificate
       # of Education (PGCE) or other qualification which includes at
       # least one module or some credits at postgraduate
-      # (master’s) Level 7 on successful completion the
+      # (master's) Level 7 on successful completion the
       # programme.
       postgraduate: "PG",
 
       # Both professional and postgraduate: the student has the option of taking at least one
-      # postgraduate (master’s) Level 7 module or obtaining some
+      # postgraduate (master's) Level 7 module or obtaining some
       # postgraduate-level credits as part of the programme.
       professional_postgraduate: "BO",
     }
@@ -61,7 +61,11 @@ module WithQualifications
     end
 
     def qualifications_description
-      qualifications.map(&:upcase).sort.join(" with ")
+      if qualifications
+        qualifications.map(&:upcase).sort.join(" with ")
+      else
+        ''
+      end
     end
 
     def qualification=(value)

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -19,4 +19,5 @@ class CoursePolicy
   alias_method :sync_with_search_and_compare?, :update?
   alias_method :publish?, :update?
   alias_method :publishable?, :update?
+  alias_method :new?, :index?
 end

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -19,7 +19,7 @@ module API
                  :english, :maths, :science, :gcse_subjects_required, :age_range_in_years
 
       attribute :start_date do
-        @object.start_date.strftime("%B %Y")
+        @object.start_date.strftime("%B %Y") if @object.start_date
       end
 
       attribute :applications_open_from do

--- a/app/services/subject_mapper_service.rb
+++ b/app/services/subject_mapper_service.rb
@@ -92,6 +92,8 @@ class SubjectMapperService
   }.freeze
 
   def self.get_subject_list(course_title, ucas_subjects)
+    return [] if course_title.nil?
+
     ucas_subjects = ucas_subjects.map(&:strip).map(&:downcase)
     level = Subjects::CourseLevel.new(ucas_subjects).level
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,7 @@ Rails.application.routes.draw do
           post :sync_with_search_and_compare, on: :member
           post :publish, on: :member
           post :publishable, on: :member
+          get :new, on: :new
         end
         resources :sites, only: %i[index update show create]
         resources :recruitment_cycles, only: %i[index]

--- a/spec/models/concerns/with_qualifications_spec.rb
+++ b/spec/models/concerns/with_qualifications_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe WithQualifications, type: :model do
     end
   end
 
+  describe '#qualifications_description' do
+    context 'no qualification present' do
+      subject { build(:course, qualification: nil) }
+
+      its(:qualifications_description) { should eq '' }
+    end
+  end
+
   describe "#qualification= and its dependent attribute profpost_flag" do
     subject { build(:course, qualification: :pgce_with_qts) }
 

--- a/spec/policies/course_policy_spec.rb
+++ b/spec/policies/course_policy_spec.rb
@@ -5,10 +5,8 @@ describe CoursePolicy do
 
   subject { described_class }
 
-  permissions :index? do
-    it 'allows the :index action for any authenticated user' do
-      should permit(user)
-    end
+  permissions :index?, :new? do
+    it { should permit(user, Course) }
   end
 
   permissions :show?, :update? do

--- a/spec/requests/api/v2/providers/courses/new_spec.rb
+++ b/spec/requests/api/v2/providers/courses/new_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+describe 'GET /providers/:provider_code/courses/new' do
+  let(:recruitment_cycle) { find_or_create :recruitment_cycle }
+  let(:organisation)      { create :organisation }
+  let(:provider) do
+    create :provider,
+           organisations: [organisation],
+           recruitment_cycle: recruitment_cycle
+  end
+  let(:user)    { create :user, organisations: [organisation] }
+  let(:payload) { { email: user.email } }
+  let(:token)   { build_jwt :apiv2, payload: payload }
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+  let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+
+  describe '#new' do
+    it 'returns a new course resource' do
+      get "/api/v2/recruitment_cycles/#{recruitment_cycle.year}" \
+          "/providers/#{provider.provider_code}" \
+          "/courses/new",
+          headers: { 'HTTP_AUTHORIZATION' => credentials }
+
+      course = provider.courses.new # Course.new(provider: provider)
+      rendered_course = jsonapi_renderer.render(
+        course,
+        class: {
+          Course: API::V2::SerializableCourse
+        }
+      )
+      # Converting the rendered course to JSON and back normalises any symbols
+      # into strings. Better #deep_symbolize_keys because it also does values.
+      jsonapi_course = JSON.parse(rendered_course.to_json)
+      jsonapi_response = JSON.parse(response.body)
+      expect(jsonapi_response['data']).to eq jsonapi_course['data']
+    end
+  end
+end

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -180,4 +180,13 @@ describe API::V2::SerializableCourse do
     its(%w[required_qualifications])    { should eq enrichment.required_qualifications }
     its(%w[salary_details])             { should eq enrichment.salary_details }
   end
+
+  context 'a new course' do
+    let(:provider) { create :provider }
+    let(:course) { Course.new(provider: provider) }
+
+    subject { parsed_json['data'] }
+
+    it { should have_attribute(:start_date).with_value(nil) }
+  end
 end

--- a/spec/services/subject_mapper_service_spec.rb
+++ b/spec/services/subject_mapper_service_spec.rb
@@ -148,5 +148,12 @@ describe SubjectMapperService do
         end
       end
     end
+
+    context 'a new course' do
+      it 'returns an empty list of subjects' do
+        subjects = described_class.get_subject_list(nil, [])
+        expect(subjects).to eq []
+      end
+    end
   end
 end


### PR DESCRIPTION
### Changes proposed in this pull request

From the ticket:

> ## What
>
> Add "new" endpoint for courses to mcbe that returns default `edit_options` to be
> used when generating the "new" pages on the frontend.


### Context

From the ticket:


> ## Why
> 
> We are keeping the logic behind course states constrained to the backend, so we
> need to be able to query it to find out what outcomes are available, for courses
> as we step the user through the wizard steps.

### Guidance to review

This is required by [1938 Add "new" page for course outcomes](https://trello.com/c/4HGV6r3S/1938-m-add-new-page-for-course-outcomes).

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
