### PR TITLE
Fix typo in existing spec name

### DIFF
--- a/spec/lib/mcb/commands/courses/list_spec.rb
+++ b/spec/lib/mcb/commands/courses/list_spec.rb
@@ -1,6 +1,6 @@
 require "mcb_helper"
 
-describe "mcb providers list" do
+describe "mcb courses list" do
   def execute_list(arguments: [], input: [])
     with_stubbed_stdout(stdin: input.join("\n")) do
       $mcb.run(["courses", "list", *arguments])


### PR DESCRIPTION
### Context

I want this off my mental stack, hence separate PR for trivial thing.

### Changes proposed in this pull request

See trivial diff

### Guidance to review

:ship:

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally