### PR TITLE
[2044] add created at and changed at timestamp for providers to api v1

### DIFF
--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -32,7 +32,7 @@ class ProviderSerializer < ActiveModel::Serializer
 
   attributes :institution_code, :institution_name, :institution_type, :accrediting_provider,
              :address1, :address2, :address3, :address4, :postcode, :region_code, :scheme_member,
-             :utt_application_alerts, :type_of_gt12
+             :utt_application_alerts, :type_of_gt12, :created_at, :changed_at
 
              # application alert recipient has not been added into the enum in the contact model
              # as it does not share the name and email attribute. It is simply a contact email
@@ -86,6 +86,14 @@ class ProviderSerializer < ActiveModel::Serializer
 
   def recruitment_cycle
     object.recruitment_cycle.year
+  end
+
+  def created_at
+    object.created_at.iso8601
+  end
+
+  def changed_at
+    object.changed_at.iso8601
   end
 
 private

--- a/docs/api.md
+++ b/docs/api.md
@@ -403,8 +403,8 @@ endpoint) if any of these are true:
 | scheme_member          | Text                 | `Y` or `N`                                                                                                 |                                                                                                      |
 | recruitment_cycle      | Text                 |                                                                                                            | 4-character year                                                                                     |
 | gt12_contact_address   | Text                 |                                                                                                            | Email or URL for the candidate to contact that will be inserted into the GT12 letter sent them.      |
-| created_at             | ISO 8601 date string | "2019-07-18T12:00:00Z"                                                                                     | (NOT YET IMPLEMENTED) A timestamp of when this provider was first added to the database.             |
-| changed_at             | ISO 8601 date string | "2019-07-18T14:14:07Z"                                                                                     | (NOT YET IMPLEMENTED) A timestamp of when this provider was last changed in the database.                                  |
+| created_at             | ISO 8601 date string | "2019-07-18T12:00:00Z"                                                                                     | A timestamp of when this provider was first added to the database.             |
+| changed_at             | ISO 8601 date string | "2019-07-18T14:14:07Z"                                                                                     | A timestamp of when this provider was last changed in the database.                                  |
 
 
 ### Example response body
@@ -428,6 +428,8 @@ endpoint) if any of these are true:
     "scheme_member": "Y",
     "recruitment_cycle": "2019",
     "gt12_contact_address": "info@asmescitt.education.uk",
+    "created_at": "2019-07-18T12:00:00Z",
+    "changed_at": "2019-07-18T14:14:07Z",
     "campuses": [
       {
         "campus_code": "",

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -217,7 +217,9 @@ describe 'Providers API', type: :request do
                   'email' => 'application_alert_recipient@acmescitt.education.uk',
                   'telephone' => ''
                 }
-              ]
+              ],
+              'created_at' => provider.created_at.iso8601,
+              'changed_at' => provider.changed_at.iso8601
             },
             {
               'accrediting_provider' => 'Y',
@@ -272,7 +274,9 @@ describe 'Providers API', type: :request do
                   'email' => 'finance@acmeuniversity.education.uk',
                   'telephone' => '01273 345 678'
                 }
-              ]
+              ],
+              'created_at' => provider2.created_at.iso8601,
+              'changed_at' => provider2.changed_at.iso8601
             }
           ]
         )

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -31,7 +31,7 @@ require "rails_helper"
 
 describe ProviderSerializer do
   let(:ucas_preferences) { build(:provider_ucas_preference, type_of_gt12: :coming_or_not) }
-  let(:provider) { create :provider, ucas_preferences: ucas_preferences }
+  let(:provider) { create :provider, ucas_preferences: ucas_preferences, changed_at: Time.now + 60 }
 
   subject { serialize(provider) }
 

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -46,6 +46,8 @@ describe ProviderSerializer do
   it { should include(institution_type: provider.provider_type) }
   it { should include(accrediting_provider: provider.accrediting_provider_before_type_cast) }
   it { should include(recruitment_cycle: provider.recruitment_cycle.year) }
+  it { should include(created_at: provider.created_at.iso8601) }
+  it { should include(changed_at: provider.changed_at.iso8601) }
 
   describe 'type_of_gt12' do
     subject { serialize(provider)['type_of_gt12'] }


### PR DESCRIPTION
### Context
v1 api providers endpoint
created at and changed at timestamp for providers

### Changes proposed in this pull request
Added created at and changed at timestamp for providers to api v1
Amended docs to reflect changes

### Guidance to review
`/api/v1/2019/providers`

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
