### PR TITLE
Raise an error if trying to publish with invalid site statuses

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -163,6 +163,7 @@ class Course < ApplicationRecord
   validates :level, presence: { message: "^There is a problem with this course. Contact support to fix it (Error: L)" }, on: :publish
   validates :subjects, presence: true, on: :publish
   validate :validate_enrichment_publishable, on: :publish
+  validate :validate_site_statuses_publishable, on: :publish
   validate :validate_enrichment
   validate :validate_course_syncable, on: :sync
   validate :validate_qualification, on: :update
@@ -538,6 +539,14 @@ private
 
   def validate_enrichment_publishable
     validate_enrichment :publish
+  end
+
+  def validate_site_statuses_publishable
+    site_statuses.each do |site_status|
+      unless site_status.valid?
+        raise RuntimeError.new("Site status invalid: #{site_status.errors.full_messages.first}")
+      end
+    end
   end
 
   def set_defaults

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -544,7 +544,7 @@ private
   def validate_site_statuses_publishable
     site_statuses.each do |site_status|
       unless site_status.valid?
-        raise RuntimeError.new("Site status invalid: #{site_status.errors.full_messages.first}")
+        raise RuntimeError.new("Site status invalid on course #{provider.provider_code}/#{course_code}: #{site_status.errors.full_messages.first}")
       end
     end
   end

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -231,7 +231,7 @@ describe "Publish API v2", type: :request do
         it "raises an error" do
           expect { subject }.to(raise_error(
                                   RuntimeError,
-                                  "Site status invalid: Vac status (full_time_vacancies) must be consistent with course study mode part_time",
+                                  "Site status invalid on course #{provider.provider_code}/#{course.course_code}: Vac status (full_time_vacancies) must be consistent with course study mode part_time",
                ))
         end
       end

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -214,6 +214,27 @@ describe "Publish API v2", type: :request do
           end
         end
       end
+
+      context "an inconsistent course and site status", focus: true do
+        let(:course) {
+          create(:course,
+                 provider: provider,
+                 study_mode: "full_time",
+                 enrichments: [enrichment],
+                 site_statuses: [build(:site_status, :new, :full_time_vacancies)])
+        }
+
+        before do
+          course.update_attribute(:study_mode, "part_time")
+        end
+
+        it "raises an error" do
+          expect { subject }.to(raise_error(
+                                  RuntimeError,
+                                  "Site status invalid: Vac status (full_time_vacancies) must be consistent with course study mode part_time",
+               ))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Avoid publishing bad site statuses/courses in the event that the relationship between a course and it's site statuses has been corrupted somehow.

This happened before and the cause was fixed in #905

This will flag bad data and let us fix the data/causes before Publish/Find get into a broken state.

An error message would swallow the error show the user a message they couldn't recover from.
