### PR TITLE
`is_published` should be true when `:published_with_unpublished_changes`

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -424,7 +424,7 @@ class Course < ApplicationRecord
   end
 
   def is_published?
-    content_status == :published
+    %i{published published_with_unpublished_changes}.include? content_status
   end
 
   def funding_type=(funding_type)

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1269,5 +1269,15 @@ describe Course, type: :model do
         expect(course.is_published?).to eq(true)
       end
     end
+
+    context "course is published with unpublished changes" do
+      let(:enrichment) { create(:course_enrichment, :subsequent_draft) }
+      let(:course) { create(:course, enrichments: [enrichment]) }
+
+      it "returns true" do
+        expect(course.content_status).to eq(:published_with_unpublished_changes)
+        expect(course.is_published?).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
Expand the scope of "is_published" to all published courses.

Before this change courses that were published_with_unpublished_changes:
- wouldn't be sync'd to Find when editing details
- would allow editing of properties that shouldn't be edited after publish

Added a test, which was initially failing.
