### PR TITLE
2396 assign contacts with name

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -21,6 +21,10 @@ class Contact < ApplicationRecord
 
   audited associated_with: :provider
 
+  validates :name, presence: true
+  validates :email, email: true, presence: true
+  validates :telephone, phone: { message: "^Enter a valid telephone number" }, allow_nil: true
+
   enum type: {
     admin: "admin",
          utt: "utt",

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -23,7 +23,7 @@ class Contact < ApplicationRecord
 
   validates :name, presence: true
   validates :email, email: true, presence: true
-  validates :telephone, phone: { message: "^Enter a valid telephone number" }, allow_nil: true
+  validates :telephone, phone: true, allow_nil: true
 
   enum type: {
     admin: "admin",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,14 @@ en:
         address3: "Town or city"
     errors:
       models:
+        contact:
+          attributes:
+            email:
+              blank: "^Enter email address"
+            name:
+              blank: "^Enter name"
+            telephone:
+              blank: "^Enter a valid telephone number"
         site:
           attributes:
             location_name:

--- a/db/migrate/20191023195941_assign_provider_name_to_contacts.rb
+++ b/db/migrate/20191023195941_assign_provider_name_to_contacts.rb
@@ -1,0 +1,8 @@
+class AssignProviderNameToContacts < ActiveRecord::Migration[6.0]
+  def change
+    ucas_contacts_without_name = Contact.where(name: nil)
+    ucas_contacts_without_name.each do |contact|
+      contact.update(name: contact.provider.contact_name, telephone: contact.provider.telephone)
+    end
+  end
+end

--- a/db/migrate/20191023195941_assign_provider_name_to_contacts.rb
+++ b/db/migrate/20191023195941_assign_provider_name_to_contacts.rb
@@ -1,6 +1,6 @@
 class AssignProviderNameToContacts < ActiveRecord::Migration[6.0]
   def change
-    ucas_contacts_without_name = Contact.where(name: nil)
+    ucas_contacts_without_name = Contact.where(name: nil).includes(:provider)
     ucas_contacts_without_name.each do |contact|
       contact.update(name: contact.provider.contact_name, telephone: contact.provider.telephone)
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_16_115552) do
+ActiveRecord::Schema.define(version: 2019_10_23_195941) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -36,6 +36,7 @@ describe Contact, type: :model do
   describe "on update" do
     let(:provider) { create(:provider, contacts: contacts, changed_at: 5.minute.ago) }
     let(:contacts) { [build(:contact)] }
+    let(:contact) { contacts.first }
 
     before do
       provider
@@ -44,6 +45,57 @@ describe Contact, type: :model do
     it "should touch the provider" do
       contacts.first.save
       expect(provider.reload.changed_at).to be_within(1.second).of Time.now.utc
+    end
+
+
+    it { should validate_presence_of(:name) }
+
+    describe "telephone" do
+      it "validates telephone is present" do
+        contact.telephone = ""
+        contact.valid?
+
+        expect(contact.errors[:telephone]).to include("^Enter a valid telephone number")
+      end
+
+      it "Correctly validates valid phone numbers" do
+        contact.telephone = "+447 123 123 123"
+        expect(contact.valid?).to be true
+      end
+
+      it "Correctly invalidates invalid phone numbers" do
+        contact.telephone = "123foo456"
+        expect(contact.valid?).to be false
+        expect(contact.errors[:telephone]).to include("^Enter a valid telephone number")
+      end
+
+      it "Does not validate the telephone if it is not present"do
+        contact.email = "foo@bar.com"
+
+        expect(contact.valid?).to be true
+      end
+    end
+
+    describe "email" do
+      it "validates email is present" do
+        contact.email = ""
+        contact.valid?
+
+        expect(contact.errors[:email]).to include("^Enter an email address in the correct format, like name@example.com")
+      end
+
+      it "validates email contains an @ symbol" do
+        contact.email = "bar"
+        contact.valid?
+
+        expect(contact.errors[:email]).to include("^Enter an email address in the correct format, like name@example.com")
+      end
+
+      it "Does not validate the email if it is not present"do
+        contact.email = "foo@bar.com"
+
+        expect(contact.valid?).to be true
+      end
     end
   end
 end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -68,12 +68,6 @@ describe Contact, type: :model do
         expect(contact.valid?).to be false
         expect(contact.errors[:telephone]).to include("^Enter a valid telephone number")
       end
-
-      it "Does not validate the telephone if it is not present"do
-        contact.email = "foo@bar.com"
-
-        expect(contact.valid?).to be true
-      end
     end
 
     describe "email" do
@@ -91,7 +85,7 @@ describe Contact, type: :model do
         expect(contact.errors[:email]).to include("^Enter an email address in the correct format, like name@example.com")
       end
 
-      it "Does not validate the email if it is not present"do
+      it "Does not validate the email if it is present"do
         contact.email = "foo@bar.com"
 
         expect(contact.valid?).to be true


### PR DESCRIPTION
### Context
UCAS Contacts

### Changes proposed in this pull request
- Ensure all UCAS contacts have a name, telephone number and email

### Guidance to review
🚢 

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
