### PR TITLE
[2245] Add financial incentive model

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -101,6 +101,7 @@ class Course < ApplicationRecord
 
   has_many :course_subjects
   has_many :subjects, through: :course_subjects
+  has_many :financial_incentives, through: :subjects
   has_many :course_ucas_subjects
   has_many :ucas_subjects, through: :course_ucas_subjects
   has_many :site_statuses
@@ -312,10 +313,6 @@ class Course < ApplicationRecord
     end
   end
 
-  def dfe_subjects
-    UCASSubjectMapperService.get_subject_list(name, ucas_subjects.map(&:subject_name))
-  end
-
   def ucas_level
     UCASSubjects::CourseLevel.new(ucas_subjects.map(&:subject_name)).ucas_level
   end
@@ -381,23 +378,23 @@ class Course < ApplicationRecord
   end
 
   def has_bursary?
-    dfe_subjects.any?(&:has_bursary?)
+    financial_incentives.any?(&:bursary_amount?)
   end
 
   def has_scholarship_and_bursary?
-    dfe_subjects.any?(&:has_scholarship_and_bursary?)
+    financial_incentives.any?(&:scholarship?) && financial_incentives.any?(&:bursary_amount?)
   end
 
   def has_early_career_payments?
-    dfe_subjects.any?(&:has_early_career_payments?)
+    financial_incentives.any?(&:early_career_payments?)
   end
 
   def bursary_amount
-    dfe_subjects&.first&.bursary_amount
+    financial_incentives&.first&.bursary_amount
   end
 
   def scholarship_amount
-    dfe_subjects&.first&.scholarship_amount
+    financial_incentives&.first&.scholarship
   end
 
   def self_accredited?

--- a/app/models/financial_incentive.rb
+++ b/app/models/financial_incentive.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: financial_incentive
+#
+#  id                    :bigint           not null, primary key
+#  subject_id            :bigint           not null
+#  bursary_amount        :string
+#  early_career_payments :string
+#  scholarship           :string
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#
+
+class FinancialIncentive < ApplicationRecord
+  belongs_to :subject
+end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -11,6 +11,7 @@
 class Subject < ApplicationRecord
   has_many :course_subjects
   has_many :courses, through: :course_subjects
+  has_one :financial_incentive
 
   def to_sym
     subject_name.parameterize.underscore.to_sym

--- a/db/migrate/20190930110525_create_financial_incentive.rb
+++ b/db/migrate/20190930110525_create_financial_incentive.rb
@@ -1,0 +1,12 @@
+class CreateFinancialIncentive < ActiveRecord::Migration[6.0]
+  def change
+    create_table :financial_incentive do |t|
+      t.belongs_to :subject, null: false, foreign_key: true
+      t.string :bursary_amount
+      t.string :early_career_payments
+      t.string :scholarship
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_30_102958) do
+ActiveRecord::Schema.define(version: 2019_09_30_110525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -156,6 +156,16 @@ ActiveRecord::Schema.define(version: 2019_09_30_102958) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
+
+  create_table "financial_incentive", force: :cascade do |t|
+    t.bigint "subject_id", null: false
+    t.string "bursary_amount"
+    t.string "early_career_payments"
+    t.string "scholarship"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["subject_id"], name: "index_financial_incentive_on_subject_id"
   end
 
   create_table "nctl_organisation", id: :serial, force: :cascade do |t|
@@ -309,6 +319,7 @@ ActiveRecord::Schema.define(version: 2019_09_30_102958) do
   add_foreign_key "course_site", "site", name: "FK_course_site_site_site_id", on_delete: :cascade
   add_foreign_key "course_ucas_subject", "course", name: "FK_course_subject_course_course_id", on_delete: :cascade
   add_foreign_key "course_ucas_subject", "ucas_subject", name: "FK_course_subject_subject_subject_id", on_delete: :cascade
+  add_foreign_key "financial_incentive", "subject"
   add_foreign_key "nctl_organisation", "organisation", name: "FK_nctl_organisation_organisation_organisation_id", on_delete: :cascade
   add_foreign_key "organisation_provider", "organisation", name: "FK_organisation_provider_organisation_organisation_id"
   add_foreign_key "organisation_provider", "provider", name: "FK_organisation_provider_provider_provider_id"

--- a/spec/factories/financial_incentives.rb
+++ b/spec/factories/financial_incentives.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: financial_incentive
+#
+#  id                    :bigint           not null, primary key
+#  subject_id            :bigint           not null
+#  bursary_amount        :string
+#  early_career_payments :string
+#  scholarship           :string
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#
+
+FactoryBot.define do
+  # TODO: use known subject list
+  factory :financial_incentive do
+  end
+end

--- a/spec/models/financial_incentive_spec.rb
+++ b/spec/models/financial_incentive_spec.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: financial_incentive
+#
+#  id                    :bigint           not null, primary key
+#  subject_id            :bigint           not null
+#  bursary_amount        :string
+#  early_career_payments :string
+#  scholarship           :string
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#
+
+require "rails_helper"
+
+describe FinancialIncentive, type: :model do
+  pending
+end

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -16,4 +16,9 @@ describe Subject, type: :model do
   it { should have_many(:courses).through(:course_subjects) }
   its(:to_sym) { should eq(:modern_languages_other) }
   its(:to_s) { should eq("Modern languages (other) (101)") }
+
+  it "can get a financial incentive" do
+    financial_incentive = create(:financial_incentive, subject: subject)
+    expect(subject.financial_incentive).to eq(financial_incentive)
+  end
 end


### PR DESCRIPTION
### Context
We currently have a bunch of logic to do with financial incentives hardcoded in DFESubject, DFESubject will be going away and hardcoding makes things harder for rollover.

### Changes proposed in this pull request
Move this logic to the new FinancialIncentive model and remove course's dependency on DFESubject.

### Guidance to review

### Checklist

- [X] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
