### PR TITLE
[1947] Reimplement "Welcome to find" email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,9 @@ gem 'custom_error_message', git: 'https://github.com/nanamkim/custom-err-msg.git
 # Soft delete
 gem 'discard'
 
+# Gov Notify
+gem 'govuk_notify_rails'
+
 group :development, :test do
   # add info about db structure to models and other files
   gem 'annotate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,9 @@ GEM
       rubocop-rails (~> 2)
       rubocop-rspec (~> 1.28)
       scss_lint
+    govuk_notify_rails (2.1.0)
+      notifications-ruby-client (>= 2.9.0)
+      rails (>= 4.1.0)
     guard (2.15.0)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -228,6 +231,8 @@ GEM
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    notifications-ruby-client (4.0.0)
+      jwt (>= 1.5, < 3)
     parallel (1.17.0)
     parser (2.6.3.0)
       ast (~> 2.4.0)
@@ -410,6 +415,7 @@ DEPENDENCIES
   faker
   faraday
   govuk-lint
+  govuk_notify_rails
   guard
   guard-rspec
   guard-rubocop

--- a/app/controllers/api/v2/sessions_controller.rb
+++ b/app/controllers/api/v2/sessions_controller.rb
@@ -14,6 +14,8 @@ module API
           )
         )
 
+        send_welcome_email
+
         render jsonapi: @current_user
       end
 
@@ -29,6 +31,11 @@ module API
             :first_name,
             :last_name
           )
+      end
+
+      def send_welcome_email
+        welcome_email_service = SendWelcomeEmailService.new(mailer: WelcomeEmailMailer)
+        welcome_email_service.execute(current_user: @current_user)
       end
     end
   end

--- a/app/mailers/welcome_email_mailer.rb
+++ b/app/mailers/welcome_email_mailer.rb
@@ -1,0 +1,11 @@
+class WelcomeEmailMailer < GovukNotifyRails::Mailer
+  def send_welcome_email(first_name:, email:)
+    set_template(Settings.govuk_notify.welcome_email_template_id)
+
+    set_personalisation(
+      first_name: first_name,
+    )
+
+    mail(to: email)
+  end
+end

--- a/app/services/send_welcome_email_service.rb
+++ b/app/services/send_welcome_email_service.rb
@@ -1,0 +1,18 @@
+class SendWelcomeEmailService
+  def initialize(mailer:)
+    @mailer = mailer
+  end
+
+  def execute(current_user:)
+    return if current_user.first_login_date_utc
+
+    time_now = Time.now.utc
+
+    current_user.update(
+      first_login_date_utc: time_now,
+      welcome_email_date_utc: time_now
+    )
+
+    @mailer.send_welcome_email(first_name: current_user.first_name, email: current_user.email)
+  end
+end

--- a/app/services/send_welcome_email_service.rb
+++ b/app/services/send_welcome_email_service.rb
@@ -13,6 +13,6 @@ class SendWelcomeEmailService
       welcome_email_date_utc: time_now
     )
 
-    @mailer.send_welcome_email(first_name: current_user.first_name, email: current_user.email)
+    @mailer.send_welcome_email(first_name: current_user.first_name, email: current_user.email).deliver_now
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,6 +7,7 @@ require "active_job/railtie"
 require "active_record/railtie"
 require "action_controller/railtie"
 require "action_view/railtie"
+require "action_mailer/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,4 +44,6 @@ Rails.application.configure do
   end
 
   config.active_job.queue_adapter = :test
+
+  config.action_mailer.delivery_method = :test
 end

--- a/config/initializers/mailers.rb
+++ b/config/initializers/mailers.rb
@@ -1,0 +1,1 @@
+ActionMailer::Base.add_delivery_method :govuk_notify, GovukNotifyRails::Delivery, api_key: ENV['GOVUK_NOTIFY_API_KEY']

--- a/config/initializers/mailers.rb
+++ b/config/initializers/mailers.rb
@@ -1,1 +1,1 @@
-ActionMailer::Base.add_delivery_method :govuk_notify, GovukNotifyRails::Delivery, api_key: ENV['GOVUK_NOTIFY_API_KEY']
+ActionMailer::Base.add_delivery_method :govuk_notify, GovukNotifyRails::Delivery, api_key: Settings.govuk_notify.api_key

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,2 +1,4 @@
 authentication:
   secret: secret
+govuk_notify:
+  api_key: its_a_secret

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,4 +1,4 @@
 govuk_notify:
-  api_key: please_change_me
+  api_key: cafe-cafecafe-cafe-cafe-cafe-cafecafecafe-cafecafe-cafe-cafe-cafe-cafecafecafe
   welcome_email_template_id: please_change_me
 

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,0 +1,4 @@
+govuk_notify:
+  api_key: please_change_me
+  welcome_email_template_id: please_change_me
+

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -20,6 +20,7 @@ FactoryBot.define do
     email { Faker::Internet.email }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
+    first_login_date_utc { Faker::Time.backward(days: 1).utc }
     accept_terms_date_utc { Faker::Time.backward(days: 1).utc }
     sign_in_user_id { SecureRandom.uuid }
 

