### PR TITLE
2055 add build new course endpoint

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -7,13 +7,13 @@ module API
 
       before_action :build_recruitment_cycle
       before_action :build_provider
-      before_action :build_course, except: %i[index new create]
+      before_action :build_course, except: %i[index build_new create]
 
       deserializable_resource :course,
                               only: %i[update publish publishable create],
                               class: API::V2::DeserializableCourse
 
-      def new
+      def build_new
         authorize Course
 
         @course = @provider.courses.new

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -19,9 +19,9 @@ module API
         @course = @provider.courses.new
 
         if build_new_course(course_params)
-          render jsonapi: @course
+          render jsonapi: @course, meta: { edit_options: @course.edit_course_options }
         else
-          render jsonapi_errors: @course.errors, status: :unprocessable_entity
+          render jsonapi_errors: @course.errors, status: :unprocessable_entity, meta: { edit_options: @course.edit_course_options }
         end
       end
 
@@ -112,8 +112,9 @@ module API
       end
 
       def build_new_course(course_params)
-        # first request has params so return true to indicate success
-        return true unless course_params.values.any?
+        # Skip validations when building a new course with no params,
+        # so that frontend can get the initial edit_options:
+        # return true unless course_params.values.any?
 
         # add any enum related validation errors
         return unless @course.course_params_assignable(course_params)

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -19,5 +19,5 @@ class CoursePolicy
   alias_method :sync_with_search_and_compare?, :update?
   alias_method :publish?, :update?
   alias_method :publishable?, :update?
-  alias_method :new?, :index?
+  alias_method :build_new?, :index?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,7 +108,10 @@ Rails.application.routes.draw do
           post :sync_with_search_and_compare, on: :member
           post :publish, on: :member
           post :publishable, on: :member
-          get :new, on: :new
+          # We use build_new instead of new because of limitation in using a
+          # custom endpoint called "new" in JSON API Client. See the course.rb
+          # model in frontend.
+          get :build_new, on: :collection
         end
         resources :sites, only: %i[index update show create]
         resources :recruitment_cycles, only: %i[index]

--- a/spec/policies/course_policy_spec.rb
+++ b/spec/policies/course_policy_spec.rb
@@ -5,7 +5,7 @@ describe CoursePolicy do
 
   subject { described_class }
 
-  permissions :index?, :new? do
+  permissions :index?, :build_new? do
     it { should permit(user, Course) }
   end
 

--- a/spec/requests/api/v2/providers/courses/build_new_spec.rb
+++ b/spec/requests/api/v2/providers/courses/build_new_spec.rb
@@ -16,6 +16,88 @@ describe 'GET /providers/:provider_code/courses/build_new' do
   end
   let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
 
