### PR TITLE
[2360] Touch provider on contact update and push correct contact data to UCAS

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -15,6 +15,8 @@
 class Contact < ApplicationRecord
   self.inheritance_column = "_unused"
 
+  include TouchProvider
+
   belongs_to :provider
 
   audited associated_with: :provider

--- a/db/migrate/20191016115552_update_providers_with_ucas_contacts_changed_at.rb
+++ b/db/migrate/20191016115552_update_providers_with_ucas_contacts_changed_at.rb
@@ -1,0 +1,8 @@
+class UpdateProvidersWithUCASContactsChangedAt < ActiveRecord::Migration[6.0]
+  def change
+    providers = Provider.select { |provider| provider.contacts.any? }
+    providers.each do |provider_with_contacts|
+      provider_with_contacts.update(changed_at: Time.now)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_08_113447) do
+ActiveRecord::Schema.define(version: 2019_10_16_115552) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -33,7 +33,7 @@ describe Contact, type: :model do
     end
   end
 
-  describe 'on update' do
+  describe "on update" do
     let(:provider) { create(:provider, contacts: contacts, changed_at: 5.minute.ago) }
     let(:contacts) { [build(:contact)] }
 
@@ -41,7 +41,7 @@ describe Contact, type: :model do
       provider
     end
 
-    it 'should touch the provider' do
+    it "should touch the provider" do
       contacts.first.save
       expect(provider.reload.changed_at).to be_within(1.second).of Time.now.utc
     end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -32,4 +32,18 @@ describe Contact, type: :model do
               .with_suffix("contact")
     end
   end
+
+  describe 'on update' do
+    let(:provider) { create(:provider, contacts: contacts, changed_at: 5.minute.ago) }
+    let(:contacts) { [build(:contact)] }
+
+    before do
+      provider
+    end
+
+    it 'should touch the provider' do
+      contacts.first.save
+      expect(provider.reload.changed_at).to be_within(1.second).of Time.now.utc
+    end
+  end
 end


### PR DESCRIPTION
### Context

In the current implementation of UCAS contacts being updated the provider's changed_at is not being updated. This has meant that some of the 15 providers that have updated their contacts have not been pushed to UCAS va the V1 API. 

### Changes proposed in this pull request
- Update the providers changed_at when a contact is updated
- A migration that touches the 15 provider's with updated contacts 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
