### PR TITLE
[2412] Fix ucas_preferences where there is no existing record

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -155,6 +155,7 @@ module API
       def update_ucas_preferences
         return if ucas_preferences_params.blank?
 
+        @provider.ucas_preferences = ProviderUCASPreference.new if @provider.ucas_preferences.nil?
         @provider.ucas_preferences.assign_attributes(ucas_preferences_params)
         @provider.ucas_preferences.save
       end

--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -155,7 +155,9 @@ module API
       def update_ucas_preferences
         return if ucas_preferences_params.blank?
 
-        @provider.ucas_preferences = ProviderUCASPreference.new if @provider.ucas_preferences.nil?
+        if @provider.ucas_preferences.nil?
+          @provider.ucas_preferences = ProviderUCASPreference.new
+        end
         @provider.ucas_preferences.assign_attributes(ucas_preferences_params)
         @provider.ucas_preferences.save
       end

--- a/spec/requests/api/v2/providers/update_provider_ucas_preferences.rb
+++ b/spec/requests/api/v2/providers/update_provider_ucas_preferences.rb
@@ -30,7 +30,7 @@ describe "PATCH recruitment_cycles/year/providers/:provider_code/courses/:course
     perform_request(updated_provider_ucas_preferences)
   end
 
-  subject { provider.ucas_preferences.reload }
+  subject { provider.reload.ucas_preferences.reload }
 
   context "for a provider with existing preferences" do
     let(:provider) do

--- a/spec/requests/api/v2/providers/update_provider_ucas_preferences.rb
+++ b/spec/requests/api/v2/providers/update_provider_ucas_preferences.rb
@@ -7,31 +7,8 @@ describe "PATCH recruitment_cycles/year/providers/:provider_code/courses/:course
       "/providers/#{provider.provider_code}"
   end
 
-  def perform_request(updated_provider_ucas_preferences)
-    jsonapi_data = jsonapi_renderer.render(
-      provider,
-      class: {
-        Provider: API::V2::SerializableProvider,
-      },
-    )
-
-    jsonapi_data[:data][:attributes] = updated_provider_ucas_preferences
-
-    patch request_path,
-          headers: { "HTTP_AUTHORIZATION" => credentials },
-          params: {
-            _jsonapi: jsonapi_data,
-          }
-  end
-
   let(:recruitment_cycle) { find_or_create :recruitment_cycle }
   let(:organisation) { create :organisation }
-  let(:provider)     do
-    create :provider,
-           organisations: [organisation],
-           recruitment_cycle: recruitment_cycle,
-           ucas_preferences: ucas_preferences
-  end
   let(:user)         { create :user, organisations: [organisation] }
   let(:payload)      { { email: user.email } }
   let(:token)        { build_jwt :apiv2, payload: payload }
@@ -39,7 +16,6 @@ describe "PATCH recruitment_cycles/year/providers/:provider_code/courses/:course
     ActionController::HttpAuthentication::Token.encode_credentials(token)
   end
   let(:ucas_preferences) { build(:provider_ucas_preference, type_of_gt12: :no_response, send_application_alerts: :all) }
-
 
   let(:updated_provider_ucas_preferences) do
     {
@@ -54,18 +30,57 @@ describe "PATCH recruitment_cycles/year/providers/:provider_code/courses/:course
     perform_request(updated_provider_ucas_preferences)
   end
 
-  context "provider has updated provider ucas_preferences" do
-    it "returns http success" do
-      expect(response).to have_http_status(:success)
+  subject { provider.ucas_preferences.reload }
+
+  context "for a provider with existing preferences" do
+    let(:provider) do
+      create :provider,
+             organisations: [organisation],
+             recruitment_cycle: recruitment_cycle,
+             ucas_preferences: ucas_preferences
     end
 
-    subject { provider.ucas_preferences.reload }
-
-    describe "type_of_gt12" do
-      its(:type_of_gt12) { should eq updated_provider_ucas_preferences[:type_of_gt12] }
-      its(:gt12_response_destination) { should eq updated_provider_ucas_preferences[:gt12_contact] }
-      its(:application_alert_email) { should eq updated_provider_ucas_preferences[:application_alert_contact] }
-      its(:send_application_alerts) { should eq updated_provider_ucas_preferences[:send_application_alerts] }
+    it "is successful" do
+      expect(response).to have_http_status(:success)
+      check_attributes_assigned
     end
   end
+
+  context "for a provider without existing preferences" do
+    let(:provider) do
+      create :provider,
+             organisations: [organisation],
+             recruitment_cycle: recruitment_cycle,
+             ucas_preferences: nil
+    end
+
+    it "is successful" do
+      expect(response).to have_http_status(:success)
+      check_attributes_assigned
+    end
+  end
+end
+
+def perform_request(updated_provider_ucas_preferences)
+  jsonapi_data = jsonapi_renderer.render(
+    provider,
+    class: {
+      Provider: API::V2::SerializableProvider,
+    },
+    )
+
+  jsonapi_data[:data][:attributes] = updated_provider_ucas_preferences
+
+  patch request_path,
+        headers: { "HTTP_AUTHORIZATION" => credentials },
+        params: {
+          _jsonapi: jsonapi_data,
+        }
+end
+
+def check_attributes_assigned
+  expect(subject.type_of_gt12).to eq updated_provider_ucas_preferences[:type_of_gt12]
+  expect(subject.gt12_response_destination).to eq updated_provider_ucas_preferences[:gt12_contact]
+  expect(subject.application_alert_email).to eq updated_provider_ucas_preferences[:application_alert_contact]
+  expect(subject.send_application_alerts).to eq updated_provider_ucas_preferences[:send_application_alerts]
 end


### PR DESCRIPTION
### Context

https://sentry.io/organizations/dfe-bat/issues/1295662651/

```
NoMethodError: undefined method `assign_attributes' for nil:NilClass
app/controllers/api/v2/providers_controller.rb:158:in `update_ucas_preferences'
@provider.ucas_preferences.assign_attributes(ucas_preferences_params)
app/controllers/api/v2/providers_controller.rb:36:in `update'
update_ucas_preferences
(58 additional frame(s) were not displayed)
```

~ 230 provider records out of 1900 are in this state

### Changes proposed in this pull request

* Failing test (commit 1)
* Fix ucas_preferences where there is no existing record (commit 2)

Before: 500 error saving contacts on new provider
After: 200 success

### Guidance to review

:eyes: :ship:

Is this idiomatic rails? https://github.com/DFE-Digital/manage-courses-backend/pull/940/files#diff-39dc04fe15459326f96c330daef49bb7R158

 ```
@provider.ucas_preferences = ProviderUCASPreference.new if @provider.ucas_preferences.nil?
```

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally