### PR TITLE
[2018] Readme - add libpq-dev as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@
 - Ruby 2.6.1
 - postgresql-9.6 postgresql-contrib-9.6
 
+#### Linux
+
+To be able to bundle on linux (for the `pg` gem) you need the postgres header files:
+
+   sudo apt install libpq-dev
+
 ### Docker
 
 - docker


### PR DESCRIPTION
`bundle` didn't work on a fresh linux install without it

### Context

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
