### PR TITLE
[2126] mcb - fix rolling over already-rolled over providers

### DIFF
--- a/spec/lib/mcb/commands/providers/rollover_spec.rb
+++ b/spec/lib/mcb/commands/providers/rollover_spec.rb
@@ -1,68 +1,117 @@
 require 'mcb_helper'
 
 describe 'mcb providers rollover' do
-  def perform_rollover(provider_code)
-    stderr = nil
-    output = with_stubbed_stdout(stderr: stderr) do
-      cmd.run([provider_code])
-    end
-    [output, stderr]
-  end
-
   let(:lib_dir) { Rails.root.join('lib') }
   let(:cmd) do
     Cri::Command.load_file("#{lib_dir}/mcb/commands/providers/rollover.rb")
   end
+
+  let!(:next_recruitment_cycle) { find_or_create :recruitment_cycle, :next }
+  let(:email) { 'user@education.gov.uk' }
   let(:course)              { build :course, enrichments: [course_enrichment] }
   let(:course_enrichment)   { build :course_enrichment, :published }
   let(:provider_enrichment) { build :provider_enrichment, :published }
   let(:site)                { build :site }
+
   let!(:site_status) {
     create :site_status,
            :with_no_vacancies,
            course: course,
            site: site
   }
-  let!(:provider) {
+
+  let(:current_cycle_provider) {
     create :provider,
            enrichments: [provider_enrichment],
            courses: [course],
            sites: [site]
   }
 
-  let!(:next_recruitment_cycle) { find_or_create :recruitment_cycle, :next }
-
-  let(:email) { 'user@education.gov.uk' }
-
   before do
-    allow(MCB).to receive(:config).and_return(email: email)
+    perform_rollover
   end
 
-  it "copies a provider and it's courses" do
-    perform_rollover(provider.provider_code)
-
-    new_provider = next_recruitment_cycle.providers.find_by(
-      provider_code: provider.provider_code
+  subject(:next_cycle_provider) do
+    next_recruitment_cycle.providers.find_by(
+      provider_code: current_cycle_provider.provider_code
     )
-    expect(new_provider).not_to be_nil
-    expect(new_provider).not_to eq provider
-    # Currently failing, uncomment when fixed.
-    # expect(new_provider.enrichments.count).to eq 1
-    # expect(new_provider.enrichments.first).to be_draft
+  end
 
-    new_course = new_provider.courses.find_by(
+  let(:new_course) do
+    next_cycle_provider.courses.find_by(
       course_code: course.course_code
     )
-    expect(new_course).not_to be_nil
-    expect(new_course).not_to eq course
-    expect(new_course.enrichments.count).to eq 1
-    expect(new_course.enrichments.first).to be_rolled_over
+  end
 
-    new_site = new_provider.sites.find_by(code: site.code)
+  it "copies the provider" do
+    expect(next_cycle_provider).not_to be_nil
+    expect(next_cycle_provider).not_to eq current_cycle_provider
+  end
+
+  it "copies the provider's site" do
+    new_site = next_cycle_provider.sites.find_by(code: site.code)
     expect(new_site).not_to be_nil
     expect(new_site).not_to eq site
+  end
+
+  it "copies the course" do
+    expect(new_course).not_to be_nil
+    expect(new_course).not_to eq course
+  end
+
+  it "copies the course enrichments" do
+    expect(new_course.enrichments.count).to eq 1
+    expect(new_course.enrichments.first).to be_rolled_over
+  end
+
+  it "copies the course's site" do
+    new_site = next_cycle_provider.sites.find_by(code: site.code)
     expect(new_course.sites).to eq [new_site]
     expect(new_course.site_statuses.first).to be_full_time_vacancies
     expect(new_course.site_statuses.first).to be_status_new_status
+  end
+
+  xit "copies the provider enrichments" do
+    # todo: ?? Currently failing, uncomment when fixed.
+    expect(next_cycle_provider.enrichments.count).to eq 1
+    expect(next_cycle_provider.enrichments.first).to be_draft
+  end
+
+  context "when provider already rolled over" do
+    it 'copies a new course' do
+      course2 = create(:course, provider: current_cycle_provider)
+      current_cycle_provider.courses.reload
+
+      rollover_again
+
+      duplicated_course2 = next_cycle_provider.courses.find_by(course_code: course2.course_code)
+      expect(duplicated_course2).not_to be_nil
+      expect(duplicated_course2).not_to eq(course2)
+      expect(next_cycle_provider.courses.length).to eq(current_cycle_provider.courses.length)
+    end
+
+    it 'copies a new site' do
+      site2 = create(:site, provider: current_cycle_provider)
+      current_cycle_provider.sites.reload
+
+      rollover_again
+
+      duplicated_site2 = next_cycle_provider.sites.find_by(code: site2.code)
+      expect(duplicated_site2).not_to be_nil
+      expect(duplicated_site2).not_to eq(site2)
+      expect(next_cycle_provider.sites.length).to eq(current_cycle_provider.sites.length)
+    end
+  end
+
+  def perform_rollover
+    stderr = nil
+    output = with_stubbed_stdout(stderr: stderr) do
+      cmd.run([current_cycle_provider.provider_code])
+    end
+    [output, stderr]
+  end
+
+  def rollover_again
+    perform_rollover
   end
 end

--- a/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
+++ b/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
@@ -69,6 +69,18 @@ describe Providers::CopyToRecruitmentCycleService do
         expect { service.execute(provider: provider, new_recruitment_cycle: new_recruitment_cycle) }
           .not_to(change { new_recruitment_cycle.reload.providers.count })
       end
+
+      it 'copies over the sites' do
+        service.execute(provider: provider, new_recruitment_cycle: new_recruitment_cycle)
+
+        expect(mocked_copy_site_service).to have_received(:execute).with(site: site, new_provider: new_provider)
+      end
+
+      it 'copies over the courses' do
+        service.execute(provider: provider, new_recruitment_cycle: new_recruitment_cycle)
+
+        expect(mocked_copy_course_service).to have_received(:execute).with(course: course, new_provider: new_provider)
+      end
     end
 
     it 'assigns the new provider to organisation' do


### PR DESCRIPTION
### Context

Previous output:

> /home/tim/repo/dfe/manage/backend/app/services/sites/copy_to_provider_service.rb:4:
> in `execute': undefined method `sites' for nil:NilClass (NoMethodError)

This was because `new_provider` was `nil` if the rollover copy of the
provider already existed.

I moved [the commented out test](https://github.com/DFE-Digital/manage-courses-backend/blob/531324991aeefe4e13555edec3430d6e975c2c60/spec/lib/mcb/commands/providers/rollover_spec.rb#L49) into an `xit`. Needs investigating but isn't a regression.

### Changes proposed in this pull request

* Fix it.
* Add coverage at unit and integration level.

### Guidance to review

:ship:

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally