### PR TITLE
[2510] - Add Request ID support to MCBE

### DIFF
--- a/app/controllers/api/v2/application_controller.rb
+++ b/app/controllers/api/v2/application_controller.rb
@@ -42,6 +42,7 @@ module API
       def assign_sentry_contexts
         Raven.user_context(id:              @current_user&.id)
         Raven.tags_context(sign_in_user_id: @current_user&.sign_in_user_id)
+        Raven.extra_context(request_id: request.uuid)
       end
 
       def append_info_to_payload(payload)
@@ -53,6 +54,7 @@ module API
             sign_in_id: current_user.sign_in_user_id,
           }
         end
+        payload[:request_id] = request.uuid
       end
     end
   end

--- a/spec/controllers/api/v2/application_controller_spec.rb
+++ b/spec/controllers/api/v2/application_controller_spec.rb
@@ -71,4 +71,17 @@ describe API::V2::ApplicationController, type: :controller do
       end
     end
   end
+
+  describe "#append_info_to_payload" do
+    it "sets the request_id in the payload to the request uuid" do
+      payload = {}
+      request_uuid = SecureRandom.uuid
+
+      allow(request).to receive(:uuid).and_return(request_uuid)
+
+      controller.__send__(:append_info_to_payload, payload)
+
+      expect(payload[:request_id]).to eq request_uuid
+    end
+  end
 end


### PR DESCRIPTION
### Context
When a request comes in, add the value of the X-Request-ID to the logs, and ensure this value gets sent to the MCBE. This so we can track a requests journey through the system.

See frontend PR - https://github.com/DFE-Digital/manage-courses-frontend/pull/765

### Changes proposed in this pull request
- Send request ID to Kibana and Sentry

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
