### PR TITLE
[1876] Add recruitment cycle to Provider.to_s

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -234,7 +234,7 @@ class Provider < ApplicationRecord
   end
 
   def to_s
-    "#{provider_name} (#{provider_code})"
+    "[#{provider_code}] #{provider_name} (#{recruitment_cycle})"
   end
 
   def copy_to_recruitment_cycle(new_recruitment_cycle)

--- a/spec/lib/mcb/commands/users/revoke_spec.rb
+++ b/spec/lib/mcb/commands/users/revoke_spec.rb
@@ -76,7 +76,7 @@ describe 'mcb users revoke' do
       end
 
       it 'informs the support agent that it is not going to do anything' do
-        expect(output).to include("#{id_or_email_or_sign_in_id} already has no access to #{provider.provider_name}")
+        expect(output).to include("#{id_or_email_or_sign_in_id} already has no access to #{provider}")
       end
     end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -42,7 +42,7 @@ describe Provider, type: :model do
 
   subject { provider }
 
-  its(:to_s) { should eq('ACME SCITT (A01)') }
+  its(:to_s) { should eq('[A01] ACME SCITT (2019/20)') }
 
   describe 'auditing' do
     it { should be_audited.except(:changed_at) }


### PR DESCRIPTION
### Context
As it stands providers that have been rolled over cannot be distinguished from their initial versions.

### Changes proposed in this pull request
Change `Provider.to_s()` to print the code, name and recruitment cycle e.g: `[A01] Kings College London (2019/20)`

### Guidance to review

### Checklist

- [X] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
