### PR TITLE
1906 remove applications accepted from field from course site

### DIFF
--- a/app/controllers/api/v2/site_statuses_controller.rb
+++ b/app/controllers/api/v2/site_statuses_controller.rb
@@ -17,7 +17,6 @@ module API
           .require(:site_status)
           .except(:id, :type, :site_id, :site_type, :has_vacancies?)
           .permit(
-            :applications_accepted_from,
             :publish,
             :status,
             :vac_status,

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -233,11 +233,7 @@ class Course < ApplicationRecord
   end
 
   def open_for_applications?
-    if site_statuses.loaded?
-      site_statuses.select(&:open_for_applications?).any?
-    else
-      site_statuses.open_for_applications.any?
-    end
+    applications_open_from.present? && applications_open_from <= Time.now.utc && findable?
   end
 
   def has_vacancies?

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -74,25 +74,10 @@ class SiteStatus < ApplicationRecord
     status_running? && published_on_ucas?
   end
 
-  # scope :applications_being_accepted_now, -> {
-  #   where.not(applications_accepted_from: nil).
-  #   where("applications_accepted_from <= ?", Time.now.utc)
-  # }
-
-  # def applications_being_accepted_now?
-  #   applications_accepted_from.present? &&
-  #     applications_accepted_from <= Time.now.utc
-  # end
-
   scope :with_vacancies, -> { where.not(vac_status: :no_vacancies) }
   def with_vacancies?
     !no_vacancies?
   end
-
-  # scope :open_for_applications, -> { findable.applications_being_accepted_now.with_vacancies }
-  # def open_for_applications?
-  #   findable? && applications_being_accepted_now?
-  # end
 
   def self.default_vac_status_given(study_mode:)
     case study_mode
@@ -115,7 +100,6 @@ private
 
   def set_defaults
     self.status ||= :new_status
-    # self.applications_accepted_from = nil
     self.publish ||= :unpublished
   end
 

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -74,25 +74,25 @@ class SiteStatus < ApplicationRecord
     status_running? && published_on_ucas?
   end
 
-  scope :applications_being_accepted_now, -> {
-    where.not(applications_accepted_from: nil).
-    where("applications_accepted_from <= ?", Time.now.utc)
-  }
+  # scope :applications_being_accepted_now, -> {
+  #   where.not(applications_accepted_from: nil).
+  #   where("applications_accepted_from <= ?", Time.now.utc)
+  # }
 
-  def applications_being_accepted_now?
-    applications_accepted_from.present? &&
-      applications_accepted_from <= Time.now.utc
-  end
+  # def applications_being_accepted_now?
+  #   applications_accepted_from.present? &&
+  #     applications_accepted_from <= Time.now.utc
+  # end
 
   scope :with_vacancies, -> { where.not(vac_status: :no_vacancies) }
   def with_vacancies?
     !no_vacancies?
   end
 
-  scope :open_for_applications, -> { findable.applications_being_accepted_now.with_vacancies }
-  def open_for_applications?
-    findable? && applications_being_accepted_now?
-  end
+  # scope :open_for_applications, -> { findable.applications_being_accepted_now.with_vacancies }
+  # def open_for_applications?
+  #   findable? && applications_being_accepted_now?
+  # end
 
   def self.default_vac_status_given(study_mode:)
     case study_mode
@@ -115,7 +115,7 @@ private
 
   def set_defaults
     self.status ||= :new_status
-    self.applications_accepted_from ||= Time.zone.today
+    # self.applications_accepted_from = nil
     self.publish ||= :unpublished
   end
 

--- a/app/serializers/api/v2/serializable_site_status.rb
+++ b/app/serializers/api/v2/serializable_site_status.rb
@@ -3,7 +3,7 @@ module API
     class SerializableSiteStatus < JSONAPI::Serializable::Resource
       type "site_statuses"
 
-      attributes :vac_status, :publish, :status, :applications_accepted_from, :has_vacancies?
+      attributes :vac_status, :publish, :status, :has_vacancies?
 
       has_one :site
     end

--- a/app/serializers/site_status_serializer.rb
+++ b/app/serializers/site_status_serializer.rb
@@ -35,7 +35,7 @@ class SiteStatusSerializer < ActiveModel::Serializer
   end
 
   def course_open_date
-    object.applications_accepted_from
+    object.course.applications_open_from
   end
 
   def name

--- a/app/services/sites/copy_to_course_service.rb
+++ b/app/services/sites/copy_to_course_service.rb
@@ -4,12 +4,10 @@ module Sites
       new_vac_status = SiteStatus.default_vac_status_given(
         study_mode: new_course.study_mode,
       )
-      new_start_date = new_course.recruitment_cycle.application_start_date
 
       new_course.site_statuses.create(
         site: new_site,
         vac_status: new_vac_status,
-        applications_accepted_from: new_start_date,
         status: :new_status,
       )
     end

--- a/db/migrate/20190806102256_add_applications_open_from_to_courses.rb
+++ b/db/migrate/20190806102256_add_applications_open_from_to_courses.rb
@@ -9,10 +9,7 @@ class AddApplicationsOpenFromToCourses < ActiveRecord::Migration[5.2]
     say_with_time "Setting applications_open_from to one held within sites" do
       current_recruitment_cycle = RecruitmentCycle.current_recruitment_cycle
       current_recruitment_cycle.courses.includes(:site_statuses).includes(provider: :recruitment_cycle).all.each do |course|
-        if !course.site_statuses.empty?
-          applications_open_from = course.site_statuses.min_by(&:applications_accepted_from).applications_accepted_from
-          course.update_column(:applications_open_from, applications_open_from)
-        else
+        if course.site_statuses.empty?
           course.update_column(:applications_open_from, current_recruitment_cycle.application_start_date)
         end
       end

--- a/db/migrate/20191008113447_remove_applications_accepted_from_from_course_site.rb
+++ b/db/migrate/20191008113447_remove_applications_accepted_from_from_course_site.rb
@@ -1,0 +1,9 @@
+class RemoveApplicationsAcceptedFromFromCourseSite < ActiveRecord::Migration[6.0]
+  def up
+    remove_column :course_site, :applications_accepted_from
+  end
+
+  def down
+    # There no going back
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_08_103747) do
+ActiveRecord::Schema.define(version: 2019_10_08_113447) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -115,7 +115,6 @@ ActiveRecord::Schema.define(version: 2019_10_08_103747) do
   end
 
   create_table "course_site", id: :serial, force: :cascade do |t|
-    t.date "applications_accepted_from"
     t.integer "course_id"
     t.text "publish"
     t.integer "site_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -81,7 +81,6 @@ def create_standard_provider_and_courses_for_cycle(recruitment_cycle, superuser)
     publish: "Y",
     course: primary_course,
     status: "R",
-    applications_accepted_from: Date.new(2018, 10, 23),
   )
 
   secondary_course1 = Course.create!(
@@ -257,7 +256,6 @@ def create_standard_provider_and_courses_for_cycle(recruitment_cycle, superuser)
     publish: "Y",
     course: modern_language_course3,
     status: "N",
-    applications_accepted_from: Date.new(2018, 10, 2),
   )
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -109,7 +109,6 @@ def create_standard_provider_and_courses_for_cycle(recruitment_cycle, superuser)
     publish: "Y",
     course: secondary_course1,
     status: "N",
-    applications_accepted_from: Date.new(2018, 10, 2),
   )
 
   secondary_course2 = Course.create!(
@@ -138,7 +137,6 @@ def create_standard_provider_and_courses_for_cycle(recruitment_cycle, superuser)
     publish: "Y",
     course: secondary_course2,
     status: "N",
-    applications_accepted_from: Date.new(2018, 10, 2),
   )
 
   further_education_course = Course.create!(
@@ -166,7 +164,6 @@ def create_standard_provider_and_courses_for_cycle(recruitment_cycle, superuser)
     publish: "Y",
     course: further_education_course,
     status: "N",
-    applications_accepted_from: Date.new(2018, 10, 2),
   )
 
   modern_language_course1 = Course.create!(
@@ -195,7 +192,6 @@ def create_standard_provider_and_courses_for_cycle(recruitment_cycle, superuser)
     publish: "Y",
     course: modern_language_course1,
     status: "N",
-    applications_accepted_from: Date.new(2018, 10, 2),
   )
 
   modern_language_course2 = Course.create!(
@@ -224,7 +220,6 @@ def create_standard_provider_and_courses_for_cycle(recruitment_cycle, superuser)
     publish: "Y",
     course: modern_language_course2,
     status: "N",
-    applications_accepted_from: Date.new(2018, 10, 2),
   )
 
   modern_language_course3 = Course.create!(

--- a/lib/mcb/render.rb
+++ b/lib/mcb/render.rb
@@ -125,7 +125,6 @@ module MCB
         :vac_status,
         :status,
         :publish,
-        :applications_accepted_from,
       ]
     end
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -45,7 +45,12 @@ FactoryBot.define do
     age_range_in_years { "3_to_7" }
     resulting_in_pgce_with_qts
     start_date { DateTime.new(provider.recruitment_cycle.year.to_i, 9, 1) }
-    applications_open_from { Faker::Time.between(from: DateTime.new(provider.recruitment_cycle.year.to_i - 1, 10, 1), to: DateTime.new(provider.recruitment_cycle.year.to_i, 9, 29)) }
+    applications_open_from {
+      Faker::Time.between(
+        from: DateTime.new(provider.recruitment_cycle.year.to_i - 1, 10, 1),
+        to: DateTime.new(provider.recruitment_cycle.year.to_i, 9, 29),
+      )
+    }
 
     transient do
       age { nil }

--- a/spec/factories/site_statuses.rb
+++ b/spec/factories/site_statuses.rb
@@ -68,18 +68,6 @@ FactoryBot.define do
       status { :suspended }
     end
 
-    trait :applications_being_accepted_now do
-      applications_accepted_from { Faker::Date.between(from: 2.days.ago, to: 0.days.ago) }
-    end
-
-    trait :applications_being_accepted_from_2019 do
-      applications_accepted_from { DateTime.new(2019).utc }
-    end
-
-    trait :applications_being_accepted_in_future do
-      applications_accepted_from { Faker::Date.forward(days: 90) }
-    end
-
     trait :findable do
       running
       published

--- a/spec/lib/mcb/commands/apiv1/courses/find_spec.rb
+++ b/spec/lib/mcb/commands/apiv1/courses/find_spec.rb
@@ -58,7 +58,6 @@ describe '"mcb apiv1 courses find"' do
                         site_status.vac_status_before_type_cast,
                         site_status.status_before_type_cast,
                         site_status.publish_before_type_cast,
-                        site_status.applications_accepted_from.strftime("%Y-%m-%d"),
                       ))
   end
 end

--- a/spec/lib/mcb/commands/courses/show_spec.rb
+++ b/spec/lib/mcb/commands/courses/show_spec.rb
@@ -54,7 +54,6 @@ describe "mcb courses show" do
           site_status2.vac_status,
           site_status2.status,
           site_status2.publish,
-          site_status2.applications_accepted_from.strftime("%Y-%m-%d"),
         ),
       )
     end
@@ -80,7 +79,6 @@ describe "mcb courses show" do
           site_status1.vac_status,
           site_status1.status,
           site_status1.publish,
-          site_status1.applications_accepted_from.strftime("%Y-%m-%d"),
         ),
       )
     end

--- a/spec/lib/mcb/editor/courses_editor_spec.rb
+++ b/spec/lib/mcb/editor/courses_editor_spec.rb
@@ -703,10 +703,8 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
           "start_date" => Date.new(current_year, 9, 1),
           "program_type" => desired_attributes[:route],
         )
+
         expect(created_course.accrediting_provider).to eq(provider)
-        expect(
-          created_course.site_statuses.map(&:applications_accepted_from).uniq,
-        ).to eq([Date.new(last_year, 11, 1)])
       end
 
       it "does not create the course if creation isn't confirmed" do

--- a/spec/lib/mcb/editor/courses_editor_spec.rb
+++ b/spec/lib/mcb/editor/courses_editor_spec.rb
@@ -182,13 +182,10 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
 
         before do
           sites.collect do |site|
-            course.site_statuses.create(
-              site: site,
-              status: :running,
-              vac_status: :part_time_vacancies,
-              publish: :published,
-              applications_accepted_from: Date.new(last_year, 10, 9),
-            )
+            course.site_statuses.create(site: site,
+                                        status: :running,
+                                        vac_status: :part_time_vacancies,
+                                        publish: :published)
           end
         end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -150,7 +150,7 @@ describe Course, type: :model do
   describe "no site statuses" do
     its(:site_statuses) { should be_empty }
     its(:findable?) { should be false }
-    its(:open_for_applications?) { should be false }
+    # its(:open_for_applications?) { should be false }
     its(:has_vacancies?) { should be false }
   end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -150,7 +150,7 @@ describe Course, type: :model do
   describe "no site statuses" do
     its(:site_statuses) { should be_empty }
     its(:findable?) { should be false }
-    # its(:open_for_applications?) { should be false }
+    its(:open_for_applications?) { should be false }
     its(:has_vacancies?) { should be false }
   end
 
@@ -191,8 +191,6 @@ describe Course, type: :model do
     let(:suspended) { build(:site_status, :suspended) }
     let(:with_any_vacancy) { build(:site_status, :with_any_vacancy) }
     let(:default) { build(:site_status) }
-    let(:applications_being_accepted_now) { build(:site_status, :applications_being_accepted_now) }
-    let(:applications_being_accepted_in_future) { build(:site_status, :applications_being_accepted_in_future) }
     let(:site_status_with_no_vacancies) { build(:site_status, :with_no_vacancies) }
 
     describe "#findable_site_statuses" do
@@ -286,14 +284,14 @@ describe Course, type: :model do
       let(:findable_without_vacancies) { build(:site_status, :findable, :with_no_vacancies) }
       context "for a single site status that has vacancies" do
         let(:subject) {
-          create(:course, site_statuses: [findable, applications_being_accepted_now, with_any_vacancy])
+          create(:course, site_statuses: [findable, with_any_vacancy])
         }
 
         its(:has_vacancies?) { should be true }
       end
 
       context "for a site status with vacancies and others without" do
-        let(:findable_with_vacancies) { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_now) }
+        let(:findable_with_vacancies) { build(:site_status, :findable, :with_any_vacancy) }
         let(:subject) {
           create(:course, site_statuses: [findable_with_vacancies, findable_without_vacancies])
         }
@@ -307,14 +305,6 @@ describe Course, type: :model do
         }
 
         its(:has_vacancies?) { should be false }
-      end
-
-      context "when the site is findable but only opens in the future" do
-        let(:findable_with_vacancies) { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_in_future) }
-        let(:subject) {
-          create(:course, site_statuses: [findable_with_vacancies])
-        }
-        its(:has_vacancies?) { should be true }
       end
 
       context "when only discontinued and suspended site statuses have vacancies" do
@@ -335,14 +325,14 @@ describe Course, type: :model do
 
       context "for a single site status that has vacancies" do
         let(:subject) {
-          create(:course, site_statuses: [findable, applications_being_accepted_now, with_any_vacancy]).reload
+          create(:course, site_statuses: [findable, with_any_vacancy]).reload
         }
 
         its(:has_vacancies?) { should be true }
       end
 
       context "for a site status with vacancies and others without" do
-        let(:findable_with_vacancies) { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_now) }
+        let(:findable_with_vacancies) { build(:site_status, :findable, :with_any_vacancy) }
         let(:subject) {
           create(:course, site_statuses: [findable_with_vacancies, findable_without_vacancies]).reload
         }
@@ -356,14 +346,6 @@ describe Course, type: :model do
         }
 
         its(:has_vacancies?) { should be false }
-      end
-
-      context "when the site is findable but only opens in the future" do
-        let(:findable_with_vacancies) { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_in_future) }
-        let(:subject) {
-          create(:course, site_statuses: [findable_with_vacancies]).reload
-        }
-        its(:has_vacancies?) { should be true }
       end
 
       context "when only discontinued and suspended site statuses have vacancies" do
@@ -380,69 +362,139 @@ describe Course, type: :model do
     end
 
     describe "open_for_applications?" do
-      context "with at least one site status applications_being_accepted_now" do
-        context "single site status applications_being_accepted_now as it open now" do
-          let(:findable_with_vacancies) { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_now) }
-          let(:subject) {
-            create(:course, site_statuses: [findable_with_vacancies])
-          }
+      let(:site_statuses) { [] }
 
-          its(:site_statuses) { should_not be_empty }
-          its(:open_for_applications?) { should be true }
-        end
+      let(:applications_open_from) { Time.now.utc }
 
-        context "single site status applications_being_accepted_now as it open future" do
-          let(:subject) {
-            create(:course, site_statuses: [applications_being_accepted_in_future])
-          }
+      let(:course) do
+        create(:course,
+               site_statuses: site_statuses,
+               applications_open_from: applications_open_from)
+      end
 
-          its(:site_statuses) { should_not be_empty }
+      let(:subject) {
+        course
+      }
+
+      context "no site statuses" do
+        context "applications_open_from is in present or past" do
           its(:open_for_applications?) { should be false }
         end
+        context "applications_open_from is in future" do
+          let(:applications_open_from) { Time.now.utc + 1.days }
+          its(:open_for_applications?) { should be false }
+        end
+      end
 
-        context "site statuses applications_being_accepted_now as it open now & future" do
-          let(:findable_with_vacancies_now) { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_now) }
-          let(:findable_with_vacancies_in_future) { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_in_future) }
-          let(:subject) {
-            create(:course, site_statuses: [findable_with_vacancies_now, findable_with_vacancies_in_future])
-          }
+      context "with site statuses" do
+        context "with only a single findable site statuses" do
+          let(:site_statuses) { [findable] }
+          context "applications_open_from is in present or past" do
+            its(:open_for_applications?) { should be true }
+          end
+          context "applications_open_from is in future" do
+            let(:applications_open_from) { Time.now.utc + 1.days }
+            its(:open_for_applications?) { should be false }
+          end
+        end
 
-          its(:site_statuses) { should_not be_empty }
-          its(:open_for_applications?) { should be true }
+        context "with at least a single findable site statuses" do
+          let(:site_statuses) do
+            [default, findable, new_site_status,
+             site_status_with_no_vacancies, suspended, with_any_vacancy]
+          end
+
+          context "applications_open_from is in present or past" do
+            its(:open_for_applications?) { should be true }
+          end
+          context "applications_open_from is in future" do
+            let(:applications_open_from) { Time.now.utc + 1.days }
+            its(:open_for_applications?) { should be false }
+          end
+        end
+
+        context "with no findable site statuses" do
+          let(:site_statuses) do
+            [default, new_site_status, site_status_with_no_vacancies,
+             suspended, with_any_vacancy]
+          end
+
+          context "applications_open_from is in present or past" do
+            its(:open_for_applications?) { should be false }
+          end
+          context "applications_open_from is in future" do
+            let(:applications_open_from) { Time.now.utc + 1.days }
+            its(:open_for_applications?) { should be false }
+          end
         end
       end
     end
 
     describe "open_for_applications? (when site_statuses not loaded)" do
-      context "with at least one site status applications_being_accepted_now" do
-        context "single site status applications_being_accepted_now as it open now" do
-          let(:findable_with_vacancies) { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_now) }
-          let(:subject) {
-            create(:course, site_statuses: [findable_with_vacancies]).reload
-          }
+      let(:site_statuses) { [] }
 
-          its(:site_statuses) { should_not be_empty }
-          its(:open_for_applications?) { should be true }
-        end
+      let(:applications_open_from) { Time.now.utc }
 
-        context "single site status applications_being_accepted_now as it open future" do
-          let(:subject) {
-            create(:course, site_statuses: [applications_being_accepted_in_future]).reload
-          }
+      let(:course) do
+        create(:course,
+               site_statuses: site_statuses,
+               applications_open_from: applications_open_from)
+      end
 
-          its(:site_statuses) { should_not be_empty }
+      let(:subject) {
+        course.reload
+      }
+
+      context "no site statuses" do
+        context "applications_open_from is in present or past" do
           its(:open_for_applications?) { should be false }
         end
+        context "applications_open_from is in future" do
+          let(:applications_open_from) { Time.now.utc + 1.days }
+          its(:open_for_applications?) { should be false }
+        end
+      end
 
-        context "site statuses applications_being_accepted_now as it open now & future" do
-          let(:findable_with_vacancies_now) { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_now) }
-          let(:findable_with_vacancies_in_future) { build(:site_status, :findable, :with_any_vacancy, :applications_being_accepted_in_future) }
-          let(:subject) {
-            create(:course, site_statuses: [findable_with_vacancies_now, findable_with_vacancies_in_future]).reload
-          }
+      context "with site statuses" do
+        context "with only a single findable site statuses" do
+          let(:site_statuses) { [findable] }
+          context "applications_open_from is in present or past" do
+            its(:open_for_applications?) { should be true }
+          end
+          context "applications_open_from is in future" do
+            let(:applications_open_from) { Time.now.utc + 1.days }
+            its(:open_for_applications?) { should be false }
+          end
+        end
 
-          its(:site_statuses) { should_not be_empty }
-          its(:open_for_applications?) { should be true }
+        context "with at least a single findable site statuses" do
+          let(:site_statuses) do
+            [default, findable, new_site_status,
+             site_status_with_no_vacancies, suspended, with_any_vacancy]
+          end
+
+          context "applications_open_from is in present or past" do
+            its(:open_for_applications?) { should be true }
+          end
+          context "applications_open_from is in future" do
+            let(:applications_open_from) { Time.now.utc + 1.days }
+            its(:open_for_applications?) { should be false }
+          end
+        end
+
+        context "with no findable site statuses" do
+          let(:site_statuses) do
+            [default, new_site_status, site_status_with_no_vacancies,
+             suspended, with_any_vacancy]
+          end
+
+          context "applications_open_from is in present or past" do
+            its(:open_for_applications?) { should be false }
+          end
+          context "applications_open_from is in future" do
+            let(:applications_open_from) { Time.now.utc + 1.days }
+            its(:open_for_applications?) { should be false }
+          end
         end
       end
     end

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -16,12 +16,6 @@ require "rails_helper"
 RSpec.describe SiteStatus, type: :model do
   it_behaves_like "Touch course", :site_status
 
-  RSpec::Matchers.define :be_open_for_applications do
-    match do |actual|
-      SiteStatus.open_for_applications.include?(actual)
-    end
-  end
-
   RSpec::Matchers.define :have_vacancies do
     match do |actual|
       SiteStatus.with_vacancies.include?(actual)
@@ -87,40 +81,6 @@ RSpec.describe SiteStatus, type: :model do
 
     describe "if running and published on UCAS" do
       it { should include(create(:site_status, :running, :published)) }
-    end
-  end
-
-  describe "applications open?" do
-    describe "if on find, application date open and has full-time vacancies" do
-      subject { create(:site_status, :findable, :applications_being_accepted_now, :full_time_vacancies) }
-      it { should be_open_for_applications }
-    end
-
-    describe "if on find, application date open and has part-time vacancies" do
-      let(:course) { build(:course, study_mode: :part_time) }
-      subject { create(:site_status, :findable, :applications_being_accepted_now, :part_time_vacancies, course: course) }
-      it { should be_open_for_applications }
-    end
-
-    describe "if on find, application date open and has both full-time and part-time vacancies" do
-      let(:course) { build(:course, study_mode: :full_time_or_part_time) }
-      subject { create(:site_status, :findable, :applications_being_accepted_now, :both_full_time_and_part_time_vacancies, course: course) }
-      it { should be_open_for_applications }
-    end
-
-    describe "if not on find" do
-      subject { create(:site_status, :suspended) }
-      it { should_not be_open_for_applications }
-    end
-
-    describe "if on find but applications accepted in the future" do
-      subject { create(:site_status, :findable, :applications_being_accepted_in_future) }
-      it { should_not be_open_for_applications }
-    end
-
-    describe "if on find, applications accepted now but no vacancies" do
-      subject { create(:site_status, :findable, :applications_being_accepted_now, :with_no_vacancies) }
-      it { should_not be_open_for_applications }
     end
   end
 

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -506,11 +506,9 @@ describe "Courses API", type: :request do
       let(:course1) { create(:course, study_mode: "full_time", profpost_flag: "postgraduate", program_type: "higher_education_programme", provider: provider1) }
       let(:course2) { create(:course, study_mode: "full_time", profpost_flag: "postgraduate", program_type: "higher_education_programme", provider: provider1) }
 
-      let!(:status1) do
-        create(:site_status, status: :new_status, course: course1, vac_status: "full_time_vacancies", applications_accepted_from: Date.new(current_year, 7, 23))
-      end
-      let!(:status2) { create(:site_status, status: :new_status, course: course2, vac_status: "full_time_vacancies", applications_accepted_from: Date.new(current_year, 7, 24)) }
-      let!(:status3) { create(:site_status, status: :running, course: course2, vac_status: "full_time_vacancies", applications_accepted_from: Date.new(current_year, 7, 24)) }
+      let!(:status1) { create(:site_status, status: :new_status, course: course1, vac_status: "full_time_vacancies") }
+      let!(:status2) { create(:site_status, status: :new_status, course: course2, vac_status: "full_time_vacancies") }
+      let!(:status3) { create(:site_status, status: :running, course: course2, vac_status: "full_time_vacancies") }
 
       it "does not send courses marked new" do
         get "/api/v1/#{current_year}/courses", headers: { "HTTP_AUTHORIZATION" => credentials }

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -53,13 +53,13 @@ describe "Courses API", type: :request do
                                    program_type: :scitt_programme,
                                    modular: "",
                                    provider: provider,
+                                   applications_open_from: "#{previous_year}-10-09 00:00:00",
                                    age: 2.hours.ago)
 
         FactoryBot.create(:site_status,
                           vac_status: :full_time_vacancies,
                           publish: "Y",
                           status: :running,
-                          applications_accepted_from: "#{previous_year}-10-09 00:00:00",
                           course: course,
                           site: site)
 

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -179,8 +179,8 @@ describe "Courses API v2", type: :request do
                 "vac_status" => site_status.vac_status,
                 "publish" => site_status.publish,
                 "status" => site_status.status,
-                "applications_accepted_from" => site_status.applications_accepted_from.strftime("%Y-%m-%d"),
                 "has_vacancies?" => true,
+                "applications_accepted_from" => "2019-01-01",
               },
               "relationships" => {
                 "site" => {

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -16,6 +16,7 @@ describe "Courses API v2", type: :request do
   let(:previous_year) { current_year - 1 }
   let(:next_year)     { current_year + 1 }
 
+  let(:applications_open_from) { Time.now.utc }
   let(:findable_open_course) {
     create(:course, :resulting_in_pgce_with_qts, :with_apprenticeship,
            level: :secondary,
@@ -31,14 +32,13 @@ describe "Courses API v2", type: :request do
            english: :must_have_qualification_at_application_time,
            science: :must_have_qualification_at_application_time,
            age_range_in_years: "3_to_7",
-           applications_open_from: Date.new(current_year, 1, 1))
+           applications_open_from: applications_open_from)
   }
 
   let(:courses_site_status) {
     build(:site_status,
           :findable,
           :with_any_vacancy,
-          :applications_being_accepted_now,
           site: create(:site, provider: provider))
   }
   let(:enrichment)     { build :course_enrichment, :published }
@@ -180,7 +180,6 @@ describe "Courses API v2", type: :request do
                 "publish" => site_status.publish,
                 "status" => site_status.status,
                 "has_vacancies?" => true,
-                "applications_accepted_from" => "2019-01-01",
               },
               "relationships" => {
                 "site" => {
@@ -290,7 +289,7 @@ describe "Courses API v2", type: :request do
               "is_send?" => true,
               "subjects" => %w[Mathematics],
               "level" => "secondary",
-              "applications_open_from" => "#{current_year}-01-01",
+              "applications_open_from" => provider.courses[0].applications_open_from.strftime("%Y-%m-%d"),
               "about_course" => enrichment.about_course,
               "course_length" => enrichment.course_length,
               "fee_details" => enrichment.fee_details,

--- a/spec/requests/api/v2/site_statuses_spec.rb
+++ b/spec/requests/api/v2/site_statuses_spec.rb
@@ -103,7 +103,6 @@ describe "Site Helpers API V2" do
           expect(json_data).to have_id(site_status.id.to_s)
           expect(json_data).to have_type("site_statuses")
           expect(json_data).to have_attributes(
-            :applications_accepted_from,
             :publish,
             :status,
             :vac_status,

--- a/spec/requests/api/v2/site_statuses_spec.rb
+++ b/spec/requests/api/v2/site_statuses_spec.rb
@@ -58,7 +58,6 @@ describe "Site Helpers API V2" do
         }
       end
       let(:site_status_params)         { params.dig :_jsonapi, :data, :attributes }
-      let(:applications_accepted_from) { "2019-01-01 00:00:00" }
       let(:publish)                    { "published" }
       let(:status)                     { "discontinued" }
       let(:vac_status)                 { "no_vacancies" }
@@ -66,7 +65,6 @@ describe "Site Helpers API V2" do
 
       before do
         site_status_params.merge!(
-          applications_accepted_from: applications_accepted_from,
           publish:                    publish,
           status:                     status,
           vac_status:                 vac_status,
@@ -74,13 +72,6 @@ describe "Site Helpers API V2" do
       end
 
       subject { perform_request }
-
-      it "updates applications_accepted_from on the site status" do
-        expect { subject }.to(
-          change { site_status.reload.applications_accepted_from }
-          .to(Date.parse(applications_accepted_from)),
-        )
-      end
 
       it "updates publish on the site status" do
         expect { subject }.to(change { site_status.reload.publish }

--- a/spec/serializers/search_and_compare/course_serializer_spec.rb
+++ b/spec/serializers/search_and_compare/course_serializer_spec.rb
@@ -75,8 +75,7 @@ describe SearchAndCompare::CourseSerializer do
 
       let(:site_status1) do
         build :site_status, :findable, :full_time_vacancies,
-              site: site1,
-              applications_accepted_from: "2018-10-09T00:00:00"
+              site: site1
       end
 
       let(:site2) do

--- a/spec/services/sites/copy_to_course_service_spec.rb
+++ b/spec/services/sites/copy_to_course_service_spec.rb
@@ -28,6 +28,5 @@ describe Sites::CopyToCourseService do
 
     it { should be_full_time_vacancies }
     it { should be_status_new_status }
-    its(:applications_accepted_from) { should eq new_recruitment_cycle.application_start_date }
   end
 end


### PR DESCRIPTION
### Context
Leftovers from when `course` table introduced `applications_open_from`

### Changes proposed in this pull request
Remove `applications_accepted_from` from `course_site` as is superseded by `applications_open_from` from `course` table

Realign/unify logic used to calculate `open_for_applications?` on the `course` model

### Guidance to review
:rabbit: :hole: :ship: 
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
