### PR TITLE
[1947] Ensure welcome emails are retried

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@
 
 ## Setting up the app in development
 
+### Settings
+
+If you are going to login with a user who hasn't recieved the welcome email - you will need to set the following settings to their correct values in `config/settings/development.local.yml`:
+
+- `govuk_notify.api_key`
+- `govuk_notify.welcome_email_template_id`
+
 ### Native
 
 0. If you haven't already, follow this [tutorial](https://gorails.com/setup) to setup your Rails environment, make sure to install PostgreSQL 9.6 as the database

--- a/app/services/send_welcome_email_service.rb
+++ b/app/services/send_welcome_email_service.rb
@@ -4,15 +4,27 @@ class SendWelcomeEmailService
   end
 
   def execute(current_user:)
+    set_first_login_date(current_user)
+    send_welcome_email(current_user)
+  end
+
+private
+
+  def set_first_login_date(current_user)
     return if current_user.first_login_date_utc
 
-    time_now = Time.now.utc
-
     current_user.update(
-      first_login_date_utc: time_now,
-      welcome_email_date_utc: time_now
+      first_login_date_utc: Time.now.utc
     )
+  end
+
+  def send_welcome_email(current_user)
+    return if current_user.welcome_email_date_utc
 
     @mailer.send_welcome_email(first_name: current_user.first_name, email: current_user.email).deliver_now
+
+    current_user.update(
+      welcome_email_date_utc: Time.now.utc
+    )
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,3 +14,6 @@ search_api:
   # Auth token used between backend and search-and-compare-api to authorize requests.
   secret: banana
 current_recruitment_cycle: 2019
+govuk_notify:
+  api_key: please_change_me
+  welcome_email_template_id: please_change_me

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,4 +1,2 @@
 authentication:
   secret: secret
-govuk_notify:
-  api_key: its_a_secret

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     first_login_date_utc { Faker::Time.backward(days: 1).utc }
+    welcome_email_date_utc { Faker::Time.backward(days: 1).utc }
     accept_terms_date_utc { Faker::Time.backward(days: 1).utc }
     sign_in_user_id { SecureRandom.uuid }
 

--- a/spec/requests/api/v2/session_spec.rb
+++ b/spec/requests/api/v2/session_spec.rb
@@ -106,16 +106,16 @@ describe '/api/v2/sessions', type: :request do
         end
       end
 
-      context 'on first login' do
-        let(:user) { create(:user, first_login_date_utc: nil) }
+      context 'When the user has not received a welcome email' do
+        let(:user) { create(:user, welcome_email_date_utc: nil) }
 
         it 'Sends a welcome email to the user' do
           expect(govuk_notify_request).to have_been_made
         end
       end
 
-      context 'on second login' do
-        let(:user) { create(:user, first_login_date_utc: 10.days.ago) }
+      context 'When the user has received a welcome email' do
+        let(:user) { create(:user) }
 
         it 'Does not send a welcome email to the user' do
           expect(govuk_notify_request).not_to have_been_made

--- a/spec/services/send_welcome_email_service_spec.rb
+++ b/spec/services/send_welcome_email_service_spec.rb
@@ -10,7 +10,8 @@ describe SendWelcomeEmailService do
       spy(
         first_name: 'Meowington',
         email: 'meowington@cat.net',
-        first_login_date_utc: nil
+        first_login_date_utc: nil,
+        welcome_email_date_utc: nil
       )
     end
 
@@ -41,7 +42,8 @@ describe SendWelcomeEmailService do
     let(:current_user_spy) do
       spy(
         first_name: 'Meowington',
-        first_login_date_utc: Time.local(2018, 1, 1).utc
+        first_login_date_utc: Time.local(2018, 1, 1).utc,
+        welcome_email_date_utc: Time.local(2018, 1, 1).utc
       )
     end
 
@@ -51,12 +53,41 @@ describe SendWelcomeEmailService do
       expect(current_user_spy).not_to have_received(:update).with(hash_including(first_login_date_utc: Time.now.utc))
     end
 
-    it 'does not update their welcome email date' do
-      expect(current_user_spy).not_to have_received(:update).with(hash_including(welcome_email_date_utc: Time.now.utc))
+    context 'And has received a welcome email' do
+      it 'does not update their welcome email date' do
+        expect(current_user_spy).not_to have_received(:update).with(hash_including(welcome_email_date_utc: Time.now.utc))
+      end
+
+      it 'does not send the welcome email' do
+        expect(mailer_spy).not_to have_received(:send_welcome_email)
+      end
     end
 
-    it 'does not send the welcome email' do
-      expect(mailer_spy).not_to have_received(:send_welcome_email)
+    context 'And has not received a welcome email' do
+      let(:current_user_spy) do
+        spy(
+          email: 'meowington@cat.net',
+          first_name: 'Meowington',
+          first_login_date_utc: Time.local(2018, 1, 1).utc,
+          welcome_email_date_utc: nil
+        )
+      end
+
+      it 'sets their welcome email date to now' do
+        expect(current_user_spy).to have_received(:update).with(hash_including(welcome_email_date_utc: Time.now.utc))
+      end
+
+      it 'sends the welcome email' do
+        expect(mailer_spy).to have_received(:send_welcome_email)
+      end
+
+      it 'sends the email to the user' do
+        expect(mailer_spy).to have_received(:send_welcome_email).with(hash_including(email: 'meowington@cat.net'))
+      end
+
+      it 'sends the users first name in the email' do
+        expect(mailer_spy).to have_received(:send_welcome_email).with(hash_including(first_name: 'Meowington'))
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

When logging in locally - it was found that if it was the first login it would throw a 500 but still update the email received.

### Changes proposed in this pull request

- Update the README to expose the environment variables that will need to be set in order to login for the first time locally
- Don't update the welcome email sent time until after it's sent

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
