### PR TITLE
[2207] don't retry when we get 502 from sac api for bulk sync

### DIFF
--- a/app/jobs/bulk_sync_courses_to_find_job.rb
+++ b/app/jobs/bulk_sync_courses_to_find_job.rb
@@ -1,6 +1,9 @@
 class BulkSyncCoursesToFindJob < ApplicationJob
   queue_as :find_sync
 
+  class SearchAndCompareRequestError < StandardError
+  end
+
   def perform
     syncable_courses = RecruitmentCycle.syncable_courses
 
@@ -8,10 +11,18 @@ class BulkSyncCoursesToFindJob < ApplicationJob
       request = SearchAndCompareAPIService::Request.new
 
       unless request.bulk_sync(syncable_courses)
-        raise(RuntimeError.new(
-                "Error #{request.response.status} received syncing courses: " \
-                + syncable_courses.join('; ')
-              ))
+        if request.response.status == 502
+          # Make sure we don't trigger retries for 502, which we get because
+          # the request sac api takes too long for the lb that fronts it, and
+          # it's timeout cannot be changed.
+          Rails.logger.error "Error 502 received syncing courses: " \
+                             + syncable_courses.join('; ')
+        else
+          raise(SearchAndCompareRequestError.new(
+                  "Error #{request.response.status} received syncing courses: " \
+                  + syncable_courses.join('; ')
+                ))
+        end
       end
     end
   end

--- a/spec/jobs/bulk_sync_courses_to_find_job_spec.rb
+++ b/spec/jobs/bulk_sync_courses_to_find_job_spec.rb
@@ -29,4 +29,38 @@ describe BulkSyncCoursesToFindJob, type: :job do
 
     described_class.perform_now
   end
+
+  context "search and compare raises a 403 error" do
+    let(:sacapi_response) { spy(status: 403) }
+    let(:sacapi_service) { spy(response: sacapi_response) }
+
+    before do
+      allow(sacapi_service).to receive(:bulk_sync).and_return(false)
+      allow(SearchAndCompareAPIService::Request).to receive(:new)
+                                                      .and_return(sacapi_service)
+    end
+
+    it 'raises an error if it gets an error' do
+      expect {
+        described_class.perform_now
+      }.to raise_error(BulkSyncCoursesToFindJob::SearchAndCompareRequestError)
+    end
+  end
+
+  context "search and compare raises a 502 error" do
+    let(:sacapi_response) { spy(status: 502) }
+    let(:sacapi_service) { spy(response: sacapi_response) }
+
+    before do
+      allow(sacapi_service).to receive(:bulk_sync).and_return(false)
+      allow(SearchAndCompareAPIService::Request).to receive(:new)
+                                                      .and_return(sacapi_service)
+    end
+
+    it 'raises an error if it gets an error' do
+      expect {
+        described_class.perform_now
+      }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
### Context

We get an error from sacui fairly regularly with this process, and as the bulk sync is a pretty heavy job we don't want a bunch of these retrying in the background. And the job just reruns every 2 hours anyway. Until we sort how not to get errors every time it kicks off we should drop failed job runs.

### Changes proposed in this pull request

Disable Sidekiq retries for the bulk sync job.

### Guidance to review

:shipit: . o ( This is blocking implementing bulk sync in prod. )

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
