### PR TITLE
[2127] Data cleanup post UCAS to DfE subjects migration

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -98,7 +98,11 @@ class Course < ApplicationRecord
              optional: true
 
   has_many :course_subjects
+<<<<<<< HEAD
   has_many :subjects, through: :course_subjects
+=======
+  has_many :subjects, through: :cours_subjects
+>>>>>>> [2127] Add migration to create subject table
   has_many :course_ucas_subjects
   has_many :ucas_subjects, through: :course_ucas_subjects
   has_many :site_statuses

--- a/app/models/course_subject.rb
+++ b/app/models/course_subject.rb
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 # == Schema Information
 #
 # Table name: course_subject
@@ -7,6 +8,8 @@
 #  subject_id :integer
 #
 
+=======
+>>>>>>> [2127] Add migration to create subject table
 class CourseSubject < ApplicationRecord
   self.table_name = 'course_subject'
 

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -25,7 +25,11 @@
 #  age_range_in_years        :string
 #  applications_open_from    :date
 #  is_send                   :boolean          default(FALSE)
+<<<<<<< HEAD
 #  level                     :string
+=======
+#  level                     :integer          default("primary")
+>>>>>>> [2128] Fixed lint issues
 #
 
 class CourseSerializer < ActiveModel::Serializer

--- a/db/migrate/20190913125905_migrate_subjects.rb
+++ b/db/migrate/20190913125905_migrate_subjects.rb
@@ -1,4 +1,5 @@
 class MigrateSubjects < ActiveRecord::Migration[5.2]
+<<<<<<< HEAD
   def up
     say_with_time 'populating/migrating course subjects' do
       all_subjects = Subject.all
@@ -25,4 +26,17 @@ class MigrateSubjects < ActiveRecord::Migration[5.2]
     CourseSubject.connection.truncate :course_subject
     Course.all.each { |c| c.update_column(:level, nil) }
   end
+=======
+  def change
+    say_with_time 'populating migrating course subjects' do
+      all_subject = Subject.all
+      all_course_includes_ucas_subjects = Course.includes(:ucas_subjects)
+      all_course_includes_ucas_subjects.each do |course|
+        course.level = course.ucas_level
+        course.subjects = all_subject.where :subject_name => course.dfe_subjects.map(&:to_s)
+        course.save
+      end
+    end
+  end
+>>>>>>> [2123] Added migration for subjects
 end

--- a/db/migrate/20190916155318_clean_up_course_subject_data_post_migration.rb
+++ b/db/migrate/20190916155318_clean_up_course_subject_data_post_migration.rb
@@ -1,0 +1,42 @@
+# rubocop:disable Metrics/BlockLength
+class CleanUpCourseSubjectDataPostMigration < ActiveRecord::Migration[5.2]
+  def change
+    say_with_time 'cleansing subject data' do
+      courses = RecruitmentCycle.second.courses
+      subjects = Subject.where(subject_name: ['French',
+                                              'English as a Second Language',
+                                              'German',
+                                              'Italian',
+                                              'Japanese',
+                                              'Mandarin',
+                                              'Russian',
+                                              'Spanish',
+                                              'Modern languages (other)'])
+
+      primary = Subject.find_by!(subject_name: 'Primary')
+      modern_languages = Subject.find_by!(subject_name: 'Modern Languages')
+      science = Subject.find_by!(subject_name: 'Science')
+      courses.each do |course|
+        case course
+        when course.subjects.count > 1 && course.subjects.exists?(subject_name: 'Primary')
+          course.subjects -= [primary]
+        when course.subjects.count == 4 && course.subjects.exists?(subject_name: ['Physics', 'Biology', 'Chemistry', 'Balanced Science'])
+          course.update(subjects: [science])
+        when course.subjects.count == 1 && course.subjects.exists?(subject_name: 'Balanced Science')
+          course.update(subjects: [science])
+        when course.subjects.exists?(subject_name: 'Humanities')
+          course.update(subjects: [Subject.find_by!(subject_name: 'History'), Subject.find_by!(subject_name: 'Geography')])
+        when (course.subjects & subjects).any?
+          course.subjects += [modern_languages]
+        end
+      end
+
+      geography = Subject.find_by!(subject_name: 'Geography')
+      pe = Subject.find_by!(subject_name: 'Physical Education')
+
+      course = c.find_by!(course_code: '3CZ2')
+      course.update(level: 'primary', subjects: [pe, geography])
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_12_162820) do
+ActiveRecord::Schema.define(version: 2019_09_13_125905) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_12_131116) do
+ActiveRecord::Schema.define(version: 2019_09_12_162820) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -91,15 +91,7 @@ ActiveRecord::Schema.define(version: 2019_09_12_131116) do
     t.string "age_range_in_years"
     t.date "applications_open_from"
     t.boolean "is_send", default: false
