### PR TITLE
[2274] sync courses from un-enriched providers

### DIFF
--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -34,7 +34,6 @@ class RecruitmentCycle < ApplicationRecord
     def syncable_courses
       current_recruitment_cycle.providers
         .includes(:enrichments, :latest_published_enrichment)
-        .select(&:publishable?)
         .flat_map(&:syncable_courses)
     end
   end


### PR DESCRIPTION
### Context

We originally believed we wouldn't be syncing courses for providers who hadn't added enrichments. We now are.

### Changes proposed in this pull request

Don't filter out providers that aren't "publishable" when generating list for bulk sync.

### Guidance to review

This is customer-affecting bug, about 270 courses are currently affected by this issue.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
