### PR TITLE
[1809] Withdraw course updates

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -106,9 +106,9 @@ module API
       def withdraw
         authorize @course
         if @course.is_published?
-          raise RuntimeError.new("This course has not been published and should be deleted not withdrawn")
-        else
           @course.withdraw
+        else
+          raise RuntimeError.new("This course has not been published and should be deleted not withdrawn")
         end
       end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -455,7 +455,7 @@ class Course < ApplicationRecord
   end
 
   def withdraw
-    if !is_published?
+    if is_published?
       site_statuses.each do |site_status|
         site_status.update(vac_status: :no_vacancies, status: :suspended)
       end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -293,6 +293,8 @@ class Course < ApplicationRecord
       end
     elsif newest_enrichment.published?
       :published
+    elsif newest_enrichment.withdrawn?
+      :withdrawn
     elsif newest_enrichment.has_been_published_before?
       :published_with_unpublished_changes
     elsif newest_enrichment.rolled_over?
@@ -459,12 +461,19 @@ class Course < ApplicationRecord
       site_statuses.each do |site_status|
         site_status.update(vac_status: :no_vacancies, status: :suspended)
       end
+
+      withdraw_latest_enrichment
     else
       errors.add(:withdraw, "Courses that have not been published should be deleted not withdrawn")
     end
   end
 
 private
+
+  def withdraw_latest_enrichment
+    newest_enrichment = enrichments.latest_first.first
+    newest_enrichment.withdraw
+  end
 
   def assignable_after_publish(course_params)
     relevant_params = course_params.slice(:is_send, :applications_open_from, :application_start_date)

--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -18,7 +18,7 @@
 class CourseEnrichment < ApplicationRecord
   include TouchCourse
   before_create :set_defaults
-  enum status: %i[draft published rolled_over]
+  enum status: %i[draft published rolled_over withdrawn]
 
   jsonb_accessor :json_data,
                  about_course: [:string, store_key: "AboutCourse"],
@@ -113,6 +113,10 @@ class CourseEnrichment < ApplicationRecord
     data = { status: :draft }
     data[:last_published_timestamp_utc] = nil if initial_draft
     update(data)
+  end
+
+  def withdraw
+    update(status: "withdrawn")
   end
 
 private

--- a/spec/factories/course_enrichments.rb
+++ b/spec/factories/course_enrichments.rb
@@ -100,6 +100,11 @@ FactoryBot.define do
     last_published_timestamp_utc { 5.days.ago }
   end
 
+  trait :withdrawn do
+    status { :withdrawn }
+    last_published_timestamp_utc { 5.days.ago }
+  end
+
   trait :subsequent_draft do
     status { :draft }
     last_published_timestamp_utc { 5.days.ago }

--- a/spec/models/course/withdraw_spec.rb
+++ b/spec/models/course/withdraw_spec.rb
@@ -12,11 +12,19 @@ describe Course, type: :model do
       course.withdraw
     end
 
-    context "an published course" do
+    context "a published course" do
       let(:enrichment) { build(:course_enrichment, :published) }
 
       it "should not be findable" do
-        expect(course.findable?).to be_falsey
+        expect(course.findable?).to eq(false)
+      end
+
+      it "should not be published" do
+        expect(course.is_published?).to eq(false)
+      end
+
+      it "should not be syncable" do
+        expect(course.syncable?).to eq(false)
       end
 
       it "should have updated the courses site statuses to be suspended and have no vacancies" do
@@ -26,6 +34,10 @@ describe Course, type: :model do
         expect(site_status2.status).to eq("suspended")
         expect(site_status3.vac_status).to eq("no_vacancies")
         expect(site_status3.status).to eq("suspended")
+      end
+
+      it "should have a content_status of withdrawn" do
+        expect(course.content_status).to eq(:withdrawn)
       end
     end
 

--- a/spec/models/course/withdraw_spec.rb
+++ b/spec/models/course/withdraw_spec.rb
@@ -12,7 +12,9 @@ describe Course, type: :model do
       course.withdraw
     end
 
-    context "an unpublished course" do
+    context "an published course" do
+      let(:enrichment) { build(:course_enrichment, :published) }
+
       it "should not be findable" do
         expect(course.findable?).to be_falsey
       end
@@ -27,9 +29,7 @@ describe Course, type: :model do
       end
     end
 
-    context "a published course" do
-      let(:enrichment) { build(:course_enrichment, :published) }
-
+    context "an unpublished course" do
       it "should not have updated the courses site statuses or vac status" do
         expect(site_status1.vac_status).to eq("full_time_vacancies")
         expect(site_status1.status).to eq("running")

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -333,4 +333,14 @@ describe CourseEnrichment, type: :model do
       end
     end
   end
+
+  describe "#withdraw" do
+    let(:enrichment) { create(:course_enrichment, :published) }
+
+    it "sets the status to withdrawn" do
+      enrichment.withdraw
+
+      expect(enrichment.status).to eq("withdrawn")
+    end
+  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -653,6 +653,14 @@ describe Course, type: :model do
 
       it { should eq :rolled_over }
     end
+
+    context "When the enrichments are withdrawn" do
+      let(:enrichment) { create :course_enrichment, status: :withdrawn }
+
+      it "should have a content status of withdrawn" do
+        expect(course.content_status).to eq(:withdrawn)
+      end
+    end
   end
 
   describe "qualifications" do
@@ -1277,6 +1285,16 @@ describe Course, type: :model do
       it "returns true" do
         expect(course.content_status).to eq(:published_with_unpublished_changes)
         expect(course.is_published?).to eq(true)
+      end
+    end
+
+    context "course is withdrawn" do
+      let(:enrichment) { create(:course_enrichment, :withdrawn) }
+      let(:course) { create(:course, enrichments: [enrichment]) }
+
+      it "returns false" do
+        expect(course.content_status).to eq(:withdrawn)
+        expect(course.is_published?).to eq(false)
       end
     end
   end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -479,20 +479,20 @@ describe "Courses API v2", type: :request do
     end
 
     subject do
-      post path, headers: { "HTTP_AUTHORIZATION" => credentials }
+      post_withdraw
       response
     end
 
     include_examples "Unauthenticated, unauthorised, or not accepted T&Cs"
 
-    context "when the course has not been published" do
-      before do
-        post_withdraw
-      end
+    context "when the course has been published" do
+      let(:enrichment) { build(:course_enrichment, :published) }
 
       it { should have_http_status(:success) }
 
       it "should have updated the courses site statuses to be suspended and have no vacancies" do
+        post_withdraw
+
         expect(site_status1.reload.vac_status).to eq("no_vacancies")
         expect(site_status1.reload.status).to eq("suspended")
         expect(site_status2.reload.vac_status).to eq("no_vacancies")
@@ -502,12 +502,14 @@ describe "Courses API v2", type: :request do
       end
 
       it "should no longer be findable" do
+        post_withdraw
+
         expect(course.reload.findable?).to be_falsey
       end
     end
 
     context "when the course has not been published" do
-      let(:enrichment) { build(:course_enrichment, :published) }
+      let(:enrichment) { build(:course_enrichment) }
 
       it "should raise an error" do
         expect { post_withdraw }.to raise_error("This course has not been published and should be deleted not withdrawn")


### PR DESCRIPTION
### Context

The withdraw course check had it's if condition backwards, this needed to be flipped.

Additionally, we needed to update the `content_status` to `withdrawn` so the frontend could respond appropriately

### Changes proposed in this pull request
- Flip the check
- Edit the content status

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x]  Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
