### PR TITLE
[2437] Update courses title when subjects are updated

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -178,6 +178,9 @@ module API
         return if subject_ids.nil?
 
         @course.subjects = Subject.where(id: subject_ids)
+        generate_course_title_service = Courses::GenerateCourseTitleService.new
+        @course.name = generate_course_title_service.execute(course: @course)
+        @course.save
       end
 
       def build_provider
@@ -259,7 +262,8 @@ module API
                   :sites_types,
                   :course_code,
                   :subjects_ids,
-                  :subjects_types)
+                  :subjects_types,
+                  :name)
           .permit(
             :english,
             :maths,
@@ -270,7 +274,6 @@ module API
             :applications_open_from,
             :study_mode,
             :is_send,
-            :name,
             :accrediting_provider_code,
             :funding_type,
             :level,

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -94,6 +94,7 @@ module API
         update_enrichment
         update_sites
         update_subjects
+
         @course.ensure_site_statuses_match_study_mode if @course.study_mode_previously_changed?
 
         should_sync = site_ids.present? && @course.should_sync?

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -58,7 +58,7 @@ FactoryBot.define do
     end
 
     trait :secondary do
-      age_range_in_years { "11_to_18" }
+      age_range_in_years { "16_to_18" }
       level { :secondary }
     end
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -58,7 +58,7 @@ FactoryBot.define do
     end
 
     trait :secondary do
-      age_range_in_years { "16_to_18" }
+      age_range_in_years { "11_to_18" }
       level { :secondary }
     end
 
@@ -106,7 +106,6 @@ FactoryBot.define do
       if course.subjects.any?
         generate_course_title_service = Courses::GenerateCourseTitleService.new
         course.name = generate_course_title_service.execute(course: course)
-        course.save
       end
 
       # We've just created a course with this provider's code, so ensure it's

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -87,16 +87,26 @@ FactoryBot.define do
           course.level = "further_education"
         end
       end
+
+      if course.subjects.any?
+        generate_course_title_service = Courses::GenerateCourseTitleService.new
+        course.name = generate_course_title_service.execute(course: course)
+      end
     end
 
     after(:create) do |course, evaluator|
       # This is important to retain the relationship behaviour between
       # course and it's enrichment
-
       if evaluator.age.present?
         course.created_at = evaluator.age
         course.updated_at = evaluator.age
         course.changed_at = evaluator.age
+      end
+
+      if course.subjects.any?
+        generate_course_title_service = Courses::GenerateCourseTitleService.new
+        course.name = generate_course_title_service.execute(course: course)
+        course.save
       end
 
       # We've just created a course with this provider's code, so ensure it's

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -79,14 +79,13 @@ describe "Courses API", type: :request do
       it "JSON body response contains expected course attributes" do
         get "/api/v1/#{current_year}/courses",
             headers: { "HTTP_AUTHORIZATION" => credentials }
-
         json = JSON.parse(response.body)
         expect(json). to eq([
                               {
                                 "course_code" => "2HPF",
                                 "start_month" => "#{current_year}-09-01T00:00:00Z",
                                 "start_month_string" => "September",
-                                "name" => "Religious Education",
+                                "name" => Course.first.name,
                                 "study_mode" => "F",
                                 "copy_form_required" => "Y",
                                 "profpost_flag" => "PG",

--- a/spec/requests/api/v2/providers/courses/update_subject_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_subject_spec.rb
@@ -79,5 +79,9 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
       expect(course.reload.subjects.first.id).to eq(subject1.id)
       expect(course.reload.subjects.second.id).to eq(subject2.id)
     end
+
+    it "updates the name of the course" do
+      expect(course.reload.name).to eq("English with Mathematics")
+    end
   end
 end

--- a/spec/serializers/search_and_compare/course_serializer_spec.rb
+++ b/spec/serializers/search_and_compare/course_serializer_spec.rb
@@ -19,7 +19,7 @@ describe SearchAndCompare::CourseSerializer do
                level: "primary",
                provider: provider,
                accrediting_provider: accrediting_provider,
-               name: "Primary (Special Educational Needs)",
+               name: "Primary (SEND)",
                course_code: "2KXB",
                start_date: "2019-08-01T00:00:00",
                program_type: :school_direct_salaried_training_programme,
@@ -41,6 +41,8 @@ describe SearchAndCompare::CourseSerializer do
           end
         end
       end
+
+
 
       let(:published_enrichment) do
         build :course_enrichment, :published,

--- a/spec/serializers/search_and_compare/test_data.json
+++ b/spec/serializers/search_and_compare/test_data.json
@@ -1,6 +1,6 @@
 {
   "Id": 0,
-  "Name": "Primary (Special Educational Needs)",
+  "Name": "Primary (SEND)",
   "ProgrammeCode": "2KXB",
   "ProviderCodeName": null,
   "ProviderId": 0,


### PR DESCRIPTION
### Context

The title courses title(name attribute) is not currently being updated when it's subjects are being updated.

### Changes proposed in this pull request
- update the course's name when it's subjects are updated
- refactor the course factory to use the correct name if is has subjects

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
