### PR TITLE
Remove subject code from subject `to_s`

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -18,6 +18,6 @@ class Subject < ApplicationRecord
   end
 
   def to_s
-    "#{subject_name} (#{subject_code})"
+    subject_name
   end
 end

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -15,7 +15,7 @@ describe Subject, type: :model do
 
   it { should have_many(:courses).through(:course_subjects) }
   its(:to_sym) { should eq(:modern_languages_other) }
-  its(:to_s) { should eq("Modern languages (other) (101)") }
+  its(:to_s) { should eq("Modern languages (other)") }
 
   it "can get a financial incentive" do
     financial_incentive = create(:financial_incentive, subject: subject)


### PR DESCRIPTION
Avoid confusion when choosing subjects during course editing and creation in MCB.

Consider:
`9. [ ] Computing (11)`

If a user types 11, the course has the wrong subject assigned.

### Before
```
1. continue
2. [ ] Art and design (W1)
3. [ ] Biology (C1)
4. [ ] Business studies (08)
5. [ ] Chemistry (F1)
6. [ ] Citizenship (09)
7. [ ] Classics (Q8)
8. [ ] Communication and media studies (P3)
9. [ ] Computing (11)
10. [ ] Dance (12)
11. [ ] Design and technology (DT)
12. [ ] Drama (13)
13. [ ] Economics (L1)
14. [ ] English (Q3)
15. [ ] English as a second or other language (16)
16. [ ] French (15)
17. [ ] Geography (F8)
18. [ ] German (17)
19. [ ] Health and social care (L5)
20. [ ] History (V1)
21. [ ] Italian (18)
22. [ ] Japanese (19)
23. [ ] Mandarin (20)
24. [x] Mathematics (G1)
25. [ ] Modern languages (other) (24)
26. [ ] Music (W3)
27. [ ] Philosophy (P1)
28. [ ] Physical education (C6)
29. [ ] Physics (F3)
30. [ ] Psychology (C8)
31. [ ] Religious education (V6)
32. [ ] Russian (21)
33. [ ] Science (F0)
34. [ ] Social sciences (14)
35. [ ] Spanish (22)
```

### After
```1. continue
2. [ ] Art and design
3. [ ] Biology
4. [ ] Business studies
5. [ ] Chemistry
6. [ ] Citizenship
7. [ ] Classics
8. [ ] Communication and media studies
9. [ ] Computing
10. [ ] Dance
11. [ ] Design and technology
12. [ ] Drama
13. [ ] Economics
14. [ ] English
15. [ ] English as a second or other language
16. [ ] French
17. [ ] Geography
18. [ ] German
19. [ ] Health and social care
20. [ ] History
21. [ ] Italian
22. [ ] Japanese
23. [ ] Mandarin
24. [x] Mathematics
25. [ ] Modern languages (other)
26. [ ] Music
27. [ ] Philosophy
28. [ ] Physical education
29. [ ] Physics
30. [ ] Psychology
31. [ ] Religious education
32. [ ] Russian
33. [ ] Science
34. [ ] Social sciences
35. [ ] Spanish
```