### PR TITLE
[2373] Turn off sidekiq in development mode

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,7 +51,7 @@ Rails.application.configure do # rubocop: disable Metrics/BlockLength
 
   config.authentication_token = ENV.fetch("AUTHENTICATION_TOKEN", "bats")
 
-  config.active_job.queue_adapter = :sidekiq
+  config.active_job.queue_adapter = :async
 
   # Logging
   config.log_level = Settings.log_level


### PR DESCRIPTION
### Context

To remove redis from the development dependencies.

You can flip it back if you need to test sidekiq.

### Changes proposed in this pull request

Turn it off, but not on again.

sidekiq -> async


### Guidance to review

:ship:


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally