### PR TITLE
[2496] Remove manage_api from the config settings

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,6 +1,3 @@
-manage_api:
-  base_url: https://api.publish-teacher-training-courses.service.gov.uk
-  secret: please_change_me
 search_api:
   base_url: https://api.find-postgraduate-teacher-training.service.gov.uk
   secret: please_change_me

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,6 +1,3 @@
-manage_api:
-  base_url: https://api.qa.publish-teacher-training-courses.service.gov.uk
-  secret: please_change_me
 search_api:
   base_url: https://api.qa.find-postgraduate-teacher-training.service.gov.uk
   secret: please_change_me

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,6 +1,3 @@
-manage_api:
-  base_url: https://api.staging.publish-teacher-training-courses.service.gov.uk
-  secret: please_change_me
 search_api:
   base_url: https://api.staging.find-postgraduate-teacher-training.service.gov.uk
   secret: please_change_me


### PR DESCRIPTION
### Context

MCAPI is being decommissioned and config/settings files still reference it.
 
### Changes proposed in this pull request

- Remove references to MCAPI

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
