### PR TITLE
[2058] Fix failing time bound test

### DIFF
--- a/spec/requests/api/v2/providers/courses/update_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_spec.rb
@@ -94,7 +94,7 @@ describe 'PATCH /providers/:provider_code/courses/:course_code' do
     include_examples 'does not allow assignment', :profpost_flag, 'BO'
     include_examples 'does not allow assignment', :program_type, 'SC'
     include_examples 'does not allow assignment', :qualification, 2
-    include_examples 'does not allow assignment', :start_date, Date.yesterday
+    include_examples 'does not allow assignment', :start_date, DateTime.new(Settings.current_recruitment_cycle, 10, 10)
     include_examples 'does not allow assignment', :study_mode, 'P'
     include_examples 'does not allow assignment', :modular, 'Modular'
     include_examples 'does not allow assignment', :english, 2


### PR DESCRIPTION
### Context

A time bound test will fail on the 01/09 every year.

### Changes proposed in this pull request
Give it set date that will never coincide with the courses start_date


- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
