### PR TITLE
[2639] Re-include provider on build new endpoint

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -32,7 +32,7 @@ module API
         json_data = JSONAPI::Serializable::Renderer.new.render(
           @course,
           class: CourseSerializersService.new.execute,
-          include: %i[subjects sites accrediting_provider],
+          include: %i[subjects sites provider accrediting_provider],
         )
 
         json_data[:data][:errors] = []

--- a/spec/requests/api/v2/build_new_course_spec.rb
+++ b/spec/requests/api/v2/build_new_course_spec.rb
@@ -32,7 +32,7 @@ describe "/api/v2/build_new_course", type: :request do
         PrimarySubject: API::V2::SerializableSubject,
         Provider: API::V2::SerializableProvider,
       },
-      include: %i[subjects sites accrediting_provider],
+      include: %i[subjects sites provider accrediting_provider],
     ).to_json)
   end
 


### PR DESCRIPTION
### Context

The frontend needs the provider to be passed back from the API in build new, this used to exist but seems to have gone AWOL

### Changes proposed in this pull request

- Re-include provider

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
