### PR TITLE
[2488] - Run specs locally in parallel

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,4 +1,7 @@
 # This is to allow specs to be run in parallel without falling over
+# due to a subtle bug in bundler load paths
+# https://github.com/grosser/parallel_tests/issues/649
+# https://github.com/bundler/bundler/issues/5005#issuecomment-251025953
 # See discussion on https://github.com/DFE-Digital/manage-courses-backend/pull/970
 ---
 BUNDLE_DISABLE_EXEC_LOAD: "true"

--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,4 @@
+# This is to allow specs to be run in parallel without falling over
+# See discussion on https://github.com/DFE-Digital/manage-courses-backend/pull/970
+---
+BUNDLE_DISABLE_EXEC_LOAD: "true"

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,6 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
-# Ignore bundler config.
-/.bundle
-
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/Gemfile
+++ b/Gemfile
@@ -167,5 +167,6 @@ group :test do
   gem "rspec_junit_formatter"
   gem "shoulda-matchers", "~> 4.1"
   gem "simplecov", require: false
+  gem "simplecov-console"
   gem "webmock"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -110,6 +110,9 @@ group :development, :test do
   # GOV.UK interpretation of rubocop for linting Ruby
   gem "govuk-lint"
 
+  # run specs in parallel
+  gem "parallel_tests"
+
   # A little extra console goodness
   gem "pry"
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
     annotate (3.0.2)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 13.0)
+    ansi (1.5.0)
     api-pagination (4.8.2)
     application_insights (0.5.6)
     ast (2.4.0)
@@ -387,6 +388,10 @@ GEM
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
+    simplecov-console (0.5.0)
+      ansi
+      simplecov
+      terminal-table
     simplecov-html (0.10.2)
     spring (2.1.0)
     spring-commands-rspec (1.0.4)
@@ -491,6 +496,7 @@ DEPENDENCIES
   sidekiq
   sidekiq-cron
   simplecov
+  simplecov-console
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,6 +256,8 @@ GEM
     notifications-ruby-client (4.0.0)
       jwt (>= 1.5, < 3)
     parallel (1.17.0)
+    parallel_tests (2.29.2)
+      parallel
     parser (2.6.5.0)
       ast (~> 2.4.0)
     patience_diff (1.1.0)
@@ -467,6 +469,7 @@ DEPENDENCIES
   kaminari
   listen (>= 3.0.5, < 3.3)
   logstash-logger (~> 0.26.1)
+  parallel_tests
   pg
   pkg-config (~> 1.4.0)
   pry

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ If you are going to login with a user who hasn't recieved the welcome email - yo
 ### Native
 
 0. If you haven't already, follow this [tutorial](https://gorails.com/setup) to setup your Rails environment, make sure to install PostgreSQL 9.6 as the database
-1. Run `bundle install` to install the gem dependencies
-2. Run `bundle exec rails db:setup` to create a development and testing database
+1. Run `bundle install` to install the gem dependencies.
+2. Run `bundle exec rails db:setup` to create a development and testing database.
 3. Run `bundle exec rails server` to launch the app on http://localhost:3001.
 
 ### Docker
@@ -55,10 +55,6 @@ docker-compose exec web /bin/sh -c "bundle exec rails db:setup"
 
 Then open http://localhost:3001 to see the app.
 
-## Running specs, linter (with auto correct) and annotate models and serializers
-```
-bundle exec rake
-```
 
 ## Running specs
 ```
@@ -71,6 +67,19 @@ Or through guard (`--no-interactions` allows the use of `pry` inside tests):
 bundle exec guard --no-interactions
 ```
 
+## Running specs in parallel
+
+When running specs in parallel for the first time you will first need to set up
+your test databases. 
+
+`bundle exec rails parallel:setup`
+
+To run the specs in parallel:
+`bundle exec rails parallel:spec`
+
+To drop the test databases:
+`bundle exec rails parallel:drop`
+
 ## Linting
 
 It's best to lint just your app directories and not those belonging to the framework:
@@ -81,6 +90,12 @@ bundle exec rubocop app config db lib spec --format clang
 or
 
 docker-compose exec web /bin/sh -c "bundle exec rubocop app config db lib spec Gemfile --format clang"
+```
+
+## Running specs, linter (with auto correct) and annotate models and serializers
+
+```
+bundle exec rake
 ```
 
 ## Accessing API

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,10 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks
 
-task lint: ['lint:ruby']
-task annotate: ['db:annotate']
+task lint: ["lint:ruby"]
+task annotate: ["db:annotate"]
 task default: %i[spec annotate lint]

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,7 +13,7 @@ development:
 
 test:
   <<: *default
-  database: <%= ENV['DB_DATABASE'] || 'manage_courses_backend_test' %>
+  database: <%= ENV['DB_DATABASE'] || "manage_courses_backend_test#{ENV['TEST_ENV_NUMBER']}" %>
 
 staging:
   <<: *default

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,9 +2,6 @@
 require "database_cleaner"
 require "spec_helper"
 
-require "simplecov"
-SimpleCov.start
-
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../config/environment", __dir__)
 # Prevent database truncation if the environment is production

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,19 @@ require "super_diff/rspec"
 require "fakefs/spec_helpers"
 require "webmock/rspec"
 require "audited-rspec"
+require "simplecov"
+require "simplecov-console"
+
+SimpleCov.formatter = SimpleCov::Formatter::Console
+SimpleCov.start
+# If running specs in parallel this ensures SimpleCov results appears
+# upon completion of all specs
+if ENV["PARALLEL_TEST_GROUPS"]
+  SimpleCov.at_exit do
+    result = SimpleCov.result
+    result.format! if ParallelTests.number_of_running_processes <= 1
+  end
+end
 
 # Pull in all the files in spec/support automatically.
 Dir["./spec/support/**/*.rb"].each { |file| require file }


### PR DESCRIPTION
### Context
The work required to make these specs run in parallel is very similar to https://github.com/DFE-Digital/manage-courses-frontend/pull/742 however we now have a database to contend with.

_Rationale for changes?_
- Slow running specs eat up valuable dev-time.
- It's a pain to have to manually open up SimpleCov results right?

### Changes proposed in this pull request
Adds:
-  the `parallel_tests` gem to speed up tests
- the `simplecov-console` gem to print SimpleCov test output to the console

The default rake task has been amended so that parallel specs run by default (using 12 cores) 

### Guidance to review
- to change the number of cores used when running the default Rake task `bundle exec rake` set a `'PARALLEL_CORES'` env var to what ever your machine can handle.
- to just run the tests in parallel run `bundle exec rake parallel:spec`
- _NOTE_ - a local bundle config has been added to address a known 'bundler' gem bug. See comments below. Thanks @timabell for helping to debug this 🥇 

### How fast are the tests now?
(utilising 12 cores)

Before:
160 seconds 

After:
4 cores - 89 seconds
12 cores - 66 seconds

### SimpleCov console output
<img width="1623" alt="simplecov" src="https://user-images.githubusercontent.com/5256922/68209128-a0eeec00-ffca-11e9-9f04-d84095e92677.png">

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
