### PR TITLE
[2476] Refactor content status to service 

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -281,24 +281,8 @@ class Course < ApplicationRecord
 
   def content_status
     newest_enrichment = enrichments.latest_first.first
-
-    if newest_enrichment.nil?
-      if next_recruitment_cycle?
-        :rolled_over
-      else
-        :empty
-      end
-    elsif newest_enrichment.published?
-      :published
-    elsif newest_enrichment.withdrawn?
-      :withdrawn
-    elsif newest_enrichment.has_been_published_before?
-      :published_with_unpublished_changes
-    elsif newest_enrichment.rolled_over?
-      :rolled_over
-    else
-      :draft
-    end
+    content_status_service = Courses::ContentStatusService.new
+    content_status_service.execute(newest_enrichment, next_recruitment_cycle?)
   end
 
   def ucas_status

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -282,7 +282,7 @@ class Course < ApplicationRecord
   def content_status
     newest_enrichment = enrichments.latest_first.first
     content_status_service = Courses::ContentStatusService.new
-    content_status_service.execute(newest_enrichment, next_recruitment_cycle?)
+    content_status_service.execute(newest_enrichment, recruitment_cycle)
   end
 
   def ucas_status

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -41,6 +41,10 @@ class RecruitmentCycle < ApplicationRecord
     RecruitmentCycle.find_by(year: year.to_i + 1)
   end
 
+  def next?
+    RecruitmentCycle.next_recruitment_cycle == self
+  end
+
   def current?
     RecruitmentCycle.current_recruitment_cycle == self
   end

--- a/app/services/courses/content_status_service.rb
+++ b/app/services/courses/content_status_service.rb
@@ -1,8 +1,8 @@
 module Courses
   class ContentStatusService
-    def execute(enrichment, next_cycle_boolean)
+    def execute(enrichment, recruitment_cycle)
       if !enrichment.present?
-        if next_cycle_boolean
+        if recruitment_cycle.next?
           :rolled_over
         else
           :empty

--- a/app/services/courses/content_status_service.rb
+++ b/app/services/courses/content_status_service.rb
@@ -1,0 +1,23 @@
+module Courses
+  class ContentStatusService
+    def execute(enrichment, next_cycle_boolean)
+      if !enrichment.present?
+        if next_cycle_boolean
+          :rolled_over
+        else
+          :empty
+        end
+      elsif enrichment.published?
+        :published
+      elsif enrichment.withdrawn?
+        :withdrawn
+      elsif enrichment.has_been_published_before?
+        :published_with_unpublished_changes
+      elsif enrichment.rolled_over?
+        :rolled_over
+      else
+        :draft
+      end
+    end
+  end
+end

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -132,5 +132,18 @@ describe RecruitmentCycle, type: :model do
         expect(second_cycle.next).to eq(third_cycle)
       end
     end
+
+    describe "next?" do
+      let(:current_cycle) { find_or_create :recruitment_cycle }
+      let(:next_cycle) { find_or_create :recruitment_cycle, :next }
+
+      it "should return true when it's the next cycle" do
+        expect(next_cycle.next?).to be(true)
+      end
+
+      it "should return true false it's not the next cycle" do
+        expect(current_cycle.next?).to be(false)
+      end
+    end
   end
 end

--- a/spec/services/courses/content_status_service_spec.rb
+++ b/spec/services/courses/content_status_service_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+describe Courses::ContentStatusService do
+  let(:service) { described_class.new }
+  let(:execute_service) { service.execute(enrichment, next_cycle_boolean) }
+  let(:next_cycle_boolean) { false }
+
+  context "when the enrichment parameter is nil" do
+    let(:enrichment) { nil }
+
+    context "and belongs to the next recruitment" do
+      let(:next_cycle_boolean) { true }
+
+      it "returns rolled over" do
+        expect(execute_service).to eq :rolled_over
+      end
+    end
+
+    context "and does not belong to the next recruitment cycle" do
+      it "returns empty" do
+        expect(execute_service).to eq :empty
+      end
+    end
+  end
+
+  context "when the enrichment has been published" do
+    let(:enrichment) { build(:course_enrichment, :published) }
+
+    it "returns rolled over" do
+      expect(execute_service).to eq :published
+    end
+  end
+
+  context "when the enrichment has been withdrawn" do
+    let(:enrichment) { build(:course_enrichment, :withdrawn) }
+
+    it "returns rolled over" do
+      expect(execute_service).to eq :withdrawn
+    end
+  end
+
+  context "when the enrichment has been been published previously" do
+    let(:enrichment) { build(:course_enrichment, :subsequent_draft) }
+
+    it "returns rolled over" do
+      expect(execute_service).to eq :published_with_unpublished_changes
+    end
+  end
+
+  context "when the enrichment has been rolled over" do
+    let(:enrichment) { build(:course_enrichment, :rolled_over) }
+
+    it "returns rolled over" do
+      expect(execute_service).to eq :rolled_over
+    end
+  end
+
+  context "when the enrichment is a draft enrichment" do
+    let(:enrichment) { build(:course_enrichment) }
+
+    it "returns rolled over" do
+      expect(execute_service).to eq :draft
+    end
+  end
+end

--- a/spec/services/courses/content_status_service_spec.rb
+++ b/spec/services/courses/content_status_service_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 describe Courses::ContentStatusService do
   let(:service) { described_class.new }
-  let(:execute_service) { service.execute(enrichment, next_cycle_boolean) }
-  let(:next_cycle_boolean) { false }
+  let(:execute_service) { service.execute(enrichment, recruitment_cycle) }
+  let(:recruitment_cycle) { find_or_create(:recruitment_cycle) }
 
   context "when the enrichment parameter is nil" do
     let(:enrichment) { nil }
 
     context "and belongs to the next recruitment" do
-      let(:next_cycle_boolean) { true }
+      let(:recruitment_cycle) { find_or_create(:recruitment_cycle, :next) }
 
       it "returns rolled over" do
         expect(execute_service).to eq :rolled_over


### PR DESCRIPTION
### Context

The course model is currently over 600 lines and has become a bit of a god class

### Changes proposed in this pull request
- refactor content status into a service object

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
