### PR TITLE
[2205] Update db seeds for subjects

### DIFF
--- a/app/services/subject_creator_service.rb
+++ b/app/services/subject_creator_service.rb
@@ -1,0 +1,98 @@
+class SubjectCreatorService
+  def initialize(primary_subject: PrimarySubject,
+      secondary_subject: SecondarySubject,
+      further_education_subject: FurtherEducationSubject,
+      modern_languages_subject: ModernLanguagesSubject,
+      discontinued_subject: DiscontinuedSubject)
+    @primary_subject = primary_subject
+    @secondary_subject = secondary_subject
+    @further_education_subject = further_education_subject
+    @modern_languages_subject = modern_languages_subject
+    @discontinued_subject = discontinued_subject
+  end
+
+  def execute
+    primary = [
+      { subject_name: "Primary", subject_code: "00" },
+      { subject_name: "Primary with English", subject_code: "01" },
+      { subject_name: "Primary with geography and history", subject_code: "02" },
+      { subject_name: "Primary with mathematics", subject_code: "03" },
+      { subject_name: "Primary with modern languages", subject_code: "04" },
+      { subject_name: "Primary with physical education", subject_code: "06" },
+      { subject_name: "Primary with science", subject_code: "07" },
+    ]
+
+    secondary = [
+      { subject_name: "Art and design", subject_code: "W1" },
+      { subject_name: "Science", subject_code:  "F0" },
+      { subject_name: "Biology", subject_code:  "C1" },
+      { subject_name: "Business studies", subject_code: "08" },
+      { subject_name: "Chemistry", subject_code: "F1" },
+      { subject_name: "Citizenship", subject_code:  "09" },
+      { subject_name: "Classics", subject_code: "Q8" },
+      { subject_name: "Communication and media studies", subject_code: "P3" },
+      { subject_name: "Computing", subject_code: "11" },
+      { subject_name: "Dance", subject_code: "12" },
+      { subject_name: "Design and technology", subject_code: "DT" },
+      { subject_name: "Drama", subject_code: "13" },
+      { subject_name: "Economics", subject_code: "L1" },
+      { subject_name: "English", subject_code: "Q3" },
+      { subject_name: "Geography", subject_code: "F8" },
+      { subject_name: "Health and social care", subject_code: "L5" },
+      { subject_name: "History", subject_code:  "V1" },
+      { subject_name: "Mathematics", subject_code: "G1" },
+      { subject_name: "Music", subject_code: "W3" },
+      { subject_name: "Philosophy", subject_code: "P1" },
+      { subject_name: "Physical education", subject_code: "C6" },
+      { subject_name: "Physics", subject_code: "F3" },
+      { subject_name: "Psychology", subject_code: "C8" },
+      { subject_name: "Religious education", subject_code: "V6" },
+      { subject_name: "Social sciences", subject_code: "14" },
+      # NOTE: no subject_code for 'Modern Languages' because this is just a stub used to trigger
+      # selection of actual entries from `modern_languages` list
+      { subject_name: "Modern Languages", subject_code: nil },
+    ]
+
+    modern_languages = [
+      { subject_name: "French", subject_code: "15" },
+      { subject_name: "English as a second or other language", subject_code: "16" },
+      { subject_name: "German", subject_code: "17" },
+      { subject_name: "Italian", subject_code: "18" },
+      { subject_name: "Japanese", subject_code:  "19" },
+      { subject_name: "Mandarin", subject_code:  "20" },
+      { subject_name: "Russian", subject_code:  "21" },
+      { subject_name: "Spanish", subject_code:  "22" },
+      { subject_name: "Modern languages (other)", subject_code: "24" },
+    ]
+
+    further_education = [
+      { subject_name: "Further education", subject_code: "41" },
+    ]
+
+    # old 2019 DfE subjects
+    discontinued = [
+      { subject_name: "Humanities" },
+      { subject_name: "Balanced Science" },
+    ]
+
+    primary.each do |subject|
+      @primary_subject.find_or_create_by(subject_name: subject[:subject_name], subject_code: subject[:subject_code])
+    end
+
+    secondary.each do |subject|
+      @secondary_subject.find_or_create_by(subject_name: subject[:subject_name], subject_code: subject[:subject_code])
+    end
+
+    modern_languages.each do |subject|
+      @modern_languages_subject.find_or_create_by(subject_name: subject[:subject_name], subject_code: subject[:subject_code])
+    end
+
+    further_education.each do |subject|
+      @further_education_subject.find_or_create_by(subject_name: subject[:subject_name], subject_code: subject[:subject_code])
+    end
+
+    discontinued.each do |subject|
+      @discontinued_subject.find_or_create_by(subject_name: subject[:subject_name])
+    end
+  end
+end

--- a/db/migrate/20190912162820_create_subject_table.rb
+++ b/db/migrate/20190912162820_create_subject_table.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/BlockLength
 class CreateSubjectTable < ActiveRecord::Migration[5.2]
   def change
     create_table :subject do |t|
@@ -8,83 +7,7 @@ class CreateSubjectTable < ActiveRecord::Migration[5.2]
     end
 
     say_with_time "populating subjects" do
-      primary = [
-        { subject_name: "Primary", subject_code: "00" },
-        { subject_name: "Primary with English", subject_code: "01" },
-        { subject_name: "Primary with geography and history", subject_code: "02" },
-        { subject_name: "Primary with mathematics", subject_code: "03" },
-        { subject_name: "Primary with modern languages", subject_code: "04" },
-        { subject_name: "Primary with physical education", subject_code: "06" },
-        { subject_name: "Primary with science", subject_code: "07" },
-      ]
-
-      secondary = [
-        { subject_name: "Art and design", subject_code: "W1" },
-        { subject_name: "Science", subject_code:  "F0" },
-        { subject_name: "Biology", subject_code:  "C1" },
-        { subject_name: "Business studies", subject_code: "08" },
-        { subject_name: "Chemistry", subject_code: "F1" },
-        { subject_name: "Citizenship", subject_code:  "09" },
-        { subject_name: "Classics", subject_code: "Q8" },
-        { subject_name: "Communication and media studies", subject_code: "P3" },
-        { subject_name: "Computing", subject_code: "11" },
-        { subject_name: "Dance", subject_code: "12" },
-        { subject_name: "Design and technology", subject_code: "DT" },
-        { subject_name: "Drama", subject_code: "13" },
-        { subject_name: "Economics", subject_code: "L1" },
-        { subject_name: "English", subject_code: "Q3" },
-        { subject_name: "Geography", subject_code: "F8" },
-        { subject_name: "Health and social care", subject_code: "L5" },
-        { subject_name: "History", subject_code:  "V1" },
-        { subject_name: "Mathematics", subject_code: "G1" },
-        { subject_name: "Music", subject_code: "W3" },
-        { subject_name: "Philosophy", subject_code: "P1" },
-        { subject_name: "Physical education", subject_code: "C6" },
-        { subject_name: "Physics", subject_code: "F3" },
-        { subject_name: "Psychology", subject_code: "C8" },
-        { subject_name: "Religious education", subject_code: "V6" },
-        { subject_name: "Social sciences", subject_code: "14" },
-        # NOTE: no subject_code for 'Modern Languages' because this is just a stub used to trigger
-        # selection of actual entries from `modern_languages` list
-        { subject_name: "Modern Languages", subject_code: nil },
-      ]
-
-      modern_languages = [
-        { subject_name: "French", subject_code: "15" },
-        { subject_name: "English as a second or other language", subject_code: "16" },
-        { subject_name: "German", subject_code: "17" },
-        { subject_name: "Italian", subject_code: "18" },
-        { subject_name: "Japanese", subject_code:  "19" },
-        { subject_name: "Mandarin", subject_code:  "20" },
-        { subject_name: "Russian", subject_code:  "21" },
-        { subject_name: "Spanish", subject_code:  "22" },
-        { subject_name: "Modern languages (other)", subject_code: "24" },
-      ]
-
-      further_education = [
-        { subject_name: "Further education", subject_code: "41" },
-      ]
-
-      primary.each do |subject|
-        PrimarySubject.create(subject_name: subject[:subject_name], subject_code: subject[:subject_code])
-      end
-
-      secondary.each do |subject|
-        SecondarySubject.create(subject_name: subject[:subject_name], subject_code: subject[:subject_code])
-      end
-
-      modern_languages.each do |subject|
-        ModernLanguagesSubject.create(subject_name: subject[:subject_name], subject_code: subject[:subject_code])
-      end
-
-      further_education.each do |subject|
-        FurtherEducationSubject.create(subject_name: subject[:subject_name], subject_code: subject[:subject_code])
-      end
-
-      # old 2019 DfE subjects
-      DiscontinuedSubject.create(subject_name: "Humanities")
-      DiscontinuedSubject.create(subject_name: "Balanced Science")
+      SubjectCreatorService.new.execute
     end
   end
 end
