### PR TITLE
[2003] Add migration to copy provider enrichments

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -119,6 +119,7 @@ module API
 
         enrichment = @provider.enrichments.find_or_initialize_draft
         enrichment.assign_attributes(enrichment_params)
+        enrichment.status = 'draft' if enrichment.rolled_over?
 
         enrichment.save
       end

--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -20,7 +20,7 @@ class ProviderEnrichment < ApplicationRecord
   before_save :ensure_region_code_is_an_integer_in_json_data
   before_create :set_provider_code
 
-  enum status: { draft: 0, published: 1 }
+  enum status: { draft: 0, published: 1, rolled_over: 2 }
 
   belongs_to :provider,
              inverse_of: 'enrichments'
@@ -34,7 +34,7 @@ class ProviderEnrichment < ApplicationRecord
 
   scope :latest_created_at, -> { order(created_at: :desc) }
   scope :latest_published_at, -> { order(last_published_at: :desc) }
-  scope :draft, -> { where(status: 'draft') }
+  scope :draft, -> { where(status: %w[draft rolled_over]) }
 
   jsonb_accessor :json_data,
                  email: [:string, store_key: 'Email'],
@@ -64,6 +64,10 @@ class ProviderEnrichment < ApplicationRecord
             :address1, :address3, :address4,
             :postcode, :train_with_us, :train_with_disability,
             presence: true, on: :publish
+
+  def draft?
+    status.in? %w[draft rolled_over]
+  end
 
   def has_been_published_before?
     last_published_at.present?

--- a/app/services/provider_enrichments/rollover_enrichment_to_provider_service.rb
+++ b/app/services/provider_enrichments/rollover_enrichment_to_provider_service.rb
@@ -1,0 +1,10 @@
+module ProviderEnrichments
+  class RolloverEnrichmentToProviderService
+    def execute(enrichment:, new_provider:)
+      new_enrichment = enrichment.dup
+      new_enrichment.last_published_at = nil
+      new_enrichment.provider = new_provider
+      new_enrichment.rolled_over!
+    end
+  end
+end

--- a/db/migrate/20190820095253_copy_enrichments_to_next_cycle.rb
+++ b/db/migrate/20190820095253_copy_enrichments_to_next_cycle.rb
@@ -1,0 +1,25 @@
+class CopyEnrichmentsToNextCycle < ActiveRecord::Migration[5.2]
+  def up
+    next_providers = RecruitmentCycle.next_recruitment_cycle.providers.all
+    rollover_service = ProviderEnrichments::RolloverEnrichmentToProviderService.new
+
+    current_providers_with_enrichments.each do |provider|
+      next if provider.enrichments.empty?
+
+      last_enrichment = provider.enrichments.order(created_at: :desc, id: :desc).first.dup
+
+      next_cycle_provider = next_providers.find { |n| n.provider_code == provider.provider_code }
+      rollover_service.execute(enrichment: last_enrichment, new_provider: next_cycle_provider)
+    end
+  end
+
+  def down
+    RecruitmentCycle.next_recruitment_cycle.providers.each { |provider| provider.enrichments.destroy_all }
+  end
+
+private
+
+  def current_providers_with_enrichments
+    RecruitmentCycle.current_recruitment_cycle.providers.includes(:enrichments).all.reject { |provider| provider.enrichments.empty? }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_16_111150) do
+ActiveRecord::Schema.define(version: 2019_08_20_095253) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"

--- a/spec/factories/provider_enrichments.rb
+++ b/spec/factories/provider_enrichments.rb
@@ -34,7 +34,7 @@ FactoryBot.define do
     address4 { Faker::Address.state }
     postcode { Faker::Address.postcode }
     telephone { '01234 123 123 ext 123' }
-    region_code { 'eastern' }
+    region_code { ProviderEnrichment.region_codes.values.sample }
     train_with_us { Faker::Lorem.sentence.to_s }
     train_with_disability { Faker::Lorem.sentence.to_s }
     accrediting_provider_enrichments { nil }

--- a/spec/models/provider_enrichment_spec.rb
+++ b/spec/models/provider_enrichment_spec.rb
@@ -323,4 +323,18 @@ describe ProviderEnrichment, type: :model do
       end
     end
   end
+
+  describe 'Rollover' do
+    let(:enrichment) { build(:provider_enrichment) }
+
+    before { enrichment.rolled_over! }
+
+    it 'has a status of "rolled over"' do
+      expect(enrichment.status).to eq("rolled_over")
+    end
+
+    it 'is marked as a draft' do
+      expect(enrichment.draft?). to be true
+    end
+  end
 end

--- a/spec/requests/api/v2/providers/update_spec.rb
+++ b/spec/requests/api/v2/providers/update_spec.rb
@@ -471,4 +471,19 @@ describe 'PATCH /providers/:provider_code' do
     include_examples 'only one attribute has changed', :train_with_us, 'changed train with us'
     include_examples 'only one attribute has changed', :train_with_disability, 'changed train with disability'
   end
+
+  describe 'Updating a rolled over enrichment' do
+    let(:enrichment) { build :provider_enrichment, status: 'rolled_over' }
+    let(:enrichments) { [enrichment] }
+
+    let(:updated_enrichment) { enrichment.reload }
+
+    before do
+      perform_request update_provider
+    end
+
+    it 'Sets the provider enrichment status to draft' do
+      expect(updated_enrichment.status).to eq('draft')
+    end
+  end
 end

--- a/spec/services/provider_enrichments/rollover_enrichment_to_provider_service_spec.rb
+++ b/spec/services/provider_enrichments/rollover_enrichment_to_provider_service_spec.rb
@@ -1,0 +1,38 @@
+describe ProviderEnrichments::RolloverEnrichmentToProviderService do
+  let(:service) { described_class.new }
+
+  def duplicated_provider_enrichments(enrichment)
+    enrichment.attributes.except(
+      'id',
+      'provider_id',
+      'created_at',
+      'updated_at',
+      'status'
+    )
+  end
+
+  context 'Copying provider enrichment to a new provider' do
+    let(:enrichment) { create(:provider_enrichment, provider: create(:provider)) }
+    let(:new_provider) { create(:provider) }
+
+    before do
+      service.execute(enrichment: enrichment, new_provider: new_provider)
+      new_provider.reload
+    end
+
+    it 'Adds the enrichment to the new provider' do
+      new_enrichment = new_provider.enrichments.first
+
+      expect(new_enrichment.provider_id).to eq(new_provider.id)
+      expect(duplicated_provider_enrichments(new_enrichment)).to eq(duplicated_provider_enrichments(enrichment))
+    end
+
+    it 'Sets the last published timestamp of the copy to nil' do
+      expect(new_provider.enrichments.first.last_published_at).to be_nil
+    end
+
+    it 'Marks the enrichment as rolled over' do
+      expect(new_provider.enrichments.first.rolled_over?).to be true
+    end
+  end
+end


### PR DESCRIPTION
### Context

In order to make providers cycle aware (https://trello.com/c/wXf4ncic/1854-s-make-provider-cycle-aware) we would like to ensure that when they go to the "About your org" pages for the next cycle they are met with data, rather than it being blank. 

### Changes proposed in this pull request

- Adds migration which goes over current providers and copies the last enrichment to the current cycle
    - Copying only the last mirrors how courses were rolled over


### Guidance to review

- Check out the branch to your local machine
- Ensure you have production-like data (in terms of quantity)
- Run the migrations

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
