### PR TITLE
[2235] Test personal information isnt being leaked in logging

### DIFF
--- a/app/controllers/api/v2/application_controller.rb
+++ b/app/controllers/api/v2/application_controller.rb
@@ -9,7 +9,7 @@ module API
 
       def authenticate
         authenticate_or_request_with_http_token do |token|
-          @current_user = AuthenticationService.new.execute(token)
+          @current_user = AuthenticationService.new(logger: Rails.logger).execute(token)
           assign_sentry_contexts
           assign_logstash_contexts
           @current_user.present?

--- a/app/controllers/api/v2/application_controller.rb
+++ b/app/controllers/api/v2/application_controller.rb
@@ -9,7 +9,7 @@ module API
 
       def authenticate
         authenticate_or_request_with_http_token do |token|
-          @current_user = AuthenticationService.call(token)
+          @current_user = AuthenticationService.new.execute(token)
           assign_sentry_contexts
           assign_logstash_contexts
           @current_user.present?

--- a/app/services/authentication_service.rb
+++ b/app/services/authentication_service.rb
@@ -1,15 +1,8 @@
 class AuthenticationService
   attr_accessor :encoded_token, :user
 
-  def self.call(encoded_token)
-    new(encoded_token).call
-  end
-
-  def initialize(encoded_token)
+  def execute(encoded_token)
     @encoded_token = encoded_token
-  end
-
-  def call
     @user = user_by_sign_in_user_id || user_by_email
 
     update_user_information

--- a/app/services/authentication_service.rb
+++ b/app/services/authentication_service.rb
@@ -83,10 +83,12 @@ private
 
     user = User.find_by(sign_in_user_id: sign_in_user_id_from_token)
     if user
-      logger.debug("User found from sign_in_user_id in token " + {
+      logger.debug {
+        "User found from sign_in_user_id in token " + {
                      sign_in_user_id: sign_in_user_id_from_token,
                      user: log_safe_user(user),
-                   }.to_s)
+                   }.to_s
+      }
     end
     user
   end

--- a/app/services/authentication_service.rb
+++ b/app/services/authentication_service.rb
@@ -1,6 +1,10 @@
 class AuthenticationService
   attr_accessor :encoded_token, :user
 
+  def initialize(logger:)
+    @logger = logger
+  end
+
   def execute(encoded_token)
     @encoded_token = encoded_token
     @user = user_by_sign_in_user_id || user_by_email
@@ -16,9 +20,7 @@ class AuthenticationService
 
 private
 
-  def logger
-    Rails.logger
-  end
+  attr_reader :logger
 
   def decoded_token
     @decoded_token ||= JWT.decode(

--- a/spec/services/authentication_service_spec.rb
+++ b/spec/services/authentication_service_spec.rb
@@ -5,6 +5,7 @@ describe AuthenticationService do
     let(:first_name) { user.first_name }
     let(:last_name) { user.last_name }
     let(:sign_in_user_id) { user.sign_in_user_id }
+    let(:logger_spy) { spy }
     let(:payload) do
       {
         email:           email,
@@ -13,8 +14,9 @@ describe AuthenticationService do
         last_name: last_name,
       }
     end
+    let(:service) { described_class.new(logger: logger_spy) }
 
-    subject { described_class.new.execute(encode_token(payload)) }
+    subject { service.execute(encode_token(payload)) }
 
     def encode_token(payload)
       JWT.encode(

--- a/spec/services/authentication_service_spec.rb
+++ b/spec/services/authentication_service_spec.rb
@@ -1,5 +1,5 @@
 describe AuthenticationService do
-  describe ".call" do
+  describe "#execute" do
     let(:user) { create(:user) }
     let(:email) { user.email }
     let(:first_name) { user.first_name }
@@ -14,7 +14,7 @@ describe AuthenticationService do
       }
     end
 
-    subject { described_class.call(encode_token(payload)) }
+    subject { described_class.new.execute(encode_token(payload)) }
 
     def encode_token(payload)
       JWT.encode(


### PR DESCRIPTION
### Context

When we added logging, we opted to avoid testing it as we wanted to fix an urgent issue. This refactors the service to allow for the testing of logging and also tests the logging

### Changes proposed in this pull request

- Refactor authentication service to invert dependencies
- Test the logging
- Fix a bug caught by the tests

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