-<<<<<<< HEAD
-<<<<<<< HEAD
     t.string "level"
-=======
-    t.integer "level", default: 0
->>>>>>> [2128] Add level to course via migration
-=======
-    t.integer "level", default: 0
->>>>>>> [2128] Add level to course via migration
     t.index ["accrediting_provider_code"], name: "index_course_on_accrediting_provider_code"
     t.index ["accrediting_provider_id"], name: "IX_course_accrediting_provider_id"
     t.index ["changed_at"], name: "index_course_on_changed_at", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_13_112820) do
+ActiveRecord::Schema.define(version: 2019_09_12_162820) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -91,7 +91,11 @@ ActiveRecord::Schema.define(version: 2019_09_13_112820) do
     t.string "age_range_in_years"
     t.date "applications_open_from"
     t.boolean "is_send", default: false
+<<<<<<< HEAD
     t.string "level"
+=======
+    t.integer "level", default: 0
+>>>>>>> [2128] Add level to course via migration
     t.index ["accrediting_provider_code"], name: "index_course_on_accrediting_provider_code"
     t.index ["accrediting_provider_id"], name: "IX_course_accrediting_provider_id"
     t.index ["changed_at"], name: "index_course_on_changed_at", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_13_125905) do
+ActiveRecord::Schema.define(version: 2019_09_12_131116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -92,7 +92,11 @@ ActiveRecord::Schema.define(version: 2019_09_13_125905) do
     t.date "applications_open_from"
     t.boolean "is_send", default: false
 <<<<<<< HEAD
+<<<<<<< HEAD
     t.string "level"
+=======
+    t.integer "level", default: 0
+>>>>>>> [2128] Add level to course via migration
 =======
     t.integer "level", default: 0
 >>>>>>> [2128] Add level to course via migration

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_12_162820) do
+ActiveRecord::Schema.define(version: 2019_09_16_155318) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -25,7 +25,11 @@
 #  age_range_in_years        :string
 #  applications_open_from    :date
 #  is_send                   :boolean          default(FALSE)
+<<<<<<< HEAD
 #  level                     :string
+=======
+#  level                     :integer          default("primary")
+>>>>>>> [2128] Fixed lint issues
 #
 
 FactoryBot.define do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -25,7 +25,11 @@
 #  age_range_in_years        :string
 #  applications_open_from    :date
 #  is_send                   :boolean          default(FALSE)
+<<<<<<< HEAD
 #  level                     :string
+=======
+#  level                     :integer          default("primary")
+>>>>>>> [2128] Fixed lint issues
 #
 
 require 'rails_helper'

--- a/spec/serializers/course_serializer_spec.rb
+++ b/spec/serializers/course_serializer_spec.rb
@@ -26,6 +26,7 @@
 #  applications_open_from    :date
 #  is_send                   :boolean          default(FALSE)
 #  level                     :string
+#
 require "rails_helper"
 
 RSpec.describe CourseSerializer do


### PR DESCRIPTION
### Context

Post the subject migration taking place there are quite a few bits of erroneous data due to how the subject mapper works. 

The following needs to take place: 

2019 Course with `Primary` + one `other primary` subjects
2020 Course with be just assigned  `other primary` subject
(If a course includes primary and another subject remove the primary subject from the courses subjects)

2019 Course with `Physics`, `Biology`, `Chemistry`, `Balanced science`
2020 Course with be assigned with one `Science` subject

2019 Course with `Balanced science`
2020 Course with be assigned with `Science` subject


2019 Course with `Humanities`
2020 Course with be assigned with both `Geography`, `History` subjects

### Modern foreign languages
2019 Courses with any of the following
`French`
`English as a Second Language`
`German`
`Italian`
`Japanese`
`Mandarin`
`Russian`
`Spanish`
`Modern languages (other)`
2020 Course with be assigned with `Modern languages` in additional to the named languages

```
`Modern languages (other)` => `Modern languages` , `Modern languages (other)`
```


```
`Russian` => `Modern languages` , `Russian`
```

```
`Spanish`, `Russian` => `Modern languages` , `Russian`, 
`Spanish`
```

Physical Education with Geography (W75/3CZ2) 
level needs to be secondary and subjects needs to be Geography and P.E (currently primary)

### Changes proposed in this pull request

- Actions all the above via a migration
### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
