### PR TITLE
[1858] Allow the modification of course subjects

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -29,14 +29,7 @@ module API
         # https://github.com/jsonapi-rb/jsonapi-rails/issues/113
         json_data = JSONAPI::Serializable::Renderer.new.render(
           @course,
-          class: {
-            Course: SerializableCourse,
-            Subject: SerializableSubject,
-            PrimarySubject: SerializableSubject,
-            SecondarySubject: SerializableSubject,
-            ModernLanguagesSubject: SerializableSubject,
-            FurtherEducationSubject: SerializableSubject,
-          },
+          class: CourseSerializersService.new.execute,
           include: [:subjects],
         )
 
@@ -59,36 +52,12 @@ module API
         authorize @provider, :can_list_courses?
         authorize Course
 
-        render jsonapi: @provider.courses, include: params[:include], class: {
-          Course: SerializableCourse,
-          SiteStatus: SerializableSiteStatus,
-          Site: SerializableSite,
-          Subject: SerializableSubject,
-          PrimarySubject: SerializableSubject,
-          SecondarySubject: SerializableSubject,
-          ModernLanguagesSubject: SerializableSubject,
-          FurtherEducationSubject: SerializableSubject,
-          Provider: SerializableProvider,
-          ProviderEnrichment: SerializableProviderEnrichment,
-          RecruitmentCycle: SerializableRecruitmentCycle,
-        }
+        render jsonapi: @provider.courses, include: params[:include], class: CourseSerializersService.new.execute
       end
 
       def show
         # https://github.com/jsonapi-rb/jsonapi-rails/issues/113
-        render jsonapi: @course, include: params[:include], class: {
-          Course: SerializableCourse,
-          SiteStatus: SerializableSiteStatus,
-          Site: SerializableSite,
-          Subject: SerializableSubject,
-          PrimarySubject: SerializableSubject,
-          SecondarySubject: SerializableSubject,
-          ModernLanguagesSubject: SerializableSubject,
-          FurtherEducationSubject: SerializableSubject,
-          Provider: SerializableProvider,
-          ProviderEnrichment: SerializableProviderEnrichment,
-          RecruitmentCycle: SerializableRecruitmentCycle,
-        }
+        render jsonapi: @course, include: params[:include], class: CourseSerializersService.new.execute
       end
 
       def sync_with_search_and_compare

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -86,7 +86,9 @@ module API
         update_course
         update_enrichment
         update_sites
+        update_subjects
         @course.ensure_site_statuses_match_study_mode if @course.study_mode_previously_changed?
+
         should_sync = site_ids.present? && @course.should_sync?
         has_synced? if should_sync
 
@@ -159,6 +161,12 @@ module API
         @course.errors[:sites] << "^You must choose at least one location" if site_ids.empty?
       end
 
