### PR TITLE
[2086] Expose the providers ucas contacts on api v2

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -306,6 +306,10 @@ class Provider < ApplicationRecord
     scitt == 'Y'
   end
 
+  def generated_ucas_contact(type)
+    contacts.find_by!(type: type).slice('name', 'email', 'telephone') if contacts.map(&:type).include?(type)
+  end
+
 private
 
   def add_enrichment_errors(enrichment)

--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -57,6 +57,27 @@ module API
         @object.last_published_at&.iso8601
       end
 
+      attribute :admin_contact do
+        @object.generated_ucas_contact('admin')
+      end
+
+      attribute :utt_contact do
+        @object.generated_ucas_contact('utt')
+      end
+
+      attribute :web_link_contact do
+        @object.generated_ucas_contact('web_link')
+      end
+
+      attribute :fraud_contact do
+        @object.generated_ucas_contact('fraud')
+      end
+
+      attribute :finance_contact do
+        @object.generated_ucas_contact('finance')
+      end
+
+
       enrichment_attribute :train_with_us
       enrichment_attribute :train_with_disability
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -711,4 +711,61 @@ describe Provider, type: :model do
       its(:is_it_really_really_a_scitt?) { should be_falsey }
     end
   end
+
+  describe '#generated_ucas_contact' do
+    let(:provider) { create :provider, contacts: [contact1, contact2, contact3, contact4, contact5] }
+    let(:contact1)  { build(:contact, :admin_type) }
+    let(:contact2)  { build(:contact, :utt_type) }
+    let(:contact3)  { build(:contact, :web_link_type) }
+    let(:contact4)  { build(:contact, :fraud_type) }
+    let(:contact5)  { build(:contact, :finance_type) }
+
+    context 'for an admin contact' do
+      subject { provider.generated_ucas_contact(contact1.type) }
+
+      its([:name]) { should eq contact1.name }
+      its([:email]) { should eq contact1.email }
+      its([:telephone]) { should eq contact1.telephone }
+    end
+
+    context 'for a utt contact' do
+      subject { provider.generated_ucas_contact(contact2.type) }
+
+      its([:name]) { should eq contact2.name }
+      its([:email]) { should eq contact2.email }
+      its([:telephone]) { should eq contact2.telephone }
+    end
+
+    context 'for a web link contact' do
+      subject { provider.generated_ucas_contact(contact3.type) }
+
+      its([:name]) { should eq contact3.name }
+      its([:email]) { should eq contact3.email }
+      its([:telephone]) { should eq contact3.telephone }
+    end
+
+    context 'for a fraud contact' do
+      subject { provider.generated_ucas_contact(contact4.type) }
+
+      its([:name]) { should eq contact4.name }
+      its([:email]) { should eq contact4.email }
+      its([:telephone]) { should eq contact4.telephone }
+    end
+
+    context 'for a finance contact' do
+      subject { provider.generated_ucas_contact(contact5.type) }
+
+      its([:name]) { should eq contact5.name }
+      its([:email]) { should eq contact5.email }
+      its([:telephone]) { should eq contact5.telephone }
+    end
+
+    context 'when there is no contact' do
+      let(:provider) { create(:provider) }
+
+      subject { provider.generated_ucas_contact('admin') }
+
+      it { should eq nil }
+    end
+  end
 end

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -18,8 +18,10 @@ describe 'Providers API v2', type: :request do
     let!(:provider) {
       create(:provider,
              organisations: [organisation],
-             enrichments: [enrichment])
+             enrichments: [enrichment],
+             contacts: [contact])
     }
+    let(:contact) { build(:contact) }
     let(:enrichment) { build(:provider_enrichment, :published) }
 
     let(:json_response) { JSON.parse(response.body) }
@@ -209,8 +211,10 @@ describe 'Providers API v2', type: :request do
              sites: [site],
              organisations: [organisation],
              enrichments: [enrichment],
-             courses: courses)
+             courses: courses,
+             contacts: [contact])
     end
+    let(:contact) { build(:contact) }
 
     let(:token) do
       JWT.encode payload,
@@ -251,6 +255,15 @@ describe 'Providers API v2', type: :request do
               "provider_name" => accrediting_provider.provider_name,
               "description" => description,
             }],
+            "admin_contact" => {
+                "name" => contact.name,
+                "email" => contact.email,
+                "telephone" => contact.telephone
+               },
+               "utt_contact" => nil,
+               "web_link_contact" => nil,
+               "fraud_contact" => nil,
+               "finance_contact" => nil
           },
           "relationships" => {
             "sites" => {
@@ -323,6 +336,15 @@ describe 'Providers API v2', type: :request do
                 "provider_name" => accrediting_provider.provider_name,
                 "description" => description,
               }],
+              "admin_contact" => {
+                   "name" => contact.name,
+                   "email" => contact.email,
+                   "telephone" => contact.telephone
+                 },
+                 "utt_contact" => nil,
+                 "web_link_contact" => nil,
+                 "fraud_contact" => nil,
+                 "finance_contact" => nil
             },
             "relationships" => {
               "sites" => {

--- a/spec/serializers/api/v2/serializable_provider_spec.rb
+++ b/spec/serializers/api/v2/serializable_provider_spec.rb
@@ -3,8 +3,14 @@ require 'rails_helper'
 describe API::V2::SerializableProvider do
   let(:accrediting_provider) { create(:provider, :accredited_body) }
   let(:course) { create(:course, accrediting_provider: accrediting_provider) }
-  let(:provider) { create :provider, courses: [course] }
+  let(:provider) { create :provider, courses: [course], contacts: [contact1, contact2, contact3, contact4, contact5] }
   let(:resource) { described_class.new object: provider }
+  let(:contact1)  { build(:contact, :admin_type) }
+  let(:contact2)  { build(:contact, :utt_type) }
+  let(:contact3)  { build(:contact, :web_link_type) }
+  let(:contact4)  { build(:contact, :fraud_type) }
+  let(:contact5)  { build(:contact, :finance_type) }
+
 
   it 'sets type to providers' do
     expect(resource.jsonapi_type).to eq :providers
@@ -27,4 +33,44 @@ describe API::V2::SerializableProvider do
       }
     ])
   end
+
+  it {
+    should have_attribute(:admin_contact).with_value(
+      "name" => contact1.name,
+      "email" => contact1.email,
+      "telephone" => contact1.telephone
+    )
+  }
+
+  it {
+    should have_attribute(:utt_contact).with_value(
+      "name" => contact2.name,
+      "email" => contact2.email,
+      "telephone" => contact2.telephone
+    )
+  }
+
+  it {
+    should have_attribute(:web_link_contact).with_value(
+      "name" => contact3.name,
+      "email" => contact3.email,
+      "telephone" => contact3.telephone
+    )
+  }
+
+  it {
+    should have_attribute(:fraud_contact).with_value(
+      "name" => contact4.name,
+      "email" => contact4.email,
+      "telephone" => contact4.telephone
+    )
+  }
+
+  it {
+    should have_attribute(:finance_contact).with_value(
+      "name" => contact5.name,
+      "email" => contact5.email,
+      "telephone" => contact5.telephone
+    )
+  }
 end


### PR DESCRIPTION
### Context

UCAS have asked for providers to be able to edit their contacts on publish (admin, utt etc.)
This is the first of several cards and exposes the providers ucas contacts on the v2 api.

### Changes proposed in this pull request

- Expose the providers ucas contacts on the v2 api

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
