### PR TITLE
[2319] add state machine for course

### DIFF
--- a/db/migrate/20191021210133_add_state_to_course.rb
+++ b/db/migrate/20191021210133_add_state_to_course.rb
@@ -1,0 +1,5 @@
+class AddStateToCourse < ActiveRecord::Migration[6.0]
+  def change
+    add_column :course, :state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -91,6 +91,7 @@ ActiveRecord::Schema.define(version: 2019_10_23_195941) do
     t.date "applications_open_from"
     t.boolean "is_send", default: false
     t.string "level"
+    t.string "state"
     t.index ["accrediting_provider_code"], name: "index_course_on_accrediting_provider_code"
     t.index ["accrediting_provider_id"], name: "IX_course_accrediting_provider_id"
     t.index ["changed_at"], name: "index_course_on_changed_at", unique: true


### PR DESCRIPTION
### Context

To simplify how we understand the state of a course, currently we derive it from several dynamic values, but reasoning what it is to be able to work with it is painful this way. We think that by driving the state with a state machine will simplify this.

### Changes proposed in this pull request

Just simply add a `state` column and the basics of the state machine, as we expect it should be, to `course`. It doesn't actually do anything except sketch how we think it will work, and prove that we can introduce it without breaking anything (yet).

### Guidance to review

More PRs to come, this is just trying to chip away at it so we avoid having one big, nasty PR to review.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
