### PR TITLE
[2045] add created at and changed at timestamp for courses to api v1

### DIFF
--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -35,7 +35,7 @@ class CourseSerializer < ActiveModel::Serializer
 
   attributes :course_code, :start_month, :name, :study_mode, :copy_form_required, :profpost_flag,
              :program_type, :modular, :english, :maths, :science, :recruitment_cycle,
-             :start_month_string, :age_range
+             :start_month_string, :age_range, :created_at, :changed_at
 
   def profpost_flag
     object.profpost_flag_before_type_cast
@@ -79,6 +79,14 @@ class CourseSerializer < ActiveModel::Serializer
 
   def recruitment_cycle
     object.provider.recruitment_cycle.year
+  end
+
+  def created_at
+    object.created_at.iso8601
+  end
+
+  def changed_at
+    object.changed_at.iso8601
   end
 
   # Course now has a `is_send` attribute so we do not need to model `SEND` courses using the

--- a/docs/api.md
+++ b/docs/api.md
@@ -197,8 +197,8 @@ endpoint) if any of these are true:
 | provider             | Provider                    | A provider entity            | See the provider entity documentation below (without address data)  |
 | accrediting_provider | Provider                    | null or a provider entity    | See the provider entity documentation below (without address data)  |
 | age_range            | Text                        | "P", "S", "M", "O"           | Age of students targeted by this course.                            |
-| created_at           | ISO 8601 date string        | "2019-07-18T12:00:00Z"       | (NOT YET IMPLEMENTED) A timestamp of when this provider was first added to the database. |
-| changed_at           | ISO 8601 date string        | "2019-07-18T14:14:07Z"       | (NOT YET IMPLEMENTED) A timestamp of when this provider was last changed in the database. |
+| created_at           | ISO 8601 date string        | "2019-07-18T12:00:00Z"       | A timestamp of when this provider was first added to the database. |
+| changed_at           | ISO 8601 date string        | "2019-07-18T14:14:07Z"       | A timestamp of when this provider was last changed in the database. |
 
 ### Course codes
 
@@ -228,6 +228,8 @@ endpoint) if any of these are true:
     "qualification": 1,
     "recruitment_cycle": "2019",
     "age_range": "S",
+    "created_at": "2019-07-18T12:00:00Z",
+    "changed_at": "2019-07-18T14:14:07Z",
     "campus_statuses": [
       {
         "campus_code": "-",

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -116,7 +116,9 @@ describe "Courses API", type: :request do
                                   "accrediting_provider" => 'Y',
                                   "scheme_member" => "Y"
                                 },
-                                "accrediting_provider" => nil
+                                "accrediting_provider" => nil,
+                                "created_at" => provider.courses.first.created_at.iso8601,
+                                "changed_at" => provider.courses.first.changed_at.iso8601
                               }
                             ])
       end

--- a/spec/serializers/course_serializer_spec.rb
+++ b/spec/serializers/course_serializer_spec.rb
@@ -30,13 +30,15 @@
 require "rails_helper"
 
 RSpec.describe CourseSerializer do
-  let(:course) { create :course, provider: provider }
+  let(:course) { create :course, provider: provider, changed_at: Time.now + 60 }
   let(:provider) { build(:provider) }
   subject { serialize(course) }
 
   it { should include(course_code: course.course_code) }
   it { should include(name: course.name) }
   it { should include(recruitment_cycle: course.provider.recruitment_cycle.year) }
+  it { should include(created_at: course.created_at.iso8601) }
+  it { should include(changed_at: course.changed_at.iso8601) }
   it { is_expected.to_not have_key(:is_send) } # Ensure V2 API is not being included.
 
   context 'when the course is SEND' do


### PR DESCRIPTION
### Context
v1 api courses endpoint
created at and changed at timestamp for courses

### Changes proposed in this pull request
Added created at and changed at timestamp for courses to api v1
Amended docs to reflect changes

### Guidance to review
`/api/v1/2019/courses`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
