### PR TITLE
[2631] Add sites to course creation

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -32,7 +32,7 @@ module API
         json_data = JSONAPI::Serializable::Renderer.new.render(
           @course,
           class: CourseSerializersService.new.execute,
-          include: %i[subjects sites provider accrediting_provider],
+          include: [:subjects, :sites, :accrediting_provider, :provider, provider: [:sites]],
         )
 
         json_data[:data][:errors] = []

--- a/spec/bin/mcb_spec.rb
+++ b/spec/bin/mcb_spec.rb
@@ -21,9 +21,13 @@ describe "running the mcb script" do
 
     context "default config" do
       it "raises an error if the config does not exist", stub_init_rails: false do
-        expect {
-          MCB.start_mcb_repl(%W[-E my_nonexistent_environment])
-        }.to raise_error(Errno::ENOENT, "No such file or directory - Could not find config/azure_environments.yml, consult the MCB section of README.md")
+        FakeFS do
+          FileUtils.mkdir_p("/config")
+
+          expect {
+            MCB.start_mcb_repl(%W[-E my_nonexistent_environment])
+          }.to raise_error(Errno::ENOENT, "No such file or directory - Could not find config/azure_environments.yml, consult the MCB section of README.md")
+        end
       end
 
       it "raises an error if an environment cannot be found", stub_init_rails: false do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,10 @@ SimpleCov.minimum_coverage 75
 SimpleCov.start "rails" do
   add_filter "/mcb/"
 end
+SimpleCov.start do
+  add_filter "spec"
+end
+
 # If running specs in parallel this ensures SimpleCov results appears
 # upon completion of all specs
 if ENV["TEST_ENV_NUMBER"]


### PR DESCRIPTION
### Context
In order for https://github.com/DFE-Digital/manage-courses-frontend/pull/798 to function correctly the course needs to have site information.  

### Changes proposed in this pull request
Provide the provider sites when requesting a course object from `build_new()`.

### Guidance to review
We'll want to have an include parameter at some point, but I think this works for now.  
  
This also includes a fix for a test which was breaking if `config/azure_environments.yml` was present on your real filesystem.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
