### PR TITLE
[2352] Add potential subjects to edit options

### DIFF
--- a/app/models/concerns/courses/edit_options.rb
+++ b/app/models/concerns/courses/edit_options.rb
@@ -8,6 +8,7 @@ module Courses
     include StudyModeConcern
     include IsSendConcern
     include ApplicationsOpenConcern
+    include SubjectsConcern
 
     included do
       # When changing edit options here be sure to update the edit_options in the
@@ -24,6 +25,7 @@ module Courses
           show_is_send: show_is_send?,
           show_start_date: show_start_date?,
           show_applications_open: show_applications_open?,
+          subjects: potential_subjects,
         }
       end
     end

--- a/app/models/concerns/courses/edit_options/subjects_concern.rb
+++ b/app/models/concerns/courses/edit_options/subjects_concern.rb
@@ -1,0 +1,19 @@
+module Courses
+  module EditOptions
+    module SubjectsConcern
+      extend ActiveSupport::Concern
+      included do
+        # When changing anything here be sure to update the edit_options in the
+        # courses factory in manage-courses-frontend:
+        #
+        # https://github.com/DFE-Digital/manage-courses-frontend/blob/master/spec/factories/courses.rb
+        def potential_subjects
+          JSONAPI::Serializable::Renderer.new.render(
+            CourseAssignableMasterSubjectService.new.execute(self),
+            class: CourseSerializersService.new.execute,
+          )[:data]
+        end
+      end
+    end
+  end
+end

--- a/app/services/course_assignable_master_subject_service.rb
+++ b/app/services/course_assignable_master_subject_service.rb
@@ -1,0 +1,22 @@
+class CourseAssignableMasterSubjectService
+  def initialize(
+    primary_subject: PrimarySubject,
+    secondary_subject: SecondarySubject,
+    further_education_subject: FurtherEducationSubject
+)
+    @primary_subject = primary_subject
+    @secondary_subject = secondary_subject
+    @further_education_subject = further_education_subject
+  end
+
+  def execute(course)
+    case course.level
+    when "primary"
+      @primary_subject.all
+    when "secondary"
+      @secondary_subject.all
+    when "further_education"
+      @further_education_subject.all
+    end
+  end
+end

--- a/spec/models/concerns/courses/edit_options_spec.rb
+++ b/spec/models/concerns/courses/edit_options_spec.rb
@@ -4,13 +4,28 @@ describe Course, type: :model do
   let(:course) { create(:course, level: "primary", subjects: [subjects]) }
   let(:subjects) { create(:subject, :primary) }
 
-  context "entry_requirements" do
+  describe "subjects" do
+    let(:course) { create(:course, level: "primary", subjects: []) }
+
+    it "returns the subjects the user can choose according to their level" do
+      primary_subject = create(:subject, :primary_with_mathematics)
+      create(:subject, :biology)
+
+      expect(course.potential_subjects).to match_array(
+        [
+          { id: primary_subject.id.to_s, type: :subjects, attributes: { subject_name: primary_subject.subject_name, subject_code: primary_subject.subject_code } },
+        ],
+      )
+    end
+  end
+
+  describe "entry_requirements" do
     it "returns the entry requirements that users can choose between" do
       expect(course.entry_requirements).to eq(%i[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test])
     end
   end
 
-  context "qualifications" do
+  describe "qualifications" do
     context "for a course that’s not further education" do
       it "returns only QTS options for users to choose between" do
         expect(course.qualification_options).to eq(%w[qts pgce_with_qts pgde_with_qts])
@@ -32,7 +47,7 @@ describe Course, type: :model do
     end
   end
 
-  context "age_range" do
+  describe "age_range" do
     context "for primary" do
       it "returns the correct ages range for users to co choose between" do
         expect(course.age_range_options).to eq(%w[3_to_7 5_to_11 7_to_11 7_to_14])
@@ -48,7 +63,7 @@ describe Course, type: :model do
     end
   end
 
-  context "start_date_options" do
+  describe "start_date_options" do
     let(:recruitment_year) { course.provider.recruitment_cycle.year.to_i }
 
     it "should return the correct options for the recruitment_cycle" do
@@ -79,7 +94,7 @@ describe Course, type: :model do
     end
   end
 
-  context "available_start_date_options" do
+  describe "available_start_date_options" do
     let(:recruitment_year) { course.provider.recruitment_cycle.year.to_i }
 
     context "when unpublished" do
@@ -98,7 +113,7 @@ describe Course, type: :model do
     end
   end
 
-  context "is_send" do
+  describe "is_send" do
     let(:recruitment_year) { course.provider.recruitment_cycle.year.to_i }
 
     context "when unpublished" do
@@ -117,7 +132,7 @@ describe Course, type: :model do
     end
   end
 
-  context "applications_open" do
+  describe "applications_open" do
     let(:recruitment_year) { course.provider.recruitment_cycle.year.to_i }
 
     context "when unpublished" do

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -167,6 +167,16 @@ describe "Courses API v2", type: :request do
                   "show_is_send" => false,
                   "show_start_date" => false,
                   "show_applications_open" => false,
+                  "subjects" => [
+                    {
+                      "id" => course_subject_mathematics.id.to_s,
+                      "type" => "subjects",
+                      "attributes" => {
+                        "subject_name" => course_subject_mathematics.subject_name,
+                        "subject_code" => course_subject_mathematics.subject_code,
+                      },
+                    },
+                  ],
                 },
               },
             },
@@ -370,6 +380,16 @@ describe "Courses API v2", type: :request do
                 "show_is_send" => false,
                 "show_start_date" => false,
                 "show_applications_open" => false,
+                "subjects" => [
+                  {
+                    "id" => course_subject_mathematics.id.to_s,
+                    "type" => "subjects",
+                    "attributes" => {
+                      "subject_name" => course_subject_mathematics.subject_name,
+                      "subject_code" => course_subject_mathematics.subject_code,
+                    },
+                  },
+                ],
               },
             },
           }],

--- a/spec/services/course_assignable_master_subjects_service_spec.rb
+++ b/spec/services/course_assignable_master_subjects_service_spec.rb
@@ -1,0 +1,33 @@
+describe CourseAssignableMasterSubjectService do
+  let(:service) do
+    described_class.new(
+      primary_subject: primary_model,
+      secondary_subject: secondary_model,
+      further_education_subject: further_education_model,
+    )
+  end
+  let(:primary_model) { spy(all: []) }
+  let(:secondary_model) { spy(all: []) }
+  let(:further_education_model) { spy(all: []) }
+
+  it "gets all primary subjects if the level is primary" do
+    course = create(:course, level: "primary")
+
+    expect(service.execute(course)).to eq([])
+    expect(primary_model).to have_received(:all)
+  end
+
+  it "gets all secondary subjects if the level is secondary" do
+    course = create(:course, level: "secondary")
+
+    expect(service.execute(course)).to eq([])
+    expect(secondary_model).to have_received(:all)
+  end
+
+  it "gets all further education subjects if the level is further education" do
+    course = create(:course, level: "further_education")
+
+    expect(service.execute(course)).to eq([])
+    expect(further_education_model).to have_received(:all)
+  end
+end


### PR DESCRIPTION
### Context
As it stands the frontend has no subjects to choose from for subject editing.  

### Changes proposed in this pull request
Send potential master subjects via edit options.

### Guidance to review

### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [x] Rebased master
- [X] Cleaned commit history
- [x] Tested by running locally
