### PR TITLE
[2313] optimise sync course

### DIFF
--- a/app/models/subjects/secondary_subject.rb
+++ b/app/models/subjects/secondary_subject.rb
@@ -10,6 +10,6 @@
 
 class SecondarySubject < Subject
   def self.modern_languages
-    find_by(subject_name: "Modern Languages")
+    @modern_languages ||= find_by(subject_name: "Modern Languages")
   end
 end

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -101,9 +101,7 @@ class CourseSerializer < ActiveModel::Serializer
   # Course now has a `is_send` attribute so we do not need to model `SEND` courses using the
   # Subject. However, API V1 is still expecting the Subject so we add it back in.
   def subjects
-    subjects_array = object.subjects
-      .where.not(type: "DiscontinuedSubject")
-      .where.not(subject_code: nil).to_a
+    subjects_array = object.syncable_subjects.to_a
 
     return subjects_array unless object.is_send?
 

--- a/app/serializers/search_and_compare/course_serializer.rb
+++ b/app/serializers/search_and_compare/course_serializer.rb
@@ -229,10 +229,8 @@ module SearchAndCompare
 
     def course_subjects
       # CourseSubject_Mapping
-      object.subjects
-      .where.not(type: "DiscontinuedSubject")
-      .where.not(subject_code: nil)
-      .map do |subject|
+      object.syncable_subjects
+        .map do |subject|
         {
           **default_course_subjects_value,
           Subject:

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -31,14 +31,8 @@ FactoryBot.define do
 
     trait :primary_with_mathematics do
       subject_name { "Primary with mathematics" }
-      subject_code { "01" }
+      subject_code { "03" }
       type { "PrimarySubject" }
-    end
-
-    trait :primary_with_mathematics do
-      subject_name { "Primary with mathematics" }
-      subject_code { "04" }
-      type { :PrimarySubject }
     end
 
     trait :mathematics do
@@ -118,6 +112,17 @@ FactoryBot.define do
       subject_code { "C1" }
       type { :SecondarySubject }
     end
+
+    trait :modern_languages do
+      subject_name { "Modern Languages" }
+      subject_code { nil }
+      type { :SecondarySubject }
+    end
+  end
+
+  factory :secondary_subject do
+    sequence(:subject_code, &:to_s)
+    subject_name { Faker::ProgrammingLanguage.name }
 
     trait :modern_languages do
       subject_name { "Modern Languages" }

--- a/spec/lib/mcb/editor/courses_editor_spec.rb
+++ b/spec/lib/mcb/editor/courses_editor_spec.rb
@@ -16,7 +16,7 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
   let!(:japanese) { find_or_create(:subject, :japanese) }
   let!(:primary_with_mathematics) { find_or_create(:subject, :primary_with_mathematics) }
   let!(:biology) { find_or_create(:subject, :biology) }
-  let!(:modern_languages) { find_or_create(:subject, :modern_languages) }
+  let(:modern_languages) { find_or_create(:secondary_subject, :modern_languages) }
   let!(:further_education) { find_or_create(:subject, :further_education) }
   let(:current_cycle) { find_or_create :recruitment_cycle }
   let!(:next_cycle) { find_or_create :recruitment_cycle, :next }
@@ -264,9 +264,11 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
           let(:level) { "secondary" }
           let(:age_range_in_years) { "11_to_16" }
           it "attaches new subjects" do
-            expect { run_editor("edit subjects", "2", "continue", "exit") }.
-              to change { course.subjects.reload.sort_by(&:subject_name) }.
-              from([]).to(match_array([biology.becomes(SecondarySubject)]))
+            expect {
+              run_editor("edit subjects", "[ ] Biology", "continue", "exit")
+            }.to change { course.subjects.reload.sort_by(&:subject_name) }
+                   .from([])
+                   .to(match_array([biology.becomes(SecondarySubject)]))
           end
         end
 
@@ -275,9 +277,11 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
           let(:level) { "secondary" }
           let(:age_range_in_years) { "11_to_16" }
           it "removes existing subjects" do
-            expect { run_editor("edit subjects", "2", "continue", "exit")[:stdout] }.
-            to change { course.subjects.reload.sort_by(&:subject_name) }.
-            from(match_array([biology.becomes(SecondarySubject)])).to([])
+            expect {
+              run_editor("edit subjects", "[x] Biology", "continue", "exit")
+            }.to change { course.subjects.reload.sort_by(&:subject_name) }
+                   .from(match_array([biology.becomes(SecondarySubject)]))
+                   .to([])
           end
         end
 
@@ -570,7 +574,8 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
             "",
           )[:stdout]
 