+      def update_subjects
+        return if subject_ids.nil?
+
+        @course.subjects = Subject.where(id: subject_ids)
+      end
+
       def build_provider
         @provider = @recruitment_cycle.providers.find_by!(
           provider_code: params[:provider_code].upcase,
@@ -194,7 +202,12 @@ module API
                   :study_mode,
                   :is_send,
                   :accrediting_provider_code,
-                  :funding_type)
+                  :funding_type,
+                  :name,
+                  :course_code,
+                  :subjects_ids,
+                  :subjects_types,
+                  :level)
           .permit(
             :about_course,
             :course_length,
@@ -231,7 +244,9 @@ module API
                   :type,
                   :sites_ids,
                   :sites_types,
-                  :course_code)
+                  :course_code,
+                  :subjects_ids,
+                  :subjects_types)
           .permit(
             :english,
             :maths,
@@ -255,6 +270,10 @@ module API
 
       def funding_type_params
         params.fetch(:course, {})[:funding_type]
+      end
+
+      def subject_ids
+        params.fetch(:course, {})[:subjects_ids]
       end
 
       def has_synced?

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -59,7 +59,19 @@ module API
         authorize @provider, :can_list_courses?
         authorize Course
 
-        render jsonapi: @provider.courses, include: params[:include]
+        render jsonapi: @provider.courses, include: params[:include], class: {
+          Course: SerializableCourse,
+          SiteStatus: SerializableSiteStatus,
+          Site: SerializableSite,
+          Subject: SerializableSubject,
+          PrimarySubject: SerializableSubject,
+          SecondarySubject: SerializableSubject,
+          ModernLanguagesSubject: SerializableSubject,
+          FurtherEducationSubject: SerializableSubject,
+          Provider: SerializableProvider,
+          ProviderEnrichment: SerializableProviderEnrichment,
+          RecruitmentCycle: SerializableRecruitmentCycle,
+        }
       end
 
       def show

--- a/app/deserializers/api/v2/deserializable_course.rb
+++ b/app/deserializers/api/v2/deserializable_course.rb
@@ -35,6 +35,7 @@ module API
       attributes(*COURSE_ATTRIBUTES)
 
       has_many :sites
+      has_many :subjects
 
       def reverse_mapping
         declared_attributes = DeserializableCourse.attr_blocks.keys

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -31,10 +31,6 @@ module API
         @object.last_published_at&.iso8601
       end
 
-      attribute :subjects do
-        @object.subjects.map(&:subject_name)
-      end
-
       attribute :about_accrediting_body do
         @object.accrediting_provider_description
       end
@@ -52,6 +48,7 @@ module API
 
       has_many :site_statuses
       has_many :sites
+      has_many :subjects
 
       enrichment_attribute :about_course
       enrichment_attribute :course_length

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -9,5 +9,5 @@
 #
 
 class SubjectSerializer < ActiveModel::Serializer
-  attributes :subject_name, :subject_code
+  attributes :subject_name, :subject_code, :type
 end

--- a/app/services/course_serializers_service.rb
+++ b/app/services/course_serializers_service.rb
@@ -1,0 +1,43 @@
+class CourseSerializersService
+  def initialize(
+    course_serializer: API::V2::SerializableCourse,
+    subject_serializer: API::V2::SerializableSubject,
+    primary_subject_serializer: API::V2::SerializableSubject,
+    secondary_subject_serializer: API::V2::SerializableSubject,
+    modern_languages_subject_serializer: API::V2::SerializableSubject,
+    further_education_subject_serializer: API::V2::SerializableSubject,
+    site_status_serializer: API::V2::SerializableSiteStatus,
+    site_serializer: API::V2::SerializableSite,
+    provider_serializer: API::V2::SerializableProvider,
+    provider_enrichment_serializer: API::V2::SerializableProviderEnrichment,
+    recruitment_cycle_serializer: API::V2::SerializableRecruitmentCycle
+  )
+    @course_serializer = course_serializer
+    @subject_serializer = subject_serializer
+    @primary_subject_serializer = primary_subject_serializer
+    @secondary_subject_serializer = secondary_subject_serializer
+    @modern_languages_subject_serializer = modern_languages_subject_serializer
+    @further_education_subject_serializer = further_education_subject_serializer
+    @site_serializer = site_serializer
+    @site_status_serializer = site_status_serializer
+    @provider_serializer = provider_serializer
+    @provider_enrichment_serializer = provider_enrichment_serializer
+    @recruitment_cycle_serializer = recruitment_cycle_serializer
+  end
+
+  def execute
+    {
+      Course: @course_serializer,
+      Subject: @subject_serializer,
+      PrimarySubject: @primary_subject_serializer,
+      SecondarySubject: @secondary_subject_serializer,
+      ModernLanguagesSubject: @modern_languages_subject_serializer,
+      FurtherEducationSubject: @further_education_subject_serializer,
+      SiteStatus: @site_status_serializer,
+      Site: @site_serializer,
+      Provider: @provider_serializer,
+      ProviderEnrichment: @provider_enrichment_serializer,
+      RecruitmentCycle: @recruitment_cycle_serializer,
+    }
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,7 @@
 require "faker"
 Faker::Config.locale = "en-GB"
 
+CourseSubject.destroy_all
 Course.destroy_all
 Subject.destroy_all
 Site.destroy_all
@@ -142,7 +143,7 @@ def create_standard_provider_and_courses_for_cycle(recruitment_cycle, superuser)
     science: nil,
     modular: "",
     qualification: :pgce,
-    level: "secondary",
+    level: "Further education",
     subjects: [
       FurtherEducationSubject.find_by(subject_name: "Further education"),
     ],

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -65,6 +65,16 @@ FactoryBot.define do
     end
 
     after(:create) do |course, evaluator|
+      if evaluator.level.nil?
+        if course.subjects.exists?(type: "PrimarySubject")
+          course.level = "primary"
+        elsif course.subjects.exists?(type: "SecondarySubject")
+          course.level = "secondary"
+        elsif course.subjects.exists?(type: "FurtherEducationSubject")
+          course.level = "further_education"
+        end
+      end
+
       # This is important to retain the relationship behaviour between
       # course and it's enrichment
 
@@ -77,6 +87,10 @@ FactoryBot.define do
       # We've just created a course with this provider's code, so ensure it's
       # up-to-date and has this course loaded.
       course.provider.reload
+    end
+
+    trait :infer_level do
+      level { nil }
     end
 
     trait :resulting_in_qts do

--- a/spec/lib/mcb/commands/apiv1/courses/find_spec.rb
+++ b/spec/lib/mcb/commands/apiv1/courses/find_spec.rb
@@ -4,10 +4,10 @@ describe '"mcb apiv1 courses find"' do
   it "displays the info for the given course" do
     course1 = create(:course)
 
-    subject = build(:subject, :primary)
+    subject = create(:subject, :biology)
     site_status = build(:site_status)
 
-    course2 = create(:course, subjects: [subject], site_statuses: [site_status])
+    course2 = create(:course, :infer_level, subjects: [subject], site_statuses: [site_status])
 
 
     url = "http://localhost:3001/api/v1/#{RecruitmentCycle.current_recruitment_cycle.year}/courses"

--- a/spec/lib/mcb/commands/courses/show_spec.rb
+++ b/spec/lib/mcb/commands/courses/show_spec.rb
@@ -18,8 +18,8 @@ describe "mcb courses show" do
     new_provider
   end
 
-  let(:subject1) { build(:subject) }
-  let(:subject2) { build(:subject) }
+  let(:subject1) { create(:subject, :primary_with_mathematics) }
+  let(:subject2) { create(:subject, :primary_with_mathematics) }
   let(:site_status1) { build(:site_status) }
   let(:site_status2) { build(:site_status) }
 

--- a/spec/models/concerns/courses/edit_options_spec.rb
+++ b/spec/models/concerns/courses/edit_options_spec.rb
@@ -22,7 +22,7 @@ describe Course, type: :model do
 
     context "for a further education course" do
       let(:course) { create(:course, level: "further_education", subjects: [subjects]) }
-      let(:subjects) { build(:subject, :further_education) }
+      let(:subjects) { create(:subject, :further_education) }
       it "returns only QTS options for users to choose between" do
         expect(course.qualification_options).to eq(%w[pgce pgde])
         course.qualification_options.each do |q|
@@ -41,7 +41,7 @@ describe Course, type: :model do
 
     context "for secondary" do
       let(:course) { create(:course, level: "secondary", subjects: [subjects]) }
-      let(:subjects) { create(:subject) }
+      let(:subjects) { create(:subject, :biology) }
       it "returns the correct age ranges for users to co choose between" do
         expect(course.age_range_options).to eq(%w[11_to_16 11_to_18 14_to_19])
       end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -63,14 +63,14 @@ describe Course, type: :model do
 
   describe "#ensure_modern_languages" do
     it "adds modern languages if a languages subject is selected" do
-      course = build(:course, subjects: [arabic])
+      course = build(:course, level: "secondary", subjects: [arabic])
       course.ensure_modern_languages
       expect(course.subjects).to match_array([modern_languages, arabic])
       expect(course).to be_valid
     end
 
     it "does not duplicate add modern language if it has already been added" do
-      course = build(:course, subjects: [modern_languages, arabic])
+      course = build(:course, level: "secondary", subjects: [modern_languages, arabic])
       course.ensure_modern_languages
       expect(course.subjects).to match_array([modern_languages, arabic])
       expect(course).to be_valid
@@ -124,6 +124,84 @@ describe Course, type: :model do
         it "should add level and subjects" do
           expect(subject.errors.full_messages).to match_array(["There is a problem with this course. Contact support to fix it (Error: L)", "There is a problem with this course. Contact support to fix it (Error: S)"])
         end
+      end
+    end
+
+    context "if subjects are empty" do
+      let(:course) { create(:course) }
+
+      it "passes validation" do
+        expect(course.valid?).to be_truthy
+      end
+    end
+
+    context "course has been assigned secondary level" do
+      let(:course) { create(:course, level: "secondary", subjects: [create(:subject, :english, type: :SecondarySubject)]) }
+
+      context "modern foreign languages" do
+        it "validates even with multiple languages" do
+          course.subjects = [modern_languages, create(:subject, :japanese), create(:subject, :french)]
+          expect(course.valid?).to be_truthy
+        end
+      end
+
+      it "validates if the subject is of that level" do
+        course.subjects = [create(:subject, :mathematics, type: :SecondarySubject)]
+        expect(course.valid?).to be_truthy
+      end
+
+      it "does not validate if the subject is not of that level" do
+        course.subjects = [create(:subject, :mathematics, type: :PrimarySubject)]
+        expect(course.valid?).to be_falsey
+        expect(course.errors[:subjects]).to eq(["must be secondary"])
+      end
+
+      it "does not validate if there are more than 2 subjects" do
+        course.subjects = [create(:subject, :mathematics, type: :SecondarySubject), create(:subject, :mathematics, type: :SecondarySubject), create(:subject, :mathematics, type: :SecondarySubject)]
+        expect(course.valid?).to be_falsey
+        expect(course.errors[:subjects]).to eq(["has too many subjects"])
+      end
+    end
+
+    context "course has been assigned primary level" do
+      let(:course) { create(:course, level: :primary, subjects: [create(:subject, :english, type: :PrimarySubject)]) }
+
+      it "validates if the subject is of that level" do
+        course.subjects = [create(:subject, :mathematics, type: :PrimarySubject)]
+        expect(course.valid?).to be_truthy
+      end
+
+      it "does not validate if the subject is not of that level" do
+        course.subjects = [create(:subject, :mathematics, type: :SecondarySubject)]
+        expect(course.valid?).to be_falsey
+        expect(course.errors[:subjects]).to eq(["must be primary"])
+      end
+
+      it "does not validate if there is more than one subject" do
+        course.subjects = [create(:subject, :mathematics, type: :PrimarySubject), create(:subject, :mathematics, type: :PrimarySubject)]
+        expect(course.valid?).to be_falsey
+        expect(course.errors[:subjects]).to eq(["has too many subjects"])
+      end
+    end
+
+    context "course has been assigned further education level" do
+      let(:course) { create(:course, :infer_level, qualification: "pgce", subjects: [create(:subject, :english, type: :FurtherEducationSubject)]) }
+
+      it "validates if the subject is of that level" do
+        course.subjects = [create(:subject, :further_education)]
+        expect(course.valid?).to be_truthy
+      end
+
+      it "does not validate if the subject is not of that level" do
+        course.subjects = [create(:subject, :biology)]
+        expect(course.valid?).to be_falsey
+        expect(course.errors[:subjects]).to eq(["must be further education"])
+      end
+
+      it "does not validate if there is more than one subject" do
+        course.subjects = [create(:subject, :further_education), create(:subject, :further_education)]
+        expect(course.valid?).to be_falsey
+        expect(course.errors[:subjects]).to eq(["has too many subjects"])
       end
     end
   end
@@ -779,7 +857,7 @@ describe Course, type: :model do
 
   context "bursaries and scholarships" do
     let!(:financial_incentive) { create(:financial_incentive, subject: modern_languages, bursary_amount: 255, scholarship: 1415, early_career_payments: 32) }
-    subject { create(:course, subjects: [modern_languages]) }
+    subject { create(:course, level: "secondary", subjects: [modern_languages]) }
 
     it { should have_bursary }
     it { should have_scholarship_and_bursary }
@@ -1025,21 +1103,21 @@ describe Course, type: :model do
   end
 
   describe "#syncable?" do
-    let(:courses_subjects) { [build(:subject, :primary)] }
+    let(:courses_subjects) { [create(:subject, :biology)] }
     let(:site_status) { build(:site_status, :findable) }
 
-    subject { create(:course, subjects: courses_subjects, site_statuses: [site_status]) }
+    subject { create(:course, :infer_level, subjects: courses_subjects, site_statuses: [site_status]) }
 
     its(:syncable?) { should be_truthy }
 
     context "invalid courses" do
       context "course which has only discontinued subject subject type" do
-        let(:courses_subjects) { [build(:subject, :humanities)] }
+        let(:courses_subjects) { [create(:subject, :humanities)] }
         its(:syncable?) { should be_falsey }
       end
 
       context "course which has only modern lanaguage secondary subject type" do
-        let(:courses_subjects) { [build(:subject, :modern_languages)] }
+        let(:courses_subjects) { [create(:subject, :modern_languages)] }
         its(:syncable?) { should be_falsey }
       end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -156,6 +156,12 @@ describe Course, type: :model do
         expect(course.errors[:subjects]).to eq(["must be secondary"])
       end
 
+      it "validates if there are only 2 subjects" do
+        course.subjects = [create(:subject, :mathematics, type: :SecondarySubject), create(:subject, :mathematics, type: :SecondarySubject)]
+        expect(course.valid?).to be_truthy
+        expect(course.errors[:subjects]).to eq([])
+      end
+
       it "does not validate if there are more than 2 subjects" do
         course.subjects = [create(:subject, :mathematics, type: :SecondarySubject), create(:subject, :mathematics, type: :SecondarySubject), create(:subject, :mathematics, type: :SecondarySubject)]
         expect(course.valid?).to be_falsey

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -332,14 +332,14 @@ describe Provider, type: :model do
     end
 
     describe "#syncable_courses" do
-      let(:site) { build(:site) }
-      let(:dfe_subject) { build(:subject, :primary) }
-      let(:findable_site_status_1) { build(:site_status, :findable, site: site) }
-      let(:findable_site_status_2) { build(:site_status, :findable, site: site) }
-      let(:suspended_site_status) { build(:site_status, :suspended, site: site) }
-      let(:syncable_course) { build(:course, site_statuses: [findable_site_status_1], subjects: [dfe_subject]) }
-      let(:suspended_course) { build(:course, site_statuses: [suspended_site_status], subjects: [dfe_subject]) }
-      let(:invalid_subject_course) { build(:course, site_statuses: [findable_site_status_2], subjects: []) }
+      let(:site) { create(:site) }
+      let(:dfe_subject) { create(:subject, :primary) }
+      let(:findable_site_status_1) { create(:site_status, :findable, site: site) }
+      let(:findable_site_status_2) { create(:site_status, :findable, site: site) }
+      let(:suspended_site_status) { create(:site_status, :suspended, site: site) }
+      let(:syncable_course) { create(:course, :infer_level, site_statuses: [findable_site_status_1], subjects: [dfe_subject]) }
+      let(:suspended_course) { create(:course, :infer_level, site_statuses: [suspended_site_status], subjects: [dfe_subject]) }
+      let(:invalid_subject_course) { create(:course, :infer_level, level: "primary", site_statuses: [findable_site_status_2], subjects: []) }
 
       subject { create(:provider, courses: [syncable_course, suspended_course, invalid_subject_course], sites: [site]) }
 

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -87,10 +87,14 @@ describe RecruitmentCycle, type: :model do
       let(:course_enrichment) { build(:course_enrichment, :published) }
       let(:subjects) { [create(:subject, :further_education)] }
       let(:course) do
-        create(:course, provider: provider,
-               site_statuses: [site_status],
-               enrichments: [course_enrichment],
-               subjects: subjects)
+        create(
+          :course,
+          :infer_level,
+          provider: provider,
+          site_statuses: [site_status],
+          enrichments: [course_enrichment],
+          subjects: subjects,
+        )
       end
       let(:syncable_courses) { [course] }
 

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -170,6 +170,7 @@ describe "Courses API", type: :request do
                                   {
                                     "subject_code" => "G2",
                                     "subject_name" => "German",
+                                    "type" => "ModernLanguagesSubject",
                                   },
                                 ],
                                 "provider" => {
@@ -541,7 +542,9 @@ describe "Courses API", type: :request do
 
         expect(json["subjects"].length).to eq(2)
         expect(json["subjects"]).to include(
-          "subject_code" => "U3", "subject_name" => "Special Educational Needs",
+          "subject_code" => "U3",
+          "subject_name" => "Special Educational Needs",
+          "type" => nil,
         )
       end
 

--- a/spec/requests/api/v1/subject_spec.rb
+++ b/spec/requests/api/v1/subject_spec.rb
@@ -32,18 +32,22 @@ describe "Subjecs API", type: :request do
           {
             "subject_name" => "English",
             "subject_code" => "E",
+            "type" => "SecondarySubject",
           },
           {
             "subject_name" => "French",
             "subject_code" => "F1",
+            "type" => "ModernLanguagesSubject",
           },
           {
             "subject_name" => "Primary",
             "subject_code" => "00",
+            "type" => "PrimarySubject",
           },
           {
             "subject_name" => "Further education",
             "subject_code" => "41",
+            "type" => "FurtherEducationSubject",
           },
         ])
     end

