### PR TITLE
[2469] Ensure we set the name and phone for application alert recipient

### DIFF
--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -126,9 +126,9 @@ private
     if object.ucas_preferences&.application_alert_email
       [{
         type: "application_alert_recipient",
-        name: "",
+        name: object.contact_name,
         email: object.ucas_preferences&.application_alert_email,
-        telephone: "",
+        telephone: object.telephone,
       }]
     end
   end

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -216,9 +216,9 @@ describe "Providers API", type: :request do
                 },
                 {
                   "type" => "application_alert_recipient",
-                  "name" => "",
+                  "name" => "Amy Smith",
                   "email" => "application_alert_recipient@acmescitt.education.uk",
-                  "telephone" => "",
+                  "telephone" => "020 812 345 678",
                 },
               ],
               "created_at" => provider.created_at.iso8601,

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -70,9 +70,9 @@ describe ProviderSerializer do
 
       subject { application_alert_recipient }
 
-      its([:name]) { should eq "" }
+      its([:name]) { should eq provider.contact_name }
       its([:email]) { should eq provider.ucas_preferences.application_alert_email }
-      its([:telephone]) { should eq "" }
+      its([:telephone]) { should eq provider.telephone }
     end
 
     context "if nil" do


### PR DESCRIPTION
### Context
"application alert recipient" should have a name and telephone

### Changes proposed in this pull request
Add the provider contact name and telephone to the "application alert recipient" contact on V1 API for UCAS

### Guidance to review
🚢 

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
