### PR TITLE
[2130] Data cleanup post UCAS to DfE subjects migration

### DIFF
--- a/db/migrate/20190916155318_clean_up_course_subject_data_post_migration.rb
+++ b/db/migrate/20190916155318_clean_up_course_subject_data_post_migration.rb
@@ -1,0 +1,42 @@
+# rubocop:disable Metrics/BlockLength
+class CleanUpCourseSubjectDataPostMigration < ActiveRecord::Migration[5.2]
+  def change
+    say_with_time 'cleansing subject data' do
+      courses = RecruitmentCycle.second.courses
+      subjects = Subject.where(subject_name: ['French',
+                                              'English as a Second Language',
+                                              'German',
+                                              'Italian',
+                                              'Japanese',
+                                              'Mandarin',
+                                              'Russian',
+                                              'Spanish',
+                                              'Modern languages (other)'])
+
+      primary = Subject.find_by!(subject_name: 'Primary')
+      modern_languages = Subject.find_by!(subject_name: 'Modern Languages')
+      science = Subject.find_by!(subject_name: 'Science')
+      courses.each do |course|
+        case course
+        when course.subjects.count > 1 && course.subjects.exists?(subject_name: 'Primary')
+          course.subjects -= [primary]
+        when course.subjects.count == 4 && course.subjects.exists?(subject_name: ['Physics', 'Biology', 'Chemistry', 'Balanced Science'])
+          course.update(subjects: [science])
+        when course.subjects.count == 1 && course.subjects.exists?(subject_name: 'Balanced Science')
+          course.update(subjects: [science])
+        when course.subjects.exists?(subject_name: 'Humanities')
+          course.update(subjects: [Subject.find_by!(subject_name: 'History'), Subject.find_by!(subject_name: 'Geography')])
+        when (course.subjects & subjects).any?
+          course.subjects += [modern_languages]
+        end
+      end
+
+      geography = Subject.find_by!(subject_name: 'Geography')
+      pe = Subject.find_by!(subject_name: 'Physical Education')
+
+      course = c.find_by!(course_code: '3CZ2')
+      course.update(level: 'primary', subjects: [pe, geography])
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_13_125905) do
+ActiveRecord::Schema.define(version: 2019_09_16_155318) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"


### PR DESCRIPTION
### Context

Post the subject migration taking place there are quite a few bits of erroneous data due to how the subject mapper works. 

The following needs to take place: 

2019 Course with `Primary` + one `other primary` subjects
2020 Course with be just assigned  `other primary` subject
(If a course includes primary and another subject remove the primary subject from the courses subjects)

2019 Course with `Physics`, `Biology`, `Chemistry`, `Balanced science`
2020 Course with be assigned with one `Science` subject

2019 Course with `Balanced science`
2020 Course with be assigned with `Science` subject


2019 Course with `Humanities`
2020 Course with be assigned with both `Geography`, `History` subjects

### Modern foreign languages
2019 Courses with any of the following
`French`
`English as a Second Language`
`German`
`Italian`
`Japanese`
`Mandarin`
`Russian`
`Spanish`
`Modern languages (other)`
2020 Course with be assigned with `Modern languages` in additional to the named languages

```
`Modern languages (other)` => `Modern languages` , `Modern languages (other)`
```


```
`Russian` => `Modern languages` , `Russian`
```

```
`Spanish`, `Russian` => `Modern languages` , `Russian`, 
`Spanish`
```

Physical Education with Geography (W75/3CZ2) 
level needs to be secondary and subjects needs to be Geography and P.E (currently primary)

### Changes proposed in this pull request

- Actions all the above via a migration
### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
