### PR TITLE
[2299] Set secondary science requirements to not_set

### DIFF
--- a/db/migrate/20191007103707_fix_secondary_science_course_requirements.rb
+++ b/db/migrate/20191007103707_fix_secondary_science_course_requirements.rb
@@ -2,9 +2,7 @@ class FixSecondaryScienceCourseRequirements < ActiveRecord::Migration[6.0]
   def up
     # There is no requirement for Science for secondary courses
     say_with_time "setting secondary science course requirements to not_set" do
-      Course.select { |course| course.level == "secondary" && !course.science.nil? }.each do |course|
-        course.update_attribute("science", nil)
-      end
+      Course.where(level: "secondary").where.not(science: nil).update_all(science: nil)
     end
   end
 end

--- a/db/migrate/20191007103707_fix_secondary_science_course_requirements.rb
+++ b/db/migrate/20191007103707_fix_secondary_science_course_requirements.rb
@@ -1,0 +1,10 @@
+class FixSecondaryScienceCourseRequirements < ActiveRecord::Migration[6.0]
+  def up
+    # There is no requirement for Science for secondary courses
+    say_with_time "setting secondary science course requirements to not_set" do
+      Course.select { |course| course.level == "secondary" && !course.science.nil? }.each do |course|
+        course.update(science: nil)
+      end
+    end
+  end
+end

--- a/db/migrate/20191007103707_fix_secondary_science_course_requirements.rb
+++ b/db/migrate/20191007103707_fix_secondary_science_course_requirements.rb
@@ -3,7 +3,7 @@ class FixSecondaryScienceCourseRequirements < ActiveRecord::Migration[6.0]
     # There is no requirement for Science for secondary courses
     say_with_time "setting secondary science course requirements to not_set" do
       Course.select { |course| course.level == "secondary" && !course.science.nil? }.each do |course|
-        course.update(science: nil)
+        course.update_attribute("science", nil)
       end
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_04_162845) do
+ActiveRecord::Schema.define(version: 2019_10_07_103707) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"


### PR DESCRIPTION
### Context

Similar to https://github.com/DFE-Digital/manage-courses-backend/pull/640

There are no minimum GCSE requirements for science in secondary courses. Most are set to nil, set everything else to nil too (ie not set).

We've already removed the ability to edit these codes in frontend.

### Changes proposed in this pull request

Set any non nil secondary course science requirement to nil (eg :not_set – but nil enums behave weirdly, so using nil explicitly)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
