### PR TITLE
Fix default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,10 @@
 require "simplecov"
 require_relative "config/application"
 
+task default: []
+
 Rails.application.load_tasks
+Rake::Task["default"].clear
 
 task lint: ["lint:ruby"]
 task annotate: ["db:annotate"]


### PR DESCRIPTION
### Context
When running the default rake task specs are no longer running in parallel. This was a result of [this change](https://github.com/DFE-Digital/manage-courses-backend/pull/1001).

### Changes proposed in this pull request
Revert back to clearing the default rake task (so that specs are not run in series) and create a default rake task so that rake tasks (such as db migrations) do not trip over when run in the production environment.

### Guidance to review
- Please run 'be rake` locally and check specs run in parallel
- The run `RAILS_ENV=production bundle exec rails db:migrate` and make sure you do **not** get the error _Don't know how to build task 'default'_.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
