### PR TITLE
[2365] Allow subjects to be set in course creation

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -128,12 +128,13 @@ module API
         )
         course_code = generate_code_service.execute
 
-        course = Course.new(course_params.merge(provider: @provider, course_code: course_code))
+        @course = Course.new(course_params.merge(provider: @provider, course_code: course_code))
+        update_subjects
 
-        if course.save
-          render jsonapi: course.reload
+        if @course.save
+          render jsonapi: @course.reload
         else
-          render jsonapi_errors: course.errors, status: :unprocessable_entity
+          render jsonapi_errors: @course.errors, status: :unprocessable_entity
         end
       end
 

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -175,7 +175,7 @@ describe API::V2::SerializableCourse do
     let(:course) { create(:course, subjects: subjects) }
 
     describe "are taken from the course" do
-      let(:subjects) { [find_or_create(:subject, :primary)] }
+      let(:subjects) { [find_or_create(:primary_subject, :primary)] }
       it { expect(subject["attributes"]).to include("level" => "primary") }
       it { expect(subject["attributes"]).to include("subjects" => %w[Primary]) }
     end


### PR DESCRIPTION
### Context
We would like to be able to edit subjects during course creation, but as it stands the backend does not do the work of assigning subjects.

### Changes proposed in this pull request
Run `update_subjects` during course creation so that subjects can be set.

### Guidance to review

### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [x] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
