### PR TITLE
[2542] Add descriptive error for missing MCB environment

### DIFF
--- a/spec/bin/mcb_spec.rb
+++ b/spec/bin/mcb_spec.rb
@@ -2,19 +2,40 @@ require "spec_helper"
 require "mcb_helper"
 
 describe "running the mcb script" do
-  describe "config flag" do
-    let(:config_file) { Tempfile.new(["new_config_file", ".yml"]) }
-    let(:config)      { { "new" => "day" } }
+  describe "config" do
+    context "when the config is specified" do
+      let(:config_file) { Tempfile.new(["new_config_file", ".yml"]) }
+      let(:config)      { { "new" => "day" } }
 
-    it "can set the path to the config file" do
-      result = with_stubbed_stdout do
-        File.write config_file.path, config.to_yaml
-        $mcb.run(%W[-c #{config_file.path} config show])
+      it "can set the path to the config file" do
+        result = with_stubbed_stdout do
+          File.write config_file.path, config.to_yaml
+          $mcb.run(%W[-c #{config_file.path} config show])
+        end
+        result = result[:stdout]
+
+        expect(MCB.config_file).to eq config_file.path
+        expect(result).to eq config.to_yaml
       end
-      result = result[:stdout]
+    end
 
-      expect(MCB.config_file).to eq config_file.path
-      expect(result).to eq config.to_yaml
+    context "default config" do
+      it "raises an error if the config does not exist", stub_init_rails: false do
+        expect {
+          MCB.start_mcb_repl(%W[-E my_nonexistent_environment])
+        }.to raise_error(Errno::ENOENT, "No such file or directory - Could not find config/azure_environments.yml, consult the MCB section of README.md")
+      end
+
+      it "raises an error if an environment cannot be found", stub_init_rails: false do
+        FakeFS do
+          FileUtils.mkdir_p("/config")
+          File.write "config/azure_environments.yml", "azure:"
+
+          expect {
+            MCB.start_mcb_repl(%W[-E my_nonexistent_environment])
+          }.to raise_error(KeyError, "The environment 'my_nonexistent_environment' could not be found, have you made sure to add it to your config/azure_environments.yml?")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Context
If a user specifies an environment that is not listed in the config file they will receive a cryptic `KeyError`, this is an error that is likely to appear often and as such should be clear in order to avoid wasting time during setup.

### Changes proposed in this pull request
Adds a message that clarifies the error to the user.

### Guidance to review
This PR has been written in such a way that it anticipates @davidgisbey's fix for the wrong environment being used, it will direct the user to modify the correct config depending on `RAILS_ENV`.

### Checklist

- [X] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
