### PR TITLE
2613-fix CodeClimate variable error

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,6 +46,7 @@ steps:
     DOCKER_OVERRIDE: $(dockerOverride)
     dockerHubUsername: $(dockerHubUsername)
     dockerHubImageName: $(imageName)
+    CC_TEST_REPORTER_ID: $(ccReporterID)
 - script: |
     $DOCKER_OVERRIDE exec -T web /bin/sh -c "bundle exec rubocop app config db lib spec --format clang"
   displayName: 'Execute linters'


### PR DESCRIPTION
### Context

Fix variable error `The CC_TEST_REPORTER_ID variable is not set. Defaulting to a blank string.`