### PR TITLE
[2128] Rename course level to ucas_level

### DIFF
--- a/app/models/concerns/courses/edit_options/age_range_concern.rb
+++ b/app/models/concerns/courses/edit_options/age_range_concern.rb
@@ -8,7 +8,7 @@ module Courses
         #
         # https://github.com/DFE-Digital/manage-courses-frontend/blob/master/spec/factories/courses.rb
         def age_range_options
-          case level
+          case ucas_level
           when :primary
             %w[
               3_to_7

--- a/app/models/concerns/courses/edit_options/qualification_concern.rb
+++ b/app/models/concerns/courses/edit_options/qualification_concern.rb
@@ -9,7 +9,7 @@ module Courses
         # https://github.com/DFE-Digital/manage-courses-frontend/blob/master/spec/factories/courses.rb
         def qualification_options
           qualifications_with_qts, qualifications_without_qts = Course.qualifications.keys.partition { |q| q.include?('qts') }
-          level == :further_education ? qualifications_without_qts : qualifications_with_qts
+          ucas_level == :further_education ? qualifications_without_qts : qualifications_with_qts
         end
       end
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -286,8 +286,8 @@ class Course < ApplicationRecord
     SubjectMapperService.get_subject_list(name, subjects.map(&:subject_name))
   end
 
-  def level
-    Subjects::CourseLevel.new(subjects.map(&:subject_name)).level
+  def ucas_level
+    Subjects::CourseLevel.new(subjects.map(&:subject_name)).ucas_level
   end
 
   def is_fee_based?
@@ -296,7 +296,7 @@ class Course < ApplicationRecord
 
   # https://www.gov.uk/government/publications/initial-teacher-training-criteria/initial-teacher-training-itt-criteria-and-supporting-advice#c11-gcse-standard-equivalent
   def gcse_subjects_required
-    case level
+    case ucas_level
     when :primary
       %w[maths english science]
     when :secondary
@@ -467,7 +467,7 @@ private
   end
 
   def validate_qualification
-    errors.add(:qualification, "^#{qualifications_description} is not valid for a #{level.to_s.humanize.downcase} course") unless qualification_options.include?(qualification)
+    errors.add(:qualification, "^#{qualifications_description} is not valid for a #{ucas_level.to_s.humanize.downcase} course") unless qualification_options.include?(qualification)
   end
 
   def set_applications_open_from

--- a/app/models/subjects/course_level.rb
+++ b/app/models/subjects/course_level.rb
@@ -23,7 +23,7 @@ module Subjects
       @ucas_subjects = ucas_subjects
     end
 
-    def level
+    def ucas_level
       ucas_subjects = @ucas_subjects.map(&:strip).map(&:downcase)
       if (ucas_subjects & SUBJECT_LEVEL[:ucas_unexpected]).any?
         raise "found unsupported subject name(s): #{(ucas_subjects & SUBJECT_LEVEL[:ucas_unexpected]) * ', '}"

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -23,6 +23,10 @@ module API
         @object.start_date.strftime("%B %Y") if @object.start_date
       end
 
+      attribute :level do
+        @object.ucas_level
+      end
+
       attribute :applications_open_from do
         @object.applications_open_from&.iso8601
       end

--- a/app/services/subject_mapper_service.rb
+++ b/app/services/subject_mapper_service.rb
@@ -95,10 +95,10 @@ class SubjectMapperService
     return [] if course_title.nil?
 
     ucas_subjects = ucas_subjects.map(&:strip).map(&:downcase)
-    level = Subjects::CourseLevel.new(ucas_subjects).level
+    ucas_level = Subjects::CourseLevel.new(ucas_subjects).ucas_level
 
     Subjects::UCASToDFESubjectMappingCollection.
-      new(config: UCAS_TO_DFE_SUBJECT_MAPPINGS[level]).
+      new(config: UCAS_TO_DFE_SUBJECT_MAPPINGS[ucas_level]).
       to_dfe_subjects(
         ucas_subjects: ucas_subjects,
         course_title: course_title.strip.downcase

--- a/db/migrate/20190723092536_fix_fe_course_requirements.rb
+++ b/db/migrate/20190723092536_fix_fe_course_requirements.rb
@@ -1,7 +1,7 @@
 class FixFeCourseRequirements < ActiveRecord::Migration[5.2]
   def up
     say_with_time 'setting further education course requirements to not_required' do
-      Course.includes(:subjects).select { |course| course.level == :further_education }.each do |course|
+      Course.includes(:subjects).select { |course| course.ucas_level == :further_education }.each do |course|
         course.update(maths: :not_required, english: :not_required, science: :not_required)
       end
     end

--- a/lib/mcb/course_show.rb
+++ b/lib/mcb/course_show.rb
@@ -11,7 +11,7 @@ module MCB
         "Provider" => @course.provider.provider_code,
         "Accredited body" => @course.accrediting_provider&.provider_code || "Self-accrediting",
         "Subjects" => @course.dfe_subjects.join(", "),
-        "Level" => @course.level,
+        "UCAS Level" => @course.ucas_level,
         "Training locations" => @course.site_statuses.map(&:site).map(&:location_name).join(", "),
         "Start date" => @course.start_date.strftime("%b %Y"),
         "Route" => @course.program_type,

--- a/spec/models/concerns/courses/edit_options/age_range_concern_spec.rb
+++ b/spec/models/concerns/courses/edit_options/age_range_concern_spec.rb
@@ -4,14 +4,14 @@ describe Courses::EditOptions::AgeRangeConcern do
   let(:example_model) do
     klass = Class.new do
       include Courses::EditOptions::AgeRangeConcern
-      attr_accessor :level
+      attr_accessor :ucas_level
     end
 
     klass.new
   end
 
   before do
-    example_model.level = level_value
+    example_model.ucas_level = level_value
   end
 
   context 'for primary' do

--- a/spec/models/concerns/courses/edit_options/qualifications_concern_spec.rb
+++ b/spec/models/concerns/courses/edit_options/qualifications_concern_spec.rb
@@ -4,14 +4,14 @@ describe Courses::EditOptions::QualificationConcern do
   let(:example_model) do
     klass = Class.new do
       include Courses::EditOptions::QualificationConcern
-      attr_accessor :level
+      attr_accessor :ucas_level
     end
 
     klass.new
   end
 
   before do
-    example_model.level = level_value
+    example_model.ucas_level = level_value
   end
 
   context 'for a course that’s not further education' do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -502,27 +502,27 @@ describe Course, type: :model do
   context "subjects & level" do
     context 'with no subjects' do
       subject { create(:course) }
-      its(:level) { should eq(:secondary) }
+      its(:ucas_level) { should eq(:secondary) }
       its(:dfe_subjects) { should be_empty }
     end
 
     context 'with primary subjects' do
       subject { create(:course, subjects: [find_or_create(:subject, :primary)]) }
-      its(:level) { should eq(:primary) }
+      its(:ucas_level) { should eq(:primary) }
       its(:gcse_subjects_required) { should eq(%w[maths english science]) }
       its(:dfe_subjects) { should eq([DFESubject.new("Primary")]) }
     end
 
     context 'with secondary subjects' do
       subject { create(:course, subjects: [find_or_create(:subject, subject_name: "physical education")]) }
-      its(:level) { should eq(:secondary) }
+      its(:ucas_level) { should eq(:secondary) }
       its(:gcse_subjects_required) { should eq(%w[maths english]) }
       its(:dfe_subjects) { should eq([DFESubject.new("Physical education")]) }
     end
 
     context 'with further education subjects' do
       subject { create(:course, subjects: [create(:further_education_subject)]) }
-      its(:level) { should eq(:further_education) }
+      its(:ucas_level) { should eq(:further_education) }
       its(:gcse_subjects_required) { should eq([]) }
       its(:dfe_subjects) { should eq([DFESubject.new("Further education")]) }
     end

--- a/spec/models/subjects/course_level_spec.rb
+++ b/spec/models/subjects/course_level_spec.rb
@@ -4,24 +4,24 @@ module Subjects
 
     context "for a primary course" do
       let(:ucas_subjects) { %w[Primary Mathematics] }
-      its(:level) { should eq(:primary) }
+      its(:ucas_level) { should eq(:primary) }
     end
 
     context "for a secondary course" do
       let(:ucas_subjects) { %w[Secondary English] }
-      its(:level) { should eq(:secondary) }
+      its(:ucas_level) { should eq(:secondary) }
     end
 
     context "for a further education course" do
       let(:ucas_subjects) { %w[Post-compulsory Humanities] }
-      its(:level) { should eq(:further_education) }
+      its(:ucas_level) { should eq(:further_education) }
     end
 
     context "for a course with an unmapped subject" do
       let(:ucas_subjects) { ["Law", "Home economics"] }
 
       it "raises an error when fetching the level" do
-        expect { subject.level }.to raise_error(RuntimeError, "found unsupported subject name(s): law, home economics")
+        expect { subject.ucas_level }.to raise_error(RuntimeError, "found unsupported subject name(s): law, home economics")
       end
     end
   end

--- a/spec/services/subject_mapper_service_spec.rb
+++ b/spec/services/subject_mapper_service_spec.rb
@@ -5,7 +5,7 @@ describe SubjectMapperService do
     match do |input|
       @input = input
       @actual_dfe_subjects = mapped_subjects(input.fetch(:title, "Any title"), input[:ucas])
-      @actual_level = Subjects::CourseLevel.new(input[:ucas]).level
+      @actual_level = Subjects::CourseLevel.new(input[:ucas]).ucas_level
       contain_exactly(*expected).matches?(@actual_dfe_subjects) &&
         (@actual_level == @expected_level)
     end
@@ -14,14 +14,14 @@ describe SubjectMapperService do
       described_class.get_subject_list(course_title, ucas_subjects).map(&:to_s)
     end
 
-    chain :at_level do |level|
-      @expected_level = level
+    chain :at_level do |ucas_level|
+      @expected_level = ucas_level
     end
 
     failure_message do |_|
       "expected that UCAS subjects '#{@input[:ucas].join(', ')}' would map to DfE subjects '#{expected.join(', ')}' " +
-        "at #{@expected_level} level but was DfE subjects '#{@actual_dfe_subjects.join(', ')}' " +
-        "at #{@actual_level} level"
+        "at #{@expected_level} ucas_level but was DfE subjects '#{@actual_dfe_subjects.join(', ')}' " +
+        "at #{@actual_level} ucas_level"
     end
   end
 


### PR DESCRIPTION
### Context
Subjects refactor

### Changes proposed in this pull request
Rename `level` to `ucas_level` ready for new `level` attribute 

### Guidance to review
🚢 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
