### PR TITLE
[2330] Update a site_status’s vacancy status when editing a course study mode in MCB

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -3,8 +3,6 @@
 module API
   module V2
     class CoursesController < API::V2::ApplicationController
-      include StudyModeVacancyMapper
-
       before_action :build_recruitment_cycle
       before_action :build_provider
       before_action :build_course, except: %i[index new create build_new]
@@ -88,7 +86,7 @@ module API
         update_course
         update_enrichment
         update_sites
-        update_site_status_vac_statuses if @course.study_mode_previously_changed?
+        @course.ensure_site_statuses_match_study_mode if @course.study_mode_previously_changed?
         should_sync = site_ids.present? && @course.should_sync?
         has_synced? if should_sync
 
@@ -159,14 +157,6 @@ module API
         # but we can't actually revert easily from what I can tell because of the
         # remove_site! side effects that occur when it's called.
         @course.errors[:sites] << "^You must choose at least one location" if site_ids.empty?
-      end
-
-      def update_site_status_vac_statuses
-        @course.site_statuses.each do |site_status|
-          if site_status.vac_status != "no_vacancies"
-            update_vac_status(@course.study_mode, site_status)
-          end
-        end
       end
 
       def build_provider

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -32,6 +32,7 @@ class Course < ApplicationRecord
   include WithQualifications
   include ChangedAt
   include Courses::EditOptions
+  include StudyModeVacancyMapper
 
   after_initialize :set_defaults
 
@@ -439,6 +440,12 @@ class Course < ApplicationRecord
   def ensure_modern_languages
     if has_any_modern_language_subject_type? && !has_the_modern_languages_secondary_subject_type?
       subjects << SecondarySubject.modern_languages
+    end
+  end
+
+  def ensure_site_statuses_match_study_mode
+    site_statuses.select(&:with_vacancies?).each do |site_status|
+      update_vac_status(study_mode, site_status)
     end
   end
 

--- a/lib/mcb/editor/courses_editor.rb
+++ b/lib/mcb/editor/courses_editor.rb
@@ -94,6 +94,8 @@ module MCB
           edit_subjects
         elsif choice == "edit training locations"
           edit_sites
+        elsif choice == "edit study mode"
+          edit_study_mode
         elsif choice.start_with?("edit")
           attribute = choice.gsub("edit ", "").gsub(" ", "_").downcase.to_sym
           edit(attribute)
@@ -118,6 +120,11 @@ module MCB
         )
         course.ensure_modern_languages
         course.reload
+      end
+
+      def edit_study_mode
+        edit(:study_mode)
+        course.ensure_site_statuses_match_study_mode if course.study_mode_previously_changed?
       end
 
       def edit_sites


### PR DESCRIPTION
Site statuses have a vacancy status that's dependent on the course's study mode. eg A full time course has full time vacancies.

When updating the course through the UI we were ensuring this was updated. But no such checks were made in MCB.

- Move the method into the course
- Reuse the ensure method in MCB to keep changes consistent and correct

This is how site statuses got out of sync on https://trello.com/c/h4yNl5DH/

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
