### PR TITLE
[2137] Add meta information to accept terms forbidden response

### DIFF
--- a/app/controllers/api/v2/application_controller.rb
+++ b/app/controllers/api/v2/application_controller.rb
@@ -31,7 +31,10 @@ module API
               title: 'Forbidden',
               detail: 'The user has not accepted terms and conditions.'
             }
-          ]
+          ],
+          meta: {
+            error_type: :user_not_accepted_terms_and_conditions
+          }
         }
         render json: error_body, status: :forbidden
       end

--- a/spec/support/shared_examples/unauth.rb
+++ b/spec/support/shared_examples/unauth.rb
@@ -12,6 +12,11 @@ shared_examples 'Unauthenticated, unauthorised, or not accepted T&Cs' do
     let(:organisation) { create(:organisation, users: [user]) }
 
     it { should have_http_status(:forbidden) }
+
+    it 'Returns the correct error type' do
+      body = JSON.parse(subject.body)
+      expect(body["meta"]).to eq("error_type" => "user_not_accepted_terms_and_conditions")
+    end
   end
 
   context 'when unauthorised' do


### PR DESCRIPTION
### Context
We use the `403` status code to also highlight if a user has not accepted the T&C - to better differentiate between the cause of the `403` we need to provide more information.

### Changes proposed in this pull request
- Adds in meta information to the user not accepted terms failure

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
