### PR TITLE
[1877] Add recruitment cycle to Course.to_s

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -372,7 +372,7 @@ class Course < ApplicationRecord
   end
 
   def to_s
-    "#{name} (#{course_code})"
+    "#{name} (#{provider.provider_code}/#{course_code}) [#{recruitment_cycle}]"
   end
 
   def next_recruitment_cycle?

--- a/app/models/nctl_organisation.rb
+++ b/app/models/nctl_organisation.rb
@@ -6,8 +6,6 @@
 #  name            :text
 #  nctl_id         :text             not null
 #  organisation_id :integer
-#  urn             :integer
-#  ukprn           :integer
 #
 
 class NCTLOrganisation < ApplicationRecord

--- a/spec/lib/mcb/editor/provider_editor_spec.rb
+++ b/spec/lib/mcb/editor/provider_editor_spec.rb
@@ -44,7 +44,11 @@ describe MCB::Editor::ProviderEditor, :needs_audit_user do
 
         it 'lists the courses for the given provider' do
           output, = run_editor("edit courses", "continue", "exit")
-          expect(output).to include("[ ] Biology (A01X)", "[ ] History (A02X)", "[ ] Economics (A03X)")
+          expect(output).to include(
+            "[ ] Biology (#{provider_code}/A01X) [#{provider.recruitment_cycle}]",
+            "[ ] History (#{provider_code}/A02X) [#{provider.recruitment_cycle}]",
+            "[ ] Economics (#{provider_code}/A03X) [#{provider.recruitment_cycle}]"
+          )
         end
 
         it 'invokes course editing on the selected courses' do
@@ -52,8 +56,8 @@ describe MCB::Editor::ProviderEditor, :needs_audit_user do
 
           run_editor(
             "edit courses", # choose the option
-            "[ ] Biology (A01X)", # pick the first course
-            "[ ] Economics (A03X)", # pick the second course
+            "[ ] Biology (#{provider_code}/A01X) [#{provider.recruitment_cycle}]", # pick the first course
+            "[ ] Economics (#{provider_code}/A03X) [#{provider.recruitment_cycle}]", # pick the second course
             "continue", # finish selecting courses
             "exit" # from the command
           )
@@ -96,7 +100,12 @@ describe MCB::Editor::ProviderEditor, :needs_audit_user do
           it 'invokes course editing in the environment that the "providers edit" command was invoked' do
             allow($mcb).to receive(:run)
 
-            run_editor("edit courses", "[ ] Biology (A01X)", "continue", "exit")
+            run_editor(
+              "edit courses",
+              "[ ] Biology (#{provider_code}/A01X) [#{provider.recruitment_cycle}]",
+              "continue",
+              "exit"
+            )
 
             expect($mcb).to have_received(:run).with(
               %w[courses edit X12 A01X -E qa] + recruitment_cycle_year

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -29,11 +29,11 @@
 
 require 'rails_helper'
 
-RSpec.describe Course, type: :model do
+describe Course, type: :model do
   let(:course) { create(:course, name: 'Biology', course_code: '3X9F') }
   let(:subject) { course }
 
-  its(:to_s) { should eq('Biology (3X9F)') }
+  its(:to_s) { should eq("Biology (#{course.provider.provider_code}/3X9F) [2019/20]") }
   its(:modular) { should eq('') }
 
   describe 'auditing' do

--- a/spec/models/nctl_organisation_spec.rb
+++ b/spec/models/nctl_organisation_spec.rb
@@ -6,8 +6,6 @@
 #  name            :text
 #  nctl_id         :text             not null
 #  organisation_id :integer
-#  urn             :integer
-#  ukprn           :integer
 #
 
 describe NCTLOrganisation, type: :model do


### PR DESCRIPTION
### Context
As it stands courses that have been rolled over cannot be distinguished from their initial versions.

### Changes proposed in this pull request
Change `Provider.to_s()` to print the provider code, course code, name and recruitment cycle e.g: `[A1/QM1] Introductory Quantum Mechanics (2019/20)`  
  
### Guidance to review

### Checklist

- [X] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
