### PR TITLE
[2190] Expose and update ucas gt12 preferences

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -32,6 +32,7 @@ module API
         update_enrichment
         update_accrediting_enrichment
         update_ucas_contacts
+        update_ucas_preferences
 
         if @provider.valid?
           render jsonapi: @provider.reload, include: params[:include]
@@ -155,6 +156,13 @@ module API
         end
       end
 
+      def update_ucas_preferences
+        return if ucas_preferences_params.blank?
+
+        @provider.ucas_preferences.assign_attributes(ucas_preferences_params)
+        @provider.ucas_preferences.save
+      end
+
       def accredited_bodies_params
         params
           .fetch(:provider, {})
@@ -175,6 +183,8 @@ module API
             :web_link_contact,
             :fraud_contact,
             :finance_contact,
+            :type_of_gt12,
+            :gt12_contact,
           )
           .permit(accredited_bodies: %i[provider_code provider_name description])
       end
@@ -189,6 +199,8 @@ module API
             :web_link_contact,
             :fraud_contact,
             :finance_contact,
+            :type_of_gt12,
+            :gt12_contact,
           )
           .permit(
             :train_with_us,
@@ -221,6 +233,8 @@ module API
             :postcode,
             :region_code,
             :accredited_bodies,
+            :type_of_gt12,
+            :gt12_contact,
           )
           .permit(
             admin_contact: %w[name email telephone],
@@ -228,6 +242,34 @@ module API
             web_link_contact: %w[name email telephone],
             fraud_contact: %w[name email telephone],
             finance_contact: %w[name email telephone],
+          )
+      end
+
+      def ucas_preferences_params
+        params
+          .fetch(:provider, {})
+          .except(
+            :accredited_bodies,
+            :admin_contact,
+            :utt_contact,
+            :web_link_contact,
+            :fraud_contact,
+            :finance_contact,
+            :train_with_us,
+            :train_with_disability,
+            :email,
+            :telephone,
+            :website,
+            :address1,
+            :address2,
+            :address3,
+            :address4,
+            :postcode,
+            :region_code,
+          )
+          .permit(
+            :type_of_gt12,
+            :gt12_contact,
           )
       end
 

--- a/app/deserializers/api/v2/deserializable_provider.rb
+++ b/app/deserializers/api/v2/deserializable_provider.rb
@@ -19,6 +19,8 @@ module API
         web_link_contact
         fraud_contact
         finance_contact
+        type_of_gt12
+        gt12_contact
       ].freeze
 
       attributes(*PROVIDER_ATTRIBUTES)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -25,7 +25,6 @@
 #  age_range_in_years        :string
 #  applications_open_from    :date
 #  is_send                   :boolean          default(FALSE)
-#  level                     :integer          default(0)
 #
 
 class Course < ApplicationRecord

--- a/app/models/provider_ucas_preference.rb
+++ b/app/models/provider_ucas_preference.rb
@@ -30,4 +30,8 @@ class ProviderUCASPreference < ApplicationRecord
          accredited_programmes: 'Yes - for accredited programmes only',
   },
        _prefix: 'send_application_alerts_for'
+
+  def gt12_contact=(gt12_contact)
+    update(gt12_response_destination: gt12_contact)
+  end
 end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -2,10 +2,9 @@
 #
 # Table name: subject
 #
-#  id           :bigint           not null, primary key
-#  type         :text
-#  subject_code :text
+#  id           :integer          not null, primary key
 #  subject_name :text
+#  subject_code :text             not null
 #
 
 class Subject < ApplicationRecord

--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -85,6 +85,10 @@ module API
         @object.ucas_preferences&.application_alert_email
       end
 
+      attribute :type_of_gt12 do
+        @object.ucas_preferences&.type_of_gt12
+      end
+
       enrichment_attribute :train_with_us
       enrichment_attribute :train_with_disability
 

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -25,7 +25,6 @@
 #  age_range_in_years        :string
 #  applications_open_from    :date
 #  is_send                   :boolean          default(FALSE)
