### PR TITLE
[2614] Reorder outcome edit options

### DIFF
--- a/app/models/concerns/with_qualifications.rb
+++ b/app/models/concerns/with_qualifications.rb
@@ -39,7 +39,7 @@ module WithQualifications
     # subjects this course was tagged to.
     #
     # Defined here: https://github.com/DFE-Digital/manage-courses-api/blob/master/src/ManageCourses.Domain/Models/CourseQualification.cs
-    enum qualification: %i[qts pgce_with_qts pgde_with_qts pgce pgde]
+    enum qualification: %i[pgce_with_qts qts pgde_with_qts pgce pgde]
 
     # This field may seem like an unnecessary overhead when there is already a
     # database-backed `qualification` field. However it's misleading, from the

--- a/spec/models/concerns/courses/edit_options/qualifications_concern_spec.rb
+++ b/spec/models/concerns/courses/edit_options/qualifications_concern_spec.rb
@@ -18,7 +18,7 @@ describe Courses::EditOptions::QualificationConcern do
     let(:level_value) { "primary" }
 
     it "returns only QTS options for users to choose between" do
-      expect(example_model.qualification_options).to eq(%w[qts pgce_with_qts pgde_with_qts])
+      expect(example_model.qualification_options).to match_array(%w[qts pgce_with_qts pgde_with_qts])
       example_model.qualification_options.each do |q|
         expect(q).to include("qts")
       end

--- a/spec/models/concerns/courses/edit_options_spec.rb
+++ b/spec/models/concerns/courses/edit_options_spec.rb
@@ -107,7 +107,7 @@ describe Course, type: :model do
   describe "qualifications" do
     context "for a course that's not further education" do
       it "returns only QTS options for users to choose between" do
-        expect(course.qualification_options).to eq(%w[qts pgce_with_qts pgde_with_qts])
+        expect(course.qualification_options).to match_array(%w[qts pgce_with_qts pgde_with_qts])
         course.qualification_options.each do |q|
           expect(q.include?("qts")).to be_truthy
         end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -129,7 +129,7 @@ describe "Courses API v2", type: :request do
               "meta" => {
                 "edit_options" => {
                   "entry_requirements" => %w[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test],
-                  "qualifications" => %w[qts pgce_with_qts pgde_with_qts],
+                  "qualifications" => %w[pgce_with_qts qts pgde_with_qts],
                   "age_range_in_years" => %w[3_to_7 5_to_11 7_to_11 7_to_14],
                   "start_dates" => [
                     "October #{previous_year}",
@@ -533,7 +533,7 @@ describe "Courses API v2", type: :request do
             "meta" => {
               "edit_options" => {
                 "entry_requirements" => %w[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test],
-                "qualifications" => %w[qts pgce_with_qts pgde_with_qts],
+                "qualifications" => %w[pgce_with_qts qts pgde_with_qts],
                 "age_range_in_years" => %w[3_to_7 5_to_11 7_to_11 7_to_14],
                 "start_dates" => [
                   "October #{previous_year}",

--- a/spec/requests/api/v3/providers/courses/index_spec.rb
+++ b/spec/requests/api/v3/providers/courses/index_spec.rb
@@ -115,7 +115,7 @@ describe "GET v3/providers/:provider_code/courses" do
             "meta" => {
               "edit_options" => {
                 "entry_requirements" => %w[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test],
-                "qualifications" => %w[qts pgce_with_qts pgde_with_qts],
+                "qualifications" => %w[pgce_with_qts qts pgde_with_qts],
                 "age_range_in_years" => %w[3_to_7 5_to_11 7_to_11 7_to_14],
                 "start_dates" => [
                   "October #{previous_year}",

--- a/spec/requests/api/v3/providers/courses/show_spec.rb
+++ b/spec/requests/api/v3/providers/courses/show_spec.rb
@@ -142,7 +142,7 @@ describe "GET v3/providers/:provider_code/courses/:course_code" do
           "meta" => {
             "edit_options" => {
               "entry_requirements" => %w[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test],
-              "qualifications" => %w[qts pgce_with_qts pgde_with_qts],
+              "qualifications" => %w[pgce_with_qts qts pgde_with_qts],
               "age_range_in_years" => %w[3_to_7 5_to_11 7_to_11 7_to_14],
               "start_dates" => [
                 "October #{previous_year}",


### PR DESCRIPTION
### Context

MCFE Should display the options in line with the prototype, with the most common at the top and the least common at the bottom

### Changes proposed in this pull request

- Change the ordering to qualifications to be hard coded in the edit options

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
