### PR TITLE
[2135] Update users sign in id when logging in

### DIFF
--- a/app/services/authentication_service.rb
+++ b/app/services/authentication_service.rb
@@ -11,8 +11,8 @@ class AuthenticationService
 
   def call
     @user = user_by_sign_in_user_id || user_by_email
-    update_user_email if user_email_does_not_match_token?
-    update_user_sign_in_id if user_sign_in_id_does_not_match_token?
+
+    update_user_information_if_required
 
     user
   rescue DuplicateUserError => e
@@ -46,6 +46,11 @@ private
     decoded_token["sign_in_user_id"]
   end
 
+  def update_user_information_if_required
+    update_user_email if user_email_does_not_match_token?
+    update_user_sign_in_id if user_sign_in_id_does_not_match_token?
+  end
+
   def user_by_email
     if email_from_token.blank?
       logger.debug("No email in token")
@@ -77,10 +82,6 @@ private
                    }.to_s)
     end
     user
-  end
-
-  def update_user_email_needed?
-    user_email_does_not_match_token? && !email_in_use_by_another_user?
   end
 
   def user_email_does_not_match_token?

--- a/app/services/authentication_service.rb
+++ b/app/services/authentication_service.rb
@@ -12,6 +12,7 @@ class AuthenticationService
   def call
     @user = user_by_sign_in_user_id || user_by_email
     update_user_email if user_email_does_not_match_token?
+    update_user_sign_in_id if user_sign_in_id_does_not_match_token?
 
     user
   rescue DuplicateUserError => e
@@ -88,6 +89,12 @@ private
     user.email&.downcase != email_from_token
   end
 
+  def user_sign_in_id_does_not_match_token?
+    return unless user
+
+    user.sign_in_user_id != sign_in_user_id_from_token
+  end
+
   def email_in_use_by_another_user?
     user_by_email.present?
   end
@@ -109,6 +116,10 @@ private
 
       user.update(email: email_from_token)
     end
+  end
+
+  def update_user_sign_in_id
+    user.update(sign_in_user_id: sign_in_user_id_from_token)
   end
 
   def log_safe_user(user, reload: false)

--- a/spec/services/authentication_service_spec.rb
+++ b/spec/services/authentication_service_spec.rb
@@ -55,6 +55,37 @@ describe AuthenticationService do
       end
     end
 
+    context "with a valid email but invalid DfE-SignIn ID" do
+      let(:sign_in_user_id) { SecureRandom.uuid }
+      let(:payload) do
+        {
+          email:           user.email,
+          sign_in_user_id: sign_in_user_id,
+        }
+      end
+
+      it { should eq user }
+      it "update's the user's SignIn ID" do
+        expect { subject }.to(change { user.reload.sign_in_user_id }.to(sign_in_user_id))
+      end
+    end
+
+    context "with a valid email but nil DfE-SignIn ID" do
+      let(:user) { create(:user, sign_in_user_id: nil) }
+      let(:sign_in_user_id) { SecureRandom.uuid }
+      let(:payload) do
+        {
+          email:           user.email,
+          sign_in_user_id: sign_in_user_id,
+        }
+      end
+
+      it { should eq user }
+      it "update's the user's SignIn ID" do
+        expect { subject }.to(change { user.reload.sign_in_user_id }.to(sign_in_user_id))
+      end
+    end
+
     context "with a valid email but an invalid DfE-SignIn ID" do
       let(:payload) do
         {


### PR DESCRIPTION
### Context

Rails has never saved the users SignIn ID

### Changes proposed in this pull request

Save the users SignIn user ID

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