--- a/spec/requests/api/v2/build_new_course_spec.rb
+++ b/spec/requests/api/v2/build_new_course_spec.rb
@@ -19,16 +19,37 @@ describe "/api/v2/build_new_course", type: :request do
     ActionController::HttpAuthentication::Token.encode_credentials(token)
   end
   let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
-  let(:course) { Course.new(provider: provider) }
+  let(:subjects) { [] }
+  let(:course) { Course.new(provider: provider, subjects: subjects) }
   let(:course_jsonapi) do
     JSON.parse(jsonapi_renderer.render(
       course,
       class: {
         Course: API::V2::SerializableCourse,
+        Subject: API::V2::SerializableSubject,
       },
-    ).to_json)["data"]
+      include: [:subjects],
+    ).to_json)
   end
 
+  context "with subjects" do
+    let(:params) do
+      { course: {
+        name: "Foo Bar Course",
+        maths: "must_have_qualification_at_application_time",
+        english: "must_have_qualification_at_application_time",
+        subjects_ids: subjects.map(&:id),
+      } }
+    end
+    let(:subjects) { [find_or_create(:subject, :primary_with_mathematics)] }
+
+    it "returns a course with subject relationships" do
+      response = do_get params
+      expect(response).to have_http_status(:ok)
+      json_response = parse_response(response)
+      expect(json_response["data"]["relationships"]).to eq(course_jsonapi["data"]["relationships"])
+    end
+  end
   context "with no parameters" do
     let(:params) { { course: {} } }
 