-# rubocop:enable Metrics/BlockLength

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,6 +4,7 @@ Faker::Config.locale = "en-GB"
 # TODO: this can be removed ucas subjects related
 UCASSubject.destroy_all
 Course.destroy_all
+Subject.destroy_all
 Site.destroy_all
 SiteStatus.destroy_all
 Provider.destroy_all
@@ -16,21 +17,7 @@ RecruitmentCycle.destroy_all
 current_recruitment_cycle = RecruitmentCycle.create(year: "2019", application_start_date: Date.new(2018, 10, 9), application_end_date: Date.new(2019, 9, 30))
 next_recruitment_cycle = RecruitmentCycle.create(year: "2020", application_start_date: Date.new(2019, 10, 8), application_end_date: Date.new(2019, 9, 30))
 
-# TODO: use known subject list
-{
-  "Primary" => "00",
-  "Secondary" => "05",
-  "Chinese" => "T1",
-  "English" => "Q3",
-  "Mathematics" => "G1",
-  "Biology" => "C1",
-  "Further Education" => "41",
-}.each do |name, code|
-  UCASSubject.create!(
-    subject_name: name,
-    subject_code: code,
-  )
-end
+SubjectCreatorService.new.execute
 
 superuser = User.create!(
   first_name: "Super",
@@ -69,7 +56,7 @@ def create_standard_provider_and_courses_for_cycle(recruitment_cycle, superuser)
     postcode: Faker::Address.postcode,
   )
 
-  course1 = Course.create!(
+  primary_course = Course.create!(
     name: "Mathematics",
     course_code: "MAT2",
     provider: provider,
@@ -81,10 +68,9 @@ def create_standard_provider_and_courses_for_cycle(recruitment_cycle, superuser)
     science: nil,
     modular: "M",
     qualification: :pgce_with_qts,
-    # TODO: when level is set, set subjects instead ucas_subjects
-    ucas_subjects: [
-     UCASSubject.find_by(subject_name: "Secondary"),
-     UCASSubject.find_by(subject_name: "Mathematics"),
+    level: "primary",
+    subjects: [
+      PrimarySubject.find_by(subject_name: "Primary with mathematics"),
     ],
     study_mode: "F",
   )
@@ -93,12 +79,12 @@ def create_standard_provider_and_courses_for_cycle(recruitment_cycle, superuser)
     site: Site.last,
     vac_status: "F",
     publish: "Y",
-    course: course1,
+    course: primary_course,
     status: "R",
     applications_accepted_from: Date.new(2018, 10, 23),
   )
 
-  course2 = Course.create!(
+  secondary_course1 = Course.create!(
     name: "Biology",
     course_code: "BIO3",
     provider: provider,
@@ -110,12 +96,9 @@ def create_standard_provider_and_courses_for_cycle(recruitment_cycle, superuser)
     science: nil,
     modular: "",
     qualification: :pgce,
-    # TODO: when level is set, set subjects instead ucas_subjects
-    # This course is a really bad example
-    ucas_subjects: [
-     UCASSubject.find_by(subject_name: "Secondary"),
-     UCASSubject.find_by(subject_name: "Biology"),
-     UCASSubject.find_by(subject_name: "Further Education"),
+    level: "secondary",
+    subjects: [
+      SecondarySubject.find_by(subject_name: "Biology"),
     ],
     study_mode: "B",
   )
@@ -125,7 +108,154 @@ def create_standard_provider_and_courses_for_cycle(recruitment_cycle, superuser)
     site: Site.last,
     vac_status: "B",
     publish: "Y",
-    course: course2,
+    course: secondary_course1,
+    status: "N",
+    applications_accepted_from: Date.new(2018, 10, 2),
+  )
+
+  secondary_course2 = Course.create!(
+    name: "Arts",
+    course_code: "AT05",
+    provider: provider,
+    start_date: Date.new(2019, 9, 1),
+    profpost_flag: "BO",
+    program_type: "HE",
+    maths: 3,
+    english: 9,
+    science: nil,
+    modular: "",
+    qualification: :pgce,
+    level: "secondary",
+    subjects: [
+      SecondarySubject.find_by(subject_name: "Art and design"),
+      SecondarySubject.find_by(subject_name: "Music"),
+    ],
+    study_mode: "B",
+  )
+
+  SiteStatus.create!(
+    site: Site.last,
+    vac_status: "B",
+    publish: "Y",
+    course: secondary_course2,
+    status: "N",
+    applications_accepted_from: Date.new(2018, 10, 2),
+  )
+
+  further_education_course = Course.create!(
+    name: "Further Education",
+    course_code: "FE11",
+    provider: provider,
+    start_date: Date.new(2019, 9, 1),
+    profpost_flag: "BO",
+    program_type: "HE",
+    maths: 3,
+    english: 9,
+    science: nil,
+    modular: "",
+    qualification: :pgce,
+    level: "secondary",
+    subjects: [
+      FurtherEducationSubject.find_by(subject_name: "Further education"),
+    ],
+    study_mode: "B",
+  )
+
+  SiteStatus.create!(
+    site: Site.last,
+    vac_status: "B",
+    publish: "Y",
+    course: further_education_course,
+    status: "N",
+    applications_accepted_from: Date.new(2018, 10, 2),
+  )
+
+  modern_language_course1 = Course.create!(
+    name: "Other Languages",
+    course_code: "OML9",
+    provider: provider,
+    start_date: Date.new(2019, 9, 1),
+    profpost_flag: "BO",
+    program_type: "HE",
+    maths: 3,
+    english: 9,
+    science: nil,
+    modular: "",
+    qualification: :pgce,
+    level: "secondary",
+    subjects: [
+      SecondarySubject.find_by(subject_name: "Modern Languages"),
+      ModernLanguagesSubject.find_by(subject_name: "Modern languages (other)"),
+    ],
+    study_mode: "B",
+  )
+
+  SiteStatus.create!(
+    site: Site.last,
+    vac_status: "B",
+    publish: "Y",
+    course: modern_language_course1,
+    status: "N",
+    applications_accepted_from: Date.new(2018, 10, 2),
+  )
+
+  modern_language_course2 = Course.create!(
+    name: "Japanese",
+    course_code: "N7",
+    provider: provider,
+    start_date: Date.new(2019, 9, 1),
+    profpost_flag: "BO",
+    program_type: "HE",
+    maths: 3,
+    english: 9,
+    science: nil,
+    modular: "",
+    qualification: :pgce,
+    level: "secondary",
+    subjects: [
+      SecondarySubject.find_by(subject_name: "Modern Languages"),
+      ModernLanguagesSubject.find_by(subject_name: "Japanese"),
+    ],
+    study_mode: "B",
+  )
+
+  SiteStatus.create!(
+    site: Site.last,
+    vac_status: "B",
+    publish: "Y",
+    course: modern_language_course2,
+    status: "N",
+    applications_accepted_from: Date.new(2018, 10, 2),
+  )
+
+  modern_language_course3 = Course.create!(
+    name: "Modern Languages",
+    course_code: "ML1",
+    provider: provider,
+    start_date: Date.new(2019, 9, 1),
+    profpost_flag: "BO",
+    program_type: "HE",
+    maths: 3,
+    english: 9,
+    science: nil,
+    modular: "",
+    qualification: :pgce,
+    level: "secondary",
+    subjects: [
+      SecondarySubject.find_by(subject_name: "Modern Languages"),
+      ModernLanguagesSubject.find_by(subject_name: "Japanese"),
+      ModernLanguagesSubject.find_by(subject_name: "French"),
+      ModernLanguagesSubject.find_by(subject_name: "Russian"),
+      ModernLanguagesSubject.find_by(subject_name: "German"),
+    ],
+    study_mode: "B",
+  )
+
+  SiteStatus.create!(
+    site: Site.last,
+    vac_status: "B",
+    publish: "Y",
+    course: modern_language_course3,
     status: "N",
     applications_accepted_from: Date.new(2018, 10, 2),
   )

--- a/spec/requests/api/v1/subject_spec.rb
+++ b/spec/requests/api/v1/subject_spec.rb
@@ -1,14 +1,14 @@
 require "rails_helper"
 
-RSpec.describe "Subjecs API", type: :request do
+describe "Subjecs API", type: :request do
   describe "GET index" do
     before do
-      FactoryBot.find_or_create(:subject, :modern_languages)
-      FactoryBot.find_or_create(:subject, :english)
-      FactoryBot.find_or_create(:subject, :french)
-      FactoryBot.find_or_create(:subject, :primary)
-      FactoryBot.find_or_create(:subject, :further_education)
-      FactoryBot.find_or_create(:subject, :humanities)
+      find_or_create(:subject, :modern_languages)
+      find_or_create(:subject, :english)
+      find_or_create(:subject, :french)
+      find_or_create(:subject, :primary)
+      find_or_create(:subject, :further_education)
+      find_or_create(:subject, :humanities)
     end
 
     it "returns http success" do
@@ -39,8 +39,8 @@ RSpec.describe "Subjecs API", type: :request do
             "subject_code" => "00",
           },
           {
-            "subject_name" => "Further Education",
-            "subject_code" => "FE",
+            "subject_name" => "Further education",
+            "subject_code" => "41",
           },
         ])
     end