+  describe '#build_new' do
+    it 'returns a new course resource' do
+      params = nil
+      response = do_get params
+
+      course = provider.courses.new
+      expected_course_jsonapi = course_to_jsonapi(course)
+      expect(response['errors']).to be_nil
+      expect(response['data']).to_not be_nil
+      expect(response['data']).to eq expected_course_jsonapi['data']
+    end
+
+    context 'with course attributes set in query parameters' do
+      it 'intialises the course with the provider attributes' do
+        params = { course: {
+          name: 'Foo Bar Course',
+          maths: 'must_have_qualification_at_application_time',
+          english: 'must_have_qualification_at_application_time',
+        } }
+        response = do_get params
+
+        course = provider.courses.new(name: 'Foo Bar Course')
+        course.maths = :must_have_qualification_at_application_time
+        course.english = :must_have_qualification_at_application_time
+        expected_course_jsonapi = course_to_jsonapi(course)
+        expect(response['errors']).to be_nil
+        expect(response['data']).to_not be_nil
+        expect(response['data']).to eq expected_course_jsonapi['data']
+      end
+
+      context 'with an invalid value' do
+        it 'returns a useful error' do
+          params = { course: {
+            name: 'Monkey matters',
+            is_send: 'wibble', # invalid
+            maths: 'must_have_qualification_at_application_time',
+            english: 'must_have_qualification_at_application_time',
+          } }
+          response = do_get params
+
+          expect(response['errors']).to eq [{
+                                              "detail" => "Is send is not included in the list",
+                                              "source" => {},
+                                              "title" => "Invalid is_send"
+                                            }]
+          expect(response['data']).to be_nil
+        end
+      end
+
+      context 'with an invalid enum value' do
+        it 'returns a useful error' do
+          params = { course: {
+            name: 'Foo Bar Course',
+            maths: 'wibble',
+            english: 'must_have_qualification_at_application_time',
+          } }
+          response = do_get params
+
+          expect(response['errors']).to eq [{
+                                              "detail" => "Maths is invalid",
+                                              "source" => {},
+                                              "title" => "Invalid maths"
+                                            }]
+          expect(response['data']).to be_nil
+        end
+      end
+    end
+  end
+
+  # trying out avoiding let syntax by doing DRY with normal functions
+
+  def do_get(params)
+    get "/api/v2/recruitment_cycles/#{recruitment_cycle.year}" \
+          "/providers/#{provider.provider_code}" \
+          "/courses/build_new",
+        headers: { 'HTTP_AUTHORIZATION' => credentials },
+        params: params
+
+    jsonapi_response = JSON.parse(response.body)
+    jsonapi_response
+  end
+
   def course_to_jsonapi(course)
     rendered_course = jsonapi_renderer.render(
       course,
@@ -26,33 +108,5 @@ describe 'GET /providers/:provider_code/courses/build_new' do
     # Converting the rendered course to JSON and back normalises any symbols
     # into strings. Better #deep_symbolize_keys because it also does values.
     JSON.parse(rendered_course.to_json)
-  end
-
-  describe '#build_new' do
-    it 'returns a new course resource' do
-      get "/api/v2/recruitment_cycles/#{recruitment_cycle.year}" \
-          "/providers/#{provider.provider_code}" \
-          "/courses/build_new",
-          headers: { 'HTTP_AUTHORIZATION' => credentials }
-
-      expected_course_jsonapi = course_to_jsonapi(provider.courses.new)
-      jsonapi_response = JSON.parse(response.body)
-      expect(jsonapi_response['data']).to eq expected_course_jsonapi['data']
-    end
-
-    context 'with course attributes set in query parameters' do
-      it 'intialises the course with the provider attributes' do
-        get "/api/v2/recruitment_cycles/#{recruitment_cycle.year}" \
-            "/providers/#{provider.provider_code}" \
-            "/courses/build_new",
-            headers: { 'HTTP_AUTHORIZATION' => credentials },
-            params: { name: 'Foo Bar Course' }
-
-        course = provider.courses.new(name: 'Foo Bar Course')
-        expected_course_jsonapi = course_to_jsonapi(course)
-        jsonapi_response = JSON.parse(response.body)
-        expect(jsonapi_response['data']).to eq expected_course_jsonapi['data']
-      end
-    end
   end
 end

--- a/spec/requests/api/v2/providers/courses/build_new_spec.rb
+++ b/spec/requests/api/v2/providers/courses/build_new_spec.rb
@@ -16,6 +16,18 @@ describe 'GET /providers/:provider_code/courses/build_new' do
   end
   let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
 
+  def course_to_jsonapi(course)
+    rendered_course = jsonapi_renderer.render(
+      course,
+      class: {
+        Course: API::V2::SerializableCourse
+      }
+    )
+    # Converting the rendered course to JSON and back normalises any symbols
+    # into strings. Better #deep_symbolize_keys because it also does values.
+    JSON.parse(rendered_course.to_json)
+  end
+
   describe '#build_new' do
     it 'returns a new course resource' do
       get "/api/v2/recruitment_cycles/#{recruitment_cycle.year}" \
@@ -23,18 +35,24 @@ describe 'GET /providers/:provider_code/courses/build_new' do
           "/courses/build_new",
           headers: { 'HTTP_AUTHORIZATION' => credentials }
 
-      course = provider.courses.new
-      rendered_course = jsonapi_renderer.render(
-        course,
-        class: {
-          Course: API::V2::SerializableCourse
-        }
-      )
-      # Converting the rendered course to JSON and back normalises any symbols
-      # into strings. Better #deep_symbolize_keys because it also does values.
-      jsonapi_course = JSON.parse(rendered_course.to_json)
+      expected_course_jsonapi = course_to_jsonapi(provider.courses.new)
       jsonapi_response = JSON.parse(response.body)
-      expect(jsonapi_response['data']).to eq jsonapi_course['data']
+      expect(jsonapi_response['data']).to eq expected_course_jsonapi['data']
+    end
+
+    context 'with course attributes set in query parameters' do
+      it 'intialises the course with the provider attributes' do
+        get "/api/v2/recruitment_cycles/#{recruitment_cycle.year}" \
+            "/providers/#{provider.provider_code}" \
+            "/courses/build_new",
+            headers: { 'HTTP_AUTHORIZATION' => credentials },
+            params: { name: 'Foo Bar Course' }
+
+        course = provider.courses.new(name: 'Foo Bar Course')
+        expected_course_jsonapi = course_to_jsonapi(course)
+        jsonapi_response = JSON.parse(response.body)
+        expect(jsonapi_response['data']).to eq expected_course_jsonapi['data']
+      end
     end
   end
 end

--- a/spec/requests/api/v2/providers/courses/build_new_spec.rb
+++ b/spec/requests/api/v2/providers/courses/build_new_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe 'GET /providers/:provider_code/courses/new' do
+describe 'GET /providers/:provider_code/courses/build_new' do
   let(:recruitment_cycle) { find_or_create :recruitment_cycle }
   let(:organisation)      { create :organisation }
   let(:provider) do
@@ -16,14 +16,14 @@ describe 'GET /providers/:provider_code/courses/new' do
   end
   let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
 
-  describe '#new' do
+  describe '#build_new' do
     it 'returns a new course resource' do
       get "/api/v2/recruitment_cycles/#{recruitment_cycle.year}" \
           "/providers/#{provider.provider_code}" \
-          "/courses/new",
+          "/courses/build_new",
           headers: { 'HTTP_AUTHORIZATION' => credentials }
 
-      course = provider.courses.new # Course.new(provider: provider)
+      course = provider.courses.new
       rendered_course = jsonapi_renderer.render(
         course,
         class: {

--- a/spec/requests/api/v2/providers/courses/build_new_spec.rb
+++ b/spec/requests/api/v2/providers/courses/build_new_spec.rb
@@ -17,75 +17,100 @@ describe 'GET /providers/:provider_code/courses/build_new' do
   let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
 
   describe '#build_new' do
-    it 'returns a new course resource' do
-      params = nil
-      response = do_get params
+    # todo: check returns nil for edit-options which rely on fields that aren't set yet (i.e. don't blow up)
 
-      course = provider.courses.new
-      expected_course_jsonapi = course_to_jsonapi(course)
-      expect(response['errors']).to be_nil
-      expect(response['data']).to_not be_nil
-      expect(response['data']).to eq expected_course_jsonapi['data']
+    context 'with no parameters' do
+      let(:params) { { course: {} } }
+
+      it 'returns edit_options and errors but no model' do
+        response = do_get params
+        jsonapi_response = parse_response(response)
+
+        expect(jsonapi_response['errors']).not_to be_nil # because it's not valid yet
+        expect(jsonapi_response['data']).to be_nil # because it's not valid yet
+        expect(jsonapi_response['meta']).not_to be_nil
+        expect(jsonapi_response['meta']['edit_options']).not_to be_nil
+        # todo: test "level" edit_options when it's implemented because that's the first question
+        expect(jsonapi_response['meta']['edit_options']['study_modes']).to eq %w[full_time part_time full_time_or_part_time]
+      end
     end
 
-    context 'with course attributes set in query parameters' do
-      it 'intialises the course with the provider attributes' do
-        params = { course: {
+    context 'with enough attributes set in query parameters to make a valid course' do
+      let(:params) do
+        { course: {
           name: 'Foo Bar Course',
           maths: 'must_have_qualification_at_application_time',
           english: 'must_have_qualification_at_application_time',
+          # todo: why is this valid when level not set? A: because level has a default. What to do about that if anything?
         } }
+      end
+
+      it 'returns the course model and edit_options with no errors' do
         response = do_get params
+        jsonapi_response = parse_response(response)
 
         course = provider.courses.new(name: 'Foo Bar Course')
         course.maths = :must_have_qualification_at_application_time
         course.english = :must_have_qualification_at_application_time
         expected_course_jsonapi = course_to_jsonapi(course)
-        expect(response['errors']).to be_nil
-        expect(response['data']).to_not be_nil
-        expect(response['data']).to eq expected_course_jsonapi['data']
+        expect(jsonapi_response['errors']).to be_nil
+        expect(jsonapi_response['data']).not_to be_nil
+        expect(jsonapi_response['data']).to eq expected_course_jsonapi['data']
+        expect(jsonapi_response['meta']).not_to be_nil
+        expect(jsonapi_response['meta']['edit_options']).not_to be_nil
+        expect(jsonapi_response['meta']['edit_options']['study_modes']).to eq %w[full_time part_time full_time_or_part_time]
+      end
+    end
+
+    context 'with an invalid attribute set in query parameters' do
+      let(:params) do
+        { course: {
+          name: 'Foo Bar Course',
+          is_send: 'wibble', # invalid
+          maths: 'must_have_qualification_at_application_time',
+          english: 'must_have_qualification_at_application_time',
+        } }
       end
 
-      context 'with an invalid value' do
-        it 'returns a useful error' do
-          params = { course: {
-            name: 'Monkey matters',
-            is_send: 'wibble', # invalid
-            maths: 'must_have_qualification_at_application_time',
-            english: 'must_have_qualification_at_application_time',
-          } }
-          response = do_get params
+      it 'returns edit_options and errors but no model' do
+        response = do_get params
+        expect(response).to have_http_status(:unprocessable_entity)
+        jsonapi_response = parse_response(response)
 
-          expect(response['errors']).to eq [{
-                                              "detail" => "Is send is not included in the list",
-                                              "source" => {},
-                                              "title" => "Invalid is_send"
-                                            }]
-          expect(response['data']).to be_nil
-        end
+        expect(jsonapi_response['errors']).to eq [{
+                                            "detail" => "Is send is not included in the list",
+                                            "source" => {}, # todo: make this work?
+                                            "title" => "Invalid is_send"
+                                          }]
+        expect(jsonapi_response['meta']).not_to be_nil
+        expect(jsonapi_response['meta']['edit_options']).not_to be_nil
+        expect(jsonapi_response['meta']['edit_options']['study_modes']).to eq %w[full_time part_time full_time_or_part_time]
+      end
+    end
+
+    context 'with an invalid enum attribute set in query parameters' do
+      let(:params) do
+        { course: {
+          name: 'Foo Bar Course',
+          maths: 'wibble', # invalid
+          english: 'must_have_qualification_at_application_time',
+        } }
       end
 
-      context 'with an invalid enum value' do
-        it 'returns a useful error' do
-          params = { course: {
-            name: 'Foo Bar Course',
-            maths: 'wibble',
-            english: 'must_have_qualification_at_application_time',
-          } }
-          response = do_get params
+      it 'returns edit_options and errors but no model' do
+        response = do_get params
+        expect(response).to have_http_status(:unprocessable_entity)
+        jsonapi_response = parse_response(response)
 
-          expect(response['errors']).to eq [{
-                                              "detail" => "Maths is invalid",
-                                              "source" => {},
-                                              "title" => "Invalid maths"
-                                            }]
-          expect(response['data']).to be_nil
-        end
+        expect(jsonapi_response['errors']).to eq [{
+                                            "detail" => "Maths is invalid",
+                                            "source" => {},
+                                            "title" => "Invalid maths"
+                                          }]
+        expect(jsonapi_response['meta']['edit_options']['study_modes']).to eq %w[full_time part_time full_time_or_part_time]
       end
     end
   end
-
-  # trying out avoiding let syntax by doing DRY with normal functions
 
   def do_get(params)
     get "/api/v2/recruitment_cycles/#{recruitment_cycle.year}" \
@@ -93,9 +118,11 @@ describe 'GET /providers/:provider_code/courses/build_new' do
           "/courses/build_new",
         headers: { 'HTTP_AUTHORIZATION' => credentials },
         params: params
+    response
+  end
 
-    jsonapi_response = JSON.parse(response.body)
-    jsonapi_response
+  def parse_response(response)
+    JSON.parse(response.body)
   end
 
   def course_to_jsonapi(course)


### PR DESCRIPTION
### Context

Take 34

#### What

Add an endpoint that the course creation steps can use to build a new course to validate it and retrieve relevant metadata (like the edit options) without persisting it.

Just to clarify, this does not persist any changes, it only validates the attributes being set and calculates new values for the meta values.

#### Why

The course creation steps will need to be able to present the users with the correct options for each step and with any validation errors before it actually saves the course.


### Changes proposed in this pull request

* Make build_new return errors or model, and always return edit_options

### Guidance to review

```
im@max:~/repo/dfe/manage/backend(2055-add-build-new-course-endpoint)
$ be rspec spec/requests/api/v2/providers/courses/build_new_spec.rb -fd
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

GET /providers/:provider_code/courses/build_new
  #build_new
    with no parameters
      returns edit_options and errors but no model
    with enough attributes set in query parameters to make a valid course
      returns the course model and edit_options with no errors
    with an invalid attribute set in query parameters
      returns edit_options and errors but no model
    with an invalid enum attribute set in query parameters
      returns edit_options and errors but no model

Finished in 1.8 seconds (files took 2.19 seconds to load)
4 examples, 0 failures
```

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
