### PR TITLE
[2576] Expose nctl_ids on the V2 API via organisation

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -18,6 +18,8 @@ class Organisation < ApplicationRecord
 
   has_and_belongs_to_many :providers
 
+  has_many :nctl_organisations
+
   validates :name, presence: true
 
   has_associated_audits

--- a/app/serializers/api/v2/serializable_organisation.rb
+++ b/app/serializers/api/v2/serializable_organisation.rb
@@ -4,6 +4,10 @@ module API
       type "organisations"
       has_many :users
       attributes :name
+
+      attribute :nctl_organisations do
+        @object.nctl_organisations.map(&:nctl_id)
+      end
     end
   end
 end

--- a/spec/factories/nctl_organisation.rb
+++ b/spec/factories/nctl_organisation.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :nctl_organisation do
+    nctl_id { rand(1000000).to_s }
+  end
+end

--- a/spec/serializers/api/v2/serializable_organisation_spec.rb
+++ b/spec/serializers/api/v2/serializable_organisation_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 describe API::V2::SerializableOrganisation do
-  let(:organisation) { create :organisation }
+  let(:organisation) { create :organisation, nctl_organisations: [nctl_organisation] }
+  let(:nctl_organisation) { build(:nctl_organisation) }
   let(:resource) { API::V2::SerializableOrganisation.new object: organisation }
 
   it "sets type to organisations" do
@@ -12,4 +13,5 @@ describe API::V2::SerializableOrganisation do
 
   it { should have_type "organisations" }
   it { should have_attribute(:name).with_value(organisation.name.to_s) }
+  it { should have_attribute(:nctl_organisations).with_value([nctl_organisation.nctl_id]) }
 end


### PR DESCRIPTION
### Context

NCTL ids are exposed on the org index support page, but it is not currently exposed on the V2 API.

### Changes proposed in this pull request
- Expose nctl_ids as an attribute on organisation

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