-#  level                     :integer          default(0)
 #
 
 class CourseSerializer < ActiveModel::Serializer

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -2,10 +2,9 @@
 #
 # Table name: subject
 #
-#  id           :bigint           not null, primary key
-#  type         :text
-#  subject_code :text
+#  id           :integer          not null, primary key
 #  subject_name :text
+#  subject_code :text             not null
 #
 
 class SubjectSerializer < ActiveModel::Serializer

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -25,7 +25,6 @@
 #  age_range_in_years        :string
 #  applications_open_from    :date
 #  is_send                   :boolean          default(FALSE)
-#  level                     :integer          default(0)
 #
 
 FactoryBot.define do

--- a/spec/factories/provider_ucas_preferences.rb
+++ b/spec/factories/provider_ucas_preferences.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
     provider
 
     application_alert_email { Faker::Internet.email }
+    gt12_response_destination { Faker::Internet.email }
 
     type_of_gt12 do
       %i[

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -2,10 +2,9 @@
 #
 # Table name: subject
 #
-#  id           :bigint           not null, primary key
-#  type         :text
-#  subject_code :text
+#  id           :integer          not null, primary key
 #  subject_name :text
+#  subject_code :text             not null
 #
 
 FactoryBot.define do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -25,7 +25,6 @@
 #  age_range_in_years        :string
 #  applications_open_from    :date
 #  is_send                   :boolean          default(FALSE)
-#  level                     :integer          default(0)
 #
 
 require 'rails_helper'

--- a/spec/models/provider_ucas_preference_spec.rb
+++ b/spec/models/provider_ucas_preference_spec.rb
@@ -46,4 +46,18 @@ describe ProviderUCASPreference, type: :model do
               .with_prefix('send_application_alerts_for')
     end
   end
+
+  describe 'gt12_contact=' do
+    let(:provider) { create(:provider, ucas_preferences: ucas_preferences) }
+    let(:ucas_preferences) { build(:provider_ucas_preference) }
+    let(:new_email_address) { 'test@email.com' }
+
+    before do
+      provider.ucas_preferences.gt12_contact = new_email_address
+    end
+
+    it 'updates the providers gt12_response_destination attribute' do
+      expect(provider.ucas_preferences.gt12_response_destination).to eq new_email_address
+    end
+  end
 end

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -2,10 +2,9 @@
 #
 # Table name: subject
 #
-#  id           :bigint           not null, primary key
-#  type         :text
-#  subject_code :text
+#  id           :integer          not null, primary key
 #  subject_name :text
+#  subject_code :text             not null
 #
 
 require 'rails_helper'

--- a/spec/requests/api/v2/providers/update_provider_ucas_preferences.rb
+++ b/spec/requests/api/v2/providers/update_provider_ucas_preferences.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+describe 'PATCH recruitment_cycles/year/providers/:provider_code/courses/:course_code' do
+  let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+  let(:request_path) do
+    "/api/v2/recruitment_cycles/#{recruitment_cycle.year}" +
+      "/providers/#{provider.provider_code}"
+  end
+
+  def perform_request(updated_gt12_preferences)
+    jsonapi_data = jsonapi_renderer.render(
+      provider,
+      class: {
+        Provider: API::V2::SerializableProvider
+      }
+    )
+
+    jsonapi_data[:data][:attributes] = updated_gt12_preferences
+
+    patch request_path,
+          headers: { 'HTTP_AUTHORIZATION' => credentials },
+          params: {
+            _jsonapi: jsonapi_data
+          }
+  end
+
+  let(:recruitment_cycle) { find_or_create :recruitment_cycle }
+  let(:organisation) { create :organisation }
+  let(:provider)     do
+    create :provider,
+           organisations: [organisation],
+           recruitment_cycle: recruitment_cycle,
+           ucas_preferences: ucas_preferences
+  end
+  let(:user)         { create :user, organisations: [organisation] }
+  let(:payload)      { { email: user.email } }
+  let(:token)        { build_jwt :apiv2, payload: payload }
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+  let(:ucas_preferences) { build(:provider_ucas_preference, type_of_gt12: :no_response) }
+
+
+  let(:updated_gt12_preferences) do
+    {
+      type_of_gt12: 'coming_or_not',
+      gt12_contact: 'test@mail.com'
+    }
+  end
+
+  before do
+    perform_request(updated_gt12_preferences)
+  end
+
+  context "provider has updated g12 preferences" do
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+
+    subject { provider.ucas_preferences.reload }
+
+    describe 'type_of_gt12' do
+      its(:type_of_gt12) { should eq updated_gt12_preferences[:type_of_gt12] }
+      its(:gt12_response_destination) { should eq updated_gt12_preferences[:gt12_contact] }
+    end
+  end
+end

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -212,9 +212,11 @@ describe 'Providers API v2', type: :request do
              organisations: [organisation],
              enrichments: [enrichment],
              courses: courses,
-             contacts: [contact])
+             contacts: [contact],
+             ucas_preferences: ucas_preferences)
     end
     let(:contact) { build(:contact) }
