### PR TITLE
[1876] Make Provider.to_s consistent with UI

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -234,7 +234,7 @@ class Provider < ApplicationRecord
   end
 
   def to_s
-    "[#{provider_code}] #{provider_name} (#{recruitment_cycle})"
+    "#{provider_name} (#{provider_code}) [#{recruitment_cycle}]"
   end
 
   def copy_to_recruitment_cycle(new_recruitment_cycle)

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -42,7 +42,7 @@ describe Provider, type: :model do
 
   subject { provider }
 
-  its(:to_s) { should eq('[A01] ACME SCITT (2019/20)') }
+  its(:to_s) { should eq('ACME SCITT (A01) [2019/20]') }
 
   describe 'auditing' do
     it { should be_audited.except(:changed_at) }


### PR DESCRIPTION
### Context  
Feedback from previous PR for this ticket  
https://github.com/DFE-Digital/manage-courses-backend/pull/748#discussion_r318905976  

### Changes proposed in this pull request
Show providers in the format `Kings College London (A01) [2019/20]` rather than `[A01] Kings College London (2019/20)`

### Guidance to review

### Checklist

- [X] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [x] Tested by running locally