@@ -37,20 +58,14 @@ describe "/api/v2/build_new_course", type: :request do
       expect(response).to have_http_status(:ok)
       json_response = parse_response(response)
 
-      expected = {
-        "data" => course_jsonapi.merge(
-          "errors" => [
-            { "title" => "Invalid maths",
-              "detail" => "Pick an option for Maths",
-              "source" => { "pointer" => "/data/attributes/maths" } },
-            { "title" => "Invalid english",
-              "detail" => "Pick an option for English",
-              "source" => { "pointer" => "/data/attributes/english" } },
-          ],
-        ),
-      }
-
-      expect(json_response).to eq expected
+      expect(json_response["data"]["errors"]).to match_array([
+        { "title" => "Invalid maths",
+          "detail" => "Pick an option for Maths",
+          "source" => { "pointer" => "/data/attributes/maths" } },
+        { "title" => "Invalid english",
+          "detail" => "Pick an option for English",
+          "source" => { "pointer" => "/data/attributes/english" } },
+      ])
     end
   end
 
@@ -70,9 +85,7 @@ describe "/api/v2/build_new_course", type: :request do
       expect(response).to have_http_status(:ok)
       json_response = parse_response(response)
 
-      expected = { "data" => course_jsonapi.merge("errors" => []) }
-
-      expect(json_response).to eq expected
+      expect(json_response["data"]["errors"]).to match_array([])
     end
   end
 

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -26,7 +26,7 @@ describe "Publish API v2", type: :request do
     end
     let(:enrichment) { build(:course_enrichment, :initial_draft) }
     let(:site_status) { build(:site_status, :new) }
-    let(:dfe_subject) { build(:subject, :primary) }
+    let(:dfe_subject) { create(:subject, :primary) }
     let(:course) {
       create(:course,
              provider: provider,
@@ -59,16 +59,17 @@ describe "Publish API v2", type: :request do
 
     context "an unpublished course with a draft enrichment" do
       let(:enrichment) { build(:course_enrichment, :initial_draft) }
-      let(:site_status) { build(:site_status, :new) }
-      let(:dfe_subjects) { [build(:subject, :primary)] }
-      let!(:course) {
+      let(:site_status) { build(:site_status, :findable) }
+      let(:dfe_subjects) { [create(:subject, :primary_with_mathematics)] }
+      let!(:course) do
         create(:course,
+               level: "primary",
                provider: provider,
                site_statuses: [site_status],
                enrichments: [enrichment],
                subjects: dfe_subjects,
                age: 17.days.ago)
-      }
+      end
 
       before do
         Timecop.freeze

--- a/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
+++ b/spec/requests/api/v2/providers/courses/sync_with_search_and_compare_spec.rb
@@ -18,8 +18,8 @@ describe "Courses API v2", type: :request do
     end
     let(:course_enrichment) { build(:course_enrichment, :initial_draft) }
     let(:site_status) { build(:site_status, :findable) }
-    let(:dfe_subject) { build(:subject, :primary) }
-    let(:course) { create(:course, provider: provider, enrichments: [course_enrichment], site_statuses: [site_status], subjects: [dfe_subject]) }
+    let(:dfe_subject) { create(:subject, :primary_with_mathematics) }
+    let(:course) { create(:course, level: :primary, provider: provider, enrichments: [course_enrichment], site_statuses: [site_status], subjects: [dfe_subject]) }
 
     before do
       stub_request(:put, %r{#{Settings.search_api.base_url}/api/courses/})

--- a/spec/requests/api/v2/providers/courses/update_gcse_requirements_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_gcse_requirements_spec.rb
@@ -29,7 +29,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
   let(:course)            {
     create :course,
            provider: provider,
-           subjects: [build(:subject, :primary)]
+           subjects: [create(:subject, :primary)]
   }
 
   let(:credentials) do
@@ -141,7 +141,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
   end
 
   context "when not_set is provided on a secondary course" do
-    let(:secondary_subject) { build(:subject, :secondary) }
+    let(:secondary_subject) { create(:subject, :secondary) }
     let(:json_data) { JSON.parse(response.body)["errors"] }
     let(:gcse_requirements) { { english: "not_set", maths: "not_set", science: "not_set" } }
 

--- a/spec/requests/api/v2/providers/courses/update_outcomes_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_outcomes_spec.rb
@@ -33,7 +33,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
            qualification: qualification
   }
   let(:qualification) { :pgce_with_qts }
-  let(:subject) { build(:subject, :primary) }
+  let(:subject) { create(:subject, :primary) }
 
   let(:credentials) do
     ActionController::HttpAuthentication::Token.encode_credentials(token)
@@ -101,7 +101,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
       }
       let(:json_data) { JSON.parse(response.body)["errors"] }
       let(:updated_qualification) { { qualification: "pgce_with_qts" } }
-      let(:subject) { build(:subject, :further_education) }
+      let(:subject) { create(:subject, :further_education) }
       let(:qualification) { :pgce }
 
       it "returns an error" do

--- a/spec/requests/api/v2/providers/courses/update_send_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_send_spec.rb
@@ -29,7 +29,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
   let(:course)            {
     create :course,
            provider: provider,
-           subjects: [build(:subject, :primary)],
+           subjects: [create(:subject, :primary)],
            is_send: false
   }
 

--- a/spec/requests/api/v2/providers/courses/update_sites_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_sites_spec.rb
@@ -10,10 +10,10 @@ describe "PATCH /providers/:provider_code/courses/:course_code with sites" do
     ActionController::HttpAuthentication::Token.encode_credentials(token)
   end
 
-  let(:course) { create :course, provider: provider, site_statuses: [site_status], subjects: [primary_subject], enrichments: [course_enrichment] }
+  let(:course) { create(:course, :infer_level, provider: provider, site_statuses: [site_status], subjects: [primary_subject], enrichments: [course_enrichment]) }
   let(:course_enrichment) { build :course_enrichment }
   let(:site_status) { build(:site_status) }
-  let(:primary_subject) { build(:subject, :primary) }
+  let(:primary_subject) { create(:subject, :primary_with_mathematics) }
   let(:site_to_add) { create :site, provider: provider }
   let(:unwanted_site) { create :site, provider: provider }
   let(:existing_site) { create :site, provider: provider }

--- a/spec/requests/api/v2/providers/courses/update_subject_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_subject_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+describe "PATCH /providers/:provider_code/courses/:course_code" do
+  let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+
+  def perform_request(updated_subjects)
+    jsonapi_data = jsonapi_renderer.render(
+      course,
+      class: {
+        Course: API::V2::SerializableCourse,
+      },
+    )
+
+    jsonapi_data[:data][:relationships] = updated_subjects
+
+    patch "/api/v2/providers/#{course.provider.provider_code}" \
+            "/courses/#{course.course_code}",
+          headers: { "HTTP_AUTHORIZATION" => credentials },
+          params: {
+            _jsonapi: jsonapi_data,
+          }
+  end
+  let(:organisation) { create :organisation }
+  let(:provider) { create :provider, organisations: [organisation], sites: [site] }
+  let(:user) { create :user, organisations: [organisation] }
+  let(:payload) { { email: user.email } }
+  let(:token) { build_jwt :apiv2, payload: payload }
+
+  let(:site) { build(:site) }
+
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+
+  before do
+    perform_request(updated_subjects)
+  end
+
+  context "course has no subjects" do
+    let(:course) { create(:course, :infer_level, provider: provider) }
+    let(:subject) { find_or_create(:subject, :mathematics, type: :SecondarySubject) }
+    let(:updated_subjects) do
+      {
+        subjects: {
+          data: [{ "type" => "subject", "id" => subject.id.to_s }],
+        },
+      }
+    end
+
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it "adds a subject" do
+      expect(course.reload.subjects.first.id).to eq(subject.id)
+    end
+  end
+
+  context "course has subjects" do
+    let(:course) { create(:course, :infer_level, provider: provider, subjects: []) }
+    let(:subject1) { create(:subject, :english, type: :SecondarySubject) }
+    let(:subject2) { create(:subject, :mathematics, type: :SecondarySubject) }
+    let(:updated_subjects) do
+      {
+        subjects: {
+          data: [
+            { type: "subject", id: subject1.id.to_s },
+            { type: "subject", id: subject2.id.to_s },
+          ],
+        },
+      }
+    end
+
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it "adds a subject" do
+      expect(course.reload.subjects.first.id).to eq(subject1.id)
+      expect(course.reload.subjects.second.id).to eq(subject2.id)
+    end
+  end
+end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -15,6 +15,7 @@ describe "Courses API v2", type: :request do
   let(:current_year)  { current_cycle.year.to_i }
   let(:previous_year) { current_year - 1 }
   let(:next_year)     { current_year + 1 }
+  let(:subjects) { [course_subject_mathematics] }
 
   let(:applications_open_from) { Time.now.utc }
   let(:findable_open_course) do
@@ -24,7 +25,7 @@ describe "Courses API v2", type: :request do
            provider: provider,
            start_date: Time.now.utc,
            study_mode: :full_time,
-           subjects: [course_subject_mathematics],
+           subjects: subjects,
            is_send: true,
            site_statuses: [courses_site_status],
            enrichments: [enrichment],
@@ -94,7 +95,6 @@ describe "Courses API v2", type: :request do
                 "ucas_status" => "running",
                 "funding_type" => "apprenticeship",
                 "is_send?" => true,
-                "subjects" => ["Primary with mathematics"],
                 "level" => "primary",
                 "applications_open_from" =>
                   findable_open_course.applications_open_from.to_s,
@@ -132,6 +132,7 @@ describe "Courses API v2", type: :request do
                 "provider" => { "meta" => { "included" => false } },
                 "sites" => { "meta" => { "included" => false } },
                 "site_statuses" => { "data" => [{ "type" => "site_statuses", "id" => site_status.id.to_s }] },
+                "subjects" => { "data" => [{ "type" => "subjects", "id" => course_subject_mathematics.id.to_s }] },
               },
               "meta" => {
                 "edit_options" => {
@@ -172,38 +173,49 @@ describe "Courses API v2", type: :request do
             "jsonapi" => {
               "version" => "1.0",
             },
-            "included" => [{
-              "id" => site_status.id.to_s,
-              "type" => "site_statuses",
-              "attributes" => {
-                "vac_status" => site_status.vac_status,
-                "publish" => site_status.publish,
-                "status" => site_status.status,
-                "has_vacancies?" => true,
-              },
-              "relationships" => {
-                "site" => {
-                  "data" => {
-                    "type" => "sites",
+            "included" => [
+              {
+                "id" => site_status.id.to_s,
+                "type" => "site_statuses",
+                "attributes" => {
+                  "vac_status" => site_status.vac_status,
+                  "publish" => site_status.publish,
+                  "status" => site_status.status,
+                  "has_vacancies?" => true,
+                },
+                "relationships" => {
+                  "site" => {
+                    "data" => {
+                      "type" => "sites",
                       "id" => site.id.to_s,
+                    },
                   },
                 },
               },
-            }, {
-              "id" => site.id.to_s,
-              "type" => "sites",
-              "attributes" => {
-                "code" => site.code,
-                "location_name" => site.location_name,
-                "address1" => site.address1,
-                "address2" => site.address2,
-                "address3" => site.address3,
-                "address4" => site.address4,
-                "postcode" => site.postcode,
-                "region_code" => site.region_code,
-                "recruitment_cycle_year" => current_year.to_s,
+              {
+                "id" => course_subject_mathematics.id.to_s,
+                "type" => "subjects",
+                "attributes" => {
+                  "subject_name" => course_subject_mathematics.subject_name,
+                  "subject_code" => course_subject_mathematics.subject_code,
+                },
               },
-            }],
+              {
+                "id" => site.id.to_s,
+                "type" => "sites",
+                "attributes" => {
+                  "code" => site.code,
+                  "location_name" => site.location_name,
+                  "address1" => site.address1,
+                  "address2" => site.address2,
+                  "address3" => site.address3,
+                  "address4" => site.address4,
+                  "postcode" => site.postcode,
+                  "region_code" => site.region_code,
+                  "recruitment_cycle_year" => current_year.to_s,
+                },
+              },
+            ],
           )
         end
       end
@@ -302,9 +314,6 @@ describe "Courses API v2", type: :request do
               "required_qualifications" => enrichment.required_qualifications,
               "salary_details" => enrichment.salary_details,
               "last_published_at" => enrichment.last_published_timestamp_utc.iso8601,
-              "subjects" => [
-                "Primary with mathematics",
-              ],
               "has_bursary?" => false,
               "has_scholarship_and_bursary?" => false,
               "has_early_career_payments?" => false,
@@ -326,6 +335,7 @@ describe "Courses API v2", type: :request do
               "provider" => { "meta" => { "included" => false } },
               "site_statuses" => { "meta" => { "included" => false } },
               "sites" => { "meta" => { "included" => false } },
+              "subjects" => { "meta" => { "included" => false } },
             },
             "meta" => {
               "edit_options" => {

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -8,7 +8,7 @@ describe "Courses API v2", type: :request do
   let(:credentials) do
     ActionController::HttpAuthentication::Token.encode_credentials(token)
   end
-  let(:course_subject_mathematics) { find_or_create(:subject, :mathematics) }
+  let(:course_subject_mathematics) { find_or_create(:subject, :primary_with_mathematics) }
 
   let(:current_cycle) { find_or_create :recruitment_cycle }
   let(:next_cycle)    { find_or_create :recruitment_cycle, :next }
@@ -17,9 +17,9 @@ describe "Courses API v2", type: :request do
   let(:next_year)     { current_year + 1 }
 
   let(:applications_open_from) { Time.now.utc }
-  let(:findable_open_course) {
+  let(:findable_open_course) do
     create(:course, :resulting_in_pgce_with_qts, :with_apprenticeship,
-           level: :secondary,
+           level: "primary",
            name: "Mathematics",
            provider: provider,
            start_date: Time.now.utc,
@@ -33,7 +33,7 @@ describe "Courses API v2", type: :request do
            science: :must_have_qualification_at_application_time,
            age_range_in_years: "3_to_7",
            applications_open_from: applications_open_from)
-  }
+  end
 
   let(:courses_site_status) {
     build(:site_status,
@@ -94,8 +94,8 @@ describe "Courses API v2", type: :request do
                 "ucas_status" => "running",
                 "funding_type" => "apprenticeship",
                 "is_send?" => true,
-                "subjects" => %w[Mathematics],
-                "level" => "secondary",
+                "subjects" => ["Primary with mathematics"],
+                "level" => "primary",
                 "applications_open_from" =>
                   findable_open_course.applications_open_from.to_s,
                 "about_course" => enrichment.about_course,
@@ -122,7 +122,7 @@ describe "Courses API v2", type: :request do
                 "science" => "must_have_qualification_at_application_time",
                 "provider_code" => provider.provider_code,
                 "recruitment_cycle_year" => current_year.to_s,
-                "gcse_subjects_required" => %w[maths english],
+                "gcse_subjects_required" => %w[maths english science],
                 "age_range_in_years" => provider.courses[0].age_range_in_years,
                 "accrediting_provider" => nil,
                 "accrediting_provider_code" => nil,
@@ -137,7 +137,7 @@ describe "Courses API v2", type: :request do
                 "edit_options" => {
                   "entry_requirements" => %w[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test],
                   "qualifications" => %w[qts pgce_with_qts pgde_with_qts],
-                  "age_range_in_years" => %w[11_to_16 11_to_18 14_to_19],
+                  "age_range_in_years" => %w[3_to_7 5_to_11 7_to_11 7_to_14],
                   "start_dates" => [
                     "October #{previous_year}",
                     "November #{previous_year}",
@@ -287,8 +287,7 @@ describe "Courses API v2", type: :request do
               "ucas_status" => "running",
               "funding_type" => "apprenticeship",
               "is_send?" => true,
-              "subjects" => %w[Mathematics],
-              "level" => "secondary",
+              "level" => "primary",
               "applications_open_from" => provider.courses[0].applications_open_from.strftime("%Y-%m-%d"),
               "about_course" => enrichment.about_course,
               "course_length" => enrichment.course_length,
@@ -303,6 +302,9 @@ describe "Courses API v2", type: :request do
               "required_qualifications" => enrichment.required_qualifications,
               "salary_details" => enrichment.salary_details,
               "last_published_at" => enrichment.last_published_timestamp_utc.iso8601,
+              "subjects" => [
+                "Primary with mathematics",
+              ],
               "has_bursary?" => false,
               "has_scholarship_and_bursary?" => false,
               "has_early_career_payments?" => false,
@@ -314,7 +316,7 @@ describe "Courses API v2", type: :request do
                 "science" => "must_have_qualification_at_application_time",
               "provider_code" => provider.provider_code,
               "recruitment_cycle_year" => current_year.to_s,
-              "gcse_subjects_required" => %w[maths english],
+              "gcse_subjects_required" => %w[maths english science],
               "age_range_in_years" => provider.courses[0].age_range_in_years,
               "accrediting_provider" => nil,
               "accrediting_provider_code" => nil,
@@ -329,7 +331,7 @@ describe "Courses API v2", type: :request do
               "edit_options" => {
                 "entry_requirements" => %w[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test],
                 "qualifications" => %w[qts pgce_with_qts pgde_with_qts],
-                "age_range_in_years" => %w[11_to_16 11_to_18 14_to_19],
+                "age_range_in_years" => %w[3_to_7 5_to_11 7_to_11 7_to_14],
                 "start_dates" => [
                   "October #{previous_year}",
                   "November #{previous_year}",

--- a/spec/requests/api/v2/providers/publish_spec.rb
+++ b/spec/requests/api/v2/providers/publish_spec.rb
@@ -38,10 +38,10 @@ describe "Provider Publish API v2", type: :request do
       let(:enrichment) { build(:provider_enrichment, :initial_draft) }
       let(:site1) { create(:site_status, :findable) }
       let(:site2) { create(:site_status, :findable) }
-      let(:course1) { build(:course, site_statuses: [site1], subjects: [dfe_subject]) }
-      let(:course2) { build(:course, site_statuses: [site2], subjects: [dfe_subject]) }
+      let(:course1) { build(:course, :infer_level, site_statuses: [site1], subjects: [dfe_subject]) }
+      let(:course2) { build(:course, :infer_level, site_statuses: [site2], subjects: [dfe_subject]) }
 
-      let!(:dfe_subject) { build(:subject, :primary) }
+      let!(:dfe_subject) { create(:subject, :primary_with_mathematics) }
 
       let!(:provider) do
         create(

--- a/spec/requests/api/v2/providers/sync_courses_with_search_and_compare_spec.rb
+++ b/spec/requests/api/v2/providers/sync_courses_with_search_and_compare_spec.rb
@@ -7,20 +7,20 @@ describe "Courses API v2", type: :request do
     ActionController::HttpAuthentication::Token.encode_credentials(token)
   end
   let(:site) { build(:site) }
-  let(:dfe_subject) { build(:subject, :primary) }
-  let(:non_dfe_subject) { build(:subject, :modern_languages) }
+  let(:dfe_subject) { create(:subject, :primary_with_mathematics) }
+  let(:non_dfe_subject) { create(:subject, :modern_languages) }
   let(:findable_site_status_1) { build(:site_status, :findable, site: site) }
   let(:findable_site_status_2) { build(:site_status, :findable, site: site) }
   let(:suspended_site_status) { build(:site_status, :suspended, site: site) }
-  let(:syncable_course) { build(:course, site_statuses: [findable_site_status_1], subjects: [dfe_subject]) }
-  let(:suspended_course) { build(:course, site_statuses: [suspended_site_status], subjects: [dfe_subject]) }
-  let(:invalid_subject_course) { build(:course, site_statuses: [findable_site_status_2], subjects: [non_dfe_subject]) }
-  let(:provider) {
+  let(:syncable_course) { create(:course, :infer_level, site_statuses: [findable_site_status_1], subjects: [dfe_subject]) }
+  let(:suspended_course) { create(:course, :infer_level, site_statuses: [suspended_site_status], subjects: [dfe_subject]) }
+  let(:invalid_subject_course) { create(:course, :infer_level, site_statuses: [findable_site_status_2], subjects: [non_dfe_subject]) }
+  let(:provider) do
     create(:provider,
            organisations: [organisation],
              courses: [syncable_course, suspended_course, invalid_subject_course],
              sites: [site])
-  }
+  end
 
   describe "POST " do
     let(:status) { 200 }
@@ -99,13 +99,14 @@ describe "Courses API v2", type: :request do
             "/providers/#{provider.provider_code}/sync_courses_with_search_and_compare"
         end
         let(:next_cycle) { build(:recruitment_cycle, :next) }
-        let(:provider) {
+        let(:syncable_course) { build(:course, :infer_level, site_statuses: [findable_site_status_1], subjects: [dfe_subject]) }
+        let(:provider) do
           create(:provider,
                  organisations: [organisation],
                          courses: [syncable_course],
                          sites: [site],
                          recruitment_cycle: next_cycle)
-        }
+        end
 
         it "should throw an error" do
           expect { subject }.to raise_error("#{provider} is not from the current recruitment cycle")

--- a/spec/requests/api/v2/providers/update_spec.rb
+++ b/spec/requests/api/v2/providers/update_spec.rb
@@ -35,8 +35,8 @@ describe "PATCH /providers/:provider_code" do
   let(:recruitment_cycle) { find_or_create :recruitment_cycle }
   let(:organisation) { create :organisation }
   let(:site1) { build(:site_status, :findable) }
-  let(:course1) { build(:course, site_statuses: [site1], subjects: [dfe_subject]) }
-  let!(:dfe_subject) { build(:subject, :primary) }
+  let(:course1) { build(:course, level: "primary", site_statuses: [site1], subjects: [dfe_subject]) }
+  let!(:dfe_subject) { create(:subject, :primary) }
   let(:provider)     do
     create :provider,
            organisations: [organisation],

--- a/spec/requests/api/v2/providers/update_with_sync_spec.rb
+++ b/spec/requests/api/v2/providers/update_with_sync_spec.rb
@@ -44,7 +44,7 @@ describe "Provider Publish API v2", type: :request do
       let(:course1) { build(:course, site_statuses: [site1], subjects: [dfe_subject]) }
       let(:course2) { build(:course, site_statuses: [site2], subjects: [dfe_subject]) }
 
-      let!(:dfe_subject) { build(:subject, :primary) }
+      let!(:dfe_subject) { create(:subject, :primary) }
 
       let(:courses) {
         []

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -25,7 +25,6 @@ describe API::V2::SerializableCourse do
   it { should have_attribute :content_status }
   it { should have_attribute :ucas_status }
   it { should have_attribute :funding_type }
-  it { should have_attribute :subjects }
   it { should have_attribute(:applications_open_from).with_value(date_today.to_s) }
   it { should have_attribute :is_send? }
   it { should have_attribute(:level).with_value("primary") }
@@ -59,6 +58,25 @@ describe API::V2::SerializableCourse do
         .to(include(have_type("providers")
           .and(have_id(provider.id.to_s))))
     end
+  end
+
+  context "with a subject" do
+    let(:course) { create(:course, subjects: [find_or_create(:subject, :primary_with_mathematics)]) }
+    let(:accrediting_provider) { course.accrediting_provider }
+    let(:course_json) do
+      jsonapi_renderer.render(
+        course,
+        class: {
+          Course: API::V2::SerializableCourse,
+          Subject: API::V2::SerializableSubject,
+        },
+        include: [
+          :subjects,
+        ],
+      ).to_json
+    end
+
+    it { should have_relationship(:accrediting_provider) }
   end
 
   context "with an accrediting_provider" do

--- a/spec/serializers/course_serializer_spec.rb
+++ b/spec/serializers/course_serializer_spec.rb
@@ -28,7 +28,7 @@
 #  level                     :string
 require "rails_helper"
 
-RSpec.describe CourseSerializer do
+describe CourseSerializer do
   let(:course) { create :course, provider: provider, changed_at: Time.now + 60 }
   let(:provider) { build(:provider) }
   subject { serialize(course) }

--- a/spec/serializers/course_serializer_spec.rb
+++ b/spec/serializers/course_serializer_spec.rb
@@ -45,7 +45,9 @@ describe CourseSerializer do
 
     it "includes a SEND subject" do
       expect(subject[:subjects]).to include(
-        "subject_code" => "U3", "subject_name" => "Special Educational Needs",
+        "subject_code" => "U3",
+        "subject_name" => "Special Educational Needs",
+        "type" => nil,
       )
     end
   end

--- a/spec/serializers/search_and_compare/course_serializer_spec.rb
+++ b/spec/serializers/search_and_compare/course_serializer_spec.rb
@@ -8,7 +8,7 @@ describe SearchAndCompare::CourseSerializer do
 
     context "an existing course" do
       let(:subjects) do
-        [build(:subject, :primary)]
+        [create(:subject, :primary)]
       end
 
       let(:program_type) { :school_direct_salaried_training_programme }
@@ -16,6 +16,7 @@ describe SearchAndCompare::CourseSerializer do
       let(:course_enrichments) { [published_enrichment] }
       let(:course) do
         create(:course,
+               level: "primary",
                provider: provider,
                accrediting_provider: accrediting_provider,
                name: "Primary (Special Educational Needs)",

--- a/spec/serializers/subject_serializer_spec.rb
+++ b/spec/serializers/subject_serializer_spec.rb
@@ -10,7 +10,7 @@
 
 require "rails_helper"
 
-RSpec.describe SubjectSerializer do
+describe SubjectSerializer do
   let(:subject_object) { create :subject }
   subject { serialize(subject_object) }
 

--- a/spec/services/course_assignable_subject_service_spec.rb
+++ b/spec/services/course_assignable_subject_service_spec.rb
@@ -17,7 +17,6 @@ describe CourseAssignableSubjectService do
   it "gets all primary subjects if the level is primary" do
     course = create(:course, level: "primary")
 
-
     expect(service.execute(course)).to eq([])
     expect(primary_model).to have_received(:all)
   end

--- a/spec/services/course_serializers_service_spec.rb
+++ b/spec/services/course_serializers_service_spec.rb
@@ -1,0 +1,45 @@
+describe CourseSerializersService do
+  let(:course_serializer_spy) { spy }
+  let(:subject_serializer_spy) { spy }
+  let(:primary_subject_serializer_spy) { spy }
+  let(:secondary_subject_serializer_spy) { spy }
+  let(:modern_languages_subject_serializer_spy) { spy }
+  let(:further_education_subject_serializer_spy) { spy }
+  let(:site_status_serializer_spy) { spy }
+  let(:site_serializer_spy) { spy }
+  let(:provider_serializer_spy) { spy }
+  let(:provider_enrichment_serializer_spy) { spy }
+  let(:recruitment_cycle_serializer_spy) { spy }
+
+  let(:service) do
+    described_class.new(
+      course_serializer: course_serializer_spy,
+      subject_serializer: subject_serializer_spy,
+      primary_subject_serializer: primary_subject_serializer_spy,
+      secondary_subject_serializer: secondary_subject_serializer_spy,
+      modern_languages_subject_serializer: modern_languages_subject_serializer_spy,
+      further_education_subject_serializer: further_education_subject_serializer_spy,
+      site_status_serializer: site_status_serializer_spy,
+      site_serializer: site_serializer_spy,
+      provider_serializer: provider_serializer_spy,
+      provider_enrichment_serializer: provider_enrichment_serializer_spy,
+      recruitment_cycle_serializer: recruitment_cycle_serializer_spy,
+    )
+  end
+
+  it "returns the hash of classes needed for serializing courses" do
+    expect(service.execute).to eq(
+      Course: course_serializer_spy,
+      Subject: subject_serializer_spy,
+      PrimarySubject: primary_subject_serializer_spy,
+      SecondarySubject: secondary_subject_serializer_spy,
+      ModernLanguagesSubject: modern_languages_subject_serializer_spy,
+      FurtherEducationSubject: further_education_subject_serializer_spy,
+      SiteStatus: site_status_serializer_spy,
+      Site: site_serializer_spy,
+      Provider: provider_serializer_spy,
+      ProviderEnrichment: provider_enrichment_serializer_spy,
+      RecruitmentCycle: recruitment_cycle_serializer_spy,
+    )
+  end
+end


### PR DESCRIPTION
### Context
We would like to give users the ability to edit course subjects.

### Changes proposed in this pull request
Allow the course subject to be modified with `PATCH` and deserialize it correctly.

### Guidance to review
Only validation left is for MFL. Also is it correct that without ucas subjects the ucas status defaults to secondary.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
