### PR TITLE
[2292] Add foreign key to contact.provider_id

### DIFF
--- a/db/migrate/20191004152235_add_contact_provider_fk.rb
+++ b/db/migrate/20191004152235_add_contact_provider_fk.rb
@@ -1,5 +1,5 @@
 class AddContactProviderFk < ActiveRecord::Migration[6.0]
   def change
-    add_foreign_key :contact, :provider
+    add_foreign_key :contact, :provider, name: "fk_contact_provider"
   end
 end

--- a/db/migrate/20191004152235_add_contact_provider_fk.rb
+++ b/db/migrate/20191004152235_add_contact_provider_fk.rb
@@ -1,0 +1,5 @@
+class AddContactProviderFk < ActiveRecord::Migration[6.0]
+  def change
+    add_foreign_key :contact, :provider
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_01_124753) do
+ActiveRecord::Schema.define(version: 2019_10_04_152235) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -311,6 +311,7 @@ ActiveRecord::Schema.define(version: 2019_10_01_124753) do
   end
 
   add_foreign_key "access_request", "\"user\"", column: "requester_id", name: "FK_access_request_user_requester_id", on_delete: :nullify
+  add_foreign_key "contact", "provider"
   add_foreign_key "course", "provider", column: "accrediting_provider_id", name: "FK_course_provider_accrediting_provider_id"
   add_foreign_key "course", "provider", name: "FK_course_provider_provider_id", on_delete: :cascade
   add_foreign_key "course_enrichment", "\"user\"", column: "created_by_user_id", name: "FK_course_enrichment_user_created_by_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -311,7 +311,7 @@ ActiveRecord::Schema.define(version: 2019_10_04_152235) do
   end
 
   add_foreign_key "access_request", "\"user\"", column: "requester_id", name: "FK_access_request_user_requester_id", on_delete: :nullify
-  add_foreign_key "contact", "provider"
+  add_foreign_key "contact", "provider", name: "fk_contact_provider"
   add_foreign_key "course", "provider", column: "accrediting_provider_id", name: "FK_course_provider_accrediting_provider_id"
   add_foreign_key "course", "provider", name: "FK_course_provider_provider_id", on_delete: :cascade
   add_foreign_key "course_enrichment", "\"user\"", column: "created_by_user_id", name: "FK_course_enrichment_user_created_by_user_id"


### PR DESCRIPTION
### Context

Noticed when testing v1 api, looking at data with https://schemaexplorer.io/

#### before

![Selection_084](https://user-images.githubusercontent.com/19378/66220697-62150000-e6c5-11e9-9333-44eec99a425b.png)

#### after


![Selection_085](https://user-images.githubusercontent.com/19378/66220750-7b1db100-e6c5-11e9-8e0c-669a81644fb1.png)

### Changes proposed in this pull request

### Guidance to review

```
psql (10.10 (Ubuntu 10.10-0ubuntu0.18.04.1))
Type "help" for help.

manage_courses_backend_development=# \d contact
                                         Table "public.contact"
   Column    |            Type             | Collation | Nullable |               Default               
-------------+-----------------------------+-----------+----------+-------------------------------------
 id          | bigint                      |           | not null | nextval('contact_id_seq'::regclass)
 provider_id | integer                     |           | not null | 
 type        | text                        |           | not null | 
 name        | text                        |           |          | 
 email       | text                        |           |          | 
 telephone   | text                        |           |          | 
 created_at  | timestamp without time zone |           | not null | 
 updated_at  | timestamp without time zone |           | not null | 
Indexes:
    "contact_pkey" PRIMARY KEY, btree (id)
    "index_contact_on_provider_id_and_type" UNIQUE, btree (provider_id, type)
    "index_contact_on_provider_id" btree (provider_id)
Foreign-key constraints:
    "fk_contact_provider" FOREIGN KEY (provider_id) REFERENCES provider(id)
```

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally