### PR TITLE
[2303] Add migration to mark manually withdrawn courses as withdrawn

### DIFF
--- a/db/migrate/20191007125535_mark_withdrawn_courses_as_withdrawn.rb
+++ b/db/migrate/20191007125535_mark_withdrawn_courses_as_withdrawn.rb
@@ -1,0 +1,19 @@
+class MarkWithdrawnCoursesAsWithdrawn < ActiveRecord::Migration[6.0]
+  def up
+    say_with_time "Marking all courses with site statuses that have been suspended with no vacancies" do
+      courses = Course.where(site_statuses: SiteStatus.where(vac_status: "no_vacancies", status: "suspended"))
+      published_courses = courses.select(&:is_published?)
+      courses_with_all_suspended_no_vacancy_sites = published_courses.select do |course|
+        course.site_statuses.all? do |site_status|
+          site_status.vac_status == "no_vacancies" && site_status.status == "suspended"
+        end
+      end
+
+      courses_with_all_suspended_no_vacancy_sites.each do |course|
+        course.enrichments.latest_first.first.withdraw
+      end
+    end
+  end
+
+  def down; end
+end


### PR DESCRIPTION
### Context

Before the "withdrawn" content status existed, we withdraw courses manually. This updates those withdrawn in that way to fix the content status

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
