### PR TITLE
[XXX] Add enum for Provider#scheme_member

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -49,6 +49,11 @@ class Provider < ApplicationRecord
     not_an_accredited_body: 'N',
   }
 
+  enum scheme_member: {
+    is_a_UCAS_ITT_member: 'Y',
+    not_a_UCAS_ITT_member: 'N',
+  }
+
   belongs_to :recruitment_cycle
 
   has_and_belongs_to_many :organisations, join_table: :organisation_provider
@@ -336,7 +341,7 @@ private
   end
 
   def set_defaults
-    self.scheme_member ||= 'Y'
+    self.scheme_member ||= 'is_a_UCAS_ITT_member'
     self.year_code ||= recruitment_cycle.year
   end
 end

--- a/app/serializers/course_provider_serializer.rb
+++ b/app/serializers/course_provider_serializer.rb
@@ -45,4 +45,8 @@ class CourseProviderSerializer < ActiveModel::Serializer
   def accrediting_provider
     object.accrediting_provider_before_type_cast
   end
+
+  def scheme_member
+    object.scheme_member_before_type_cast
+  end
 end

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -80,6 +80,10 @@ class ProviderSerializer < ActiveModel::Serializer
     object.accrediting_provider_before_type_cast
   end
 
+  def scheme_member
+    object.scheme_member_before_type_cast
+  end
+
   def recruitment_cycle
     object.recruitment_cycle.year
   end

--- a/spec/lib/mcb/provider_editor_spec.rb
+++ b/spec/lib/mcb/provider_editor_spec.rb
@@ -191,7 +191,7 @@ describe MCB::ProviderEditor do
           expect(@output).to include("New provider has been created")
 
           expect(created_provider.attributes).to include(expected_provider_attributes)
-          expect(created_provider.scheme_member).to eq('Y')
+          expect(created_provider.is_a_UCAS_ITT_member?).to be_truthy
           expect(created_provider.year_code).to eq(RecruitmentCycle.current_recruitment_cycle.year)
         end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -675,12 +675,12 @@ describe Provider, type: :model do
         expect(provider.scheme_member).to eq('not_a_UCAS_ITT_member')
       end
 
-      it 'does not override a given value for recruitment_cycle' do
-        provider.scheme_member = 2020
+      it 'does not override a given value for year_code' do
+        provider.year_code = 2020
 
         provider.save!
 
-        expect(provider.scheme_member).to eq("2020")
+        expect(provider.year_code).to eq("2020")
       end
     end
   end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -278,6 +278,13 @@ describe Provider, type: :model do
             .with_values('accredited_body' => 'Y', 'not_an_accredited_body' => 'N')
   end
 
+  it 'defines an enum for accrediting_provider' do
+    expect(subject)
+      .to define_enum_for("scheme_member")
+            .backed_by_column_of_type(:text)
+            .with_values('is_a_UCAS_ITT_member' => 'Y', 'not_a_UCAS_ITT_member' => 'N')
+  end
+
   describe "courses" do
     let(:provider) { create(:provider, courses: [course]) }
     let(:course) { build(:course) }
@@ -649,7 +656,7 @@ describe Provider, type: :model do
 
         provider.save!
 
-        expect(provider.scheme_member).to eq('Y')
+        expect(provider.is_a_UCAS_ITT_member?).to be_truthy
       end
 
       it 'sets the year_code from the recruitment_cycle' do
@@ -661,11 +668,11 @@ describe Provider, type: :model do
       end
 
       it 'does not override a given value for scheme_member' do
-        provider.scheme_member = 'A'
+        provider.scheme_member = 'not_a_UCAS_ITT_member'
 
         provider.save!
 
-        expect(provider.scheme_member).to eq('A')
+        expect(provider.scheme_member).to eq('not_a_UCAS_ITT_member')
       end
 
       it 'does not override a given value for recruitment_cycle' do

--- a/spec/requests/api/v2/providers/update_spec.rb
+++ b/spec/requests/api/v2/providers/update_spec.rb
@@ -94,7 +94,7 @@ describe 'PATCH /providers/:provider_code' do
 
     include_examples 'does not allow assignment', :id,                   9999
     include_examples 'does not allow assignment', :provider_name,        'provider name'
-    include_examples 'does not allow assignment', :scheme_member,        'scheme member'
+    include_examples 'does not allow assignment', :scheme_member,        :not_a_UCAS_ITT_member
     include_examples 'does not allow assignment', :contact_name,         'contact name'
     include_examples 'does not allow assignment', :year_code,            'year code'
     include_examples 'does not allow assignment', :provider_code,        'provider code'


### PR DESCRIPTION
### Context
The `Provider#scheme_member` field stores whether the given provider is a member of UCAS's ITT scheme (and is consequently able to accept applications to its courses).

### Changes proposed in this pull request
Introduce an enum for the attribute, which defines default scopes that can be used for filtering.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
