### PR TITLE
[2509] add semantic logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,9 @@ gem "sidekiq-cron"
 # Offshore logging
 gem "logstash-logger", "~> 0.26.1"
 
+# Semantic Logger makes logs pretty
+gem "rails_semantic_logger"
+
 group :development, :test do
   # add info about db structure to models and other files
   gem "annotate"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,6 +308,10 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails_semantic_logger (4.4.3)
+      rack
+      railties (>= 3.2)
+      semantic_logger (~> 4.4)
     railties (6.0.1)
       actionpack (= 6.0.1)
       activesupport (= 6.0.1)
@@ -371,6 +375,8 @@ GEM
     scss_lint (0.58.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5, >= 3.5.5)
+    semantic_logger (4.6.0)
+      concurrent-ruby (~> 1.0)
     sentry-raven (2.12.2)
       faraday (>= 0.7.6, < 1.0)
     shellany (0.0.1)
@@ -484,6 +490,7 @@ DEPENDENCIES
   pundit
   rails (~> 6.0)
   rails-controller-testing
+  rails_semantic_logger
   rainbow
   rb-readline
   rspec-its

--- a/app/services/authentication_service.rb
+++ b/app/services/authentication_service.rb
@@ -65,7 +65,7 @@ private
 
     @user_by_email ||= User.find_by("lower(email) = ?", email_from_token)
     if @user_by_email
-      logger.debug {
+      logger.info {
         "User found by email address " + {
           user: log_safe_user(@user_by_email),
         }.to_s
@@ -82,7 +82,7 @@ private
 
     user = User.find_by(sign_in_user_id: sign_in_user_id_from_token)
     if user
-      logger.debug {
+      logger.info {
         "User found from sign_in_user_id in token " + {
                      sign_in_user_id: sign_in_user_id_from_token,
                      user: log_safe_user(user),

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,4 @@
-Rails.application.configure do # rubocop: disable Metrics/BlockLength
+Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on
@@ -56,11 +56,5 @@ Rails.application.configure do # rubocop: disable Metrics/BlockLength
   # Logging
   config.log_level = Settings.log_level
 
-  if Settings.logstash.host && Settings.logstash.port
-    config.active_record.logger = nil # Don't log SQL to logstash
-    config.logger = LogStashLogger.new(Settings.logstash.to_h)
-  else
-    config.logger = ActiveSupport::Logger.new(STDOUT)
-    config.logger.warn("logstash not configured, falling back to standard Rails logging")
-  end
+  config.logger = ActiveSupport::Logger.new(STDOUT)
 end

--- a/config/initializers/logstash.rb
+++ b/config/initializers/logstash.rb
@@ -2,15 +2,5 @@ LogStashLogger.configure do |config|
   config.customize_event do |event|
     event["application"] = Settings.application
     event["environment"] = Rails.env
-
-    if Thread.current.key? :logstash
-      if Thread.current[:logstash].key? :user_id
-        event["user_id"] = Thread.current[:logstash][:user_id]
-      end
-
-      if Thread.current[:logstash].key? :sign_in_user_id
-        event["sign_in_user_id"] = Thread.current[:logstash][:sin_in_user_id]
-      end
-    end
   end
 end

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -9,7 +9,7 @@ if Settings.logstash.host && Settings.logstash.port
     # event, anyway, so we move it there.
     if event["payload"].present?
       event.append(event["payload"])
-      event["payload"] = event["payload"].to_json
+      event["payload"] = nil
     end
   end
 

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -1,0 +1,18 @@
+if Settings.logstash.host && Settings.logstash.port
+  logstash_formatter = Proc.new do |event|
+    # The value here appears to break logging to logstash / elasticsearch
+    event["duration"] = event["duration_ms"]
+    event["duration_ms"] = nil
+
+    # For some reason logstash / elasticsearch drops events where the payload
+    # is a hash. These are more conveniently accessed at the top level of the
+    # event, anyway, so we move it there.
+    if event["payload"].present?
+      event.append(event["payload"])
+      event["payload"] = event["payload"].to_json
+    end
+  end
+
+  log_stash = LogStashLogger.new(Settings.logstash.to_h.merge(customize_event: logstash_formatter))
+  SemanticLogger.add_appender(logger: log_stash, level: :info, formatter: :json)
+end

--- a/spec/services/authentication_service_spec.rb
+++ b/spec/services/authentication_service_spec.rb
@@ -42,7 +42,7 @@ describe AuthenticationService do
 
       it "Safely logs that the user was found by sign_in_user_id" do
         subject
-        expect(logger_spy).to have_received(:debug) do |*_args, &block|
+        expect(logger_spy).to have_received(:info) do |*_args, &block|
           message = block.call
           expect(message).to start_with("User found from sign_in_user_id in token")
           expect(message).to include("sign_in_user_id=>\"#{sign_in_user_id}\"")
@@ -93,7 +93,7 @@ describe AuthenticationService do
       it "Safely logs that the user was found by their email" do
         subject
 
-        expect(logger_spy).to have_received(:debug) do |*_args, &block|
+        expect(logger_spy).to have_received(:info) do |*_args, &block|
           message = block.call
           expect(message).to start_with("User found by email address")
           expect(message).not_to include(user.email)


### PR DESCRIPTION
### Context

Default Rails logging to logstash is messy and painful to use.

### Changes proposed in this pull request

Introduce `semantic_logger` which makes request logging to Logstash sane, and also pretties up file logging.

#### Before

12 events are logged for a single API request for a Provider's page. 2 of the events are custom events for authentication (won't show in Prod), and the rest is basically an event per line logged for Rails. And also none of the attributes are broken out to individual fields for searchability:

![image](https://user-images.githubusercontent.com/15608/68479826-2ec91200-022b-11ea-9a22-03cfb46f3326.png)


#### After

4 events are logged for a single API request for the provider's endpoint. Same as above, 2 of the events are custom events for authentication (and won't show in Prod), one is for the actual request and another is an extra one that the JSONAPI has spat out to tell us how long it took to generate the JSON. That one should be integrated with the request event, one day.

Also, here you can see that as part of the request event, there are plenty of fields we can use to search or filter on, such as `path`, `method`, or even timing info.

![image](https://user-images.githubusercontent.com/15608/68479451-4b187f00-022a-11ea-837f-8b56100f059c.png)

### Guidance to review

To test this locally you need to define `SETTINGS__LOGSTASH__HOST` and `SETTINGS__LOGSTASH__PORT` to value you can get from our logit.io account.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
