### PR TITLE
[2053] Reduce provider search to 5 items

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -86,7 +86,7 @@ module API
 
         found_providers = policy_scope(@recruitment_cycle.providers)
           .search_by_code_or_name(params[:query])
-          .limit(30)
+          .limit(5)
 
         render(
           jsonapi: found_providers,

--- a/spec/requests/api/v2/providers/suggest_provider_spec.rb
+++ b/spec/requests/api/v2/providers/suggest_provider_spec.rb
@@ -69,7 +69,7 @@ describe 'GET /suggest' do
     ])
   end
 
-  it 'limits responses to a maximum of 30 items' do
+  it 'limits responses to a maximum of 5 items' do
     36.times do
       create(:provider, provider_name: 'provider X', organisations: [organisation], recruitment_cycle: next_recruitment_cycle)
     end
@@ -77,7 +77,7 @@ describe 'GET /suggest' do
     get "/api/v2/recruitment_cycles/#{next_recruitment_cycle.year}/providers/suggest?query=provider",
         headers: { 'HTTP_AUTHORIZATION' => credentials }
 
-    expect(JSON.parse(response.body)['data'].length).to eq(30)
+    expect(JSON.parse(response.body)['data'].length).to eq(5)
   end
 
   it 'returns bad request if query is empty' do


### PR DESCRIPTION
### Context

We don't need more for either the autocomplete or the no-JS fallback.

### Changes proposed in this pull request

`s/30/5/`

### Guidance to review

:ship:

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally