### PR TITLE
[2086] Make each UCAS contact type unique for a provider

### DIFF
--- a/db/migrate/20190904131906_change_contact_types_to_be_unique_to_provider.rb
+++ b/db/migrate/20190904131906_change_contact_types_to_be_unique_to_provider.rb
@@ -1,0 +1,5 @@
+class ChangeContactTypesToBeUniqueToProvider < ActiveRecord::Migration[5.2]
+  def change
+    add_index :contact, %i[provider_id type], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_20_095253) do
+ActiveRecord::Schema.define(version: 2019_09_04_131906) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 2019_08_20_095253) do
     t.text "telephone"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["provider_id", "type"], name: "index_contact_on_provider_id_and_type", unique: true
     t.index ["provider_id"], name: "index_contact_on_provider_id"
   end
 


### PR DESCRIPTION
### Context

There should only be able to be one contact for each UCAS contact type for each provider

### Changes proposed in this pull request

- Migration to make the contact type unique to each provider_id

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
