### PR TITLE
[2412] Include provider in build_new

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -32,7 +32,7 @@ module API
         json_data = JSONAPI::Serializable::Renderer.new.render(
           @course,
           class: CourseSerializersService.new.execute,
-          include: %i[subjects sites],
+          include: %i[subjects sites provider],
         )
 
         json_data[:data][:errors] = []

--- a/spec/requests/api/v2/build_new_course_spec.rb
+++ b/spec/requests/api/v2/build_new_course_spec.rb
@@ -29,8 +29,9 @@ describe "/api/v2/build_new_course", type: :request do
         Course: API::V2::SerializableCourse,
         Subject: API::V2::SerializableSubject,
         PrimarySubject: API::V2::SerializableSubject,
+        Provider: API::V2::SerializableProvider,
       },
-      include: %i[subjects sites],
+      include: %i[subjects sites provider],
     ).to_json)
   end
 


### PR DESCRIPTION
### Context
In order to be able to determine information about courses in relation to their providers for https://github.com/DFE-Digital/manage-courses-frontend/pull/773.

### Changes proposed in this pull request
Include the provider in the response for `build_new`.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
