### PR TITLE
Added prod.yml file

### DIFF
--- a/config/settings/prod.yml
+++ b/config/settings/prod.yml
@@ -1,0 +1,6 @@
+manage_api:
+  base_url: https://api.publish-teacher-training-courses.service.gov.uk
+  secret: please_change_me
+search_api:
+  base_url: https://api.find-postgraduate-teacher-training.service.gov.uk
+  secret: please_change_me


### PR DESCRIPTION
Context
Created new file with service domains for mc and sac api urls. Existing files i.e. new_prod.yml and production.yml are using azurewebsites domain.
new_prod.yml and production.yml can be deleted after successful migration to vsts.

Changes proposed in this pull request
Created prod.yml file with settings copied from production.yml but with service domain instead of azurewebsite.net urls.
