### PR TITLE
[2565] - Configure Geocoder gem to use existing Redis instance

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -7,8 +7,8 @@ Geocoder.configure(
   use_https: true, # use HTTPS for lookup requests? (if supported)
   # http_proxy: nil,                  # HTTP proxy server (user:pass@host:port)
   # https_proxy: nil,                 # HTTPS proxy server (user:pass@host:port)
-  api_key: Settings.gcp_api_key,      # API key for geocoding service
-  cache: Redis.new,                   # cache object (must respond to #[], #[]=, and #del)
+  api_key: Settings.gcp_api_key, # API key for geocoding service
+  cache: Redis.new(password: Settings.mcbg.redis_password), # cache object (must respond to #[], #[]=, and #del)
   # cache_prefix: 'geocoder:',  # prefix (string) to use for all cache keys
 
   # Exceptions that should not be rescued by default


### PR DESCRIPTION
### Context
Geocoder has the ability to cache requests. This PR configures it to use the existing Redis instance

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
