### PR TITLE
[2251] Remove provider contact enrichment validation for publish

### DIFF
--- a/app/models/provider_enrichment.rb
+++ b/app/models/provider_enrichment.rb
@@ -60,10 +60,8 @@ class ProviderEnrichment < ApplicationRecord
 
   validates :telephone, phone: { message: "^Enter a valid telephone number" }, allow_nil: true
 
-  validates :website, :telephone,
-            :address1, :address3, :address4,
-            :postcode, :train_with_us, :train_with_disability,
-            presence: true, on: :publish
+  validates :train_with_us, presence: true, on: :publish
+  validates :train_with_disability, presence: true, on: :publish
 
   def draft?
     status.in? %w[draft rolled_over]

--- a/spec/models/provider_enrichment_spec.rb
+++ b/spec/models/provider_enrichment_spec.rb
@@ -175,15 +175,6 @@ describe ProviderEnrichment, type: :model do
     end
 
     describe "on publish" do
-      it { should validate_presence_of(:email).on(:publish).with_message("^Enter an email address in the correct format, like name@example.com") }
-      it { should validate_presence_of(:website).on(:publish) }
-      it { should validate_presence_of(:telephone).on(:publish).with_message("^Enter a valid telephone number") }
-
-      it { should validate_presence_of(:address1).on(:publish) }
-      it { should validate_presence_of(:address3).on(:publish) }
-      it { should validate_presence_of(:address4).on(:publish) }
-
-      it { should validate_presence_of(:postcode).on(:publish) }
       it { should validate_presence_of(:train_with_us).on(:publish) }
       it { should validate_presence_of(:train_with_disability).on(:publish) }
     end

--- a/spec/requests/api/v2/providers/publish_spec.rb
+++ b/spec/requests/api/v2/providers/publish_spec.rb
@@ -96,28 +96,16 @@ describe "Provider Publish API v2", type: :request do
         it { should have_http_status(:unprocessable_entity) }
 
         it "has validation error details" do
-          expect(json_data.count).to eq 9
+          expect(json_data.count).to eq 3
           expect(json_data[0]["detail"]).to eq("Enter an email address in the correct format, like name@example.com")
-          expect(json_data[1]["detail"]).to eq("Enter website")
-          expect(json_data[2]["detail"]).to eq("Enter a valid telephone number")
-          expect(json_data[3]["detail"]).to eq("Enter building or street")
-          expect(json_data[4]["detail"]).to eq("Enter town or city")
-          expect(json_data[5]["detail"]).to eq("Enter county")
-          expect(json_data[6]["detail"]).to eq("Enter a postcode in the format ‘SW10 1AA’")
-          expect(json_data[7]["detail"]).to eq("Enter details about training with you")
-          expect(json_data[8]["detail"]).to eq("Enter details about training with a disability")
+          expect(json_data[1]["detail"]).to eq("Enter details about training with you")
+          expect(json_data[2]["detail"]).to eq("Enter details about training with a disability")
         end
 
         it "has validation error pointers" do
           expect(json_data[0]["source"]["pointer"]).to eq("/data/attributes/email")
-          expect(json_data[1]["source"]["pointer"]).to eq("/data/attributes/website")
-          expect(json_data[2]["source"]["pointer"]).to eq("/data/attributes/telephone")
-          expect(json_data[3]["source"]["pointer"]).to eq("/data/attributes/address1")
-          expect(json_data[4]["source"]["pointer"]).to eq("/data/attributes/address3")
-          expect(json_data[5]["source"]["pointer"]).to eq("/data/attributes/address4")
-          expect(json_data[6]["source"]["pointer"]).to eq("/data/attributes/postcode")
-          expect(json_data[7]["source"]["pointer"]).to eq("/data/attributes/train_with_us")
-          expect(json_data[8]["source"]["pointer"]).to eq("/data/attributes/train_with_disability")
+          expect(json_data[1]["source"]["pointer"]).to eq("/data/attributes/train_with_us")
+          expect(json_data[2]["source"]["pointer"]).to eq("/data/attributes/train_with_disability")
         end
       end
     end

--- a/spec/requests/api/v2/providers/publishable_spec.rb
+++ b/spec/requests/api/v2/providers/publishable_spec.rb
@@ -65,28 +65,16 @@ describe "Provider Publishable API v2", type: :request do
         it { should have_http_status(:unprocessable_entity) }
 
         it "has validation error details" do
-          expect(json_data.count).to eq 9
+          expect(json_data.count).to eq 3
           expect(json_data[0]["detail"]).to eq("Enter an email address in the correct format, like name@example.com")
-          expect(json_data[1]["detail"]).to eq("Enter website")
-          expect(json_data[2]["detail"]).to eq("Enter a valid telephone number")
-          expect(json_data[3]["detail"]).to eq("Enter building or street")
-          expect(json_data[4]["detail"]).to eq("Enter town or city")
-          expect(json_data[5]["detail"]).to eq("Enter county")
-          expect(json_data[6]["detail"]).to eq("Enter a postcode in the format ‘SW10 1AA’")
-          expect(json_data[7]["detail"]).to eq("Enter details about training with you")
-          expect(json_data[8]["detail"]).to eq("Enter details about training with a disability")
+          expect(json_data[1]["detail"]).to eq("Enter details about training with you")
+          expect(json_data[2]["detail"]).to eq("Enter details about training with a disability")
         end
 
         it "has validation error pointers" do
           expect(json_data[0]["source"]["pointer"]).to eq("/data/attributes/email")
-          expect(json_data[1]["source"]["pointer"]).to eq("/data/attributes/website")
-          expect(json_data[2]["source"]["pointer"]).to eq("/data/attributes/telephone")
-          expect(json_data[3]["source"]["pointer"]).to eq("/data/attributes/address1")
-          expect(json_data[4]["source"]["pointer"]).to eq("/data/attributes/address3")
-          expect(json_data[5]["source"]["pointer"]).to eq("/data/attributes/address4")
-          expect(json_data[6]["source"]["pointer"]).to eq("/data/attributes/postcode")
-          expect(json_data[7]["source"]["pointer"]).to eq("/data/attributes/train_with_us")
-          expect(json_data[8]["source"]["pointer"]).to eq("/data/attributes/train_with_disability")
+          expect(json_data[1]["source"]["pointer"]).to eq("/data/attributes/train_with_us")
+          expect(json_data[2]["source"]["pointer"]).to eq("/data/attributes/train_with_disability")
         end
       end
     end


### PR DESCRIPTION
### Context
Provider contact details enrichments

### Changes proposed in this pull request
Remove all validation on enrichment contact details for "publishing"

### Guidance to review
🚢 

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
