### PR TITLE
[2454] Remove obsoleted functionality (part 1)

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -184,16 +184,6 @@ class Course < ApplicationRecord
       .courses.find_by(course_code: course_code)
   end
 
-  # To stop the API sending not valid values we have to write our own setter to ensure we get
-  # correct booleans stored.
-  def is_send=(value)
-    if value.to_s.in?(%w[true false 0 1])
-      super(value)
-    else
-      super(nil)
-    end
-  end
-
   def recruitment_cycle
     provider.recruitment_cycle
   end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -14,8 +14,7 @@
 class Organisation < ApplicationRecord
   has_many :organisation_users
 
-  # dependent destroy because https://stackoverflow.com/questions/34073757/removing-relations-is-not-being-audited-by-audited-gem/34078860#34078860
-  has_many :users, through: :organisation_users, dependent: :destroy
+  has_many :users, through: :organisation_users
 
   has_and_belongs_to_many :providers
 

--- a/db/migrate/20191101095530_remove_course_enrichment_legacy.rb
+++ b/db/migrate/20191101095530_remove_course_enrichment_legacy.rb
@@ -1,0 +1,6 @@
+class RemoveCourseEnrichmentLegacy < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :course_enrichment, :ucas_course_code
+    remove_column :course_enrichment, :provider_code
+  end
+end

--- a/spec/lib/mcb/commands/courses/list_spec.rb
+++ b/spec/lib/mcb/commands/courses/list_spec.rb
@@ -102,8 +102,10 @@ describe "mcb providers list" do
 
       command_output = execute_list(arguments: ["-r", additional_cycle.year])[:stdout]
 
-      expect(command_output).to include(course2.course_code)
-      expect(command_output).to include(course2.name)
+      expect(command_output)
+        .to have_cell_containing(course2.course_code).at_column(2)
+      expect(command_output)
+        .to have_cell_containing(course2.name).at_column(3)
 
       expect(command_output)
         .not_to have_cell_containing(course1.course_code).at_column(2)

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1368,13 +1368,6 @@ describe Course, type: :model do
 
       its(:is_send) { is_expected.to be(false) }
     end
-
-    context "when value is a string that is not like a boolean" do
-      let(:value) { "blah-blah" }
-
-      its(:is_send) { is_expected.to be_nil }
-      it { is_expected.to_not be_valid }
-    end
   end
 
   describe "#self_accredited?" do

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -47,6 +47,16 @@ describe Organisation, type: :model do
   describe "auditing" do
     it { should be_audited }
     it { should have_associated_audits }
+
+    it "a destroyed user" do
+      user = create(:user)
+      user.save!
+      organisation = create(:organisation)
+      organisation.add_user(user)
+      user.remove_access_to(organisation)
+      organisation.reload
+      expect(organisation.associated_audits.last.action).to eq("destroy")
+    end
   end
 
   describe "#add_user" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -125,7 +125,7 @@ describe User, type: :model do
     describe "one organisation" do
       before do
         subject.organisations = [organisation, other_organisation]
-        subject.remove_access_to organisation
+        subject.remove_access_to(organisation)
       end
 
       it "removes the right organisation"do

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -215,7 +215,7 @@ describe "Publish API v2", type: :request do
         end
       end
 
-      context "an inconsistent course and site status", focus: true do
+      context "an inconsistent course and site status" do
         let(:course) {
           create(:course,
                  provider: provider,

--- a/spec/requests/api/v2/providers/courses/update_send_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_send_spec.rb
@@ -87,17 +87,4 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
       expect(course.reload.is_send).to eq(@is_send)
     end
   end
-
-  context "for any course" do
-    context "when a bad `is_send` is submitted" do
-      let(:json_data) { JSON.parse(response.body)["errors"] }
-      let(:updated_is_send) { { is_send: "blah_blah" } }
-
-      it "returns an error" do
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(json_data.count).to eq 1
-        expect(response.body).to include("Invalid is_send")
-      end
-    end
-  end
 end

--- a/spec/support/parse_text_table.rb
+++ b/spec/support/parse_text_table.rb
@@ -57,7 +57,7 @@ end
 RSpec::Matchers.define :have_cell_containing do |text|
   match do |table_output|
     cells = get_row_and_column_cells_in_output(table_output)
-    cells.any? { |cell| cell.match?(text) }
+    cells.any? { |cell| cell&.match?(text) }
   end
 
   def get_row_and_column_cells_in_output(table_output)


### PR DESCRIPTION
### Context
There are a number of pieces of code that are no longer necessary increasing cognitive load.

### Changes proposed in this pull request
Remove any obsoleted functionality and anything dependent on it.

### Guidance to review
This eliminates the dependent destroy on organisations [seems to have now been fixed](https://github.com/rails/rails/issues/7618) (and additionally adds a test to ensure it functions correctly), the use of obsoleted columns in course_enrichments and the obsoleted is_send= setter.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
