### PR TITLE
[2519] Add a new endpoint for getting accredited body courses

### DIFF
--- a/app/controllers/api/v2/accredited_body/courses_controller.rb
+++ b/app/controllers/api/v2/accredited_body/courses_controller.rb
@@ -1,0 +1,29 @@
+module API
+  module V2
+    module AccreditedBody
+      class CoursesController < API::V2::ApplicationController
+        before_action :build_recruitment_cycle
+        before_action :build_provider
+
+        def index
+          authorize @provider, :can_list_courses?
+          render jsonapi: @provider.current_accredited_courses, include: params[:include], class: CourseSerializersService.new.execute
+        end
+
+      private
+
+        def build_provider
+          @provider = @recruitment_cycle.providers.find_by!(
+            provider_code: params[:provider_code].upcase,
+            )
+        end
+
+        def build_recruitment_cycle
+          @recruitment_cycle = RecruitmentCycle.find_by(
+            year: params[:recruitment_cycle_year],
+            ) || RecruitmentCycle.current_recruitment_cycle
+        end
+      end
+    end
+  end
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -75,13 +75,18 @@ class Provider < ApplicationRecord
   has_many :courses, -> { kept }
   has_one :ucas_preferences, class_name: "ProviderUCASPreference"
   has_many :contacts
-  has_many :accredited_courses,
+  has_many :accredited_courses, # use current_accredited_courses to filter to courses in the same cycle as this provider
+           -> { where(discarded_at: nil) },
            class_name: "Course",
            foreign_key: :accrediting_provider_code,
            primary_key: :provider_code,
            inverse_of: :accrediting_provider
 
   has_many :accrediting_providers, -> { distinct }, through: :courses
+
+  def current_accredited_courses
+    accredited_courses.select { |c| c.provider.recruitment_cycle == recruitment_cycle }
+  end
 
   scope :changed_since, ->(timestamp) do
     if timestamp.present?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,9 @@ Rails.application.routes.draw do
         resources :sites, only: %i[index update show create]
         resources :recruitment_cycles, only: %i[index]
         post :sync_courses_with_search_and_compare, on: :member
+        namespace :accredited_body do
+          resources :courses, only: :index
+        end
       end
 
       resources :providers,

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -494,4 +494,48 @@ describe Provider, type: :model do
       )
     end
   end
+
+  describe "#accredited_courses" do
+    subject { provider.accredited_courses }
+
+    let(:provider) { create :provider, :accredited_body }
+    let!(:findable_course) do
+      create :course, name: "findable-course",
+             accrediting_provider: provider,
+             site_statuses: [build(:site_status, :findable)]
+    end
+    let!(:discarded_course) do
+      create :course, :deleted,
+             name: "deleted-course",
+             accrediting_provider: provider
+    end
+    let!(:discontinued_course) do
+      create :course,
+             name: "discontinued-course",
+             accrediting_provider: provider,
+             site_statuses: [build(:site_status, :discontinued)]
+    end
+
+    it { should include findable_course }
+    it { should include discontinued_course }
+    it { should_not include discarded_course }
+
+    describe "#current_accredited_courses" do
+      subject { provider.current_accredited_courses }
+
+      let(:last_years_provider) do
+        # make provider_codes the same to simulate a rolled over provider
+        create :provider, :previous_recruitment_cycle, provider_code: provider.provider_code
+      end
+      let!(:last_years_course) do
+        create :course,
+               name: "last-years-course",
+               provider: last_years_provider,
+               accrediting_provider: provider,
+               site_statuses: [build(:site_status, :discontinued)]
+      end
+
+      it { should_not include last_years_course }
+    end
+  end
 end

--- a/spec/requests/api/v2/providers/accredited_body/courses_spec.rb
+++ b/spec/requests/api/v2/providers/accredited_body/courses_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+describe "Accredited Provider API v2", type: :request do
+  let(:user)         { create(:user) }
+  let(:organisation) { create(:organisation, users: [user]) }
+  let(:payload)      { { email: user.email } }
+  let(:token)        { build_jwt :apiv2, payload: payload }
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+  let(:organisation) { create(:organisation, users: [user]) }
+  let(:provider)       { create :provider, :accredited_body, organisations: [organisation] }
+  let(:course) { findable_course }
+  let!(:findable_course) do
+    create :course, name: "findable-course",
+           accrediting_provider: provider,
+           site_statuses: [build(:site_status, :findable)]
+  end
+  let(:jsonapi_response) { JSON.parse(response.body) }
+  let(:jsonapi_courses) {
+    JSON.parse(
+      JSONAPI::Serializable::Renderer.new.render(
+        [course],
+        class: {
+          Course: API::V2::SerializableCourse,
+        },
+        ).to_json,
+      )
+  }
+
+  describe "GET index" do
+    before do
+      path = "/api/v2/providers/#{provider.provider_code}" +
+        "/accredited_body/courses"
+      get path, headers: { "HTTP_AUTHORIZATION" => credentials }
+    end
+
+    it "returns the array of courses for which the provider is the accredited body" do
+      expect(response).to have_http_status(:success)
+      expect(jsonapi_response["data"]).to eq jsonapi_courses["data"]
+    end
+  end
+end


### PR DESCRIPTION
### Context

Working on giving providers direct access to courses they are the accredited body for. Next up, getting frontend to turn this into a csv.

### Changes proposed in this pull request

* Add a new endpoint for getting accredited body courses

### Guidance to review

:ship:

    token=`mcb apiv2 token generate -S secret your.name@digital.education.gov.uk`
    curl http://localhost:3001/api/v2/providers/P80/accredited_body/courses.json -H "Authorization: Bearer $token"

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally