### PR TITLE
[2417] Add missing spec for FinancialIncentive

### DIFF
--- a/spec/models/financial_incentive_spec.rb
+++ b/spec/models/financial_incentive_spec.rb
@@ -14,5 +14,7 @@
 require "rails_helper"
 
 describe FinancialIncentive, type: :model do
-  pending
+  describe "associations" do
+    it { should belong_to(:subject) }
+  end
 end


### PR DESCRIPTION
### Context

`pending`!

### Changes proposed in this pull request

* Add missing spec for FinancialIncentive

### Guidance to review

:ship:

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally