### PR TITLE
[2517] Refactor mcb.rb to use opts[:env] when loading the settings file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ coverage/
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+config/azure_environments.yml
 
 *.patch
 *.swp

--- a/README.md
+++ b/README.md
@@ -194,15 +194,22 @@ can be useful for people who aren't as familiar with the app, or with certain
 complex operations that just aren't already packaged up in the app.
 
 In order to use the external environment functionality you must set the
-environments in `config/settings/development.local.yml` like so:  
+environments in ```config/azure_environments.yml ```like so:  
 ```
-azure:
-  <environment name>:
+qa:
     webapp: <webapp>
     rgroup: <rgroup>
     subscription: <subscription>
+staging:
+  webapp: <webapp>
+  rgroup: <rgroup>
+  subscription: <subscription>
+production:
+  webapp: <webapp>
+  rgroup: <rgroup>
+  subscription: <subscription>
 ```
-If you are a member of the Find team you may find a filled out config [here](https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/1182761062/MCB+Configuration?atlOrigin=eyJpIjoiMzdkOGJlNGU0NTNhNDYyMGI4NTI3Mzg2ZTVjZGEyMjUiLCJwIjoiYyJ9).
+If you are a member of the Find team you may find a filled out config [here](https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/1182761062/MCB+Configuration?atlOrigin=eyJpIjoiZDg0N2Q2ZTg0NTRiNDQ1MmEwZWQ3M2VhZjMyYjIxNjEiLCJwIjoiYyJ9n).
 
 The script's functionality is accessed using sub-commands with built-in
 documentation. This is the best way to discover it's functionality and the

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -4,8 +4,3 @@ mcbg:
   redis_password:
 system_authentication_token: "Ge32"
 log_level: debug
-azure:
-  qa:
-    webapp: dummy-webapp
-    rgroup: dummy-rgroup
-    subscription: dummy-subscription

--- a/spec/lib/mcb/commands/db_spec.rb
+++ b/spec/lib/mcb/commands/db_spec.rb
@@ -24,7 +24,12 @@ describe "mcb db" do
         "PG_PASSWORD"                            => "azpass",
         "RAILS_ENV"                              => "qa",
       }
+
+      azure_qa_settings = { webapp: "s121d01-mcbe-as",
+                            rgroup: "s121d01-mcbe-rg",
+                            subscription: "s121-findpostgraduateteachertraining-development" }
       allow(MCB::Azure).to(receive(:get_config).and_return(app_config))
+      allow(MCB).to(receive(:env_to_azure_map)).and_return(azure_qa_settings)
     end
 
     it "runs psql for azure server" do


### PR DESCRIPTION
### Context
![image](https://user-images.githubusercontent.com/42515961/69158492-6f077a80-0ade-11ea-83d6-bcd72f60e4ac.png)

Sync to find was not working correctly due to the above method in mcb.rb`

### Changes proposed in this pull request
- refactors the above to use opts[:env] to ensure the correct settings are being used for the selected environment.
- adds an azure section to the settings/qa.local.yml, settings/staging.local.yml, settings/production.local.yml files
- updates the README on how to connect to MCB (add .local files for qa, staging and prod.

### Guidance to review
The updated confluence is here.
https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/1182761062/MCB+Configuration
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
