### PR TITLE
[2055] Add build new course endpoint

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -7,7 +7,7 @@ module API
 
       before_action :build_recruitment_cycle
       before_action :build_provider
-      before_action :build_course, except: %i[index new create]
+      before_action :build_course, except: %i[index new create build_new]
 
       deserializable_resource :course,
                               only: %i[update publish publishable create],
@@ -19,6 +19,21 @@ module API
         @course = @provider.courses.new
 
         render jsonapi: @course, include: params[:include]
+      end
+
+      # For creating and validating a course model without persisting it to the database.
+      # Used by the new course wizard in frontend.
+      def build_new
+        authorize @provider
+        course = Course.new(provider: @provider)
+        course.assign_attributes(course_params)
+        course.valid?
+        response = {
+          course: course,
+          errors: course.errors,
+          edit_options: course.edit_course_options,
+        }
+        render json: response
       end
 
       def index

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -21,32 +21,30 @@ module API
         render jsonapi: @course, include: params[:include]
       end
 
-      # For creating and validating a course model without persisting it to the database.
-      # Used by the new course wizard in frontend.
       def build_new
         authorize @provider
         course = Course.new(provider: @provider)
         course.assign_attributes(course_params)
         course.valid?
 
-        jsonapi_data = JSONAPI::Serializable::Renderer.new.render(
+        json_data = JSONAPI::Serializable::Renderer.new.render(
           course,
           class: { Course: API::V2::SerializableCourse }
         )
 
-        jsonapi_data[:data][:errors] = []
+        json_data[:data][:errors] = []
 
         course.errors.messages.each do |error_key, _|
           course.errors.full_messages_for(error_key).each do |error_message|
-            jsonapi_data[:data][:errors] << {
-              "title" => "Invalid #{error_key.to_s}",
+            json_data[:data][:errors] << {
+              "title" => "Invalid #{error_key}",
               "detail" => error_message,
               "source" => { "pointer" => "/data/attributes/#{error_key}" }
             }
           end
         end
 
-        render json: jsonapi_data
+        render json: json_data
       end
 
       def index

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -38,4 +38,5 @@ class ProviderPolicy
   alias_method :publish?, :show?
   alias_method :publishable?, :show?
   alias_method :sync_courses_with_search_and_compare?, :show?
+  alias_method :build_new?, :show?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,6 +140,8 @@ Rails.application.routes.draw do
       resources :access_requests, only: %i[update index create show] do
         post :approve, on: :member
       end
+
+      get 'build_new_course', to: 'courses#build_new'
     end
   end
 

--- a/spec/requests/api/v2/build_new_course_spec.rb
+++ b/spec/requests/api/v2/build_new_course_spec.rb
@@ -1,0 +1,180 @@
+require "rails_helper"
+
+describe '/api/v2/build_new_course', type: :request do
+  let(:user) { create(:user, organisations: [organisation]) }
+  let(:recruitment_cycle) { find_or_create :recruitment_cycle }
+  let(:organisation)      { create :organisation }
+  let(:provider) do
+    create :provider,
+           organisations: [organisation],
+           recruitment_cycle: recruitment_cycle
+  end
+  let(:payload) { { email: user.email } }
+  let(:token) do
+    JWT.encode payload,
+               Settings.authentication.secret,
+               Settings.authentication.algorithm
+  end
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+
+  context 'with no parameters' do
+    let(:params) { { course: {} } }
+
+    it 'returns a blank course, a bunch of errors and loads of edit_options' do
+      response = do_get params
+      expect(response).to have_http_status(:ok)
+      json_response = parse_response(response)
+
+      # puts json_response # use this to get updated expected response for the below
+      # use rake lint and vim to tidy it up
+      expected = {
+        "course" =>
+         { "id" => nil,
+           "age_range" => nil,
+           "course_code" => nil,
+           "name" => nil,
+           "profpost_flag" => nil,
+           "program_type" => nil,
+           "qualification" => nil,
+           "start_date" => nil,
+           "study_mode" => nil,
+           "accrediting_provider_id" => nil,
+           "provider_id" => provider.id,
+           "modular" => "",
+           "english" => nil,
+           "maths" => nil,
+           "science" => nil,
+           "created_at" => nil,
+           "updated_at" => nil,
+           "changed_at" => nil,
+           "accrediting_provider_code" => nil,
+           "discarded_at" => nil,
+           "age_range_in_years" => nil,
+           "applications_open_from" => nil,
+           "is_send" => false },
+         "errors" => {
+           "maths" => ["^Pick an option for Maths"],
+           "english" => ["^Pick an option for English"],
+           "enrichments" => []
+         },
+         "edit_options" => {
+           "entry_requirements" => %w[must_have_qualification_at_application_time
+                                      expect_to_achieve_before_training_begins
+                                      equivalence_test],
+           "qualifications" => %w[qts pgce_with_qts pgde_with_qts],
+           "age_range_in_years" => %w[11_to_16 11_to_18 14_to_19],
+           "start_dates" => ["August 2019",
+                             "September 2019",
+                             "October 2019",
+                             "November 2019",
+                             "December 2019",
+                             "January 2020",
+                             "February 2020",
+                             "March 2020",
+                             "April 2020",
+                             "May 2020",
+                             "June 2020",
+                             "July 2020"],
+           "study_modes" => %w[full_time part_time full_time_or_part_time],
+           "program_type" => %w[pg_teaching_apprenticeship
+                                higher_education_programme],
+           "show_is_send" => true,
+           "show_start_date" => true,
+           "show_applications_open" => true
+         }
+      }
+
+      expect(json_response).to eq expected
+    end
+  end
+
+  context 'with enough attributes set in query parameters to make a valid course' do
+    let(:params) do
+      { course: {
+        name: 'Foo Bar Course',
+        maths: 'must_have_qualification_at_application_time',
+        english: 'must_have_qualification_at_application_time',
+        # todo: why is this valid when level not set? A: because level has a default. What to do about that if anything?
+      } }
+    end
+
+    it 'returns the course model and edit_options with no errors' do
+      response = do_get params
+      expect(response).to have_http_status(:ok)
+      json_response = parse_response(response)
+
+      # puts json_response # use this to get updated expected response for the below
+      # use rake lint and vim to tidy it up
+      expected = {
+        "course" =>
+          { "id" => nil,
+            "age_range" => nil,
+            "course_code" => nil,
+            "name" => "Foo Bar Course",
+            "profpost_flag" => nil,
+            "program_type" => nil,
+            "qualification" => nil,
+            "start_date" => nil,
+            "study_mode" => nil,
+            "accrediting_provider_id" => nil,
+            "provider_id" => provider.id,
+            "modular" => "",
+            "english" => "must_have_qualification_at_application_time",
+            "maths" => "must_have_qualification_at_application_time",
+            "science" => nil,
+            "created_at" => nil,
+            "updated_at" => nil,
+            "changed_at" => nil,
+            "accrediting_provider_code" => nil,
+            "discarded_at" => nil,
+            "age_range_in_years" => nil,
+            "applications_open_from" => nil,
+            "is_send" => false },
+        "errors" => {
+          "enrichments" => []
+        },
+        "edit_options" => {
+          "entry_requirements" => %w[must_have_qualification_at_application_time
+                                     expect_to_achieve_before_training_begins
+                                     equivalence_test],
+          "qualifications" => %w[qts pgce_with_qts pgde_with_qts],
+          "age_range_in_years" => %w[11_to_16 11_to_18 14_to_19],
+          "start_dates" => ["August 2019",
+                            "September 2019",
+                            "October 2019",
+                            "November 2019",
+                            "December 2019",
+                            "January 2020",
+                            "February 2020",
+                            "March 2020",
+                            "April 2020",
+                            "May 2020",
+                            "June 2020",
+                            "July 2020"],
+          "study_modes" => %w[full_time part_time full_time_or_part_time],
+          "program_type" => %w[pg_teaching_apprenticeship
+                               higher_education_programme],
+          "show_is_send" => true,
+          "show_start_date" => true,
+          "show_applications_open" => true
+        }
+      }
+
+      expect(json_response).to eq expected
+    end
+  end
+
+  def do_get(params)
+    get "/api/v2/build_new_course?year=#{recruitment_cycle.year}" \
+          "&provider_code=#{provider.provider_code}",
+        headers: { 'HTTP_AUTHORIZATION' => credentials },
+        params: params
+    response
+  end
+
+  def parse_response(response)
+    JSON.parse(response.body)
+  end
+end

--- a/spec/requests/api/v2/build_new_course_spec.rb
+++ b/spec/requests/api/v2/build_new_course_spec.rb
@@ -32,7 +32,7 @@ describe '/api/v2/build_new_course', type: :request do
   context 'with no parameters' do
     let(:params) { { course: {} } }
 
-    it 'returns a blank course, a bunch of errors and loads of edit_options' do
+    it 'returns a new course with errors' do
       response = do_get params
       expect(response).to have_http_status(:ok)
       json_response = parse_response(response)
@@ -54,19 +54,18 @@ describe '/api/v2/build_new_course', type: :request do
     end
   end
 
-  context 'with enough attributes set in query parameters to make a valid course' do
+  context 'with sufficient parameters to make a valid course' do
     let(:params) do
       { course: {
         name: 'Foo Bar Course',
         maths: 'must_have_qualification_at_application_time',
         english: 'must_have_qualification_at_application_time',
-        # todo: why is this valid when level not set? A: because level has a default. What to do about that if anything?
       } }
     end
 
     let(:course) { Course.new({ provider: provider }.merge(params[:course])) }
 
-    it 'returns the course model and edit_options with no errors' do
+    it 'returns a matching course with no errors' do
       response = do_get params
       expect(response).to have_http_status(:ok)
       json_response = parse_response(response)


### PR DESCRIPTION
### Context

Add an endpoint that the course creation steps can use to build a new course to validate it and retrieve relevant metadata (like the edit options) without persisting it.

### Changes proposed in this pull request

Adds the endpoint.

### Guidance to review

Nothing particular!

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally