### PR TITLE
[2126] cope with soft-deletes when rolling over a course

### DIFF
--- a/app/services/courses/copy_to_provider_service.rb
+++ b/app/services/courses/copy_to_provider_service.rb
@@ -32,7 +32,7 @@ module Courses
   private
 
     def course_code_already_exists_on_provider?(course:, new_provider:)
-      new_provider.courses.where(course_code: course.course_code).any?
+      new_provider.courses.with_discarded.where(course_code: course.course_code).any?
     end
 
     def copy_latest_enrichment_to_course(course, new_course)

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -129,5 +129,9 @@ FactoryBot.define do
     trait :applications_open_from_not_set do
       applications_open_from { nil }
     end
+
+    trait :deleted do
+      discarded_at { Time.now - 1.days }
+    end
   end
 end

--- a/spec/services/courses/copy_to_provider_service_spec.rb
+++ b/spec/services/courses/copy_to_provider_service_spec.rb
@@ -103,6 +103,31 @@ RSpec.describe Courses::CopyToProviderService do
     end
   end
 
+  context 'the course has been deleted in the new provider' do
+    let!(:new_course) do
+      create :course,
+             :deleted,
+             course_code: course.course_code,
+             provider: new_provider
+    end
+
+    it 'returns nil' do
+      expect(service.execute(course: course, new_provider: new_provider)).to be_nil
+    end
+
+    it 'does not make a copy of the course' do
+      service.execute(course: course, new_provider: new_provider)
+
+      expect(mocked_sites_copy_to_course_service).to_not have_received(:execute)
+    end
+
+    it 'does not make a copy of the enrichments' do
+      service.execute(course: course, new_provider: new_provider)
+
+      expect(mocked_enrichments_copy_to_course_service).to_not have_received(:execute)
+    end
+  end
+
   context 'the original course has sites' do
     let(:site) { create :site, provider: provider }
     let!(:new_site) { create :site, provider: new_provider, code: site.code }


### PR DESCRIPTION
### Context

Prod data caused `mcb providers rollover` to fall over when an already rolled over course had been soft-deleted.

### Changes proposed in this pull request

cope with soft-deletes when rolling over a course

### Guidance to review

:ship:

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally