### PR TITLE
[2323] configure mcb to use cip qa and staging envs

### DIFF
--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -315,14 +315,14 @@ module MCB
     def env_to_azure_map
       {
         "qa" => {
-          webapp: "bat-qa-mcbe-as",
-          rgroup: "bat-qa-mcbe-rg",
-          subscription: "DFE BAT Development",
+          webapp: "s121d01-mcbe-as",
+          rgroup: "s121d01-mcbe-rg",
+          subscription: "s121-findpostgraduateteachertraining-development",
         },
         "staging" => {
-          webapp: "bat-stg-mcbe-as",
-          rgroup: "bat-stg-mcbe-rg",
-          subscription: "DFE BAT Development",
+          webapp: "s121t01-mcbe-as",
+          rgroup: "s121t01-mcbe-rg",
+          subscription: "s121-findpostgraduateteachertraining-test",
         },
         "production" => {
           webapp: "bat-prod-mcbe-as",


### PR DESCRIPTION
### Context

`qa` and `staging` have moved to CIP. These are the connection details we need to connect with them.

### Changes proposed in this pull request

Use the CIP resources for `qa` and `staging`.

### Guidance to review

😞 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