--- a/spec/mailers/welcome_email_mailer_spec.rb
+++ b/spec/mailers/welcome_email_mailer_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe WelcomeEmailMailer, type: :mailer do
+  context 'Sending an email to a user' do
+    let(:mail) { described_class.send_welcome_email(first_name: 'meow', email: 'cat@meow.cat') }
+    before { mail }
+
+    it 'Sends an email with the correct template' do
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.welcome_email_template_id)
+    end
+
+    it 'Sends an email to the correct email address' do
+      expect(mail.to).to eq(['cat@meow.cat'])
+    end
+
+    it 'Includes the first name in the personalisation' do
+      expect(mail.govuk_notify_personalisation).to eq(first_name: 'meow')
+    end
+  end
+end

--- a/spec/requests/api/v2/session_spec.rb
+++ b/spec/requests/api/v2/session_spec.rb
@@ -117,7 +117,7 @@ describe '/api/v2/sessions', type: :request do
       context 'on second login' do
         let(:user) { create(:user, first_login_date_utc: 10.days.ago) }
 
-        it 'Does not sent a welcome email to the user' do
+        it 'Does not send a welcome email to the user' do
           expect(govuk_notify_request).not_to have_been_made
         end
       end

--- a/spec/requests/api/v2/session_spec.rb
+++ b/spec/requests/api/v2/session_spec.rb
@@ -49,7 +49,17 @@ describe '/api/v2/sessions', type: :request do
       let(:user) { create(:user, last_login_date_utc: 10.days.ago) }
       let(:returned_json_response) { JSON.parse response.body }
 
+      let(:govuk_notify_request) do
+        stub_request(:post, "https://api.notifications.service.gov.uk/v2/notifications/email").
+           with(
+             body: { email_address: user.email, template_id: Settings.govuk_notify.welcome_email_template_id, personalisation: { first_name: user.first_name } }.to_json
+            ).
+            to_return(status: 200, body: "{}", headers: {})
+      end
+
+
       before do
+        govuk_notify_request
         Timecop.freeze
         post '/api/v2/sessions',
              headers: { 'HTTP_AUTHORIZATION' => credentials },
@@ -93,6 +103,22 @@ describe '/api/v2/sessions', type: :request do
           user.reload
           expect(user.first_name).to eq "updated first_name"
           expect(user.last_name).to eq "updated last_name"
+        end
+      end
+
+      context 'on first login' do
+        let(:user) { create(:user, first_login_date_utc: nil) }
+
+        it 'Sends a welcome email to the user' do
+          expect(govuk_notify_request).to have_been_made
+        end
+      end
+
+      context 'on second login' do
+        let(:user) { create(:user, first_login_date_utc: 10.days.ago) }
+
+        it 'Does not sent a welcome email to the user' do
+          expect(govuk_notify_request).not_to have_been_made
         end
       end
     end

--- a/spec/services/send_welcome_email_service_spec.rb
+++ b/spec/services/send_welcome_email_service_spec.rb
@@ -1,0 +1,62 @@
+describe SendWelcomeEmailService do
+  let(:mailer_spy) { spy }
+  let(:service) { SendWelcomeEmailService.new(mailer: mailer_spy) }
+
+  before { Timecop.freeze }
+  after { Timecop.return }
+
+  context 'When the user has not logged in before' do
+    let(:current_user_spy) do
+      spy(
+        first_name: 'Meowington',
+        email: 'meowington@cat.net',
+        first_login_date_utc: nil
+      )
+    end
+
+    before { service.execute(current_user: current_user_spy) }
+
+    it 'sets their first login date to now' do
+      expect(current_user_spy).to have_received(:update).with(hash_including(first_login_date_utc: Time.now.utc))
+    end
+
+    it 'sets their welcome email date to now' do
+      expect(current_user_spy).to have_received(:update).with(hash_including(welcome_email_date_utc: Time.now.utc))
+    end
+
+    it 'sends the welcome email' do
+      expect(mailer_spy).to have_received(:send_welcome_email)
+    end
+
+    it 'sends the email to the user' do
+      expect(mailer_spy).to have_received(:send_welcome_email).with(hash_including(email: 'meowington@cat.net'))
+    end
+
+    it 'sends the users first name in the email' do
+      expect(mailer_spy).to have_received(:send_welcome_email).with(hash_including(first_name: 'Meowington'))
+    end
+  end
+
+  context 'When the user has logged in before' do
+    let(:current_user_spy) do
+      spy(
+        first_name: 'Meowington',
+        first_login_date_utc: Time.local(2018, 1, 1).utc
+      )
+    end
+
+    before { service.execute(current_user: current_user_spy) }
+
+    it 'does not update their first login date' do
+      expect(current_user_spy).not_to have_received(:update).with(hash_including(first_login_date_utc: Time.now.utc))
+    end
+
+    it 'does not update their welcome email date' do
+      expect(current_user_spy).not_to have_received(:update).with(hash_including(welcome_email_date_utc: Time.now.utc))
+    end
+
+    it 'does not send the welcome email' do
+      expect(mailer_spy).not_to have_received(:send_welcome_email)
+    end
+  end
+end


### PR DESCRIPTION
### Context

Sending the welcome email is currently handled by the C# application and needs to be rewritten.

### Changes proposed in this pull request

- Add a new service object for sending welcome emails
-  Add [`govuk_notify_rails`](https://github.com/ministryofjustice/govuk_notify_rails) gem
- Send emails via GOV.UK Notify when logging in for the first time
- Add relevant test fixtures for testing GOV.UK Notify emails

### Guidance to review

**To test locally**
- Create `config/settings/development.local.yml`
- Set the values for `govuk_notify.welcome_email_template_id` and `govuk_notify.api_key` to the correct values
- Set your users `first_login_date_utc` to `nil`
- Login

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
