### PR TITLE
[2484] Expose admin attribute to the frontend

### DIFF
--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -44,7 +44,7 @@ module API
       def user_params
         params
           .require(:user)
-          .except(:id, :type)
+          .except(:id, :type, :admin)
           .permit(
             :email,
             :first_name,

--- a/app/serializers/api/v2/serializable_user.rb
+++ b/app/serializers/api/v2/serializable_user.rb
@@ -3,7 +3,7 @@ module API
     class SerializableUser < JSONAPI::Serializable::Resource
       type "users"
 
-      attributes :first_name, :last_name, :email, :accept_terms_date_utc, :state
+      attributes :first_name, :last_name, :email, :accept_terms_date_utc, :state, :admin
     end
   end
 end

--- a/spec/requests/api/v2/access_request_spec.rb
+++ b/spec/requests/api/v2/access_request_spec.rb
@@ -176,6 +176,7 @@ describe "Access Request API V2", type: :request do
               "email" => first_access_request.requester.email,
               "accept_terms_date_utc" => first_access_request.requester.accept_terms_date_utc.utc.strftime("%FT%T.%3NZ"),
               "state" => first_access_request.requester.state,
+              "admin" => first_access_request.requester.admin,
             },
           }],
           "jsonapi" => {

--- a/spec/serializers/api/v2/serializable_user_spec.rb
+++ b/spec/serializers/api/v2/serializable_user_spec.rb
@@ -12,4 +12,13 @@ describe API::V2::SerializableUser do
 
   it { should have_type "users" }
   it { should have_attribute(:state).with_value(user.state.to_s) }
+
+  context "when a non admin user" do
+    it { should have_attribute(:admin).with_value(false) }
+  end
+
+  context "when an admin user" do
+    let(:user)     { create :user, :admin }
+    it { should have_attribute(:admin).with_value(true) }
+  end
 end


### PR DESCRIPTION
### Context

As we are porting access requests to the frontend we need a mechanism to only give access to the support section of publish to admin users.

### Changes proposed in this pull request

- Expose the admin attribute on the user serialiser

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
