### PR TITLE
[2305] Dont call update when updating funding type

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -433,20 +433,20 @@ class Course < ApplicationRecord
     case funding_type
     when "salary"
       if !self_accredited?
-        update(program_type: :school_direct_salaried_training_programme)
+        self.program_type = :school_direct_salaried_training_programme
       else
         errors.add(:program_type, "Salary is not valid for a self accredited course")
       end
     when "apprenticeship"
-      update(program_type: :pg_teaching_apprenticeship)
+      self.program_type = :pg_teaching_apprenticeship
     when "fee"
-      if !self_accredited?
-        update(program_type: :school_direct_training_programme)
-      elsif provider.scitt?
-        update(program_type: :scitt_programme)
-      else
-        update(program_type: :higher_education_programme)
-      end
+      self.program_type = if !self_accredited?
+                            :school_direct_training_programme
+                          elsif provider.scitt?
+                            :scitt_programme
+                          else
+                            :higher_education_programme
+                          end
     end
   end
 

--- a/spec/models/course/funding_type_spec.rb
+++ b/spec/models/course/funding_type_spec.rb
@@ -1,5 +1,15 @@
 RSpec.describe Course, type: :model do
   describe "#funding_type" do
+    describe "self accredited salary" do
+      let(:provider) { create(:provider) }
+      let(:course) { create(:course, provider: provider) }
+
+      it "adds an error" do
+        course.funding_type = "salary"
+        expect(course.errors.messages[:program_type]).to eq(["Salary is not valid for a self accredited course"])
+      end
+    end
+
     describe "higher education programme" do
       subject { create(:course, :with_higher_education) }
 


### PR DESCRIPTION
### Context

When creating courses - the `funding_type` attribute gets set. This can cause 500s due to an override on `funding_type=` calling update, triggering validations which attempt to validate nil data

### Changes proposed in this pull request
Set the value rather than calling update when setting funding type

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
