### PR TITLE
[2258] Only sync published course on course update

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -89,7 +89,7 @@ module API
         update_enrichment
         update_sites
         update_site_status_vac_statuses if @course.study_mode_previously_changed?
-        should_sync = site_ids.present? && @course.recruitment_cycle.current? && @course.is_published?
+        should_sync = site_ids.present? && @course.should_sync?
         has_synced? if should_sync
 
         if @course.errors.empty? && @course.valid?

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -89,7 +89,7 @@ module API
         update_enrichment
         update_sites
         update_site_status_vac_statuses if @course.study_mode_previously_changed?
-        should_sync = site_ids.present? && @course.recruitment_cycle.current?
+        should_sync = site_ids.present? && @course.recruitment_cycle.current? && @course.is_published?
         has_synced? if should_sync
 
         if @course.errors.empty? && @course.valid?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -217,8 +217,14 @@ class Course < ApplicationRecord
     valid? :publish
   end
 
+  # Is course in syncable condition
   def syncable?
     valid? :sync
+  end
+
+  # Should we attempt to sync this course with Find
+  def should_sync?
+    recruitment_cycle.current? && is_published?
   end
 
   def update_valid?

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -985,13 +985,13 @@ describe Course, type: :model do
 
     its(:syncable?) { should be_truthy }
 
-    context"invalid courses" do
+    context "invalid courses" do
       context "course which has only discontinued subject subject type" do
         let(:courses_subjects) { [build(:subject, :humanities)] }
         its(:syncable?) { should be_falsey }
       end
 
-      context "course which has only mordern lanaguage secondary subject type" do
+      context "course which has only modern lanaguage secondary subject type" do
         let(:courses_subjects) { [build(:subject, :modern_languages)] }
         its(:syncable?) { should be_falsey }
       end
@@ -1005,6 +1005,25 @@ describe Course, type: :model do
         let(:courses_subjects) { [] }
         its(:syncable?) { should be_falsey }
       end
+    end
+  end
+
+  describe "#should_sync?" do
+    let(:course_enrichment) { build :course_enrichment, :published }
+    let(:site_status) { build(:site_status, :findable) }
+    let(:provider) { build(:provider) }
+    subject { create(:course, provider: provider, site_statuses: [site_status], enrichments: [course_enrichment]) }
+
+    its(:should_sync?) { should be_truthy }
+
+    context "course not yet published" do
+      let(:course_enrichment) { build :course_enrichment }
+      its(:should_sync?) { should be_falsey }
+    end
+
+    context "course in next cycle" do
+      let(:provider) { build :provider, :next_recruitment_cycle }
+      its(:should_sync?) { should be_falsey }
     end
   end
 


### PR DESCRIPTION
### Context

When editing these locations for a provider:
https://www.publish-teacher-training-courses.service.gov.uk/organisations/1ZC/2020/courses/38BW/details

After removing a location (Inspiration Trust) on an draft course, it attempted to sync which then errored: https://sentry.io/organizations/dfe-bat/issues/1250607692/

The change was made successfully but the user sees a 500 page.

### Changes proposed in this pull request

If a course hasn't been published yet, it's not on Find, and we don't need to sync it.

This wasn't true last cycle, in 2019 a course was on Find if it had been set to running on UCAS – a course's published content was published separately.

From 2020 the only way a course gets set to running is by publishing it. So we can now include this check.

This will prevent errors when trying to sync something in a non-syncable state (eg no findable sites)

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
