### PR TITLE
[2186] Update mcb to use new subjects

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -166,6 +166,7 @@ class Course < ApplicationRecord
   validate :validate_qualification, on: :update
   validate :validate_start_date, on: :update, if: -> { provider.present? }
   validate :validate_applications_open_from, on: :update, if: -> { provider.present? }
+  validate :validate_subjects
 
   after_validation :remove_unnecessary_enrichments_validation_message
 
@@ -534,6 +535,20 @@ private
       errors.add(:applications_open_from, "#{applications_open_from} is not valid for the #{provider.recruitment_cycle.year} cycle. " +
       "A valid date must be between #{recruitment_cycle.application_start_date} and #{recruitment_cycle.application_end_date}")
     end
+  end
+
+  def validate_subjects
+    if has_any_modern_language_subject_type? & !has_the_modern_languages_secondary_subject_type?
+      subjects << SecondarySubject.modern_languages
+    end
+  end
+
+  def has_any_modern_language_subject_type?
+    subjects.any? { |subject| subject.type == "ModernLanguagesSubject" }
+  end
+
+  def has_the_modern_languages_secondary_subject_type?
+    subjects.any? { |subject| subject == SecondarySubject.modern_languages }
   end
 
   def valid_date_range

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -15,4 +15,8 @@ class Subject < ApplicationRecord
   def to_sym
     subject_name.parameterize.underscore.to_sym
   end
+
+  def to_s
+    "#{subject_name} (#{subject_code})"
+  end
 end

--- a/app/models/subjects/secondary_subject.rb
+++ b/app/models/subjects/secondary_subject.rb
@@ -9,4 +9,7 @@
 #
 
 class SecondarySubject < Subject
+  def self.modern_languages
+    find_by(subject_name: "Modern Languages")
+  end
 end

--- a/app/services/course_assignable_subject_service.rb
+++ b/app/services/course_assignable_subject_service.rb
@@ -1,0 +1,26 @@
+class CourseAssignableSubjectService
+  def initialize(
+    primary_subject: PrimarySubject,
+    secondary_subject: SecondarySubject,
+    modern_language_subject: ModernLanguagesSubject,
+    further_education_subject: FurtherEducationSubject,
+    modern_languages_parent_subject: SecondarySubject.modern_languages
+)
+    @primary_subject = primary_subject
+    @secondary_subject = secondary_subject
+    @modern_language_subject = modern_language_subject
+    @further_education_subject = further_education_subject
+    @modern_languages_parent_subject = modern_languages_parent_subject
+  end
+
+  def execute(course)
+    case course.level
+    when "primary"
+      @primary_subject.all
+    when "secondary"
+      @secondary_subject.where.not(id: @modern_languages_parent_subject) + @modern_language_subject.all
+    when "further_education"
+      @further_education_subject.all
+    end
+  end
+end

--- a/lib/mcb/cli/course_cli.rb
+++ b/lib/mcb/cli/course_cli.rb
@@ -10,6 +10,13 @@ module MCB
         @cli.ask("New course title?  ")
       end
 
+      def ask_level
+        ask_multiple_choice(
+          prompt: "What level is this course?",
+          choices: Course.levels.keys,
+        )
+      end
+
       def ask_english
         ask_gcse_subject(:english, Course::entry_requirement_options_without_nil_choice)
       end

--- a/lib/mcb/editor/courses_editor.rb
+++ b/lib/mcb/editor/courses_editor.rb
@@ -13,7 +13,6 @@ module MCB
 
       def initialize(provider:, requester:, course_codes: [], courses: nil)
         @courses = courses || load_courses(provider, course_codes)
-
         super(provider: provider, requester: requester)
       end
 
@@ -35,7 +34,7 @@ module MCB
 
       def new_course_wizard
         %i[title qualifications study_mode accredited_body start_date route maths
-           english science age_range course_code is_send].each do |attribute|
+           english science age_range level course_code is_send].each do |attribute|
           edit(attribute)
         end
 
@@ -113,9 +112,9 @@ module MCB
       end
 
       def edit_subjects
-        course.ucas_subjects = @cli.multiselect(
-          initial_items: course.ucas_subjects.to_a,
-          possible_items: ::UCASSubject.all,
+        course.subjects = @cli.multiselect(
+          initial_items: course.subjects.to_a,
+          possible_items: ::CourseAssignableSubjectService.new.execute(course),
         )
         course.reload
       end

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -32,6 +32,12 @@ FactoryBot.define do
       type { "PrimarySubject" }
     end
 
+    trait :primary_with_mathematics do
+      subject_name { "Primary with mathematics" }
+      subject_code { "04" }
+      type { :PrimarySubject }
+    end
+
     trait :mathematics do
       subject_name { "Mathematics" }
       subject_code { "G1" }
@@ -51,9 +57,9 @@ FactoryBot.define do
     end
 
     trait :further_education do
-      subject_name { "Further Education" }
-      subject_code { "FE" }
-      type { "FurtherEducationSubject" }
+      subject_name { "Further education" }
+      subject_code { "41" }
+      type { :FurtherEducationSubject }
     end
 
     trait :english do
@@ -72,6 +78,24 @@ FactoryBot.define do
       subject_name { "Humanities" }
       subject_code { nil }
       type { "DiscontinuedSubject" }
+    end
+
+    trait :japanese do
+      subject_name { "Japanese" }
+      subject_code { "19" }
+      type { :ModernLanguagesSubject }
+    end
+
+    trait :biology do
+      subject_name { "Biology" }
+      subject_code { "C1" }
+      type { :SecondarySubject }
+    end
+
+    trait :modern_languages do
+      subject_name { "Modern Languages" }
+      subject_code { nil }
+      type { :SecondarySubject }
     end
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -33,6 +33,8 @@ require "rails_helper"
 describe Course, type: :model do
   let(:course) { create(:course, name: "Biology", course_code: "3X9F") }
   let(:subject) { course }
+  let(:arabic) { create(:subject, subject_name: "Arabic", type: :ModernLanguagesSubject).becomes(ModernLanguagesSubject) }
+  let!(:modern_languages) { create(:subject, subject_name: "Modern Languages", type: :SecondarySubject).becomes(SecondarySubject) }
 
   its(:to_s) { should eq("Biology (#{course.provider.provider_code}/3X9F) [2019/20]") }
   its(:modular) { should eq("") }
@@ -54,6 +56,14 @@ describe Course, type: :model do
     it { should have_many(:site_statuses) }
     it { should have_many(:sites) }
     it { should have_many(:enrichments) }
+  end
+
+  it "implies modern languages if a languages subject is selected" do
+    expect(create(:course, subjects: [arabic]).subjects).to match_array([modern_languages, arabic])
+  end
+
+  it "does not continue to add modern language if it has already been added" do
+    expect(create(:course, subjects: [modern_languages, arabic]).subjects).to match_array([modern_languages, arabic])
   end
 
   describe "validations" do

--- a/spec/models/secondary_subject_spec.rb
+++ b/spec/models/secondary_subject_spec.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: subject
+#
+#  id           :bigint           not null, primary key
+#  type         :text
+#  subject_code :text
+#  subject_name :text
+#
+
+require "rails_helper"
+
+describe SecondarySubject, type: :model do
+  describe "#modern_languages" do
+    it "returns the modern language subject" do
+      modern_languages = create(:subject, subject_name: "Modern Languages", type: :SecondarySubject).becomes(SecondarySubject)
+      expect(SecondarySubject.modern_languages).to eq(modern_languages)
+    end
+  end
+end

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -11,8 +11,9 @@
 require "rails_helper"
 
 describe Subject, type: :model do
-  subject { find_or_create(:subject, subject_name: "Modern languages (other)") }
+  subject { find_or_create(:subject, subject_name: "Modern languages (other)", subject_code: "101") }
 
   it { should have_many(:courses).through(:course_subjects) }
   its(:to_sym) { should eq(:modern_languages_other) }
+  its(:to_s) { should eq("Modern languages (other) (101)") }
 end

--- a/spec/services/course_assignable_subject_service_spec.rb
+++ b/spec/services/course_assignable_subject_service_spec.rb
@@ -1,0 +1,44 @@
+describe CourseAssignableSubjectService do
+  let(:service) do
+    described_class.new(
+      primary_subject: primary_model,
+      secondary_subject: secondary_model,
+      further_education_subject: further_education_model,
+      modern_language_subject: modern_language_model,
+      modern_languages_parent_subject: modern_languages_parent_subject,
+    )
+  end
+  let(:primary_model) { spy(all: []) }
+  let(:secondary_model) { spy }
+  let(:further_education_model) { spy(all: []) }
+  let(:modern_language_model) { spy }
+  let(:modern_languages_parent_subject) { spy }
+
+  it "gets all primary subjects if the level is primary" do
+    course = create(:course, level: "primary")
+
+
+    expect(service.execute(course)).to eq([])
+    expect(primary_model).to have_received(:all)
+  end
+
+  context "secondary subjects" do
+    let(:secondary_model) { SecondarySubject }
+    let(:modern_language_model) { ModernLanguagesSubject }
+    let!(:modern_languages_parent_subject) { create(:subject, subject_name: "Modern Languages", type: :SecondarySubject).becomes(SecondarySubject) }
+    let!(:biology) { create(:subject, subject_name: "Biology", type: :SecondarySubject).becomes(SecondarySubject) }
+    let!(:arabic) { create(:subject, subject_name: "Arabic", type: :ModernLanguagesSubject).becomes(ModernLanguagesSubject) }
+
+    it "returns subjects other than modern language" do
+      course = create(:course, level: "secondary")
+      expect(service.execute(course)).to match_array([biology, arabic])
+    end
+  end
+
+  it "gets all further education subjects if the level is further education" do
+    course = create(:course, level: "further_education")
+
+    expect(service.execute(course)).to eq([])
+    expect(further_education_model).to have_received(:all)
+  end
+end


### PR DESCRIPTION
### Context
MCB should be able to use the new subjects rather than the UCAS subjects.  

### Changes proposed in this pull request
Use the DfE subjects instead of the UCAS subjects.  

### Guidance to review
I've added `CoursePotentialSubjectService` because this is logic that will likely be used elsewhere but that I don't think belongs in the model since it doesn't pertain directly to courses themselves but rather is an implication of its properties. I am open to feedback, I've tried to maintain a reasonable degree of coupling between it and Rails.

### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [X] Rebased ~~master~~ parent
- [X] Cleaned commit history
- [X] Tested by running locally
