### PR TITLE
[2116] Add not null constraints to provider_enrichment user fields

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -101,7 +101,7 @@ module API
       def update_accrediting_enrichment
         return if accredited_bodies_params.values.none?
 
-        enrichment = @provider.enrichments.find_or_initialize_draft
+        enrichment = @provider.enrichments.find_or_initialize_draft(current_user)
 
         enrichment.accrediting_provider_enrichments =
           accredited_bodies_params["accredited_bodies"].map do |accredited_body|
@@ -117,7 +117,7 @@ module API
       def update_enrichment
         return unless enrichment_params.values.any?
 
-        enrichment = @provider.enrichments.find_or_initialize_draft
+        enrichment = @provider.enrichments.find_or_initialize_draft(current_user)
         enrichment.assign_attributes(enrichment_params)
         enrichment.status = 'draft' if enrichment.rolled_over?
 

--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -5,10 +5,10 @@
 #  id                 :integer          not null, primary key
 #  provider_code      :text             not null
 #  json_data          :jsonb
-#  updated_by_user_id :integer
+#  updated_by_user_id :integer          not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  created_by_user_id :integer
+#  created_by_user_id :integer          not null
 #  last_published_at  :datetime
 #  status             :integer          default("draft"), not null
 #  provider_id        :integer          not null

--- a/db/migrate/20190909105439_provider_enrichment_user_not_null.rb
+++ b/db/migrate/20190909105439_provider_enrichment_user_not_null.rb
@@ -1,0 +1,18 @@
+class ProviderEnrichmentUserNotNull < ActiveRecord::Migration[5.2]
+  def up
+    production_user = User.find_by(email: 'tim.abell@digital.education.gov.uk')
+    local_seeds_user = User.find_by(email: 'super.admin@education.gov.uk')
+    local_development_user = User.first
+    some_id = (production_user || local_seeds_user || local_development_user).id
+    ProviderEnrichment.where(created_by_user_id: nil).each { |pe| pe.created_by_user_id = some_id; pe.save! }
+    ProviderEnrichment.where(updated_by_user_id: nil).each { |pe| pe.updated_by_user_id = some_id; pe.save! }
+
+    change_column_null :provider_enrichment, :updated_by_user_id, false
+    change_column_null :provider_enrichment, :created_by_user_id, false
+  end
+
+  def down
+    change_column_null :provider_enrichment, :updated_by_user_id, true
+    change_column_null :provider_enrichment, :created_by_user_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_04_131906) do
+ActiveRecord::Schema.define(version: 2019_09_09_105439) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -194,10 +194,10 @@ ActiveRecord::Schema.define(version: 2019_09_04_131906) do
   create_table "provider_enrichment", id: :serial, force: :cascade do |t|
     t.text "provider_code", null: false
     t.jsonb "json_data"
-    t.integer "updated_by_user_id"
+    t.integer "updated_by_user_id", null: false
     t.datetime "created_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
-    t.integer "created_by_user_id"
+    t.integer "created_by_user_id", null: false
     t.datetime "last_published_at"
     t.integer "status", default: 0, null: false
     t.integer "provider_id", null: false

--- a/spec/factories/provider_enrichments.rb
+++ b/spec/factories/provider_enrichments.rb
@@ -5,10 +5,10 @@
 #  id                 :integer          not null, primary key
 #  provider_code      :text             not null
 #  json_data          :jsonb
-#  updated_by_user_id :integer
+#  updated_by_user_id :integer          not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  created_by_user_id :integer
+#  created_by_user_id :integer          not null
 #  last_published_at  :datetime
 #  status             :integer          default("draft"), not null
 #  provider_id        :integer          not null

--- a/spec/factories/provider_enrichments.rb
+++ b/spec/factories/provider_enrichments.rb
@@ -39,6 +39,9 @@ FactoryBot.define do
     train_with_disability { Faker::Lorem.sentence.to_s }
     accrediting_provider_enrichments { nil }
 
+    updated_by_user_id { create(:user).id }
+    created_by_user_id { create(:user).id }
+
 
     after(:build) do |enrichment, evaluator|
       if evaluator.age.present?

--- a/spec/models/provider_enrichment_spec.rb
+++ b/spec/models/provider_enrichment_spec.rb
@@ -5,10 +5,10 @@
 #  id                 :integer          not null, primary key
 #  provider_code      :text             not null
 #  json_data          :jsonb
-#  updated_by_user_id :integer
+#  updated_by_user_id :integer          not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  created_by_user_id :integer
+#  created_by_user_id :integer          not null
 #  last_published_at  :datetime
 #  status             :integer          default("draft"), not null
 #  provider_id        :integer          not null

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -479,7 +479,7 @@ describe Provider, type: :model do
         subject.attributes.slice(*copyable_enrichment_attributes)
       end
 
-      subject { provider.enrichments.find_or_initialize_draft }
+      subject { provider.enrichments.find_or_initialize_draft(create(:user)) }
 
       context 'no enrichments' do
         let(:enrichments) { [] }


### PR DESCRIPTION
### Context

CourseExporter in c# fell over on null user, make this impossible, move
failure to earlier.

breaking because created by user id is nil
https://github.com/DFE-Digital/manage-courses-api/blob/ffa3ea9bb5536c9365f4c0fa8de71bcc03044b64/src/ManageCourses.Api/Mapping/EnrichmentConverter.cs#L69

### Changes proposed in this pull request

Data in prod already manually cleaned, but need the cleanup code in case
new records appear in prod, and also for qa/staging that  haven't been
cleaned.

### Guidance to review

:ship:

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally