### PR TITLE
[2276] Set first and last name from DfE signin

### DIFF
--- a/spec/services/authentication_service_spec.rb
+++ b/spec/services/authentication_service_spec.rb
@@ -1,6 +1,14 @@
 describe AuthenticationService do
   describe ".call" do
     let(:user) { create(:user) }
+    let(:email) { user.email }
+    let(:sign_in_user_id) { user.sign_in_user_id }
+    let(:payload) do
+      {
+        email:           email,
+        sign_in_user_id: sign_in_user_id,
+      }
+    end
 
     subject { described_class.call(encode_token(payload)) }
 
@@ -13,24 +21,11 @@ describe AuthenticationService do
     end
 
     context "with a valid DfE-SignIn ID and email" do
-      let(:payload) do
-        {
-          email:           user.email,
-          sign_in_user_id: user.sign_in_user_id,
-        }
-      end
-
       it { should eq user }
     end
 
     context "with a valid DfE-SignIn ID but invalid email" do
       let(:email) { Faker::Internet.email }
-      let(:payload) do
-        {
-          email:           email,
-          sign_in_user_id: user.sign_in_user_id,
-        }
-      end
 
       it { should eq user }
       it "update's the user's email" do
@@ -57,12 +52,6 @@ describe AuthenticationService do
 
     context "with a valid email but invalid DfE-SignIn ID" do
       let(:sign_in_user_id) { SecureRandom.uuid }
-      let(:payload) do
-        {
-          email:           user.email,
-          sign_in_user_id: sign_in_user_id,
-        }
-      end
 
       it { should eq user }
       it "update's the user's SignIn ID" do
@@ -73,12 +62,6 @@ describe AuthenticationService do
     context "with a valid email but nil DfE-SignIn ID" do
       let(:user) { create(:user, sign_in_user_id: nil) }
       let(:sign_in_user_id) { SecureRandom.uuid }
-      let(:payload) do
-        {
-          email:           user.email,
-          sign_in_user_id: sign_in_user_id,
-        }
-      end
 
       it { should eq user }
       it "update's the user's SignIn ID" do
@@ -87,18 +70,13 @@ describe AuthenticationService do
     end
 
     context "with a valid email but an invalid DfE-SignIn ID" do
-      let(:payload) do
-        {
-          email:           user.email,
-          sign_in_user_id: SecureRandom.uuid,
-        }
-      end
+      let(:sign_in_user_id) { SecureRandom.uuid }
 
       it { should eq user }
     end
 
     context "with an email that has different case from the database" do
-      let(:payload) { { email: user.email.upcase } }
+      let(:email) { user.email.upcase }
 
       before do
         user.update(email: user.email.capitalize)
@@ -108,15 +86,11 @@ describe AuthenticationService do
     end
 
     context "when the email is an empty string" do
+      let(:email) { "" }
+      let(:sign_in_user_id) { SecureRandom.uuid }
+
       before do
         user.update_attribute(:email, "")
-      end
-
-      let(:payload) do
-        {
-          email:           "",
-          sign_in_user_id: SecureRandom.uuid,
-        }
       end
 
       it "does not authenticate the user based on an empty string match" do
@@ -126,12 +100,8 @@ describe AuthenticationService do
 
     context "when the sign_in_user_id is nil" do
       let!(:user) { create(:user, sign_in_user_id: nil) }
-      let(:payload) do
-        {
-          email:           Faker::Internet.email,
-          sign_in_user_id: nil,
-        }
-      end
+      let(:email) { Faker::Internet.email }
+      let(:sign_in_user_id) { nil }
 
       it "does not authenticate the user based on a nil match" do
         expect(subject).not_to eq user

--- a/spec/services/authentication_service_spec.rb
+++ b/spec/services/authentication_service_spec.rb
@@ -2,11 +2,15 @@ describe AuthenticationService do
   describe ".call" do
     let(:user) { create(:user) }
     let(:email) { user.email }
+    let(:first_name) { user.first_name }
+    let(:last_name) { user.last_name }
     let(:sign_in_user_id) { user.sign_in_user_id }
     let(:payload) do
       {
         email:           email,
         sign_in_user_id: sign_in_user_id,
+        first_name: first_name,
+        last_name: last_name,
       }
     end
 
@@ -21,7 +25,18 @@ describe AuthenticationService do
     end
 
     context "with a valid DfE-SignIn ID and email" do
+      let(:first_name) { "#{user.first_name}_new" }
+      let(:last_name) { "#{user.last_name}_new" }
+
       it { should eq user }
+
+      it "Sets the users first name" do
+        expect { subject }.to(change { user.reload.first_name }.to(first_name))
+      end
+
+      it "Sets the users last name" do
+        expect { subject }.to(change { user.reload.last_name }.to(last_name))
+      end
     end
 
     context "with a valid DfE-SignIn ID but invalid email" do
@@ -105,6 +120,22 @@ describe AuthenticationService do
 
       it "does not authenticate the user based on a nil match" do
         expect(subject).not_to eq user
+      end
+    end
+
+    context "When the first name is nil" do
+      let(:first_name) { nil }
+
+      it "does not set the first name to nil" do
+        expect { subject }.not_to(change { user.reload.first_name })
+      end
+    end
+
+    context "When the last name is nil" do
+      let(:last_name) { nil }
+
+      it "does not set the last name to nil" do
+        expect { subject }.not_to(change { user.reload.last_name })
       end
     end
   end


### PR DESCRIPTION
### Context

We don't set the users first/last name from DfE SignIn

### Changes proposed in this pull request

Set the first/last name based on the token sent from the frontend

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
