### PR TITLE
[2449] Secure Redis connection

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -380,7 +380,7 @@
               },
               {
                 "name": "REDIS_URL",
-                "value": "[concat ('redis://',parameters('redisCacheName'),'.redis.cache.windows.net:6379')]"
+                "value": "[concat ('rediss://',parameters('redisCacheName'),'.redis.cache.windows.net:6380')]"
               },
               {
                 "name": "WEBSITE_SLOT_POLL_WORKER_FOR_CHANGE_NOTIFICATION",
@@ -572,7 +572,7 @@
               },
               {
                 "name": "REDIS_URL",
-                "value": "[concat ('redis://',parameters('redisCacheName'),'.redis.cache.windows.net:6379')]"
+                "value": "[concat ('rediss://',parameters('redisCacheName'),'.redis.cache.windows.net:6380')]"
               },
               {
                 "name": "SETTINGS__LOGSTASH__HOST",


### PR DESCRIPTION
### Context
As it stands we connect to Redis in an insecure manner, this may be a minor security risk.

### Changes proposed in this pull request
Make Sidekiq connect to Redis on port 6379 over `rediss`

### Guidance to review

### Checklist

- [X] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased master
- [X] Cleaned commit history
- [ ] Tested by running locally
