### PR TITLE
2289 sync courses when saving provider

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -35,7 +35,7 @@ module API
         update_ucas_preferences
 
         if @provider.valid?
-          courses_synced?(@provider.syncable_courses) if @recruitment_cycle.current?
+          courses_synced?(@provider.syncable_courses) if @recruitment_cycle.current? && @provider.syncable_courses.present?
           render jsonapi: @provider.reload, include: params[:include]
         else
           render jsonapi_errors: @provider.errors, status: :unprocessable_entity, include: params[:include]

--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -35,6 +35,7 @@ module API
         update_ucas_preferences
 
         if @provider.valid?
+          courses_synced?(@provider.syncable_courses) if @recruitment_cycle.current?
           render jsonapi: @provider.reload, include: params[:include]
         else
           render jsonapi_errors: @provider.errors, status: :unprocessable_entity, include: params[:include]

--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -36,6 +36,7 @@ module API
 
         if @provider.valid?
           courses_synced?(@provider.syncable_courses) if @recruitment_cycle.current? && @provider.syncable_courses.present?
+
           render jsonapi: @provider.reload, include: params[:include]
         else
           render jsonapi_errors: @provider.errors, status: :unprocessable_entity, include: params[:include]

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -77,5 +77,9 @@ FactoryBot.define do
     trait :discarded do
       discarded_at { Time.now.utc }
     end
+
+    trait :previous_recruitment_cycle do
+      recruitment_cycle { find_or_create :recruitment_cycle, :previous }
+    end
   end
 end

--- a/spec/requests/api/v2/providers/update_spec.rb
+++ b/spec/requests/api/v2/providers/update_spec.rb
@@ -398,6 +398,25 @@ describe "PATCH /providers/:provider_code" do
         end
       end
     end
+
+    let(:sync_body) do
+      include(
+        "\"ProgrammeCode\":\"#{course1.course_code}\"",
+        "\"ProgrammeCode\":\"#{course2.course_code}\"",
+      )
+    end
+
+    it "syncs the course to search-and-compare" do
+      sync_stub = stub_request(:put, %r{#{Settings.search_api.base_url}/api/courses/})
+                    .with(body: sync_body)
+                    .to_return(
+                      status: search_api_status,
+                    )
+
+      perform_request update_provider
+
+      expect(sync_stub).to have_been_requested
+    end
   end
 
   describe "from published to draft" do

--- a/spec/requests/api/v2/providers/update_spec.rb
+++ b/spec/requests/api/v2/providers/update_spec.rb
@@ -1,5 +1,6 @@
 require "rails_helper"
 
+# NOTE: given up provider and site and courses needs to be PROPERLY associated
 describe "PATCH /providers/:provider_code" do
   let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
   let(:request_path) do
@@ -81,6 +82,18 @@ describe "PATCH /providers/:provider_code" do
       train_with_disability
     ]
   end
+
+  # it "syncs the course to search-and-compare" do
+  #   sync_stub = stub_request(:put, %r{#{Settings.search_api.base_url}/api/courses/})
+  #                 .with(body: sync_body)
+  #                 .to_return(
+  #                   status: search_api_status,
+  #                 )
+
+  #   perform_request update_provider
+
+  #   expect(sync_stub).to have_been_requested
+  # end
 
   describe "with unpermitted attributes on provider object" do
     shared_examples "does not allow assignment" do |attribute, value|
@@ -404,18 +417,6 @@ describe "PATCH /providers/:provider_code" do
         "\"ProgrammeCode\":\"#{course1.course_code}\"",
         "\"ProgrammeCode\":\"#{course2.course_code}\"",
       )
-    end
-
-    it "syncs the course to search-and-compare" do
-      sync_stub = stub_request(:put, %r{#{Settings.search_api.base_url}/api/courses/})
-                    .with(body: sync_body)
-                    .to_return(
-                      status: search_api_status,
-                    )
-
-      perform_request update_provider
-
-      expect(sync_stub).to have_been_requested
     end
   end
 

--- a/spec/requests/api/v2/providers/update_spec.rb
+++ b/spec/requests/api/v2/providers/update_spec.rb
@@ -1,6 +1,5 @@
 require "rails_helper"
 
-# NOTE: given up provider and site and courses needs to be PROPERLY associated
 describe "PATCH /providers/:provider_code" do
   let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
   let(:request_path) do
@@ -23,21 +22,27 @@ describe "PATCH /providers/:provider_code" do
       jsonapi_data.dig(:data, :attributes).merge!(enrichment_data)
     end
 
-    patch request_path,
-          headers: { "HTTP_AUTHORIZATION" => credentials },
-          params: {
-            _jsonapi: jsonapi_data,
-            include: "latest_enrichment",
-          }
+    perform_enqueued_jobs do
+      patch request_path,
+            headers: { "HTTP_AUTHORIZATION" => credentials },
+            params: {
+              _jsonapi: jsonapi_data,
+              include: "latest_enrichment",
+            }
+    end
   end
 
   let(:recruitment_cycle) { find_or_create :recruitment_cycle }
   let(:organisation) { create :organisation }
+  let(:site1) { build(:site_status, :findable) }
+  let(:course1) { build(:course, site_statuses: [site1], subjects: [dfe_subject]) }
+  let!(:dfe_subject) { build(:subject, :primary) }
   let(:provider)     do
     create :provider,
            organisations: [organisation],
            recruitment_cycle: recruitment_cycle,
-           enrichments: enrichments
+           enrichments: enrichments,
+           courses: [course1]
   end
   let(:user)         { create :user, organisations: [organisation] }
   let(:payload)      { { email: user.email } }
@@ -83,17 +88,15 @@ describe "PATCH /providers/:provider_code" do
     ]
   end
 
-  # it "syncs the course to search-and-compare" do
-  #   sync_stub = stub_request(:put, %r{#{Settings.search_api.base_url}/api/courses/})
-  #                 .with(body: sync_body)
-  #                 .to_return(
-  #                   status: search_api_status,
-  #                 )
-
-  #   perform_request update_provider
-
-  #   expect(sync_stub).to have_been_requested
-  # end
+  let(:search_api_status) { 200 }
+  let(:sync_body) { WebMock::Matchers::AnyArgMatcher.new(nil) }
+  let!(:sync_stub) do
+    stub_request(:put, %r{#{Settings.search_api.base_url}/api/courses/})
+      .with(body: sync_body)
+      .to_return(
+        status: search_api_status,
+      )
+  end
 
   describe "with unpermitted attributes on provider object" do
     shared_examples "does not allow assignment" do |attribute, value|
@@ -102,6 +105,7 @@ describe "PATCH /providers/:provider_code" do
         update_provider.id = provider.id
         perform_request(provider)
         expect(provider.reload.send(attribute)).not_to eq(value)
+        expect(sync_stub).to have_been_requested
       end
     end
 
@@ -139,6 +143,10 @@ describe "PATCH /providers/:provider_code" do
       context "with sites" do
         its(:sites) { should_not include(site) }
       end
+
+      it "syncs a provider's courses" do
+        expect(sync_stub).to have_been_requested
+      end
     end
   end
 
@@ -160,6 +168,13 @@ describe "PATCH /providers/:provider_code" do
       expect {
         perform_request update_provider
       }.to(change { provider.reload.content_status }.from(:empty).to(:draft))
+    end
+
+
+    it "syncs a provider's courses" do
+      perform_request update_provider
+
+      expect(sync_stub).to have_been_requested
     end
 
     context "with no attributes to update" do
@@ -232,6 +247,11 @@ describe "PATCH /providers/:provider_code" do
     context "provider has a draft enrichment" do
       let(:enrichment) { build(:provider_enrichment) }
       let(:enrichments) { [enrichment] }
+
+      it "syncs a provider's courses" do
+        perform_request update_provider
+        expect(sync_stub).to have_been_requested
+      end
 
       it "updates the provider's draft enrichment" do
         expect {
@@ -342,6 +362,13 @@ describe "PATCH /providers/:provider_code" do
     context "provider has only a published enrichment" do
       let(:enrichment) { build :provider_enrichment, :published }
       let(:enrichments) { [enrichment] }
+
+      it "syncs a provider's courses" do
+        perform_request update_provider
+
+        expect(sync_stub).to have_been_requested
+      end
+
       it "creates a draft enrichment for the provider" do
         expect { perform_request update_provider }
           .to(
@@ -381,6 +408,12 @@ describe "PATCH /providers/:provider_code" do
           expect("Invalid enrichments".in?(subject)).to eq(false)
           expect("Invalid train_with_us".in?(subject)).to eq(true)
         end
+
+        it "does not syncs a provider's courses" do
+          perform_request update_provider
+
+          expect(sync_stub).to_not have_been_requested
+        end
       end
 
       context "bad telephone number" do
@@ -409,14 +442,13 @@ describe "PATCH /providers/:provider_code" do
             change { provider.enrichments.reload.count },
           )
         end
-      end
-    end
 
-    let(:sync_body) do
-      include(
-        "\"ProgrammeCode\":\"#{course1.course_code}\"",
-        "\"ProgrammeCode\":\"#{course2.course_code}\"",
-      )
+        it "does not syncs a provider's courses" do
+          perform_request update_provider
+
+          expect(sync_stub).to_not have_been_requested
+        end
+      end
     end
   end
 
@@ -451,6 +483,10 @@ describe "PATCH /providers/:provider_code" do
           expect(subject.enrichments.draft.first[attribute_key]).to eq(attribute_value)
         end
 
+        it "syncs a provider's courses" do
+          expect(sync_stub).to have_been_requested
+        end
+
         enrichments_attributes_key = %i[
           email
           website
@@ -478,7 +514,7 @@ describe "PATCH /providers/:provider_code" do
     let(:original_enrichment) { build :provider_enrichment, :published, created_at: Date.yesterday }
     let(:enrichments) { [original_enrichment] }
 
-    include_examples "only one attribute has changed", :email, "changed email_address"
+    include_examples "only one attribute has changed", :email, "changed@email_address.com"
     include_examples "only one attribute has changed", :website, "changed url"
     include_examples "only one attribute has changed", :address1, "changed number"
     include_examples "only one attribute has changed", :address2, "changed street"
@@ -503,6 +539,10 @@ describe "PATCH /providers/:provider_code" do
 
     it "Sets the provider enrichment status to draft" do
       expect(updated_enrichment.status).to eq("draft")
+    end
+
+    it "syncs a provider's courses" do
+      expect(sync_stub).to have_been_requested
     end
   end
 end

--- a/spec/requests/api/v2/providers/update_with_sync_spec.rb
+++ b/spec/requests/api/v2/providers/update_with_sync_spec.rb
@@ -37,8 +37,6 @@ describe "Provider Publish API v2", type: :request do
       response
     end
 
-    include_examples "Unauthenticated, unauthorised, or not accepted T&Cs"
-
     context "sync provider with latests enrichments" do
       let(:enrichment) { build(:provider_enrichment, :initial_draft) }
       let(:site1) { create(:site_status, :findable) }

--- a/spec/requests/api/v2/providers/update_with_sync_spec.rb
+++ b/spec/requests/api/v2/providers/update_with_sync_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+describe "Provider Publish API v2", type: :request do
+  let(:user)         { create(:user) }
+  let(:organisation) { create(:organisation, users: [user]) }
+  let(:provider)     { create :provider, organisations: [organisation] }
+  let(:payload)      { { email: user.email } }
+  let(:token)        { build_jwt :apiv2, payload: payload }
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+
+  describe "PATCH /providers/:provider_code" do
+    let(:publish_path) do
+      "/api/v2/recruitment_cycles/#{provider.recruitment_cycle.year}" +
+        "/providers/#{provider.provider_code}"
+    end
+
+    let(:enrichment) { build(:provider_enrichment, :initial_draft) }
+
+    subject do
+      patch publish_path,
+            headers: { "HTTP_AUTHORIZATION" => credentials },
+            params: {
+              _jsonapi: {
+                data: {
+                  attributes: {},
+                  type: "provider",
+                },
+              },
+            }
+      response
+    end
+
+    include_examples "Unauthenticated, unauthorised, or not accepted T&Cs"
+
+    context "unpublished provider with draft enrichment" do
+      let(:enrichment) { build(:provider_enrichment, :initial_draft) }
+      let(:site1) { create(:site_status, :findable) }
+      let(:site2) { create(:site_status, :findable) }
+      let(:course1) { build(:course, site_statuses: [site1], subjects: [dfe_subject]) }
+      let(:course2) { build(:course, site_statuses: [site2], subjects: [dfe_subject]) }
+
+      let!(:dfe_subject) { build(:subject, :primary) }
+
+      let!(:provider) do
+        create(
+          :provider,
+          organisations: [organisation],
+          enrichments: [enrichment],
+          courses: [course1, course2],
+        )
+      end
+
+      let(:search_api_status) { 200 }
+      let(:sync_body) { WebMock::Matchers::AnyArgMatcher.new(nil) }
+      let!(:sync_stub) do
+        stub_request(:put, %r{#{Settings.search_api.base_url}/api/courses/})
+          .with(body: sync_body)
+          .to_return(
+            status: search_api_status,
+          )
+      end
+
+      context "when the sync API is available" do
+        let(:sync_body) { include("\"ProgrammeCode\":\"#{course1.course_code}\"", "\"ProgrammeCode\":\"#{course2.course_code}\"") }
+        it "syncs a providers courses" do
+          perform_enqueued_jobs do
+            subject
+          end
+          expect(sync_stub).to have_been_requested
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Sync courses when saving a provider

### Changes proposed in this pull request
A provider's courses can only be sync

1. the provider is valid
2. it is the current recruitment cycle
3. there is syncable courses

### Guidance to review

spec/requests/api/v2/providers/update_spec.rb
- deals with 1

spec/requests/api/v2/providers/update_with_sync_spec.rb

- deals with 2 and 3

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
