### PR TITLE
[2040] Change fields to not editable when published

### DIFF
--- a/app/models/concerns/courses/edit_options.rb
+++ b/app/models/concerns/courses/edit_options.rb
@@ -7,6 +7,8 @@ module Courses
     include StartDateConcern
     include StudyModeConcern
     include ProgramTypeConcern
+    include IsSendConcern
+    include ApplicationsOpenConcern
 
     included do
       # When changing edit options here be sure to update the edit_options in the
@@ -21,6 +23,9 @@ module Courses
           start_dates: start_date_options,
           study_modes: study_mode_options,
           program_type: program_type_options,
+          show_is_send: show_is_send?,
+          show_start_date: show_start_date?,
+          show_applications_open: show_applications_open?
         }
       end
     end

--- a/app/models/concerns/courses/edit_options/applications_open_concern.rb
+++ b/app/models/concerns/courses/edit_options/applications_open_concern.rb
@@ -1,0 +1,16 @@
+module Courses
+  module EditOptions
+    module ApplicationsOpenConcern
+      extend ActiveSupport::Concern
+      included do
+        # When changing anything here be sure to update the edit_options in the
+        # courses factory in manage-courses-frontend:
+        #
+        # https://github.com/DFE-Digital/manage-courses-frontend/blob/master/spec/factories/courses.rb
+        def show_applications_open?
+          !is_published?
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/courses/edit_options/is_send_concern.rb
+++ b/app/models/concerns/courses/edit_options/is_send_concern.rb
@@ -1,0 +1,16 @@
+module Courses
+  module EditOptions
+    module IsSendConcern
+      extend ActiveSupport::Concern
+      included do
+        # When changing anything here be sure to update the edit_options in the
+        # courses factory in manage-courses-frontend:
+        #
+        # https://github.com/DFE-Digital/manage-courses-frontend/blob/master/spec/factories/courses.rb
+        def show_is_send?
+          !is_published?
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/courses/edit_options/start_date_concern.rb
+++ b/app/models/concerns/courses/edit_options/start_date_concern.rb
@@ -23,6 +23,10 @@ module Courses
            "June #{recruitment_year + 1}",
            "July #{recruitment_year + 1}"]
         end
+
+        def show_start_date?
+          !is_published?
+        end
       end
     end
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -386,23 +386,44 @@ class Course < ApplicationRecord
   # Ideally this would just use the validation, but:
   # https://github.com/rails/rails/issues/13971
   def course_params_assignable(course_params)
-    entry_requirements_assignable(course_params) &&
+    assignable_after_publish(course_params) &&
+      entry_requirements_assignable(course_params) &&
       qualification_assignable(course_params)
   end
 
+  def is_published?
+    content_status == :published
+  end
+  
 private
 
+  def assignable_after_publish(course_params)
+    relevant_params = course_params.slice(:is_send, :applications_open_from, :application_start_date)
+
+    return true if relevant_params.empty? || !is_published?
+
+    relevant_params.each do |field, _value|
+      errors.add(field.to_sym, 'cannot be changed after publish')
+    end
+    false
+  end
+
   def entry_requirements_assignable(course_params)
-    course_params.slice(:maths, :english, :science)
-      .to_h
-      .select { |_subject, value| value && !ENTRY_REQUIREMENT_OPTIONS.key?(value.to_sym) }
-      .map { |subject, _value| errors.add(subject.to_sym, "is invalid") }
-      .empty?
+    relevant_params = course_params.slice(:maths, :english, :science)
+
+    invalid_params = relevant_params.select do |_subject, value|
+      value && !ENTRY_REQUIREMENT_OPTIONS.key?(value.to_sym)
+    end
+    invalid_params.each do |subject, _value|
+      errors.add(subject.to_sym, 'is invalid')
+    end
+
+    invalid_params.empty?
   end
 
   def qualification_assignable(course_params)
     assignable = course_params[:qualification].nil? || Course::qualifications.include?(course_params[:qualification].to_sym)
-    errors.add(:qualification, "is invalid") unless assignable
+    errors.add(:qualification, 'is invalid') unless assignable
 
     assignable
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -394,7 +394,7 @@ class Course < ApplicationRecord
   def is_published?
     content_status == :published
   end
