### PR TITLE
[2518] Reload course before checking if it's syncable on publish

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -73,6 +73,7 @@ module API
         if @course.publishable?
           @course.publish_sites
           @course.publish_enrichment(@current_user)
+          @course.reload
           has_synced?
 
           head :ok

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -135,6 +135,24 @@ describe "Publish API v2", type: :request do
                ))
         end
       end
+
+      context "with a new site_status" do
+        let(:site_status) { build(:site_status, :new) }
+
+        it "Successfully publishes the course" do
+          perform_enqueued_jobs do
+            expect(subject).to have_http_status(:success)
+          end
+
+          expect(course.reload.site_statuses.first).to be_status_running
+          expect(course.site_statuses.first).to be_published_on_ucas
+          expect(course.enrichments.first).to be_published
+          expect(course.enrichments.first.updated_by_user_id).to eq user.id
+          expect(course.enrichments.first.updated_at).to be_within(1.second).of Time.now.utc
+          expect(course.enrichments.first.last_published_timestamp_utc).to be_within(1.second).of Time.now.utc
+          expect(course.changed_at).to be_within(1.second).of Time.now.utc
+        end
+      end
     end
 
     describe "failed validation" do


### PR DESCRIPTION
### Context

Publishing a course for the first time threw an error because we were checking whether the course prior to publishing changing the relations was syncable and we needed to reload

### Changes proposed in this pull request

- Reload the course before checking if it is syncable

### Guidance to review

- Find a valid course that has never been published
- Publish it

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
