### PR TITLE
[2602] Discarding a provider should discard its courses

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -113,6 +113,8 @@ class Provider < ApplicationRecord
 
   validate :add_enrichment_errors
 
+  before_discard { discard_courses }
+
   def syncable_courses
     courses.includes(
       :enrichments,
@@ -230,6 +232,10 @@ class Provider < ApplicationRecord
     services[:generate_unique_course_code].execute(
       existing_codes: courses.pluck(:course_code),
     )
+  end
+
+  def discard_courses
+    courses.each(&:discard)
   end
 
 private

--- a/spec/lib/mcb/commands/providers/discard_spec.rb
+++ b/spec/lib/mcb/commands/providers/discard_spec.rb
@@ -5,8 +5,10 @@ describe "mcb providers discard" do
     $mcb.run(["providers", "discard", *arguments])
   end
 
-  let(:provider) { create(:provider, recruitment_cycle: recruitment_cycle) }
-  let(:provider2)  { create(:provider, recruitment_cycle: next_recruitment_cycle, provider_code: provider.provider_code) }
+  let(:provider) { create(:provider, recruitment_cycle: recruitment_cycle, courses: [course]) }
+  let(:provider2)  { create(:provider, recruitment_cycle: next_recruitment_cycle, courses: [course2], provider_code: provider.provider_code) }
+  let(:course) { build(:course) }
+  let(:course2) { build(:course) }
   let(:recruitment_cycle) { find_or_create :recruitment_cycle }
   let(:next_recruitment_cycle) { find_or_create :recruitment_cycle, :next }
 
@@ -21,11 +23,14 @@ describe "mcb providers discard" do
     it "discards the provider" do
       expect(provider.reload.discarded?).to be_truthy
       expect(provider.reload.discarded_at).to be_within(1.second).of Time.now.utc
+      expect(course.reload.discarded?).to be_truthy
+      expect(course.discarded_at).to be_within(1.second).of Time.now.utc
       expect(provider2.reload.discarded?).to be_falsey
+      expect(provider2.courses.first.reload.discarded?).to be_falsey
     end
   end
 
-  context "for the current recruitment cycle" do
+  context "for the next recruitment cycle" do
     before do
       provider
       provider2
@@ -35,7 +40,10 @@ describe "mcb providers discard" do
     it "discards the provider" do
       expect(provider2.reload.discarded?).to be_truthy
       expect(provider2.reload.discarded_at).to be_within(1.second).of Time.now.utc
+      expect(course2.reload.discarded?).to be_truthy
+      expect(course2.reload.discarded_at).to be_within(1.second).of Time.now.utc
       expect(provider.reload.discarded?).to be_falsey
+      expect(provider.courses.first.reload.discarded?).to be_falsey
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -476,6 +476,36 @@ describe Provider, type: :model do
         expect(described_class.discarded.size).to eq(1)
       end
     end
+
+    context "a provider with courses" do
+      let(:provider) { create(:provider, courses: [course, course2]) }
+      let(:course) { build(:course) }
+      let(:course2) { build(:course) }
+
+      before do
+        provider.discard
+      end
+
+      it "should discard all of the providers courses" do
+        expect(course.discarded?).to be_truthy
+        expect(course2.discarded?).to be_truthy
+      end
+    end
+  end
+
+  describe "#discard_courses" do
+    let(:provider) { create(:provider, courses: [course, course2]) }
+    let(:course) { build(:course) }
+    let(:course2) { build(:course) }
+
+    before do
+      provider.discard_courses
+    end
+
+    it "should discard all of the providers courses" do
+      expect(course.discarded?).to be_truthy
+      expect(course2.discarded?).to be_truthy
+    end
   end
 
   describe "#next_available_course_code" do


### PR DESCRIPTION
### Context

When a provider is discarded it should also discard their courses.

### Changes proposed in this pull request
- Add before block that discards a providers courses before provider.discard
- Add this functionality to MCB provider discard command

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
