### PR TITLE
[1809] Add withdraw course functionality

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -103,6 +103,16 @@ module API
         @course.discard
       end
 
+      def withdraw
+        authorize @course
+        if @course.last_published_at.present?
+          #perhaps this should just be @course.discard . Not 100% sure
+          raise RuntimeError.new("This course has not been published and should be deleted not withdrawn")
+        else
+          @course.withdraw
+        end
+      end
+
       def create
         authorize @provider, :can_create_course?
         return unless course_params.values.any?

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -105,8 +105,7 @@ module API
 
       def withdraw
         authorize @course
-        if @course.last_published_at.present?
-          #perhaps this should just be @course.discard . Not 100% sure
+        if @course.is_published?
           raise RuntimeError.new("This course has not been published and should be deleted not withdrawn")
         else
           @course.withdraw

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -454,6 +454,16 @@ class Course < ApplicationRecord
     end
   end
 
+  def withdraw
+    if last_published_at.blank?
+      site_statuses.each do |site_status|
+        site_status.update(vac_status: :no_vacancies, status: :suspended)
+      end
+    else
+      errors.add(:withdraw, "Courses that have not been published should be deleted not withdrawn")
+    end
+  end
+
 private
 
   def assignable_after_publish(course_params)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -455,7 +455,7 @@ class Course < ApplicationRecord
   end
 
   def withdraw
-    if last_published_at.blank?
+    if !is_published?
       site_statuses.each do |site_status|
         site_status.update(vac_status: :no_vacancies, status: :suspended)
       end

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -20,4 +20,5 @@ class CoursePolicy
   alias_method :publish?, :update?
   alias_method :publishable?, :update?
   alias_method :new?, :index?
+  alias_method :withdraw?, :show?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,7 @@ Rails.application.routes.draw do
           post :sync_with_search_and_compare, on: :member
           post :publish, on: :member
           post :publishable, on: :member
+          post :withdraw, on: :member
           get :new, on: :new
         end
         resources :sites, only: %i[index update show create]

--- a/spec/models/course/withdraw_spec.rb
+++ b/spec/models/course/withdraw_spec.rb
@@ -2,7 +2,7 @@ describe Course, type: :model do
   describe "withdraw" do
     let(:course) { create(:course, provider: provider, site_statuses: [site_status1, site_status2, site_status3], enrichments: [enrichment]) }
     let(:provider) { build(:provider) }
-    let(:enrichment) { build(:course_enrichment, last_published_timestamp_utc: nil) }
+    let(:enrichment) { build(:course_enrichment) }
     let(:site_status1) { build(:site_status, :running, :published, :full_time_vacancies, site: site) }
     let(:site_status2) { build(:site_status, :new, :full_time_vacancies, site: site) }
     let(:site_status3) { build(:site_status, :suspended, :with_no_vacancies, site: site) }
@@ -13,7 +13,7 @@ describe Course, type: :model do
     end
 
     context "an unpublished course" do
-      it "should  not be findable" do
+      it "should not be findable" do
         expect(course.findable?).to be_falsey
       end
 
@@ -27,7 +27,7 @@ describe Course, type: :model do
       end
     end
 
-    context "an unpublished course" do
+    context "a published course" do
       let(:enrichment) { build(:course_enrichment, :published) }
 
       it "should not have updated the courses site statuses or vac status" do

