### PR TITLE
[2009] Edit course accredited body

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -167,7 +167,8 @@ module API
                   :start_date,
                   :applications_open_from,
                   :study_mode,
-                  :is_send)
+                  :is_send,
+                  :accrediting_provider_code)
           .permit(
             :about_course,
             :course_length,
@@ -216,6 +217,7 @@ module API
             :study_mode,
             :is_send,
             :name,
+            :accrediting_provider_code
           )
       end
 

--- a/app/models/accrediting_provider_enrichment.rb
+++ b/app/models/accrediting_provider_enrichment.rb
@@ -2,7 +2,7 @@ class AccreditingProviderEnrichment
   include ActiveModel::Validations
   include ActiveModel::Model
 
-  # Pascal cased as the original is store like so.
+  # Pascal cased as the original is stored like so.
   attr_accessor :UcasProviderCode, :Description
 
   validates :Description, words_count: { maximum: 100 }

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -16,7 +16,8 @@ module API
                  :content_status, :ucas_status, :funding,
                  :level, :is_send?, :has_bursary?, :has_scholarship_and_bursary?,
                  :has_early_career_payments?, :bursary_amount, :scholarship_amount,
-                 :english, :maths, :science, :gcse_subjects_required, :age_range_in_years
+                 :english, :maths, :science, :gcse_subjects_required, :age_range_in_years,
+                 :accrediting_provider, :accrediting_provider_code
 
       attribute :start_date do
         @object.start_date.strftime("%B %Y") if @object.start_date

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -118,6 +118,8 @@ describe 'Courses API v2', type: :request do
                 "recruitment_cycle_year" => "2019",
                 "gcse_subjects_required" => %w[maths english science],
                 "age_range_in_years" => provider.courses[0].age_range_in_years,
+                "accrediting_provider" => nil,
+                "accrediting_provider_code" => nil,
               },
               "relationships" => {
                 "accrediting_provider" => { "meta" => { "included" => false } },
@@ -284,6 +286,8 @@ describe 'Courses API v2', type: :request do
               "recruitment_cycle_year" => "2019",
               "gcse_subjects_required" => %w[maths english science],
               "age_range_in_years" => provider.courses[0].age_range_in_years,
+              "accrediting_provider" => nil,
+              "accrediting_provider_code" => nil,
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },
@@ -365,6 +369,27 @@ describe 'Courses API v2', type: :request do
             .to have_attribute('recruitment_cycle_year').with_value('2020')
         end
       end
+    end
+  end
+
+  describe 'PATCH course' do
+    let(:path) do
+      "/api/v2/providers/#{provider.provider_code}" +
+        "/courses/#{course.course_code}"
+    end
+    let(:accrediting_provider) { create(:provider, accrediting_provider: 'Y') }
+    let(:course) { create(:course, provider: provider, site_statuses: [site_status]) }
+    let(:site_status) { build(:site_status, :new) }
+
+    before do
+      course
+    end
+
+    it 'can update the accrediting provider' do
+      patch path, headers: { 'HTTP_AUTHORIZATION' => credentials }, params: { 'course' => { 'accrediting_provider_code' => accrediting_provider.provider_code } }
+      attributes = JSON.parse(response.body)['data']['attributes']
+      expect(attributes['accrediting_provider_code']).to eq(accrediting_provider.provider_code)
+      expect(attributes['accrediting_provider']['provider_code']).to eq(accrediting_provider.provider_code)
     end
   end
 

--- a/spec/serializers/api/v2/serializable_provider_spec.rb
+++ b/spec/serializers/api/v2/serializable_provider_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
 describe API::V2::SerializableProvider do
-  let(:provider) { create :provider, accrediting_provider: 'Y' }
+  let(:accrediting_provider) { create(:provider, :accredited_body) }
+  let(:course) { create(:course, accrediting_provider: accrediting_provider) }
+  let(:provider) { create :provider, courses: [course] }
   let(:resource) { described_class.new object: provider }
 
   it 'sets type to providers' do
@@ -13,7 +15,16 @@ describe API::V2::SerializableProvider do
   it { should have_type 'providers' }
   it { should have_attribute(:provider_code).with_value(provider.provider_code) }
   it { should have_attribute(:provider_name).with_value(provider.provider_name) }
-  it { should have_attribute(:accredited_body?).with_value(true) }
+  it { should have_attribute(:accredited_body?).with_value(false) }
   it { should have_attribute(:can_add_more_sites?).with_value(true) }
   it { should have_attribute(:recruitment_cycle_year).with_value(provider.recruitment_cycle.year) }
+  it do
+    should have_attribute(:accredited_bodies).with_value([
+      {
+        'provider_name' => accrediting_provider.provider_name,
+        'provider_code' => accrediting_provider.provider_code,
+        'description' => ''
+      }
+    ])
+  end
 end


### PR DESCRIPTION
### Context
We'd like the ability to modify a course's accredited provider, in order to do this the frontend requires a list of all the accredited providers for a given provider's courses and the ability to update the accredited provider's course.

### Changes proposed in this pull request  
Permit the modification of a course's `:accredited_provider_code`, also add testing to afford some confidence when editing providers serialisation for accrediting bodies & course updating in future.  
  
### Guidance to review

### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
