### PR TITLE
[2500] - Run specs in parallel on CI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
+require "simplecov"
 require_relative "config/application"
 
 Rails.application.load_tasks

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,9 @@ steps:
     dockerHubImageName: $(imageName)
     CC_TEST_REPORTER_ID: $(ccReporterID)
 - script: |
-    $DOCKER_OVERRIDE exec -T web /bin/sh -c 'bundle exec rake spec SPEC_OPTS="--format RspecJunitFormatter --out ./rspec-results.xml"'
+    $DOCKER_OVERRIDE exec -T web /bin/sh -c 'bundle config --local disable_exec_load true'
+    $DOCKER_OVERRIDE exec -T web /bin/sh -c 'bundle exec rake parallel:setup'
+    $DOCKER_OVERRIDE exec -T web /bin/sh -c 'bundle exec rake parallel:spec SPEC_OPTS="--format RspecJunitFormatter --out ./rspec-results.xml"'
   displayName: 'Execute tests'
   env:
     DOCKER_OVERRIDE: $(dockerOverride)


### PR DESCRIPTION
### Context
Part of a bigger section of work to run specs in parallel.

### Changes proposed in this pull request
A simple change to the azure configuration so that specs are run in parallel on CI via the `parallel_tests` gem. Azure has _two_ available cores that can be utilised.

### How much time is saved?

_Before_
~ 4 min 40 sec 

_After_
2 min 55 sec 🎉 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