--- a/spec/models/course/withdraw_spec.rb
+++ b/spec/models/course/withdraw_spec.rb
@@ -1,0 +1,47 @@
+describe Course, type: :model do
+  describe "withdraw" do
+    let(:course) { create(:course, provider: provider, site_statuses: [site_status1, site_status2, site_status3], enrichments: [enrichment]) }
+    let(:provider) { build(:provider) }
+    let(:enrichment) { build(:course_enrichment, last_published_timestamp_utc: nil) }
+    let(:site_status1) { build(:site_status, :running, :published, :full_time_vacancies, site: site) }
+    let(:site_status2) { build(:site_status, :new, :full_time_vacancies, site: site) }
+    let(:site_status3) { build(:site_status, :suspended, :with_no_vacancies, site: site) }
+    let(:site) { build(:site, provider: provider) }
+
+    before do
+      course.withdraw
+    end
+
+    context "an unpublished course" do
+      it "should  not be findable" do
+        expect(course.findable?).to be_falsey
+      end
+
+      it "should have updated the courses site statuses to be suspended and have no vacancies" do
+        expect(site_status1.vac_status).to eq("no_vacancies")
+        expect(site_status1.status).to eq("suspended")
+        expect(site_status2.vac_status).to eq("no_vacancies")
+        expect(site_status2.status).to eq("suspended")
+        expect(site_status3.vac_status).to eq("no_vacancies")
+        expect(site_status3.status).to eq("suspended")
+      end
+    end
+
+    context "an unpublished course" do
+      let(:enrichment) { build(:course_enrichment, :published) }
+
+      it "should not have updated the courses site statuses or vac status" do
+        expect(site_status1.vac_status).to eq("full_time_vacancies")
+        expect(site_status1.status).to eq("running")
+        expect(site_status2.vac_status).to eq("full_time_vacancies")
+        expect(site_status2.status).to eq("new_status")
+        expect(site_status3.vac_status).to eq("no_vacancies")
+        expect(site_status3.status).to eq("suspended")
+      end
+
+      it "should add an error to the course" do
+        expect(course.reload.errors[:withdraw].first).to eq("Courses that have not been published should be deleted not withdrawn")
+      end
+    end
+  end
+end

--- a/spec/policies/course_policy_spec.rb
+++ b/spec/policies/course_policy_spec.rb
@@ -9,7 +9,7 @@ describe CoursePolicy do
     it { should permit(user, Course) }
   end
 
-  permissions :show?, :update? do
+  permissions :show?, :update?, :withdraw? do
     let(:organisation) { create(:organisation, users: [user]) }
     let(:course) { create(:course) }
     let!(:provider) {

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -459,4 +459,30 @@ describe "Courses API v2", type: :request do
       it { should have_http_status(:success) }
     end
   end
+
+  describe "WITHDRAW" do
+    let(:path) do
+      "/api/v2/providers/#{provider.provider_code}" +
+        "/courses/#{course.course_code}/withdraw"
+    end
+
+    let(:course) { create(:course, provider: provider, site_statuses: [site_status], enrichments: [enrichment]) }
+    let(:enrichment) { build(:course_enrichment, last_published_timestamp_utc: 1.day.ago)}
+    let(:site_status1) { build(:site_status, :running) }
+    let(:site_status2) { build(:site_status, :new) }
+    let(:site_status3) { build(:site_status, :suspeneded) }
+
+    before do
+      course
+    end
+
+    subject do
+      post path, headers: { "HTTP_AUTHORIZATION" => credentials }
+      response
+    end
+
+    include_examples "Unauthenticated, unauthorised, or not accepted T&Cs"
+
+    it { should have_http_status(:success) }
+  end
 end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -467,7 +467,7 @@ describe "Courses API v2", type: :request do
     end
 
     let(:course) { create(:course, provider: provider, site_statuses: [site_status1, site_status2, site_status3], enrichments: [enrichment]) }
-    let(:enrichment) { build(:course_enrichment, last_published_timestamp_utc: nil) }
+    let(:enrichment) { build(:course_enrichment) }
     let(:site_status1) { build(:site_status, :running, :published, :full_time_vacancies, site: site) }
     let(:site_status2) { build(:site_status, :new, :full_time_vacancies, site: site) }
     let(:site_status3) { build(:site_status, :suspended, :with_no_vacancies, site: site) }


### PR DESCRIPTION
### Context
Users need to be able to withdraw a published course. Once published a course should not be able to be deleted/discarded

### Changes proposed in this pull request
- Add an endpoint for withdrawing a course

### Guidance to review
- A second PR to add a command to mcb to do this will follow.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
