### PR TITLE
FIX - Default Rake Task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,6 @@ require "simplecov"
 require_relative "config/application"
 
 Rails.application.load_tasks
-Rake::Task["default"].clear 
 
 task lint: ["lint:ruby"]
 task annotate: ["db:annotate"]


### PR DESCRIPTION
### Context
- removing 'clearing' the default Rake task.
- Fixes application tripping over when running migration in Production

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
