### PR TITLE
[2517] Fix sync course to find mcb commands

### DIFF
--- a/lib/mcb/commands/courses/sync_to_find.rb
+++ b/lib/mcb/commands/courses/sync_to_find.rb
@@ -23,6 +23,6 @@ run do |opts, args, _cmd|
     raise CriExitException.new(is_error: true)
   end
 
-  request = SearchAndCompareAPIService::Request.new
-  request.sync(courses)
+  request = SyncCoursesToFindJob.new
+  request.perform(*courses)
 end

--- a/lib/mcb/commands/courses/sync_to_find.rb
+++ b/lib/mcb/commands/courses/sync_to_find.rb
@@ -23,11 +23,6 @@ run do |opts, args, _cmd|
     raise CriExitException.new(is_error: true)
   end
 
-  courses.each do |course|
-    ManageCoursesAPIService::Request.sync_course_with_search_and_compare(
-      user.email,
-      provider.provider_code,
-      course.course_code,
-    )
-  end
+  request = SearchAndCompareAPIService::Request.new
+  request.sync(courses)
 end

--- a/lib/mcb/editor/courses_editor.rb
+++ b/lib/mcb/editor/courses_editor.rb
@@ -199,13 +199,8 @@ module MCB
       end
 
       def sync_courses_to_find
-        @courses.each do |course|
-          ManageCoursesAPIService::Request.sync_course_with_search_and_compare(
-            @requester.email,
-            @provider.provider_code,
-            course.course_code,
-          )
-        end
+        request = SearchAndCompareAPIService::Request.new
+        request.sync(@courses)
       end
 
       def find_courses(provider, course_codes)

--- a/lib/mcb/editor/courses_editor.rb
+++ b/lib/mcb/editor/courses_editor.rb
@@ -199,8 +199,8 @@ module MCB
       end
 
       def sync_courses_to_find
-        request = SearchAndCompareAPIService::Request.new
-        request.sync(@courses)
+        request = SyncCoursesToFindJob.new
+        request.perform(*@courses)
       end
 
       def find_courses(provider, course_codes)

--- a/spec/lib/mcb/commands/courses/sync_to_find_spec.rb
+++ b/spec/lib/mcb/commands/courses/sync_to_find_spec.rb
@@ -40,7 +40,7 @@ describe "mcb courses sync_to_find" do
     let!(:requester) { create(:user, email: email, organisations: provider.organisations) }
 
     describe "syncs an existing course" do
-      it "calls Seach API successfully" do
+      it "calls Search API successfully" do
         expect { sync_to_find(provider_code, course_code) }.to_not raise_error
         expect(search_api_request).to have_been_made
       end


### PR DESCRIPTION
### Context

be bin/mcb courses edit (sync to find) & be bin/mcb courses sync_to_find currently do not work as they still point to a MCAPI service. 

### Changes proposed in this pull request
- Refactor the above mcb commands to use the S&C API service

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