--- a/spec/services/subject_creator_service_spec.rb
+++ b/spec/services/subject_creator_service_spec.rb
@@ -1,0 +1,25 @@
+describe SubjectCreatorService do
+  let(:primary_model) { spy }
+  let(:secondary_model) { spy }
+  let(:further_education_model) { spy }
+  let(:modern_languages_model) { spy }
+  let(:discontinued_model) { spy }
+
+  let(:service) do
+    described_class.new(
+      primary_subject: primary_model,
+      secondary_subject: secondary_model,
+      further_education_subject: further_education_model,
+      modern_languages_subject: modern_languages_model,
+      discontinued_subject: discontinued_model,
+    )
+  end
+
+  it "creates subject data unless subject already exists" do
+    service.execute
+    expect(primary_model).to have_received(:find_or_create_by).with(subject_name: "Primary", subject_code: "00")
+    expect(secondary_model).to have_received(:find_or_create_by).with(subject_name: "Art and design", subject_code: "W1")
+    expect(further_education_model).to have_received(:find_or_create_by).with(subject_name: "Further education", subject_code: "41")
+    expect(discontinued_model).to have_received(:find_or_create_by).with(subject_name: "Humanities")
+  end
+end


### PR DESCRIPTION
### Context
As it stands seeded courses are not created with data that reflects the new subject changes.  

### Changes proposed in this pull request
Removal of old style courses from seeds and instead create new style courses. Also creates subjects in the seeds as well as refactoring the migration that creates them to avoid duplication of code.  

### Guidance to review

### Checklist

- [X] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
