### PR TITLE
[XXX] Add NCTLOrganisation model

### DIFF
--- a/app/models/nctl_organisation.rb
+++ b/app/models/nctl_organisation.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: nctl_organisation
+#
+#  id              :integer          not null, primary key
+#  name            :text
+#  nctl_id         :text             not null
+#  organisation_id :integer
+#  urn             :integer
+#  ukprn           :integer
+#
+
+class NCTLOrganisation < ApplicationRecord
+  belongs_to :organisation
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -21,4 +21,5 @@ ActiveSupport::Inflector.inflections do |inflect|
   inflect.acronym 'UCAS'
   inflect.acronym 'MFL' # Modern foreign languages
   inflect.acronym 'DFE' # Department for Education
+  inflect.acronym 'NCTL' # National College for Teaching and Leadership
 end

--- a/spec/models/nctl_organisation_spec.rb
+++ b/spec/models/nctl_organisation_spec.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: nctl_organisation
+#
+#  id              :integer          not null, primary key
+#  name            :text
+#  nctl_id         :text             not null
+#  organisation_id :integer
+#  urn             :integer
+#  ukprn           :integer
+#
+
+describe NCTLOrganisation, type: :model do
+  it { should belong_to(:organisation) }
+end


### PR DESCRIPTION
# Context
The `nctl_organisation` table contains NCTL ids associated with particular organisations. 
These are useful for linking Find organisations to other DfE services because. The Support app already displays this information.

### Changes proposed in this pull request

Add the model and spec for it. 

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
