### PR TITLE
[1957] Add site status publishing validation

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -163,6 +163,7 @@ class Course < ApplicationRecord
   validates :level, presence: true, on: :publish
   validates :subjects, presence: true, on: :publish
   validate :validate_enrichment_publishable, on: :publish
+  validate :validate_site_status_findable, on: :publish
   validate :validate_enrichment
   validate :validate_course_syncable, on: :sync
   validate :validate_qualification, on: :update
@@ -509,7 +510,7 @@ private
   end
 
   def validate_course_syncable
-    if findable?.blank?
+    unless findable?
       errors.add :site_statuses, "No findable sites."
     end
     if subjects
@@ -542,6 +543,12 @@ private
   def validate_subjects
     if has_any_modern_language_subject_type? & !has_the_modern_languages_secondary_subject_type?
       subjects << SecondarySubject.modern_languages
+    end
+  end
+
+  def validate_site_status_findable
+    unless findable?
+      errors.add(:site_statuses, "must be findable")
     end
   end
 

--- a/spec/models/course/publishable_spec.rb
+++ b/spec/models/course/publishable_spec.rb
@@ -2,7 +2,7 @@ describe Course, type: :model do
   describe "#publishable?" do
     let(:course) { create(:course) }
     let(:site) { create(:site) }
-    let(:site_status) { create(:site_status, :new, site: site) }
+    let(:site_status) { create(:site_status, :findable, site: site) }
 
     subject { course }
 
@@ -11,9 +11,9 @@ describe Course, type: :model do
     context "with enrichment" do
       let(:enrichment) { build(:course_enrichment, :subsequent_draft, created_at: 1.day.ago) }
       let(:primary_with_mathematics) { create(:subject, :primary_with_mathematics) }
-      let(:course) {
+      let(:course) do
         create(:course, subjects: [primary_with_mathematics], enrichments: [enrichment], site_statuses: [site_status])
-      }
+      end
 
       its(:publishable?) { should be_truthy }
     end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -105,14 +105,30 @@ describe Course, type: :model do
 
       context "invalid level and subjects" do
         let(:initial_draft_enrichment) { build(:course_enrichment, :published) }
-        let(:course) { create(:course, level: nil, site_statuses: [create(:site_status, :new)], enrichments: [initial_draft_enrichment]) }
+        let(:course) { create(:course, level: nil, site_statuses: [create(:site_status, :findable)], enrichments: [initial_draft_enrichment]) }
 
         before do
           subject.publishable?
         end
 
-        it "should add level and subjects" do
-          expect(subject.errors.full_messages).to match_array(["There is a problem with this course. Contact support to fix it (Error: L)", "There is a problem with this course. Contact support to fix it (Error: S)"])
+        it "should add level and subjects to errors" do
+          expect(subject.errors.full_messages).to match_array([
+            "There is a problem with this course. Contact support to fix it (Error: L)",
+            "There is a problem with this course. Contact support to fix it (Error: S)",
+          ])
+        end
+      end
+
+      context "unfindable site statuses" do
+        let(:initial_draft_enrichment) { build(:course_enrichment, :published) }
+        let(:course) { create(:course, site_statuses: [create(:site_status, :new)], enrichments: [initial_draft_enrichment], subjects: [create(:subject, :primary_with_mathematics)]) }
+
+        before do
+          subject.publishable?
+        end
+
+        it "should add site status to errors" do
+          expect(subject.errors.full_messages).to match_array(["Site statuses must be findable"])
         end
       end
     end

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -59,16 +59,16 @@ describe "Publish API v2", type: :request do
 
     context "an unpublished course with a draft enrichment" do
       let(:enrichment) { build(:course_enrichment, :initial_draft) }
-      let(:site_status) { build(:site_status, :new) }
+      let(:site_status) { build(:site_status, :findable) }
       let(:dfe_subjects) { [build(:subject, :primary)] }
-      let!(:course) {
+      let!(:course) do
         create(:course,
                provider: provider,
                site_statuses: [site_status],
                enrichments: [enrichment],
                subjects: dfe_subjects,
                age: 17.days.ago)
-      }
+      end
 
       before do
         Timecop.freeze
@@ -147,6 +147,7 @@ describe "Publish API v2", type: :request do
             "Complete your course information before publishing",
             "There is a problem with this course. Contact support to fix it (Error: S)",
             "You must pick at least one location for this course",
+            "Site statuses must be findable",
           ])
         end
       end
@@ -172,11 +173,13 @@ describe "Publish API v2", type: :request do
               "Give details about the fee for UK and EU students",
               "Enter details about the qualifications needed",
               "There is a problem with this course. Contact support to fix it (Error: S)",
+              "Site statuses must be findable",
             ])
           end
 
           it "has validation error pointers" do
             expect(json_data.map { |error| error["source"]["pointer"] }).to match_array([
+              nil,
               nil,
               "/data/attributes/about_course",
               "/data/attributes/how_school_placements_work",
@@ -209,6 +212,7 @@ describe "Publish API v2", type: :request do
               "Give details about the salary for this course",
               "Enter details about the qualifications needed",
               "There is a problem with this course. Contact support to fix it (Error: S)",
+              "Site statuses must be findable",
             ])
           end
         end

--- a/spec/requests/api/v2/providers/courses/publishable_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publishable_spec.rb
@@ -51,7 +51,7 @@ describe "Publishable API v2", type: :request do
     context "unpublished course with draft enrichment" do\
       let(:enrichment) { build(:course_enrichment, :initial_draft) }
       let(:primary_with_mathematics) { create(:subject, :primary_with_mathematics) }
-      let(:site_status) { build(:site_status, :new) }
+      let(:site_status) { build(:site_status, :findable) }
       let!(:course) do
         create(:course,
                provider: provider,
@@ -74,6 +74,7 @@ describe "Publishable API v2", type: :request do
         it { should have_http_status(:unprocessable_entity) }
         it "has validation errors" do
           expect(json_data.map { |error| error["detail"] }).to match_array([
+            "Site statuses must be findable",
             "Complete your course information before publishing",
             "You must pick at least one location for this course",
             "There is a problem with this course. Contact support to fix it (Error: S)",
@@ -95,8 +96,8 @@ describe "Publishable API v2", type: :request do
           it { should have_http_status(:unprocessable_entity) }
 
           it "has validation error details" do
-            expect(json_data.count).to eq 6
             expect(json_data.map { |error| error["detail"] }).to match_array([
+              "Site statuses must be findable",
               "There is a problem with this course. Contact support to fix it (Error: S)",
               "Enter details about this course",
               "Enter a course length",
@@ -108,6 +109,7 @@ describe "Publishable API v2", type: :request do
 
           it "has validation error pointers" do
             expect(json_data.map { |error| error["source"]["pointer"] }).to match_array([
+              nil,
               nil,
               "/data/attributes/about_course",
               "/data/attributes/how_school_placements_work",


### PR DESCRIPTION
### Context
Errors were coming through as a result of site statuses not being findable on published courses

### Changes proposed in this pull request
Prevent courses being published without findable site statuses by adding validation.

### Guidance to review

### Checklist

- [X] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
