### PR TITLE
Fix Request Store Error

### DIFF
--- a/app/controllers/api/v2/application_controller.rb
+++ b/app/controllers/api/v2/application_controller.rb
@@ -43,7 +43,7 @@ module API
       def assign_sentry_contexts
         Raven.user_context(id:              @current_user&.id)
         Raven.tags_context(sign_in_user_id: @current_user&.sign_in_user_id)
-        Raven.extra_context(request_id: RequestStore.store[:request_id])
+        Raven.extra_context(request_id: request.uuid)
       end
 
       def append_info_to_payload(payload)
@@ -55,7 +55,7 @@ module API
             sign_in_id: current_user.sign_in_user_id,
           }
         end
-        payload[:request_id] = RequestStore.store[:request_id]
+        payload[:request_id] = request.uuid
       end
 
       def store_request_id

--- a/spec/controllers/api/v2/application_controller_spec.rb
+++ b/spec/controllers/api/v2/application_controller_spec.rb
@@ -89,8 +89,7 @@ describe API::V2::ApplicationController, type: :controller do
     it "sets the request_id in the payload to the request uuid" do
       payload = {}
       request_uuid = SecureRandom.uuid
-
-      allow(RequestStore).to receive(:store).and_return(request_id: request_uuid)
+      allow(request).to receive(:uuid).and_return(request_uuid)
 
       controller.__send__(:append_info_to_payload, payload)
 


### PR DESCRIPTION
### Context

Application was blowing up when trying to assign Sentry contexts because at that point RequestStore is not accessible. So instead access the `request_id` via the `request` object.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
