### PR TITLE
[2250] Add validation for subject and level presence

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -160,6 +160,8 @@ class Course < ApplicationRecord
   validates :enrichments, presence: true, on: :publish
   validates :is_send, inclusion: { in: [true, false] }
   validates :sites, presence: true, on: :publish
+  validates :level, presence: true, on: :publish
+  validates :subjects, presence: true, on: :publish
   validate :validate_enrichment_publishable, on: :publish
   validate :validate_enrichment
   validate :validate_course_syncable, on: :sync

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,10 @@ en:
               blank: "^Complete your course information before publishing"
             sites:
               blank: "^You must pick at least one location for this course"
+            level:
+              blank: "^There is a problem with this course. Contact support to fix it (Error: L)"
+            subjects:
+              blank: "^There is a problem with this course. Contact support to fix it (Error: S)"
         course_enrichment:
           attributes:
             salary_details:

--- a/spec/models/course/publishable_spec.rb
+++ b/spec/models/course/publishable_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Course, type: :model do
+describe Course, type: :model do
   describe "#publishable?" do
     let(:course) { create(:course) }
     let(:site) { create(:site) }
@@ -10,8 +10,9 @@ RSpec.describe Course, type: :model do
 
     context "with enrichment" do
       let(:enrichment) { build(:course_enrichment, :subsequent_draft, created_at: 1.day.ago) }
+      let(:primary_with_mathematics) { create(:subject, :primary_with_mathematics) }
       let(:course) {
-        create(:course, enrichments: [enrichment], site_statuses: [site_status])
+        create(:course, subjects: [primary_with_mathematics], enrichments: [enrichment], site_statuses: [site_status])
       }
 
       its(:publishable?) { should be_truthy }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -90,15 +90,30 @@ describe Course, type: :model do
     end
 
     describe "publishable?" do
-      let(:course) { create(:course, enrichments: [invalid_enrichment]) }
-      let(:invalid_enrichment) { create(:course_enrichment, about_course: "") }
+      context "invalid enrichment" do
+        let(:course) { create(:course, enrichments: [invalid_enrichment]) }
+        let(:invalid_enrichment) { create(:course_enrichment, about_course: "") }
 
-      before do
-        subject.publishable?
+        before do
+          subject.publishable?
+        end
+
+        it "should add enrichment errors" do
+          expect(subject.errors.full_messages).to_not be_empty
+        end
       end
 
-      it "should add enrichment errors" do
-        expect(subject.errors.full_messages).to_not be_empty
+      context "invalid level and subjects" do
+        let(:initial_draft_enrichment) { build(:course_enrichment, :published) }
+        let(:course) { create(:course, level: nil, site_statuses: [create(:site_status, :new)], enrichments: [initial_draft_enrichment]) }
+
+        before do
+          subject.publishable?
+        end
+
+        it "should add level and subjects" do
+          expect(subject.errors.full_messages).to match_array(["There is a problem with this course. Contact support to fix it (Error: L)", "There is a problem with this course. Contact support to fix it (Error: S)"])
+        end
       end
     end
   end


### PR DESCRIPTION
### Context
There've been some issues with subjects and levels being missing from courses since moving away from UCAS subjects, this should help us better diagnose these issues.

### Changes proposed in this pull request
Give a validation message when either subject or level are not present.

### Guidance to review
[This test](https://github.com/DFE-Digital/manage-courses-backend/pull/853/files#diff-2370f7c60a21a83d5258e3f9f253bbb7L119) was deleted because this validation prevents it ever reaching a state where a course cannot be bulk published because it has no subjects.  
I've also refactored the request validation tests a bit while correcting them so that they aren't as fragile.

### Checklist

- [X] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [x] Tested by running locally
