### PR TITLE
include recruitment cycle in query for provider index

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -13,6 +13,7 @@ module API
         authorize Provider
         providers = policy_scope(@recruitment_cycle.providers)
                       .include_courses_counts
+                      .includes(:recruitment_cycle)
         providers = providers.where(id: @user.providers) if @user.present?
 
         render jsonapi: providers.in_order,


### PR DESCRIPTION
### Context

Noticed while doing testing that there was an N+1 query triggered when we list providers in API v2. This wouldn't have a massive affect on users since they usually only have a few providers linked to their accounts, but whenever an admin user hits the system this would cause a costly query to run.

### Changes proposed in this pull request

include `recruitment_cycle` when listing providers for `/api/v2/providers`

### Guidance to review

No Trello card as it's a one-liner. I did a quick check and I don't think we even test for `includes` on queries.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [x] Tested by running locally
