### PR TITLE
[2576]  2576 expose user sign in to frontend

### DIFF
--- a/app/serializers/api/v2/serializable_organisation.rb
+++ b/app/serializers/api/v2/serializable_organisation.rb
@@ -5,7 +5,7 @@ module API
       has_many :users
       attributes :name
 
-      attribute :nctl_organisations do
+      attribute :nctl_ids do
         @object.nctl_organisations.map(&:nctl_id)
       end
     end

--- a/app/serializers/api/v2/serializable_user.rb
+++ b/app/serializers/api/v2/serializable_user.rb
@@ -4,7 +4,7 @@ module API
       type "users"
       has_many :organisations
 
-      attributes :first_name, :last_name, :email, :accept_terms_date_utc, :state, :admin
+      attributes :first_name, :last_name, :email, :accept_terms_date_utc, :state, :admin, :sign_in_user_id
     end
   end
 end

--- a/spec/requests/api/v2/access_request_spec.rb
+++ b/spec/requests/api/v2/access_request_spec.rb
@@ -177,6 +177,7 @@ describe "Access Request API V2", type: :request do
               "accept_terms_date_utc" => first_access_request.requester.accept_terms_date_utc.utc.strftime("%FT%T.%3NZ"),
               "state" => first_access_request.requester.state,
               "admin" => first_access_request.requester.admin,
+              "sign_in_user_id" => first_access_request.requester.sign_in_user_id,
             },
             "relationships" => {
               "organisations" => {

--- a/spec/serializers/api/v2/serializable_organisation_spec.rb
+++ b/spec/serializers/api/v2/serializable_organisation_spec.rb
@@ -13,5 +13,5 @@ describe API::V2::SerializableOrganisation do
 
   it { should have_type "organisations" }
   it { should have_attribute(:name).with_value(organisation.name.to_s) }
-  it { should have_attribute(:nctl_organisations).with_value([nctl_organisation.nctl_id]) }
+  it { should have_attribute(:nctl_ids).with_value([nctl_organisation.nctl_id]) }
 end

--- a/spec/serializers/api/v2/serializable_user_spec.rb
+++ b/spec/serializers/api/v2/serializable_user_spec.rb
@@ -12,6 +12,7 @@ describe API::V2::SerializableUser do
 
   it { should have_type "users" }
   it { should have_attribute(:state).with_value(user.state.to_s) }
+  it { should have_attribute(:sign_in_user_id).with_value(user.sign_in_user_id.to_s) }
 
   context "when a non admin user" do
     it { should have_attribute(:admin).with_value(false) }


### PR DESCRIPTION
### Context

The org support page needs this to deeplink to users

### Changes proposed in this pull request
- Expose user sign in id on the v2 api
### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
