### PR TITLE
[2522] - feat(security): add Brakeman static analysis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -142,6 +142,9 @@ group :development, :test do
 end
 
 group :development do
+  # Static analysis
+  gem "brakeman"
+
   gem "listen", ">= 3.0.5", "< 3.3"
 
   # Output scaffold commands based on schema

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
     awesome_print (1.8.0)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
+    brakeman (4.7.1)
     builder (3.2.3)
     bullet (6.0.2)
       activesupport (>= 3.0.0)
@@ -454,6 +455,7 @@ DEPENDENCIES
   audited (~> 4.9)
   awesome_print
   bootsnap (>= 1.1.0)
+  brakeman
   bullet
   byebug
   config

--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,4 @@ Rails.application.load_tasks
 
 task lint: ["lint:ruby"]
 task annotate: ["db:annotate"]
-task default: %i[spec annotate lint]
+task default: %i[brakeman]

--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,4 @@ Rails.application.load_tasks
 
 task lint: ["lint:ruby"]
 task annotate: ["db:annotate"]
-task default: %i[brakeman]
+task default: %i[spec annotate lint brakeman]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,11 +38,11 @@ class User < ApplicationRecord
   scope :non_admins, -> { where.not(admin: true) }
   scope :active, -> { where.not(accept_terms_date_utc: nil) }
 
-  validates :email, presence: true, format: { with: /@/, message: "must contain @" }
+  validates :email, presence: true, format: { with: /\A.*@.*\z/, message: "must contain @" }
   validate :email_is_lowercase
 
   validates :email, if: :admin?, format: {
-    with: /@(digital\.){0,1}education\.gov\.uk\z/,
+    with: /\A.*@(digital\.){0,1}education\.gov\.uk\z/,
     message: "must be an @[digital.]education.gov.uk domain",
   }
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,6 +62,14 @@ steps:
     dockerHubImageName: $(imageName)
     CC_TEST_REPORTER_ID: $(ccReporterID)
     AGENT_JOBSTATUS: $(Agent.JobStatus)
+- script: |
+    $DOCKER_OVERRIDE exec -T web /bin/sh -c "bundle exec rake brakeman"
+  displayName: 'Execute Brakeman static analysis'
+  env:
+    DOCKER_OVERRIDE: $(dockerOverride)
+    dockerHubUsername: $(dockerHubUsername)
+    dockerHubImageName: $(imageName)
+    AGENT_JOBSTATUS: $(Agent.JobStatus)
 - task: Docker@1
   displayName: Tag image with current build number $(Build.BuildNumber)
   inputs:

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,26 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "21580fcfd1da2ed6689c6569a08286c35b9b269c65cb791a519b96c761b22cef",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "lib/mcb.rb",
+      "line": 86,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "`#{cmd}`",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "MCB",
+        "method": "s(:self).run_command"
+      },
+      "user_input": "cmd",
+      "confidence": "Medium",
+      "note": ""
+    }
+  ],
+  "updated": "2019-11-13 12:04:09 +0000",
+  "brakeman_version": "4.7.1"
+}

--- a/lib/tasks/brakeman.rake
+++ b/lib/tasks/brakeman.rake
@@ -1,0 +1,12 @@
+task :brakeman do
+  sh <<~EOSHELL
+    mkdir -p tmp && \
+    (brakeman --no-progress -5 --quiet --color --output tmp/brakeman.out --exit-on-warn && \
+    echo "No warnings or errors") || \
+    (cat tmp/brakeman.out; exit 1)
+  EOSHELL
+end
+
+if %w[development test].include? Rails.env
+  task(:default).prerequisites << task(:brakeman)
+end


### PR DESCRIPTION
### Context
Static analysis is way to identifies security flaws in an application. _Brakeman_ is a gem that provides this functionality.

### Changes proposed in this pull request
- Add Brakeman gem
- Create rake task to run static analysis locally
- Add Brakeman rake task to default rake task
- Add static analysis as a build step on CI. Build will fail if static analysis does not pass.

### Running locally
```
bundle exec brakeman
```

#### Local output

<img width="1598" alt="brakman" src="https://user-images.githubusercontent.com/5256922/68596167-b49ac680-0492-11ea-8b3c-430587a10e6d.png">


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
