### PR TITLE
[2364] Assign sites to courses for course creation

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -24,6 +24,7 @@ module API
         authorize @provider
         @course = Course.new(provider: @provider)
         update_subjects
+        update_sites
         @course.assign_attributes(course_params)
         @course.name = generate_course_title_service.execute(course: @course)
         @course.valid?
@@ -32,7 +33,7 @@ module API
         json_data = JSONAPI::Serializable::Renderer.new.render(
           @course,
           class: CourseSerializersService.new.execute,
-          include: [:subjects],
+          include: %i[subjects sites],
         )
 
         json_data[:data][:errors] = []

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -131,6 +131,7 @@ module API
 
         @course = Course.new(course_params.merge(provider: @provider, course_code: course_code))
         update_subjects
+        update_sites
 
         if @course.save
           render jsonapi: @course.reload

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -95,7 +95,7 @@ class Course < ApplicationRecord
   has_many :financial_incentives, through: :subjects
   has_many :site_statuses
   has_many :sites,
-           -> { merge(SiteStatus.where(status: %i[new_status running])) },
+           -> { distinct.merge(SiteStatus.where(status: %i[new_status running])) },
            through: :site_statuses
 
   has_many :enrichments,

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -284,6 +284,13 @@ describe Course, type: :model do
         it "does not persist the course" do
           expect(course).not_to be_persisted
         end
+
+        xcontext "Which is then saved" do
+          it "Should only have two site statuses" do
+            course.save
+            expect(course.site_statuses.count).to eq(2)
+          end
+        end
       end
 
       it "should assign new sites" do

--- a/spec/requests/api/v2/build_new_course_spec.rb
+++ b/spec/requests/api/v2/build_new_course_spec.rb
@@ -29,7 +29,7 @@ describe "/api/v2/build_new_course", type: :request do
         Subject: API::V2::SerializableSubject,
         PrimarySubject: API::V2::SerializableSubject,
       },
-      include: [:subjects],
+      include: %i[subjects sites],
     ).to_json)
   end
 
@@ -104,6 +104,29 @@ describe "/api/v2/build_new_course", type: :request do
 
 
       expect(json_response).to eq expected
+    end
+  end
+
+  context "With sites_ids" do
+    let(:site_one) { create(:site, provider: provider) }
+    let(:site_two) { create(:site, provider: provider) }
+    let(:site_ids) { [site_one.id, site_two.id] }
+
+    let(:params) do
+      {
+        course: {
+          study_mode: "full_time",
+          sites_ids: site_ids,
+        },
+      }
+    end
+
+    it "returns a matching course with site information" do
+      response = do_get params
+      json_response = parse_response(response)
+
+      course_site_ids = json_response["data"]["relationships"]["sites"]["data"].map { |s| s["id"].to_i }
+      expect(course_site_ids).to eq(site_ids)
     end
   end
 


### PR DESCRIPTION
### Context

We need to assign sites to courses in the create/build_new endpoints in order for the frontend to display them, and courses to be created with them

### Changes proposed in this pull request

- Assign sites in the course controller
- `distinct` the sites relationship in the course model
  - Due to the way we solved the issue with sites= courses will be created with duplicated site statuses
    To work around that issue for now a distinct was added to the sites has_many to ensure the frontend only receives the sites added, not duplicates

### Checklist

https://trello.com/c/bFxJArKI/2364-assign-sites-to-course-during-creation

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
