### PR TITLE
Implement public V3 courses API

### DIFF
--- a/app/controllers/api/v3/application_controller.rb
+++ b/app/controllers/api/v3/application_controller.rb
@@ -1,0 +1,29 @@
+module API
+  module V3
+    class ApplicationController < ActionController::API
+      rescue_from ActiveRecord::RecordNotFound, with: :jsonapi_404
+
+      def jsonapi_404
+        render jsonapi: nil, status: :not_found
+      end
+
+    private
+
+      def build_recruitment_cycle
+        @recruitment_cycle = RecruitmentCycle.find_by(
+          year: params[:recruitment_cycle_year],
+        ) || RecruitmentCycle.current_recruitment_cycle
+      end
+
+      def build_provider
+        @provider = @recruitment_cycle.providers.find_by!(
+          provider_code: params[:provider_code].upcase,
+        )
+      end
+
+      def build_course
+        @course = @provider.courses.find_by!(course_code: params[:code].upcase)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/courses_controller.rb
+++ b/app/controllers/api/v3/courses_controller.rb
@@ -1,0 +1,24 @@
+module API
+  module V3
+    class CoursesController < API::V3::ApplicationController
+      before_action :build_recruitment_cycle
+      before_action :build_provider
+      before_action :build_course
+
+      def show
+        if @course.is_published?
+          render jsonapi: @course, fields: fields_param
+        else
+          raise ActiveRecord::RecordNotFound
+        end
+      end
+
+      def fields_param
+        params.fetch(:fields, {})
+          .permit(:courses)
+          .to_h
+          .map { |k, v| [k, v.split(",").map(&:to_sym)] }
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,6 +147,20 @@ Rails.application.routes.draw do
       get "build_new_course", to: "courses#build_new"
     end
 
+    if Settings.feature.v3_routes
+      namespace :v3 do
+        resources :recruitment_cycles,
+                  only: %i[index show],
+                  param: :year do
+          resources :providers,
+                    only: %i[index show update],
+                    param: :code do
+            resources :courses, param: :code
+          end
+        end
+      end
+    end
+
     namespace :system do
       post :sync, to: "force_sync#sync"
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -27,3 +27,5 @@ logstash:
   port: # Our port here
   ssl_enable: true
 log_level: info
+feature:
+  v3_routes: true

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -9,3 +9,5 @@ bg_jobs:
     cron: "0 */2 * * *"
     class: "BulkSyncCoursesToFindJob"
     queue: find_sync
+feature:
+  v3_routes: false

--- a/spec/requests/api/v3/providers/courses/show_spec.rb
+++ b/spec/requests/api/v3/providers/courses/show_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+describe "GET v3/providers/:provider_code/courses/:course_code" do
+  let(:recruitment_cycle) { find_or_create :recruitment_cycle }
+  let(:provider) { create :provider, recruitment_cycle: recruitment_cycle }
+  let(:jsonapi_course) {
+    JSON.parse(
+      JSONAPI::Serializable::Renderer.new.render(
+        course,
+        class: {
+          Course: API::V2::SerializableCourse,
+        },
+      ).to_json,
+    )
+  }
+  let(:jsonapi_response) { JSON.parse(response.body) }
+  let(:route) {
+    "/api/v3/recruitment_cycles/#{recruitment_cycle.year}" \
+    "/providers/#{provider.provider_code}" \
+    "/courses/#{course.course_code}"
+  }
+  let(:course) { create :course, provider: provider, enrichments: enrichments }
+
+  context "with a published course" do
+    let(:enrichments) { [build(:course_enrichment, :published)] }
+
+    it "returns full course information" do
+      get route
+
+      expect(jsonapi_response["data"]).to eq jsonapi_course["data"]
+    end
+
+    it "returns sparse course information" do
+      requested_fields = %w[course_code name provider_code].sort
+      get route + "?fields[courses]=#{requested_fields.join(',')}"
+
+      expect(jsonapi_response["data"]["attributes"].keys).to eq requested_fields
+    end
+  end
+
+  context "with a course with no enrichments" do
+    let(:enrichments) { [] }
+
+    it "returns nil course information" do
+      get route
+
+      expect(jsonapi_response["data"]).to eq nil
+    end
+  end
+
+  context "with a course with a draft enrichment" do
+    let(:enrichments) { [build(:course_enrichment, :initial_draft)] }
+
+    it "returns nil course information" do
+      get route
+
+      expect(jsonapi_response["data"]).to eq nil
+    end
+  end
+
+  def render_course(course)
+    JSONAPI::Serializable::Renderer.new.render(
+      course,
+      class: {
+        Course: API::V2::SerializableCourse,
+      },
+    )
+  end
+end


### PR DESCRIPTION
### Context

Apply (and search-ui soon) will need to query for public course information. One proposal is to have public endpoints living under the `v3` namespace.

### Changes proposed in this pull request

Add v3 courses controller and route.

Allows us to run:

```bash
# Look ma, no auth!
curl "http://localhost:3001/api/v3/recruitment_cycles/2020/providers/2CG/courses/2Z3H" | ppjson
{
    "data": {
        "attributes": {
            "about_accrediting_body": null,
            "about_course": null,
            "accrediting_provider": {
                "accrediting_provider": "accredited_body",
...
```

And again, with sparse fields (`?fields[courses]=provider_code,course_code,name`):

```bash
curl -v "http://localhost:3001/api/v3/recruitment_cycles/2019/providers/2KN/courses/39VZ?fields\[courses\]=provider_code,course_code,name" | ppjson
{
    "data": {
        "attributes": {
            "course_code": "39VZ",
            "name": "Mathematics",
            "provider_code": "2KN"
        },
```

### Guidance to review

It's hidden behind a feature flag which is set to `false` in production, because Apply isn't running in prod yet and this allows us to kick the tires on it for a bit before. QA and staging have anonymised information.

TODO:

- [x] Write tests
- [x] Do we need any filtering for published courses, e.g. can this leak draft info if we're not careful?
- [x] ~Is everything in the course serializer fine to expose publicly, or do we need to strip some attributes out? I gave it a look and nothing jumped out at me.~ Will use a feature flag initially
- [x] Should I refactor `build_provider` + `build_course` + `build_recruitment_cycle` at a higher level e.g. `ApplicationController` since they're duplicated everywhere? May as well.
- [x] Add ability to filter for only the attributes we care about via query string params, as the response is quite long (bytes are important!)

### Checklist

- [x] ~Make sure all information from the Trello card is in here~
- [x] ~Attach to Trello card~ https://trello.com/c/bQzgIERR/115-implement-public-courses-endpoint-on-find
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
