### PR TITLE
[2476] Refactor funding_type= to service

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -411,24 +411,8 @@ class Course < ApplicationRecord
   end
 
   def funding_type=(funding_type)
-    case funding_type
-    when "salary"
-      if !self_accredited?
-        self.program_type = :school_direct_salaried_training_programme
-      else
-        errors.add(:program_type, "Salary is not valid for a self accredited course")
-      end
-    when "apprenticeship"
-      self.program_type = :pg_teaching_apprenticeship
-    when "fee"
-      self.program_type = if !self_accredited?
-                            :school_direct_training_programme
-                          elsif provider.scitt?
-                            :scitt_programme
-                          else
-                            :higher_education_programme
-                          end
-    end
+    assign_program_type_service = Courses::AssignProgramTypeService.new
+    assign_program_type_service.execute(funding_type, self)
   end
 
   def ensure_modern_languages

--- a/app/services/courses/assign_program_type_service.rb
+++ b/app/services/courses/assign_program_type_service.rb
@@ -1,0 +1,24 @@
+module Courses
+  class AssignProgramTypeService
+    def execute(funding_type, course)
+      case funding_type
+      when "salary"
+        if !course.self_accredited?
+          course.program_type = :school_direct_salaried_training_programme
+        else
+          course.errors.add(:program_type, "Salary is not valid for a self accredited course")
+        end
+      when "apprenticeship"
+        course.program_type = :pg_teaching_apprenticeship
+      when "fee"
+        course.program_type = if !course.self_accredited?
+                                :school_direct_training_programme
+                              elsif course.provider.scitt?
+                                :scitt_programme
+                              else
+                                :higher_education_programme
+                              end
+      end
+    end
+  end
+end

--- a/app/services/courses/assign_program_type_service.rb
+++ b/app/services/courses/assign_program_type_service.rb
@@ -3,21 +3,31 @@ module Courses
     def execute(funding_type, course)
       case funding_type
       when "salary"
-        if !course.self_accredited?
-          course.program_type = :school_direct_salaried_training_programme
-        else
-          course.errors.add(:program_type, "Salary is not valid for a self accredited course")
-        end
+        update_salaried_program(course)
       when "apprenticeship"
         course.program_type = :pg_teaching_apprenticeship
       when "fee"
-        course.program_type = if !course.self_accredited?
-                                :school_direct_training_programme
-                              elsif course.provider.scitt?
-                                :scitt_programme
-                              else
-                                :higher_education_programme
-                              end
+        course.program_type = update_fee_program(course)
+      end
+    end
+
+  private
+
+    def update_salaried_program(course)
+      if !course.self_accredited?
+        course.program_type = :school_direct_salaried_training_programme
+      else
+        course.errors.add(:program_type, "Salary is not valid for a self accredited course")
+      end
+    end
+
+    def update_fee_program(course)
+      if !course.self_accredited?
+        :school_direct_training_programme
+      elsif course.provider.scitt?
+        :scitt_programme
+      else
+        :higher_education_programme
       end
     end
   end

--- a/spec/requests/api/v2/build_new_course_spec.rb
+++ b/spec/requests/api/v2/build_new_course_spec.rb
@@ -7,7 +7,8 @@ describe "/api/v2/build_new_course", type: :request do
   let(:provider) do
     create :provider,
            organisations: [organisation],
-           recruitment_cycle: recruitment_cycle
+           recruitment_cycle: recruitment_cycle,
+           provider_type: "Y"
   end
   let(:payload) { { email: user.email } }
   let(:token) do
@@ -67,7 +68,6 @@ describe "/api/v2/build_new_course", type: :request do
       response = do_get params
       expect(response).to have_http_status(:ok)
       json_response = parse_response(response)
-
       expected = course_jsonapi
       expected["data"]["attributes"]["name"] = ""
       expected["data"]["errors"] = [

--- a/spec/services/courses/assign_program_type_service_spec.rb
+++ b/spec/services/courses/assign_program_type_service_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+describe Courses::AssignProgramTypeService do
+  let(:service) { described_class.new }
+  let(:course) { create(:course) }
+  let(:execute_service) { service.execute(funding_type, course) }
+
+  before do
+    execute_service
+  end
+
+  context "when the funding_type is salary" do
+    let(:funding_type) { "salary" }
+
+    context "and the course is not self_accredited" do
+      let(:course) { create(:course, :with_accrediting_provider) }
+
+      it "should return :school_direct_salaried_training_programme" do
+        expect(course.program_type).to eq("school_direct_salaried_training_programme")
+      end
+    end
+
+    context "when the course is self accredited" do
+      it "an error should be added to the course object" do
+        expect(course.errors["program_type"].first).to eq("Salary is not valid for a self accredited course")
+      end
+    end
+  end
+
+  context "when the funding_type is apprenticeship" do
+    let(:funding_type) { "apprenticeship" }
+
+    it "should return :pg_teaching_apprenticeship" do
+      expect(course.program_type).to eq("pg_teaching_apprenticeship")
+    end
+  end
+
+  context "when the funding_type is fee" do
+    let(:funding_type) { "fee" }
+    let(:provider) { build(:provider, provider_type: provider_type) }
+
+    context "and the course is not self accredited" do
+      let(:course) { create(:course, :with_accrediting_provider) }
+
+      it "should return :school_direct_training_programme" do
+        expect(course.program_type).to eq("school_direct_training_programme")
+      end
+    end
+
+    context "the course is not self accredited" do
+      context "and they are a scitt" do
+        let(:provider_type) { :scitt }
+        let(:course) { create(:course, provider: provider) }
+
+        it "should return :scitt_programme" do
+          expect(course.program_type).to eq("scitt_programme")
+        end
+      end
+
+      context "and they are a HEI" do
+        let(:provider_type) { :university }
+        let(:course) { create(:course, provider: provider) }
+
+        it "should return :higher_education_programme" do
+          expect(course.program_type).to eq("higher_education_programme")
+        end
+      end
+    end
+
+    context "with an empty funding_type paramater" do
+      let(:course) { create(:course, :with_scitt) }
+      let(:funding_type) { nil }
+
+      it "returns the courses current study mode" do
+        expect(course.program_type).to eq("scitt_programme")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

The course model is currently over 600 lines and has become a bit of a god class

### Changes proposed in this pull request
- refactor funding_type=(funding_type) into a service

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
