### PR TITLE
[2480] Restrict email for admin users to education domains

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,11 @@ class User < ApplicationRecord
   validates :email, presence: true, format: { with: /@/, message: "must contain @" }
   validate :email_is_lowercase
 
+  validates :email, if: :admin?, format: {
+    with: /@(digital\.){0,1}education\.gov\.uk\z/,
+    message: "must be an @[digital.]education.gov.uk domain",
+  }
+
   audited
 
   aasm column: "state" do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
 
     trait :admin do
       admin { true }
+      email { "factory.admin@education.gov.uk" }
     end
 
     trait :with_organisation do

--- a/spec/lib/mcb/commands/courses/audit_spec.rb
+++ b/spec/lib/mcb/commands/courses/audit_spec.rb
@@ -7,7 +7,8 @@ describe "mcb courses audit" do
     end
   end
 
-  let(:admin_user) { create :user, :admin, email: "h@i" }
+  let(:admin_email) { "aa@education.gov.uk" }
+  let(:admin_user) { create :user, :admin, email: admin_email }
 
   let(:recruitment_year1) { create :recruitment_cycle, :next }
   let(:recruitment_year2) { RecruitmentCycle.current_recruitment_cycle }
@@ -40,14 +41,14 @@ describe "mcb courses audit" do
       )[:stdout]
 
       expect(output).to have_text_table_row(admin_user.id,
-                                            "h@i",
+                                            admin_email,
                                             "update",
                                             "",
                                             "",
                                             '{"name"=>["P", "Y"],')
 
       expect(output).not_to have_text_table_row(admin_user.id,
-                                                "h@i",
+                                                admin_email,
                                                 "update",
                                                 "",
                                                 "",
@@ -70,14 +71,14 @@ describe "mcb courses audit" do
       )[:stdout]
 
       expect(output).to have_text_table_row(admin_user.id,
-                                            "h@i",
+                                            admin_email,
                                             "update",
                                             "",
                                             "",
                                             '{"name"=>["P", "B"],')
 
       expect(output).not_to have_text_table_row(admin_user.id,
-                                                "h@i",
+                                                admin_email,
                                                 "update",
                                                 "",
                                                 "",

--- a/spec/lib/mcb/commands/users/audit_spec.rb
+++ b/spec/lib/mcb/commands/users/audit_spec.rb
@@ -7,11 +7,11 @@ describe "mcb users audit" do
       "#{lib_dir}/mcb/commands/users/audit.rb",
     )
   end
+  let(:admin_email) { "aa@education.gov.uk" }
+  let(:admin_user) { create :user, :admin, email: admin_email }
+  let(:user) { create :user, email: "a@a" }
 
   it "shows the list of changes for a given user" do
-    user = create(:user, email: "a@a")
-    admin_user = create :user, :admin, email: "h@i"
-
     Audited.store[:audited_user] = admin_user
     user.update(email: "b@b")
 
@@ -21,7 +21,7 @@ describe "mcb users audit" do
     output = output[:stdout]
 
     expect(output).to have_text_table_row(admin_user.id,
-                                          "h@i",
+                                          admin_email,
                                           "update",
                                           "",
                                           "",
@@ -29,9 +29,6 @@ describe "mcb users audit" do
   end
 
   it "allows specifying user by email" do
-    user = create(:user, email: "a@a")
-    admin_user = create :user, :admin, email: "h@i"
-
     Audited.store[:audited_user] = admin_user
     user.update(email: "b@b")
 
@@ -41,7 +38,7 @@ describe "mcb users audit" do
     output = output[:stdout]
 
     expect(output).to have_text_table_row(admin_user.id,
-                                          "h@i",
+                                          admin_email,
                                           "update",
                                           "",
                                           "",
@@ -49,9 +46,6 @@ describe "mcb users audit" do
   end
 
   it "allows specifying user by sign-in id" do
-    user = create(:user, email: "a@a")
-    admin_user = create :user, :admin, email: "h@i"
-
     Audited.store[:audited_user] = admin_user
     user.update(email: "b@b")
 
@@ -61,7 +55,7 @@ describe "mcb users audit" do
     output = output[:stdout]
 
     expect(output).to have_text_table_row(admin_user.id,
-                                          "h@i",
+                                          admin_email,
                                           "update",
                                           "",
                                           "",

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -35,6 +35,14 @@ describe User, type: :model do
     it { is_expected.to validate_presence_of(:email).with_message("must contain @") }
     it { should_not allow_value("CAPS_IN_EMAIL@ACME.ORG").for(:email) }
     it { should_not allow_value("email_without_at").for(:email) }
+
+    context "for an admin-user" do
+      subject { create(:user, :admin) }
+      it { should_not allow_value("general.public@example.org").for(:email) }
+      it { should_not allow_value("some.provider@devon.gov.uk").for(:email) }
+      it { should allow_value("bobs.your.uncle@digital.education.gov.uk").for(:email) }
+      it { should allow_value("right.malarky@education.gov.uk").for(:email) }
+    end
   end
 
   describe "auditing" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -31,11 +31,11 @@ describe User, type: :model do
     it { should have_many(:providers).through(:organisations) }
   end
 
-  it { is_expected.to validate_presence_of(:email).with_message("must contain @") }
-  its(:to_s) { should eq("Jane Smith <jsmith@scitt.org>") }
-
-  it { should_not allow_value("CAPS_IN_EMAIL@ACME.ORG").for(:email) }
-  it { should_not allow_value("email_without_at").for(:email) }
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:email).with_message("must contain @") }
+    it { should_not allow_value("CAPS_IN_EMAIL@ACME.ORG").for(:email) }
+    it { should_not allow_value("email_without_at").for(:email) }
+  end
 
   describe "auditing" do
     it { should be_audited }
@@ -62,6 +62,10 @@ describe User, type: :model do
     end
 
     it { should be_rolled_over }
+  end
+
+  describe "#to_s" do
+    its(:to_s) { should eq("Jane Smith <jsmith@scitt.org>") }
   end
 
   describe "#admin?" do


### PR DESCRIPTION
### Context

* Fear, uncertainty & doubt.
* This is a follow-up to #954 

### Changes proposed in this pull request

* Restrict email for admin users to education domains
* The mighty power of test-driven development

### Guidance to review

:eyes: :ship:

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally