### PR TITLE
2356- Update psql fw template uri

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -708,7 +708,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'), 'postgresql-server-firewall-rules.json')]",
+          "uri": "[concat(variables('deploymentUrlBase'), 'postgresql-network-server-firewall-rules.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {


### PR DESCRIPTION
### Context
Related to previous merge. Due to a bug in ARM template. ARM template for PSQL firewall rules in split into two templates. see details here `https://github.com/DFE-Digital/bat-platform-building-blocks/pull/30`