### PR TITLE
[2229] Withdraw courses mcb command

### DIFF
--- a/lib/mcb/commands/providers/withdraw_courses.rb
+++ b/lib/mcb/commands/providers/withdraw_courses.rb
@@ -1,5 +1,5 @@
 summary "Withdraw courses for a pre determined list of providers"
-usage "withdraw_courses <provider code1> [provider code2] ...""
+usage "withdraw_courses <provider code1> [provider code2] ..."
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)

--- a/lib/mcb/commands/providers/withdraw_courses.rb
+++ b/lib/mcb/commands/providers/withdraw_courses.rb
@@ -1,0 +1,25 @@
+summary "Withdraw courses for a pre determined list of providers"
+usage "withdraw_courses"
+
+run do |opts, args, _cmd|
+  MCB.init_rails(opts)
+  providers = RecruitmentCycle.find_by(year: '2020').providers.where(provider_code: ['1XN',
+                                                                      '1KM',
+                                                                      '156',
+                                                                      '1PG',
+                                                                      '2BG',
+                                                                      '1OZ',
+                                                                      '2JS',
+                                                                      '1SC',
+                                                                      '169',
+                                                                      '19W',
+                                                                      '1DF',
+                                                                      '2LQ',
+                                                                      '2LL'])
+
+  providers.each do |provider|
+    provider.courses.each do |course|
+      course.withdraw
+    end
+  end
+end

--- a/lib/mcb/commands/providers/withdraw_courses.rb
+++ b/lib/mcb/commands/providers/withdraw_courses.rb
@@ -1,25 +1,11 @@
 summary "Withdraw courses for a pre determined list of providers"
-usage "withdraw_courses"
+usage "withdraw_courses <provider code1> [provider code2] ...""
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
-  providers = RecruitmentCycle.find_by(year: '2020').providers.where(provider_code: ['1XN',
-                                                                      '1KM',
-                                                                      '156',
-                                                                      '1PG',
-                                                                      '2BG',
-                                                                      '1OZ',
-                                                                      '2JS',
-                                                                      '1SC',
-                                                                      '169',
-                                                                      '19W',
-                                                                      '1DF',
-                                                                      '2LQ',
-                                                                      '2LL'])
-
-  providers.each do |provider|
-    provider.courses.each do |course|
-      course.withdraw
-    end
+  current_cycle = RecruitmentCycle.current
+  args.each do |provider_code|
+    provider = current_cycle.providers.find_by!(provider_code: provider_code.upcase)
+    provider.courses.each(&:withdraw)
   end
 end

--- a/spec/lib/mcb/commands/providers/withdraw_courses.rb
+++ b/spec/lib/mcb/commands/providers/withdraw_courses.rb
@@ -1,0 +1,34 @@
+require "mcb_helper"
+
+describe "mcb providers touch" do
+  def execute_withdraw_courses
+    $mcb.run(["providers", "withdraw_courses"])
+  end
+  let(:current_cycle) { find_or_create :recruitment_cycle }
+  let(:provider) { create(:provider, provider_code: '1XN', courses: [course, course2], sites: [site], recruitment_cycle: current_cycle) }
+  let(:course)  { build(:course, site_statuses: [site_status]) }
+  let(:course2)  { build(:course, site_statuses: [site_status2]) }
+  let(:site) { build(:site) }
+  let(:site_status) { build(:site_status, :published, :full_time_vacancies, site: site) }
+  let(:site_status2) { build(:site_status, :published, :full_time_vacancies, site: site) }
+
+  let(:provider2) { create(:provider, provider_code: '1KM', courses: [course3, course4], sites: [site2], recruitment_cycle: current_cycle) }
+  let(:course3)  { build(:course, site_statuses: [site_status3]) }
+  let(:course4)  { build(:course, site_statuses: [site_status4]) }
+  let(:site2) { build(:site) }
+  let(:site_status3) { build(:site_status, :published, :full_time_vacancies, site: site2) }
+  let(:site_status4) { build(:site_status, :published, :full_time_vacancies, site: site2) }
+
+
+  it "makes the providers coursesfor the current cycle non-findable" do
+    provider
+    provider2
+
+    execute_withdraw_courses
+
+    expect(course.reload.findable?).to eq false
+    expect(course2.reload.findable?).to eq false
+    expect(course3.reload.findable?).to eq false
+    expect(course4.reload.findable?).to eq false
+  end
+end

--- a/spec/lib/mcb/commands/providers/withdraw_courses_spec.rb
+++ b/spec/lib/mcb/commands/providers/withdraw_courses_spec.rb
@@ -1,18 +1,19 @@
 require "mcb_helper"
 
-describe "mcb providers touch" do
-  def execute_withdraw_courses
-    $mcb.run(["providers", "withdraw_courses"])
+describe "mcb providers withdraw_courses" do
+  def execute_withdraw_courses(arguments: [])
+    $mcb.run(["providers", "withdraw_courses", *arguments])
   end
+
   let(:current_cycle) { find_or_create :recruitment_cycle }
-  let(:provider) { create(:provider, provider_code: '1XN', courses: [course, course2], sites: [site], recruitment_cycle: current_cycle) }
-  let(:course)  { build(:course, site_statuses: [site_status]) }
-  let(:course2)  { build(:course, site_statuses: [site_status2]) }
+  let(:provider) { create(:provider, courses: [course, course2], sites: [site], recruitment_cycle: current_cycle) }
+  let(:course) { build(:course, site_statuses: [site_status]) }
+  let(:course2) { build(:course, site_statuses: [site_status2]) }
   let(:site) { build(:site) }
   let(:site_status) { build(:site_status, :published, :full_time_vacancies, site: site) }
   let(:site_status2) { build(:site_status, :published, :full_time_vacancies, site: site) }
 
-  let(:provider2) { create(:provider, provider_code: '1KM', courses: [course3, course4], sites: [site2], recruitment_cycle: current_cycle) }
+  let(:provider2) { create(:provider, courses: [course3, course4], sites: [site2], recruitment_cycle: current_cycle) }
   let(:course3)  { build(:course, site_statuses: [site_status3]) }
   let(:course4)  { build(:course, site_statuses: [site_status4]) }
   let(:site2) { build(:site) }
@@ -20,11 +21,10 @@ describe "mcb providers touch" do
   let(:site_status4) { build(:site_status, :published, :full_time_vacancies, site: site2) }
 
 
-  it "makes the providers coursesfor the current cycle non-findable" do
+  it "withdraws the providers courses for the current cycle" do
     provider
     provider2
-
-    execute_withdraw_courses
+    execute_withdraw_courses(arguments: [provider.provider_code, provider2.provider_code])
 
     expect(course.reload.findable?).to eq false
     expect(course2.reload.findable?).to eq false

--- a/spec/lib/mcb/commands/providers/withdraw_courses_spec.rb
+++ b/spec/lib/mcb/commands/providers/withdraw_courses_spec.rb
@@ -7,15 +7,19 @@ describe "mcb providers withdraw_courses" do
 
   let(:current_cycle) { find_or_create :recruitment_cycle }
   let(:provider) { create(:provider, courses: [course, course2], sites: [site], recruitment_cycle: current_cycle) }
-  let(:course) { build(:course, site_statuses: [site_status]) }
-  let(:course2) { build(:course, site_statuses: [site_status2]) }
+  let(:course) { build(:course, site_statuses: [site_status], enrichments: [enrichment]) }
+  let(:course2) { build(:course, site_statuses: [site_status2], enrichments: [enrichment2]) }
+  let(:enrichment) { build(:course_enrichment, :published) }
+  let(:enrichment2) { build(:course_enrichment, :published) }
   let(:site) { build(:site) }
   let(:site_status) { build(:site_status, :published, :full_time_vacancies, site: site) }
   let(:site_status2) { build(:site_status, :published, :full_time_vacancies, site: site) }
 
   let(:provider2) { create(:provider, courses: [course3, course4], sites: [site2], recruitment_cycle: current_cycle) }
-  let(:course3)  { build(:course, site_statuses: [site_status3]) }
-  let(:course4)  { build(:course, site_statuses: [site_status4]) }
+  let(:course3)  { build(:course, site_statuses: [site_status3], enrichments: [enrichment3]) }
+  let(:course4)  { build(:course, site_statuses: [site_status4], enrichments: [enrichment4]) }
+  let(:enrichment3) { build(:course_enrichment, :published) }
+  let(:enrichment4) { build(:course_enrichment, :published) }
   let(:site2) { build(:site) }
   let(:site_status3) { build(:site_status, :published, :full_time_vacancies, site: site2) }
   let(:site_status4) { build(:site_status, :published, :full_time_vacancies, site: site2) }


### PR DESCRIPTION
### Context

We need to be able to withdraw a provider's courses from find if they are no longer eligible to run teacher training.

### Changes proposed in this pull request
- Add an mcb command to remove a (or multiple) providers courses.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
