### PR TITLE
[2585] Default to nil funding type

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -296,6 +296,8 @@ class Course < ApplicationRecord
   end
 
   def funding_type
+    return nil if program_type.nil?
+
     if school_direct_salaried_training_programme?
       "salary"
     elsif pg_teaching_apprenticeship?

--- a/spec/models/course/funding_type_spec.rb
+++ b/spec/models/course/funding_type_spec.rb
@@ -39,5 +39,11 @@ RSpec.describe Course, type: :model do
 
       its(:funding_type) { should eq "apprenticeship" }
     end
+
+    describe "Default" do
+      subject { Course.new(provider: create(:provider)) }
+
+      its(:funding_type) { should be_nil }
+    end
   end
 end


### PR DESCRIPTION
### Context

`Course#build_new` on the API was returning a default `funding_type` of `"fee"` when called without a funding type given - it should instead return a `funding_type` of `nil`

### Changes proposed in this pull request

- Default funding type to nil when no program type is set

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
