### PR TITLE
[2473] Cleanup (part 2)

### DIFF
--- a/app/controllers/api/v2/sessions_controller.rb
+++ b/app/controllers/api/v2/sessions_controller.rb
@@ -15,6 +15,7 @@ module API
           ),
         )
 
+        record_first_login
         send_welcome_email
 
         render jsonapi: @current_user
@@ -32,6 +33,10 @@ module API
             :first_name,
             :last_name,
           )
+      end
+
+      def record_first_login
+        RecordFirstLoginService.new.execute(current_user: @current_user)
       end
 
       def send_welcome_email

--- a/app/services/record_first_login_service.rb
+++ b/app/services/record_first_login_service.rb
@@ -1,0 +1,7 @@
+class RecordFirstLoginService
+  def execute(current_user:)
+    return unless current_user.first_login_date_utc.nil?
+
+    current_user.update(first_login_date_utc: Time.now.utc)
+  end
+end

--- a/app/services/send_welcome_email_service.rb
+++ b/app/services/send_welcome_email_service.rb
@@ -4,21 +4,6 @@ class SendWelcomeEmailService
   end
 
   def execute(current_user:)
-    set_first_login_date(current_user)
-    send_welcome_email(current_user)
-  end
-
-private
-
-  def set_first_login_date(current_user)
-    return if current_user.first_login_date_utc
-
-    current_user.update(
-      first_login_date_utc: Time.now.utc,
-    )
-  end
-
-  def send_welcome_email(current_user)
     return if current_user.welcome_email_date_utc
 
     @mailer.send_welcome_email(first_name: current_user.first_name, email: current_user.email).deliver_now

--- a/app/validators/words_count_validator.rb
+++ b/app/validators/words_count_validator.rb
@@ -1,9 +1,13 @@
 class WordsCountValidator < ActiveModel::EachValidator
-  def validate_each(record, attribute, value)
-    return if value.blank?
+  def validate_each(record, attribute, string)
+    return if string.blank?
 
-    if value.scan(/\S+/).size > options[:maximum]
+    if word_count(string) > options[:maximum]
       record.errors[attribute] << (options[:message] || "^Reduce the word count for #{attribute.to_s.humanize(capitalize: false)}")
     end
+  end
+
+  def word_count(string)
+    string.scan(/\S+/).size
   end
 end

--- a/spec/services/authentication_service_spec.rb
+++ b/spec/services/authentication_service_spec.rb
@@ -8,7 +8,7 @@ describe AuthenticationService do
     let(:logger_spy) { spy }
     let(:payload) do
       {
-        email:           email,
+        email: email,
         sign_in_user_id: sign_in_user_id,
         first_name: first_name,
         last_name: last_name,

--- a/spec/services/record_first_login_service_spec.rb
+++ b/spec/services/record_first_login_service_spec.rb
@@ -1,0 +1,24 @@
+describe RecordFirstLoginService do
+  let(:service) { described_class.new }
+
+  context "with no previous logins" do
+    let(:current_user_spy) { spy(first_login_date_utc: nil) }
+
+    it "updates the first login date" do
+      Timecop.freeze do
+        update_time = Time.now.utc
+        service.execute(current_user: current_user_spy)
+        expect(current_user_spy).to have_received(:update).with(first_login_date_utc: update_time)
+      end
+    end
+  end
+
+  context "with previous logins" do
+    let(:current_user_spy) { spy(first_login_date_utc: Time.now) }
+
+    it "does not update the first login date" do
+      service.execute(current_user: current_user_spy)
+      expect(current_user_spy).not_to have_received(:update)
+    end
+  end
+end

--- a/spec/services/send_welcome_email_service_spec.rb
+++ b/spec/services/send_welcome_email_service_spec.rb
@@ -17,10 +17,6 @@ describe SendWelcomeEmailService do
 
     before { service.execute(current_user: current_user_spy) }
 
-    it "sets their first login date to now" do
-      expect(current_user_spy).to have_received(:update).with(hash_including(first_login_date_utc: Time.now.utc))
-    end
-
     it "sets their welcome email date to now" do
       expect(current_user_spy).to have_received(:update).with(hash_including(welcome_email_date_utc: Time.now.utc))
     end


### PR DESCRIPTION
### Context
In order to be able to deliver value it must be easy to understand and work with the code.
https://github.com/DFE-Digital/manage-courses-backend/pull/942


### Changes proposed in this pull request
This refactors any unclear or non-idiomatic lines.

### Guidance to review
Remove unused functionality from authentication service and clarify the use of MD5 as obfuscation. Moves some of SendWelcomeEmailService's functionality to RecordFirstLoginService to avoid having a service do too many things. Also includes some additional restructuring.

### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
