### PR TITLE
[2667] - BUGFIX: Update lat and long when Site and Provider address is updated

### DIFF
--- a/app/models/concerns/geolocation.rb
+++ b/app/models/concerns/geolocation.rb
@@ -14,7 +14,11 @@ module Geolocation
     end
 
     def address_changed?
-      address1_changed? || address2_changed? || address3_changed? || address4_changed? || postcode_changed?
+      saved_change_to_address1? ||
+        saved_change_to_address2? ||
+        saved_change_to_address3? ||
+        saved_change_to_address4? ||
+        saved_change_to_postcode?
     end
   end
 end

--- a/spec/models/concerns/geolocation_spec.rb
+++ b/spec/models/concerns/geolocation_spec.rb
@@ -46,42 +46,32 @@ describe Geolocation do
       it { should be(false) }
     end
 
-    context "address has not changed" do
+    context "address" do
       let(:site) {
-        build_stubbed(:site,
-                      latitude: 1.456789,
-                      longitude: 1.456789,
-                      address1: "Long Lane",
-                      address2: "Holbury",
-                      address3: "Southampton",
-                      address4: nil,
-                      postcode: "SO45 2PA")
+        create(:site,
+               latitude: 1.456789,
+               longitude: 1.456789,
+               address1: "Long Lane",
+               address2: "Holbury",
+               address3: "Southampton",
+               address4: nil,
+               postcode: "SO45 2PA")
       }
+      context "has not changed" do
+        before do
+          site.update(address1: "Long Lane")
+        end
 
-      before do
-        site.assign_attributes(address1: "Long Lane")
+        it { should be(false) }
       end
 
-      it { should be(false) }
-    end
+      context "has changed" do
+        before do
+          site.update(address1: "New address 1")
+        end
 
-    context "address not changed" do
-      let(:site) {
-        build_stubbed(:site,
-                      latitude: 1.456789,
-                      longitude: 1.456789,
-                      address1: "Long Lane",
-                      address2: "Holbury",
-                      address3: "Southampton",
-                      address4: nil,
-                      postcode: "SO45 2PA")
-      }
-
-      before do
-        site.assign_attributes(address1: "New address 1")
+        it { should be(true) }
       end
-
-      it { should be(true) }
     end
   end
 end


### PR DESCRIPTION
### Context
When a Site or Provider address was updated the lat and long was not being updated.

This was because:
- Geolocation was not running under these conditions (we should be looking at what changes _were_ saved to the db)
- Bad test setup that gave a false positive 😿 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
