### PR TITLE
[2470] Assign provider to course before other params in creation

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -132,7 +132,8 @@ module API
         generate_course_title_service = Courses::GenerateCourseTitleService.new
         course_code = generate_code_service.execute
 
-        @course = Course.new(course_params.merge(provider: @provider, course_code: course_code))
+        @course = Course.new(provider: @provider)
+        @course.assign_attributes(course_params.merge(course_code: course_code))
         update_subjects
         update_sites
 

--- a/spec/requests/api/v2/providers/courses/create_spec.rb
+++ b/spec/requests/api/v2/providers/courses/create_spec.rb
@@ -102,5 +102,22 @@ describe "Course POST #create API V2", type: :request do
         expect(created_course.course_code).to_not eq(existing_course.course_code)
       end
     end
+
+    context "When a provider is not accredited" do
+      let(:provider) { create(:provider, :accredited_body, organisations: [organisation]) }
+      let(:course) do
+        build(
+          :course,
+          provider: provider,
+          subjects: [primary_with_mathematics],
+          sites: [site_one, site_two],
+          funding_type: "fee",
+        )
+      end
+
+      it "Creates a course" do
+        expect { perform_request(course) }.to change { provider.reload.courses.count }.from(0).to(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

The course doesn't have the provider set when creating the course with all params at the same time. This calls the `funding_type=` method to be called before the provider is set

### Changes proposed in this pull request

Assign the provider to the course first before assigning other attributes

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
