### PR TITLE
[2237] migration to remove ucas subjects

### DIFF
--- a/db/migrate/20191016095315_remove_ucas_subject_and_course_ucas_subject.rb
+++ b/db/migrate/20191016095315_remove_ucas_subject_and_course_ucas_subject.rb
@@ -1,0 +1,22 @@
+class RemoveUCASSubjectAndCourseUCASSubject < ActiveRecord::Migration[6.0]
+  def up
+    drop_table :course_ucas_subject
+    drop_table :ucas_subject
+  end
+
+  def down
+    create_table "course_ucas_subject", id: :serial, force: :cascade do |t|
+      t.integer "course_id"
+      t.integer "ucas_subject_id"
+      t.index %w[course_id], name: "IX_course_subject_course_id"
+      t.index %w[ucas_subject_id], name: "IX_course_subject_subject_id"
+    end
+
+    create_table "ucas_subject", id: :serial, force: :cascade do |t|
+      t.text "subject_name"
+      t.text "subject_code", null: false
+      t.index %w[subject_code], name: "AK_subject_subject_code", unique: true
+      t.index %w[subject_name], name: "index_ucas_subject_on_subject_name"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -132,13 +132,6 @@ ActiveRecord::Schema.define(version: 2019_10_16_115552) do
     t.index ["subject_id"], name: "index_course_subject_on_subject_id"
   end
 
-  create_table "course_ucas_subject", id: :serial, force: :cascade do |t|
-    t.integer "course_id"
-    t.integer "ucas_subject_id"
-    t.index ["course_id"], name: "IX_course_subject_course_id"
-    t.index ["ucas_subject_id"], name: "IX_course_subject_subject_id"
-  end
-
   create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
   end
 
@@ -289,13 +282,6 @@ ActiveRecord::Schema.define(version: 2019_10_16_115552) do
     t.index ["subject_name"], name: "index_subject_on_subject_name"
   end
 
-  create_table "ucas_subject", id: :serial, force: :cascade do |t|
-    t.text "subject_name"
-    t.text "subject_code", null: false
-    t.index ["subject_code"], name: "AK_subject_subject_code", unique: true
-    t.index ["subject_name"], name: "index_ucas_subject_on_subject_name"
-  end
-
   create_table "user", id: :serial, force: :cascade do |t|
     t.text "email"
     t.text "first_name"
@@ -321,8 +307,6 @@ ActiveRecord::Schema.define(version: 2019_10_16_115552) do
   add_foreign_key "course_site", "site", name: "FK_course_site_site_site_id", on_delete: :cascade
   add_foreign_key "course_subject", "course", name: "fk_course_subject__course"
   add_foreign_key "course_subject", "subject", name: "fk_course_subject__subject"
-  add_foreign_key "course_ucas_subject", "course", name: "FK_course_subject_course_course_id", on_delete: :cascade
-  add_foreign_key "course_ucas_subject", "ucas_subject", name: "FK_course_subject_subject_subject_id", on_delete: :cascade
   add_foreign_key "financial_incentive", "subject"
   add_foreign_key "nctl_organisation", "organisation", name: "FK_nctl_organisation_organisation_organisation_id", on_delete: :cascade
   add_foreign_key "organisation_provider", "organisation", name: "FK_organisation_provider_organisation_organisation_id"


### PR DESCRIPTION
### Context

The tables for ucas_subject and course_ucas_subject are now redundant and need to be removed.

### Changes proposed in this pull request

- Migration to drop the tables

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
