### PR TITLE
[2295] Disable v1 API for 2019 courses

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -2,10 +2,25 @@ module API
   module V1
     class ApplicationController < ::ApplicationController
       before_action -> { skip_authorization }
+      before_action :check_recruitment_cycle_is_current_or_next_year
 
       def authenticate
         authenticate_or_request_with_http_token do |token|
           ActiveSupport::SecurityUtils.secure_compare(token, Rails.application.config.authentication_token)
+        end
+      end
+
+      def check_recruitment_cycle_is_current_or_next_year
+        current_year = Settings.current_recruitment_cycle_year
+        next_year = current_year + 1
+
+        requested_year = params[:recruitment_year]
+        is_next_or_current_year = [current_year, next_year]
+          .map(&:to_s)
+          .include?(requested_year)
+
+        unless requested_year.nil? || is_next_or_current_year
+          render json: { status: 400, message: "The specified recruitment cycle is not the current year, please use ?recruitment_year=#{current_year}" }.to_json, status: :bad_request
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,7 +87,7 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      scope "/(:recruitment_year)" do
+      scope "/(:recruitment_year)", constraints: { recruitment_year: /2020|2021/ } do
         resources :providers
         resources :subjects
         resources :courses


### PR DESCRIPTION
### Context

We want to ensure that UCAS can't access stale date, so it makes sense to make the old data 404.

### Changes proposed in this pull request

Adds a `constraints` option to the route that I've stolen from Frontend, plus checks the query string param.

### Guidance to review

UCAS can request by either specifying the param in the URL or as a query string parameter.

Have tested this locally and it seems to work fine, plus we have good test coverage.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally