### PR TITLE
[2484] Make AccessRequest respond to include url parameters

### DIFF
--- a/app/controllers/api/v2/access_requests_controller.rb
+++ b/app/controllers/api/v2/access_requests_controller.rb
@@ -20,7 +20,7 @@ module API
         if @access_request.discarded?
           render jsonapi: nil, status: :not_found
         else
-          render jsonapi: @access_request, include: [:requester]
+          render jsonapi: @access_request, include: params[:include]
         end
       end
 

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -44,7 +44,7 @@ module API
       def user_params
         params
           .require(:user)
-          .except(:id, :type, :admin)
+          .except(:id, :type, :admin, :organisations_id, :organisations_type)
           .permit(
             :email,
             :first_name,

--- a/app/serializers/api/v2/serializable_organisation.rb
+++ b/app/serializers/api/v2/serializable_organisation.rb
@@ -1,0 +1,9 @@
+module API
+  module V2
+    class SerializableOrganisation < JSONAPI::Serializable::Resource
+      type "organisations"
+      has_many :users
+      attributes :name
+    end
+  end
+end

--- a/app/serializers/api/v2/serializable_user.rb
+++ b/app/serializers/api/v2/serializable_user.rb
@@ -2,6 +2,7 @@ module API
   module V2
     class SerializableUser < JSONAPI::Serializable::Resource
       type "users"
+      has_many :organisations
 
       attributes :first_name, :last_name, :email, :accept_terms_date_utc, :state, :admin
     end

--- a/spec/requests/api/v2/access_request_spec.rb
+++ b/spec/requests/api/v2/access_request_spec.rb
@@ -107,7 +107,7 @@ describe "Access Request API V2", type: :request do
   describe "GET #show" do
     let(:first_access_request) { create(:access_request) }
     let(:access_requests_show_route) do
-      get "/api/v2/access_requests/#{first_access_request.id}",
+      get "/api/v2/access_requests/#{first_access_request.id}?include=requester",
           headers: { "HTTP_AUTHORIZATION" => credentials }
     end
 
@@ -177,6 +177,13 @@ describe "Access Request API V2", type: :request do
               "accept_terms_date_utc" => first_access_request.requester.accept_terms_date_utc.utc.strftime("%FT%T.%3NZ"),
               "state" => first_access_request.requester.state,
               "admin" => first_access_request.requester.admin,
+            },
+            "relationships" => {
+              "organisations" => {
+                "meta" => {
+                  "included" => false,
+                },
+              },
             },
           }],
           "jsonapi" => {

--- a/spec/serializers/api/v2/serializable_organisation_spec.rb
+++ b/spec/serializers/api/v2/serializable_organisation_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+describe API::V2::SerializableOrganisation do
+  let(:organisation) { create :organisation }
+  let(:resource) { API::V2::SerializableOrganisation.new object: organisation }
+
+  it "sets type to organisations" do
+    expect(resource.jsonapi_type).to eq :organisations
+  end
+
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
+
+  it { should have_type "organisations" }
+  it { should have_attribute(:name).with_value(organisation.name.to_s) }
+end


### PR DESCRIPTION
### Context
As it stands the access requests default to always include only the requester, this is inconsistent with dominant convention and prevents us extracting organisation data.

### Changes proposed in this pull request
Have the AccessRequest `show` endpoint respond to the `?include` parameter.

### Guidance to review
This is necessary as part of https://github.com/DFE-Digital/manage-courses-frontend/pull/766

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [X] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
