### PR TITLE
[2362] Ensure sites get assigned to non-persisted courses

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -377,8 +377,11 @@ class Course < ApplicationRecord
     to_remove = existing_sites - desired_sites
     to_remove.each { |site| remove_site!(site: site) }
 
-    sites.reload if persisted?
-    super(desired_sites) unless persisted?
+    if persisted?
+      sites.reload
+    else
+      super(desired_sites)
+    end
   end
 
   def has_bursary?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -305,7 +305,7 @@ class Course < ApplicationRecord
 
   def ucas_status
     return :running if findable?
-    return :new if site_statuses.empty? || site_statuses.status_new_status.any?
+    return :new if site_statuses.empty? || site_statuses.any?(&:status_new_status?)
 
     :not_running
   end
@@ -377,7 +377,8 @@ class Course < ApplicationRecord
     to_remove = existing_sites - desired_sites
     to_remove.each { |site| remove_site!(site: site) }
 
-    sites.reload
+    sites.reload if persisted?
+    super(desired_sites) unless persisted?
   end
 
   def has_bursary?

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -258,8 +258,40 @@ describe Course, type: :model do
         subject.sites = [second_site, new_site]
       end
 
+      context "with a ucas_status of new" do
+        let(:new_site_status) { create(:site_status, :new, site: site_with_new_site_status) }
+        let(:site_with_new_site_status) { create(:site) }
+        let(:subject) { create(:course, site_statuses: [new_site_status]) }
+
+        it "does not set the site to running" do
+          expect(second_site_status.reload.status).to eq("suspended")
+        end
+
+        it "should destroy the old site status" do
+          expect(SiteStatus.where(id: new_site_status.id)).to be_empty
+        end
+      end
+
+      context "With an unpersisted course" do
+        let(:course) { build(:course) }
+
+        before { course.sites = [first_site, second_site] }
+
+        it "sets the sites" do
+          expect(course.sites).to eq([first_site, second_site])
+        end
+
+        it "does not persist the course" do
+          expect(course).not_to be_persisted
+        end
+      end
+
       it "should assign new sites" do
         expect(subject.sites.to_a).to eq([second_site, new_site])
+      end
+
+      it "should set the sites to running" do
+        expect(second_site_status.reload.status).to eq("running")
       end
 
       it "should set old site_status to suspended" do


### PR DESCRIPTION
### Context

During course creation, the `build_new` endpoint does not return sites when assigned, this is because the `sites=` method is overridden to change sites based on persisted values.

This is a workaround for that behaviour

### Changes proposed in this pull request

- Add tests to existing behaviour
- Add tests for new course
- Change the logic on `sites=` where appropriate

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