+    let(:ucas_preferences) { build(:provider_ucas_preference) }
 
     let(:token) do
       JWT.encode payload,
@@ -264,8 +266,9 @@ describe 'Providers API v2', type: :request do
             "web_link_contact" => nil,
             "fraud_contact" => nil,
             "finance_contact" => nil,
-            "gt12_contact" => nil,
-            "application_alert_contact" => nil,
+            "gt12_contact" => provider.ucas_preferences.gt12_response_destination.to_s,
+            "application_alert_contact" => provider.ucas_preferences.application_alert_email,
+            "type_of_gt12" => provider.ucas_preferences.type_of_gt12.to_s
           },
           "relationships" => {
             "sites" => {
@@ -347,8 +350,9 @@ describe 'Providers API v2', type: :request do
               "web_link_contact" => nil,
               "fraud_contact" => nil,
               "finance_contact" => nil,
-              "gt12_contact" => nil,
-              "application_alert_contact" => nil,
+              "gt12_contact" => provider.ucas_preferences.gt12_response_destination.to_s,
+              "application_alert_contact" => provider.ucas_preferences.application_alert_email,
+              "type_of_gt12" => provider.ucas_preferences.type_of_gt12.to_s
             },
             "relationships" => {
               "sites" => {

--- a/spec/serializers/api/v2/serializable_provider_spec.rb
+++ b/spec/serializers/api/v2/serializable_provider_spec.rb
@@ -27,6 +27,8 @@ describe API::V2::SerializableProvider do
   it { should have_attribute(:recruitment_cycle_year).with_value(provider.recruitment_cycle.year) }
   it { should have_attribute(:gt12_contact).with_value(provider.ucas_preferences.gt12_response_destination) }
   it { should have_attribute(:application_alert_contact).with_value(provider.ucas_preferences.application_alert_email) }
+  it { should have_attribute(:type_of_gt12).with_value(provider.ucas_preferences.type_of_gt12) }
+
   it do
     should have_attribute(:accredited_bodies).with_value([
       {

--- a/spec/serializers/course_serializer_spec.rb
+++ b/spec/serializers/course_serializer_spec.rb
@@ -25,7 +25,6 @@
 #  age_range_in_years        :string
 #  applications_open_from    :date
 #  is_send                   :boolean          default(FALSE)
-#  level                     :integer          default(0)
 #
 
 require "rails_helper"

--- a/spec/serializers/subject_serializer_spec.rb
+++ b/spec/serializers/subject_serializer_spec.rb
@@ -2,10 +2,9 @@
 #
 # Table name: subject
 #
-#  id           :bigint           not null, primary key
-#  type         :text
-#  subject_code :text
+#  id           :integer          not null, primary key
 #  subject_name :text
+#  subject_code :text             not null
 #
 
 require "rails_helper"


### PR DESCRIPTION
### Context
A providers UCAS gt12 preferences need to be exposed and updatable via the V2 API as per our agreement with UCAS.

### Changes proposed in this pull request
- Expose providers type_of_gt12
-  type_of_gt12 and gt12_response_destination can be updated
- correct incorrect annotations that have accidentally been merged into master

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