-  
+
 private
 
   def assignable_after_publish(course_params)

--- a/spec/models/concerns/courses/edit_options_spec.rb
+++ b/spec/models/concerns/courses/edit_options_spec.rb
@@ -1,0 +1,126 @@
+require 'rails_helper'
+
+describe Course, type: :model do
+  let(:course) { create(:course, subjects: [subjects]) }
+  let(:subjects) { create(:subject, :primary) }
+
+  context 'entry_requirements' do
+    it 'returns the entry requirements that users can choose between' do
+      expect(course.entry_requirements).to eq(%i[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test])
+    end
+  end
+
+  context 'qualifications' do
+    context 'for a course that’s not further education' do
+      it 'returns only QTS options for users to choose between' do
+        expect(course.qualification_options).to eq(%w[qts pgce_with_qts pgde_with_qts])
+        course.qualification_options.each do |q|
+          expect(q.include?('qts')).to be_truthy
+        end
+      end
+    end
+
+    context 'for a further education course' do
+      let(:subjects) { create(:further_education_subject) }
+      it 'returns only QTS options for users to choose between' do
+        expect(course.qualification_options).to eq(%w[pgce pgde])
+        course.qualification_options.each do |q|
+          expect(q.include?('qts')).to be_falsy
+        end
+      end
+    end
+  end
+
+  context 'age_range' do
+    context 'for primary' do
+      it 'returns the correct ages range for users to co choose between' do
+        expect(course.age_range_options).to eq(%w[3_to_7 5_to_11 7_to_11 7_to_14])
+      end
+    end
+
+    context 'for secondary' do
+      let(:subjects) { create(:subject, :secondary) }
+      it 'returns the correct age ranges for users to co choose between' do
+        expect(course.age_range_options).to eq(%w[11_to_16 11_to_18 14_to_19])
+      end
+    end
+  end
+
+  context 'start_date_options' do
+    let(:recruitment_year) { course.provider.recruitment_cycle.year.to_i }
+
+    it 'should return the correct options for the recruitment_cycle' do
+      expect(course.start_date_options).to eq(
+        ["August #{recruitment_year}",
+         "September #{recruitment_year}",
+         "October #{recruitment_year}",
+         "November #{recruitment_year}",
+         "December #{recruitment_year}",
+         "January #{recruitment_year + 1}",
+         "February #{recruitment_year + 1}",
+         "March #{recruitment_year + 1}",
+         "April #{recruitment_year + 1}",
+         "May #{recruitment_year + 1}",
+         "June #{recruitment_year + 1}",
+         "July #{recruitment_year + 1}"]
+     )
+    end
+  end
+
+  context 'available_start_date_options' do
+    let(:recruitment_year) { course.provider.recruitment_cycle.year.to_i }
+
+    context 'when unpublished' do
+      it 'should return the correct options for the recruitment_cycle' do
+        expect(course.show_start_date?).to eq(true)
+      end
+    end
+
+    context 'when published' do
+      let(:enrichment) { create(:course_enrichment, :published) }
+      let(:course) { create(:course, enrichments: [enrichment]) }
+
+      it 'should return no options' do
+        expect(course.show_start_date?).to eq(false)
+      end
+    end
+  end
+
+  context 'is_send' do
+    let(:recruitment_year) { course.provider.recruitment_cycle.year.to_i }
+
+    context 'when unpublished' do
+      it 'should indicate that the option is a checkbox' do
+        expect(course.show_is_send?).to eq(true)
+      end
+    end
+
+    context 'when published' do
+      let(:enrichment) { create(:course_enrichment, :published) }
+      let(:course) { create(:course, enrichments: [enrichment]) }
+
+      it 'should indicate that the option is hidden' do
+        expect(course.show_is_send?).to eq(false)
+      end
+    end
+  end
+
+  context 'applications_open' do
+    let(:recruitment_year) { course.provider.recruitment_cycle.year.to_i }
+
+    context 'when unpublished' do
+      it 'should indicate that the option is a checkbox' do
+        expect(course.show_applications_open?).to eq(true)
+      end
+    end
+
+    context 'when published' do
+      let(:enrichment) { create(:course_enrichment, :published) }
+      let(:course) { create(:course, enrichments: [enrichment]) }
+
+      it 'should indicate that the option is hidden' do
+        expect(course.show_applications_open?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -970,7 +970,7 @@ describe Course, type: :model do
   end
 
   describe '#course_params_assignable' do
-    context 'entry requirement' do
+    describe 'when setting the entry requirement' do
       it 'can assign a valid value' do
         expect(course.course_params_assignable(maths: 'equivalence_test')).to eq(true)
         expect(course.errors.messages).to eq(enrichments: [])
@@ -982,7 +982,7 @@ describe Course, type: :model do
       end
     end
 
-    context 'qualification' do
+    describe 'when setting the qualification' do
       it 'can assign a valid qualification' do
         expect(course.course_params_assignable(qualification: 'pgce_with_qts')).to eq(true)
         expect(course.errors.messages).to eq(enrichments: [])
@@ -994,10 +994,13 @@ describe Course, type: :model do
       end
     end
 
-    context 'published' do
+    describe 'for publishing' do
       let(:user) { create(:user) }
 
-      context 'not published' do
+      context 'when not published' do
+        let(:enrichment) { create(:course_enrichment, :initial_draft) }
+        let(:course) { create(:course, enrichments: [enrichment]) }
+
         it 'can assign to SEND' do
           expect(course.course_params_assignable(is_send: true)).to eq(true)
           expect(course.errors.messages).to eq(enrichments: [])
@@ -1014,7 +1017,7 @@ describe Course, type: :model do
         end
       end
 
-      context 'course is published' do
+      context 'when published' do
         let(:enrichment) { create(:course_enrichment, :published) }
         let(:course) { create(:course, enrichments: [enrichment]) }
 
@@ -1032,6 +1035,26 @@ describe Course, type: :model do
           expect(course.course_params_assignable(application_start_date: '25/08/2019')).to eq(false)
           expect(course.errors.messages).to eq(enrichments: [], application_start_date: ['cannot be changed after publish'])
         end
+      end
+    end
+  end
+
+  describe '#is_published?' do
+    context 'course is not published' do
+      let(:enrichment) { create(:course_enrichment, :initial_draft) }
+      let(:course) { create(:course, enrichments: [enrichment]) }
+
+      it 'returns false' do
+        expect(course.is_published?).to eq(false)
+      end
+    end
+
+    context 'course is published' do
+      let(:enrichment) { create(:course_enrichment, :published) }
+      let(:course) { create(:course, enrichments: [enrichment]) }
+
+      it 'returns true' do
+        expect(course.is_published?).to eq(true)
       end
     end
   end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -968,4 +968,71 @@ describe Course, type: :model do
       its(:self_accredited?) { should be_falsey }
     end
   end
+
+  describe '#course_params_assignable' do
+    context 'entry requirement' do
+      it 'can assign a valid value' do
+        expect(course.course_params_assignable(maths: 'equivalence_test')).to eq(true)
+        expect(course.errors.messages).to eq(enrichments: [])
+      end
+
+      it 'cannot be assigned an invalid value' do
+        expect(course.course_params_assignable(maths: 'test')).to eq(false)
+        expect(course.errors.messages).to eq(enrichments: [], maths: ['is invalid'])
+      end
+    end
+
+    context 'qualification' do
+      it 'can assign a valid qualification' do
+        expect(course.course_params_assignable(qualification: 'pgce_with_qts')).to eq(true)
+        expect(course.errors.messages).to eq(enrichments: [])
+      end
+
+      it 'cannot assign invalid qualification' do
+        expect(course.course_params_assignable(qualification: 'invalid')).to eq(false)
+        expect(course.errors.messages).to eq(enrichments: [], qualification: ['is invalid'])
+      end
+    end
+
+    context 'published' do
+      let(:user) { create(:user) }
+
+      context 'not published' do
+        it 'can assign to SEND' do
+          expect(course.course_params_assignable(is_send: true)).to eq(true)
+          expect(course.errors.messages).to eq(enrichments: [])
+        end
+
+        it 'can assign to applications open from' do
+          expect(course.course_params_assignable(applications_open_from: '25/08/2019')).to eq(true)
+          expect(course.errors.messages).to eq(enrichments: [])
+        end
+
+        it 'can assign to applications open from' do
+          expect(course.course_params_assignable(application_start_date: '25/08/2019')).to eq(true)
+          expect(course.errors.messages).to eq(enrichments: [])
+        end
+      end
+
+      context 'course is published' do
+        let(:enrichment) { create(:course_enrichment, :published) }
+        let(:course) { create(:course, enrichments: [enrichment]) }
+
+        it 'cannot assign to SEND' do
+          expect(course.course_params_assignable(is_send: true)).to eq(false)
+          expect(course.errors.messages).to eq(enrichments: [], is_send: ['cannot be changed after publish'])
+        end
+
+        it 'cannot assign to applications open from' do
+          expect(course.course_params_assignable(applications_open_from: '25/08/2019')).to eq(false)
+          expect(course.errors.messages).to eq(enrichments: [], applications_open_from: ['cannot be changed after publish'])
+        end
+
+        it 'cannot assign to applications open from' do
+          expect(course.course_params_assignable(application_start_date: '25/08/2019')).to eq(false)
+          expect(course.errors.messages).to eq(enrichments: [], application_start_date: ['cannot be changed after publish'])
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -133,9 +133,25 @@ describe 'Courses API v2', type: :request do
                   "entry_requirements" => %w[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test],
                   "qualifications" => %w[qts pgce_with_qts pgde_with_qts],
                   "age_range_in_years" => %w[3_to_7 5_to_11 7_to_11 7_to_14],
-                  "start_dates" => ["August 2019", "September 2019", "October 2019", "November 2019", "December 2019", "January 2020", "February 2020", "March 2020", "April 2020", "May 2020", "June 2020", "July 2020"],
+                  "start_dates" => [
+                    "August 2019",
+                    "September 2019",
+                    "October 2019",
+                    "November 2019",
+                    "December 2019",
+                    "January 2020",
+                    "February 2020",
+                    "March 2020",
+                    "April 2020",
+                    "May 2020",
+                    "June 2020",
+                    "July 2020"
+                  ],
                   "study_modes" => %w[full_time part_time full_time_or_part_time],
-                  "program_type" => %w[pg_teaching_apprenticeship higher_education_programme]
+                  "program_type" => %w[pg_teaching_apprenticeship higher_education_programme],
+                  "show_is_send" => false,
+                  "show_start_date" => false,
+                  "show_applications_open" => false
                 }
               }
             },
