### PR TITLE
[2290] Fixed provider enrichments to use updated_at

### DIFF
--- a/app/serializers/search_and_compare/course_serializer.rb
+++ b/app/serializers/search_and_compare/course_serializer.rb
@@ -152,7 +152,7 @@ module SearchAndCompare
     def provider_enrichment
       @provider_enrichment ||= object.provider
                                  .enrichments
-                                 .max_by(&:last_published_at)
+                                 .max_by(&:updated_at)
     end
 
     def course_enrichment

--- a/spec/serializers/search_and_compare/course_serializer_spec.rb
+++ b/spec/serializers/search_and_compare/course_serializer_spec.rb
@@ -377,6 +377,54 @@ describe SearchAndCompare::CourseSerializer do
         include_examples "mapped the description section", "about this training provider accrediting", "accrediting_provider_enrichment_description"
         include_examples "mapped the description section", "training with disabilities", "train_with_disability"
 
+        context "provider has draft and published enrichments with identical last_published_at" do
+          let(:last_published_at) do
+            1.day.ago
+          end
+
+          let(:published_provider_enrichment) do
+            build :provider_enrichment, :published,
+                  last_published_at: last_published_at,
+                  address1: "c/o Claverdon Primary School",
+                  address2: "Breach Lane",
+                  address3: "Claverdon",
+                  address4: "Warwick",
+                  postcode: "CV35 8QA",
+                  telephone: "02476 347697",
+                  email: "info@gatewayalliance.co.uk",
+                  website: "http://www.gatewayalliance.co.uk",
+
+                  # DescriptionSections_Mapping section
+                  train_with_us: "train_with_us",
+                  train_with_disability: "train_with_disability",
+                  accrediting_provider_enrichments: [accrediting_provider_enrichment]
+          end
+
+          let(:draft_provider_enrichment) do
+            build :provider_enrichment, :subsequent_draft,
+                  last_published_at: last_published_at,
+                  address1: "draft_c/o Claverdon Primary School",
+                  address2: "draft_Breach Lane",
+                  address3: "draft_Claverdon",
+                  address4: "draft_Warwick",
+                  postcode: "draft_CV35 8QA",
+                  telephone: "000 000000",
+                  email: "draft_info@gatewayalliance.co.uk",
+                  website: "http://draft.co.uk",
+
+                  # DescriptionSections_Mapping section
+                  train_with_us: " draft train_with_us",
+                  train_with_disability: " draft train_with_disability",
+                  accrediting_provider_enrichments: []
+          end
+
+          let(:provider_enrichments) { [draft_provider_enrichment, published_provider_enrichment] }
+
+          include_examples "mapped the description section", "about this training provider", "train_with_us"
+          include_examples "mapped the description section", "about this training provider accrediting", "accrediting_provider_enrichment_description"
+          include_examples "mapped the description section", "training with disabilities", "train_with_disability"
+        end
+
         context "no published provider enrichment" do
           let(:provider_enrichments) { [] }
 


### PR DESCRIPTION
### Context
Provider enrichments was getting non deterministic draft vs published content becoming bulk pub

### Changes proposed in this pull request
Changed to use updated_at

### Guidance to review
:ship: 
paired with @misaka 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
