### PR TITLE
[2249] Serialize level not ucas level for v2 courses

### DIFF
--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -17,14 +17,10 @@ module API
                  :level, :is_send?, :has_bursary?, :has_scholarship_and_bursary?,
                  :has_early_career_payments?, :bursary_amount, :scholarship_amount,
                  :english, :maths, :science, :gcse_subjects_required, :age_range_in_years,
-                 :accrediting_provider, :accrediting_provider_code
+                 :accrediting_provider, :accrediting_provider_code, :level
 
       attribute :start_date do
         @object.start_date.strftime("%B %Y") if @object.start_date
-      end
-
-      attribute :level do
-        @object.ucas_level
       end
 
       attribute :applications_open_from do

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -18,6 +18,7 @@ describe "Courses API v2", type: :request do
 
   let(:findable_open_course) {
     create(:course, :resulting_in_pgce_with_qts, :with_apprenticeship,
+           level: :secondary,
            name: "Mathematics",
            provider: provider,
            start_date: Time.now.utc,

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -6,7 +6,7 @@ describe API::V2::SerializableCourse do
   let(:date_today) { Date.today }
   let(:time_now) { Time.now.utc }
   let(:course) do
-    create(:course, enrichments: [enrichment], start_date: time_now, applications_open_from: date_today)
+    create(:course, enrichments: [enrichment], start_date: time_now, applications_open_from: date_today, level: :primary)
   end
   let(:course_json) do
     jsonapi_renderer.render(
@@ -28,7 +28,7 @@ describe API::V2::SerializableCourse do
   it { should have_attribute :subjects }
   it { should have_attribute(:applications_open_from).with_value(date_today.to_s) }
   it { should have_attribute :is_send? }
-  it { should have_attribute :level }
+  it { should have_attribute(:level).with_value("primary") }
   it { should have_attribute :english }
   it { should have_attribute :maths }
   it { should have_attribute :science }


### PR DESCRIPTION
### Context
All courses created via mcb after are defaulting to `Secondary` even when created as Primary
### Changes proposed in this pull request
Serialize `level` in courses

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