@@ -303,9 +319,25 @@ describe 'Courses API v2', type: :request do
                 "entry_requirements" => %w[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test],
                 "qualifications" => %w[qts pgce_with_qts pgde_with_qts],
                 "age_range_in_years" => %w[3_to_7 5_to_11 7_to_11 7_to_14],
-                "start_dates" => ["August 2019", "September 2019", "October 2019", "November 2019", "December 2019", "January 2020", "February 2020", "March 2020", "April 2020", "May 2020", "June 2020", "July 2020"],
+                "start_dates" => [
+                  "August 2019",
+                  "September 2019",
+                  "October 2019",
+                  "November 2019",
+                  "December 2019",
+                  "January 2020",
+                  "February 2020",
+                  "March 2020",
+                  "April 2020",
+                  "May 2020",
+                  "June 2020",
+                  "July 2020"
+                ],
                 "study_modes" => %w[full_time part_time full_time_or_part_time],
-                "program_type" => %w[pg_teaching_apprenticeship higher_education_programme]
+                "program_type" => %w[pg_teaching_apprenticeship higher_education_programme],
+                "show_is_send" => false,
+                "show_start_date" => false,
+                "show_applications_open" => false
               }
             },
           }],


### PR DESCRIPTION
### Context
The fields 'SEND', 'applications open' and 'start date' shouldn't be changed after they've been published.  

### Changes proposed in this pull request
Wrap `course_params_assignable()` in tests and prevent the changing of `is_send`, `applications_open_from` and `application_start_date` when published.  

### Guidance to review
At the moment this only checks whether `content_status` is published to decide whether to permit the change, it may be the case that we should disable it with other statuses. Also it seems that the error message `enrichments: []` persists regardless of whether the data has any errors, this is a side issue that perhaps warrants further discussion.  

### Checklist

- [X] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
