### PR TITLE
[2534] - Don't use simplecov-console gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -173,6 +173,5 @@ group :test do
   gem "rspec_junit_formatter"
   gem "shoulda-matchers", "~> 4.1"
   gem "simplecov", require: false
-  gem "simplecov-console"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,6 @@ GEM
     annotate (3.0.3)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 14.0)
-    ansi (1.5.0)
     api-pagination (4.8.2)
     application_insights (0.5.6)
     ast (2.4.0)
@@ -395,10 +394,6 @@ GEM
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-console (0.6.0)
-      ansi
-      simplecov
-      terminal-table
     simplecov-html (0.10.2)
     spring (2.1.0)
     spring-commands-rspec (1.0.4)
@@ -505,7 +500,6 @@ DEPENDENCIES
   sidekiq
   sidekiq-cron
   simplecov
-  simplecov-console
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,9 @@ require "simplecov"
 require_relative "config/application"
 
 Rails.application.load_tasks
+Rake::Task["default"].clear 
 
 task lint: ["lint:ruby"]
 task annotate: ["db:annotate"]
-task default: %i[spec annotate lint brakeman]
+task parallel: ["parallel:spec"]
+task default: %i[parallel annotate lint brakeman]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,10 +7,10 @@ require "audited-rspec"
 require "simplecov"
 
 SimpleCov.minimum_coverage 75
-SimpleCov.start 'rails'
+SimpleCov.start "rails"
 # If running specs in parallel this ensures SimpleCov results appears
 # upon completion of all specs
-if ENV['TEST_ENV_NUMBER']
+if ENV["TEST_ENV_NUMBER"]
   SimpleCov.at_exit do
     result = SimpleCov.result
     result.format! if ParallelTests.number_of_running_processes <= 1
@@ -37,7 +37,7 @@ Dir["./spec/support/**/*.rb"].each { |file| require file }
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   # Reduce noise in console when running specs in parallel
-  config.silence_filter_announcements = true if ENV['TEST_ENV_NUMBER']
+  config.silence_filter_announcements = true if ENV["TEST_ENV_NUMBER"]
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,13 +5,12 @@ require "fakefs/spec_helpers"
 require "webmock/rspec"
 require "audited-rspec"
 require "simplecov"
-require "simplecov-console"
 
-SimpleCov.formatter = SimpleCov::Formatter::Console
-SimpleCov.start
+SimpleCov.minimum_coverage 75
+SimpleCov.start 'rails'
 # If running specs in parallel this ensures SimpleCov results appears
 # upon completion of all specs
-if ENV["PARALLEL_TEST_GROUPS"]
+if ENV['TEST_ENV_NUMBER']
   SimpleCov.at_exit do
     result = SimpleCov.result
     result.format! if ParallelTests.number_of_running_processes <= 1
@@ -37,6 +36,8 @@ Dir["./spec/support/**/*.rb"].each { |file| require file }
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  # Reduce noise in console when running specs in parallel
+  config.silence_filter_announcements = true if ENV['TEST_ENV_NUMBER']
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
### Context

The `simplecov-console` gem was added recently in order to print results to the console rather than publish results to the 'coverage' folder. However following discussion with team have concluded this is too noisy so am reverting back to the previous method.

### Changes proposed in this pull request

- remove `simplecov-console` gem and associated config.
- threshold added for passing Simplecov (75%). Currently the coverage is just over 75% and this is largely influenced by low code coverage in the mcb library.
- reduced noise in console when running specs in parallel

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