-          expect(Course.find_by(course_code: desired_attributes[:course_code]).subjects).to match_array(primary_with_mathematics.becomes(PrimarySubject))
+          expect(Course.find_by(course_code: desired_attributes[:course_code]).subjects)
+            .to match_array(primary_with_mathematics.becomes(PrimarySubject))
         end
 
         it "only shows further education subjects if further education level is selected" do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -348,6 +348,30 @@ describe Course, type: :model do
       end
     end
 
+    describe "#syncable_subjects" do
+      let(:subject) { create :subject, :primary }
+      let(:subject_discontinued) { create :subject, :primary, type: "DiscontinuedSubject" }
+      let(:subject_without_code) { create :subject, :primary, subject_code: nil }
+      let(:course) do
+        create :course,
+               subjects: [subject, subject_discontinued, subject_without_code]
+      end
+
+      it "returns none-discontinued subjects that have a code present" do
+        expect(course.syncable_subjects).to eq [subject]
+      end
+
+      context "with a subjects that has been loaded" do
+        it "does not use where to reload subjects" do
+          allow(course.subjects).to receive(:where)
+
+          expect(course.syncable_subjects).to eq [subject]
+
+          expect(course.subjects).not_to have_received(:where)
+        end
+      end
+    end
+
     describe "#findable?" do
       context "when #findable_site_statuses returns site statuses" do
         it "returns true" do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -34,9 +34,9 @@ describe Course, type: :model do
   let(:recruitment_cycle) { course.recruitment_cycle }
   let(:course) { create(:course, name: "Biology", course_code: "3X9F") }
   let(:subject) { course }
-  let(:arabic) { create(:subject, subject_name: "Arabic", type: :ModernLanguagesSubject).becomes(ModernLanguagesSubject) }
+  let(:arabic) { find_or_create(:subject, subject_name: "Arabic", type: :ModernLanguagesSubject).becomes(ModernLanguagesSubject) }
   let!(:financial_incentive) { create(:financial_incentive, subject: modern_languages) }
-  let!(:modern_languages) { create(:subject, subject_name: "Modern Languages", type: :SecondarySubject).becomes(SecondarySubject) }
+  let(:modern_languages) { find_or_create(:secondary_subject, :modern_languages) }
 
   its(:to_s) { should eq("Biology (#{course.provider.provider_code}/3X9F) [#{course.recruitment_cycle}]") }
   its(:modular) { should eq("") }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -349,12 +349,11 @@ describe Course, type: :model do
     end
 
     describe "#syncable_subjects" do
-      let(:subject) { create :subject, :primary }
-      let(:subject_discontinued) { create :subject, :primary, type: "DiscontinuedSubject" }
-      let(:subject_without_code) { create :subject, :primary, subject_code: nil }
+      let(:subject)          { create :subject, :primary }
+      let(:humanities)       { create :subject, :humanities }
+      let(:modern_languages) { create :secondary_subject, :modern_languages }
       let(:course) do
-        create :course,
-               subjects: [subject, subject_discontinued, subject_without_code]
+        create :course, subjects: [subject, modern_languages, humanities]
       end
 
       it "returns none-discontinued subjects that have a code present" do

--- a/spec/models/secondary_subject_spec.rb
+++ b/spec/models/secondary_subject_spec.rb
@@ -12,9 +12,21 @@ require "rails_helper"
 
 describe SecondarySubject, type: :model do
   describe "#modern_languages" do
+    let!(:modern_languages) do
+      find_or_create(:secondary_subject, :modern_languages)
+    end
+
     it "returns the modern language subject" do
-      modern_languages = create(:subject, subject_name: "Modern Languages", type: :SecondarySubject).becomes(SecondarySubject)
       expect(SecondarySubject.modern_languages).to eq(modern_languages)
+    end
+
+    it "memoises the subject object" do
+      SecondarySubject.modern_languages
+
+      allow(SecondarySubject).to receive(:find_by)
+
+      expect(SecondarySubject.modern_languages).to eq(modern_languages)
+      expect(SecondarySubject).not_to have_received(:find_by)
     end
   end
 end

--- a/spec/requests/api/v1/subject_spec.rb
+++ b/spec/requests/api/v1/subject_spec.rb
@@ -24,7 +24,7 @@ describe "Subjecs API", type: :request do
       expect(response).to have_http_status(:unauthorized)
     end
 
-    it "JSON body response contains expected provider attributes" do
+    it "JSON body response contains expected provider attributes", without_subjects: true do
       get "/api/v1/#{current_year}/subjects", headers: { "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Token.encode_credentials("bats") }
 
       json = JSON.parse(response.body)

--- a/spec/requests/api/v2/build_new_course_spec.rb
+++ b/spec/requests/api/v2/build_new_course_spec.rb
@@ -27,6 +27,7 @@ describe "/api/v2/build_new_course", type: :request do
       class: {
         Course: API::V2::SerializableCourse,
         Subject: API::V2::SerializableSubject,
+        PrimarySubject: API::V2::SerializableSubject,
       },
       include: [:subjects],
     ).to_json)

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -69,6 +69,7 @@ describe API::V2::SerializableCourse do
         class: {
           Course: API::V2::SerializableCourse,
           Subject: API::V2::SerializableSubject,
+          PrimarySubject: API::V2::SerializableSubject,
         },
         include: [
           :subjects,

--- a/spec/services/course_assignable_subject_service_spec.rb
+++ b/spec/services/course_assignable_subject_service_spec.rb
@@ -28,7 +28,7 @@ describe CourseAssignableSubjectService do
     let!(:biology) { create(:subject, subject_name: "Biology", type: :SecondarySubject).becomes(SecondarySubject) }
     let!(:arabic) { create(:subject, subject_name: "Arabic", type: :ModernLanguagesSubject).becomes(ModernLanguagesSubject) }
 
-    it "returns subjects other than modern language" do
+    it "returns subjects other than modern language", without_subjects: true do
       course = create(:course, level: "secondary")
       expect(service.execute(course)).to match_array([biology, arabic])
     end

--- a/spec/services/courses/generate_course_title_service_spec.rb
+++ b/spec/services/courses/generate_course_title_service_spec.rb
@@ -6,7 +6,7 @@ describe Courses::GenerateCourseTitleService do
   let(:is_send) { false }
   let(:level) { "primary" }
   let(:course) { Course.new(level: level, subjects: subjects, is_send: is_send) }
-  let(:modern_languages) { create(:subject, subject_name: "Modern Languages", type: :SecondarySubject).becomes(SecondarySubject) }
+  let(:modern_languages) { find_or_create(:secondary_subject, :modern_languages) }
   let(:generated_title) { service.execute(course: course) }
 
   before { modern_languages }

--- a/spec/support/reference_data.rb
+++ b/spec/support/reference_data.rb
@@ -18,4 +18,15 @@ RSpec.configure do |config|
       find_or_create :recruitment_cycle
     end
   end
+
+  # It's standard to have subjects in the DB, so create them by default, and use
+  # the tag "without_subjects: true" to make sure the subjects table is empty
+  # for tests that need it.
+  config.before(:all) do
+    SubjectCreatorService.new.execute
+  end
+
+  config.before(:each, without_subjects: true) do
+    Subject.delete_all
+  end
 end


### PR DESCRIPTION
### Context

With the recent work on subjects they weren't being preloaded causing the bulk sync job to become an N+1 query. 

### Changes proposed in this pull request

Add a method to use the already-loaded course subjects, if present, instead of always refering to the DB.

Also add memoisation of the "Modern Languages" subject to prevent DB hits.

Add creation of subjects in the specs outside of the spec transaction so that the memoised "Modern Languages" object is always the right one. This approach was taken since the subjects are singleton objects and this may present a useful optimisation approach in general to such data.

### Guidance to review

Sorry this turned into something a bit bigger than just the `syncable_subjects`, but it's all part of the boyscout approach.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
