### PR TITLE
Move RequestStore Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,9 @@ gem "logstash-logger", "~> 0.26.1"
 # Semantic Logger makes logs pretty
 gem "rails_semantic_logger"
 
+# Thread-safe global state
+gem "request_store"
+
 # IoC Container
 gem "dry-container"
 
@@ -127,9 +130,6 @@ group :development, :test do
   gem "rails-controller-testing"
 
   gem "rb-readline"
-
-  # Thread-safe global state
-  gem "request_store"
 
   # Enable shorter notation for rspec one-liners
   gem "rspec-its"


### PR DESCRIPTION
Move RequestStore gem out of the test/development group so that it is accessible in production

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
