### PR TITLE
[2085] Create endpoint for triggering bulk sync

### DIFF
--- a/app/controllers/api/system/application_controller.rb
+++ b/app/controllers/api/system/application_controller.rb
@@ -1,0 +1,13 @@
+module API
+  module System
+    class ApplicationController < ::ApplicationController
+      before_action -> { skip_authorization }
+
+      def authenticate
+        authenticate_or_request_with_http_token do |token|
+          ActiveSupport::SecurityUtils.secure_compare(token, Rails.application.config.system_authentication_token)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/system/force_sync_controller.rb
+++ b/app/controllers/api/system/force_sync_controller.rb
@@ -1,0 +1,10 @@
+module API
+  module System
+    class ForceSyncController < API::System::ApplicationController
+      def sync
+        BulkSyncCoursesToFindJob.perform_later
+        render status: :accepted
+      end
+    end
+  end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,6 +35,7 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   config.authentication_token = "bats"
+  config.system_authentication_token = "Ge32"
 
   # Check for N+1 queries
   config.after_initialize do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,6 +141,10 @@ Rails.application.routes.draw do
         post :approve, on: :member
       end
     end
+
+    namespace :system do
+      post :sync, to: 'force_sync#sync'
+    end
   end
 
   get 'error_500', to: 'error#error_500'

--- a/spec/controllers/api/system/application_controller_spec.rb
+++ b/spec/controllers/api/system/application_controller_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe API::System::ApplicationController, type: :controller do
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token
+      .encode_credentials('Ge32')
+  end
+
+  let(:unauthorized_credentials) do
+    ActionController::HttpAuthentication::Token
+      .encode_credentials('Si14')
+  end
+
+  it 'authenticates given the correct credentials' do
+    request.headers['HTTP_AUTHORIZATION'] = credentials
+    controller.response = response
+    controller.authenticate
+    expect(response).to have_http_status(:success)
+  end
+
+  it 'does not authenticate given incorrect credentials' do
+    controller.response = response
+    request.headers['HTTP_AUTHORIZATION'] = unauthorized_credentials
+    controller.authenticate
+    expect(response).to have_http_status(:unauthorized)
+  end
+end

--- a/spec/requests/api/system/force_sync_spec.rb
+++ b/spec/requests/api/system/force_sync_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe 'force sync' do
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token
+      .encode_credentials('Ge32')
+  end
+
+  before do
+    allow(BulkSyncCoursesToFindJob).to receive(:perform_later)
+  end
+
+  it 'returns success' do
+    post '/api/system/sync', headers: { 'HTTP_AUTHORIZATION' => credentials }
+    expect(response.status).to eq(202)
+  end
+
+  it 'triggers a sync' do
+    post '/api/system/sync', headers: { 'HTTP_AUTHORIZATION' => credentials }
+    expect(BulkSyncCoursesToFindJob).to have_received(:perform_later)
+  end
+end


### PR DESCRIPTION
### Context
We had this functionality in the C# version via WebJobs as Azure allowed us to manually trigger it. We would like to replicate this functionality by creating an endpoint that when sent a message will trigger the jobs.  

### Changes proposed in this pull request
Add the /api/v2/sync endpoint that when pinged will queue another sync  

### Guidance to review

### Checklist

- [X] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] ~~Rebased master~~
- [X] Cleaned commit history
- [X] Tested by running locally
