### PR TITLE
[2655] Allow Further Education courses to be created in new course flow

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -277,7 +277,7 @@ module API
 
       def update_further_education_fields
         @course.funding_type = "fee"
-        @course.subjects << FurtherEducationSubject.find
+        @course.subjects << FurtherEducationSubject.instance
       end
 
       def site_ids

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -25,6 +25,7 @@ module API
         update_subjects
         update_sites
         @course.assign_attributes(course_params)
+        update_further_education_fields if @course.level == "further_education"
         @course.name = @course.generate_name
         @course.valid?
 
@@ -129,6 +130,7 @@ module API
         @course.assign_attributes(course_params.merge(course_code: course_code))
         update_subjects
         update_sites
+        update_further_education_fields if @course.level == "further_education"
         @course.name = @course.generate_name
 
         if @course.save
@@ -271,6 +273,11 @@ module API
             :funding_type,
             :level,
           )
+      end
+
+      def update_further_education_fields
+        @course.funding_type = "fee"
+        @course.subjects << FurtherEducationSubject.find
       end
 
       def site_ids

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -154,8 +154,8 @@ class Course < ApplicationRecord
     ENTRY_REQUIREMENT_OPTIONS.reject { |option| option == :not_set }.keys.map(&:to_s)
   end
 
-  validates :maths,   inclusion: { in: entry_requirement_options_without_nil_choice }
-  validates :english, inclusion: { in: entry_requirement_options_without_nil_choice }
+  validates :maths,   inclusion: { in: entry_requirement_options_without_nil_choice }, unless: :further_education_course?
+  validates :english, inclusion: { in: entry_requirement_options_without_nil_choice }, unless: :further_education_course?
   validates :science, inclusion: { in: entry_requirement_options_without_nil_choice }, if: :gcse_science_required?
   validates :enrichments, presence: true, on: :publish
   validates :is_send, inclusion: { in: [true, false] }
@@ -174,7 +174,8 @@ class Course < ApplicationRecord
   validate :validate_subject_consistency
 
   validates :name, :profpost_flag, :program_type, :qualification, :start_date, :study_mode, presence: true
-  validates :level, :age_range_in_years, presence: true, on: :create
+  validates :age_range_in_years, presence: true, unless: :further_education_course?
+  validates :level, presence: true, on: :create
 
   after_validation :remove_unnecessary_enrichments_validation_message
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -174,7 +174,7 @@ class Course < ApplicationRecord
   validate :validate_subject_consistency
 
   validates :name, :profpost_flag, :program_type, :qualification, :start_date, :study_mode, presence: true
-  validates :age_range_in_years, presence: true, unless: :further_education_course?
+  validates :age_range_in_years, presence: true, on: :create, unless: :further_education_course?
   validates :level, presence: true, on: :create
 
   after_validation :remove_unnecessary_enrichments_validation_message

--- a/app/models/subjects/further_education_subject.rb
+++ b/app/models/subjects/further_education_subject.rb
@@ -13,4 +13,7 @@
 #
 
 class FurtherEducationSubject < Subject
+  def self.find
+    find_by(subject_name: "Further education")
+  end
 end

--- a/app/models/subjects/further_education_subject.rb
+++ b/app/models/subjects/further_education_subject.rb
@@ -13,7 +13,7 @@
 #
 
 class FurtherEducationSubject < Subject
-  def self.find
+  def self.instance
     find_by(subject_name: "Further education")
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -111,6 +111,25 @@ describe Course, type: :model do
     end
 
     describe "valid?" do
+      context "A further education course" do
+        let(:course) { build(:course, level: "further_education") }
+
+        it "Allows a blank options for age range in years" do
+          course.age_range_in_years = nil
+          expect(course.valid?).to eq(true)
+        end
+
+        it "Allows a blank option for english" do
+          course.english = nil
+          expect(course.valid?).to eq(true)
+        end
+
+        it "Allows a blank option for maths" do
+          course.maths = nil
+          expect(course.valid?).to eq(true)
+        end
+      end
+
       context "blank attribute" do
         let(:course) { build(:course, **blank_field) }
 

--- a/spec/requests/api/v2/build_new_course_spec.rb
+++ b/spec/requests/api/v2/build_new_course_spec.rb
@@ -94,6 +94,20 @@ describe "/api/v2/build_new_course", type: :request do
     end
   end
 
+  context "With a further education course" do
+    let(:course) { Course.new(provider: provider, level: :further_education) }
+    let(:params) do
+      { course: { level: :further_education } }
+    end
+
+    it "Returns the course with the funding type 'fee'" do
+      response = do_get params
+      expect(response).to have_http_status(:ok)
+      json_response = parse_response(response)
+      expect(json_response["data"]["attributes"]["funding_type"]).to eq("fee")
+    end
+  end
+
   context "with an accrediting_provider" do
     let(:course) { Course.new(provider: provider, accrediting_provider: provider2) }
     let(:params) do

--- a/spec/requests/api/v2/build_new_course_spec.rb
+++ b/spec/requests/api/v2/build_new_course_spec.rb
@@ -171,17 +171,17 @@ describe "/api/v2/build_new_course", type: :request do
                 },
               },
               {
-                "title" => "Invalid level",
-                "detail" => "Level can't be blank",
-                "source" => {
-                  "pointer" => "/data/attributes/level",
-                },
-              },
-              {
                 "title" => "Invalid age_range_in_years",
                 "detail" => "Age range in years can't be blank",
                 "source" => {
                   "pointer" => "/data/attributes/age_range_in_years",
+                },
+              },
+              {
+                "title" => "Invalid level",
+                "detail" => "Level can't be blank",
+                "source" => {
+                  "pointer" => "/data/attributes/level",
                 },
               },
         ]
@@ -259,17 +259,17 @@ describe "/api/v2/build_new_course", type: :request do
                 },
               },
               {
-                "title" => "Invalid level",
-                "detail" => "Level can't be blank",
-                "source" => {
-                  "pointer" => "/data/attributes/level",
-                },
-              },
-              {
                 "title" => "Invalid age_range_in_years",
                 "detail" => "Age range in years can't be blank",
                 "source" => {
                   "pointer" => "/data/attributes/age_range_in_years",
+                },
+              },
+              {
+                "title" => "Invalid level",
+                "detail" => "Level can't be blank",
+                "source" => {
+                  "pointer" => "/data/attributes/level",
                 },
               },
         ]

--- a/spec/requests/api/v2/providers/courses/create_spec.rb
+++ b/spec/requests/api/v2/providers/courses/create_spec.rb
@@ -119,5 +119,45 @@ describe "Course POST #create API V2", type: :request do
         expect { perform_request(course) }.to change { provider.reload.courses.count }.from(0).to(1)
       end
     end
+
+    context "When the course is a further education course" do
+      let(:course) do
+        build(
+          :course,
+          level: "further_education",
+          qualification: "pgce",
+          provider: provider,
+          sites: [site_one, site_two],
+        )
+      end
+      let(:further_education_subject) { find_or_create(:further_education_subject) }
+
+      before do
+        jsonapi_data = jsonapi_renderer.render(
+          course,
+          class: {
+            Course: API::V2::SerializableCourse,
+            Site: API::V2::SerializableSite,
+          },
+          include: %i[sites],
+        )
+
+        post create_path,
+             headers: { "HTTP_AUTHORIZATION" => credentials },
+             params: {
+               _jsonapi: { data: jsonapi_data[:data] },
+             }
+      end
+
+      it "Creates a course with a program type 'higher_education_programme'" do
+        created_course = provider.reload.courses.last
+        expect(created_course.program_type).to eq("higher_education_programme")
+      end
+
+      it "Creates a course with the further education subject" do
+        created_course = provider.reload.courses.last
+        expect(created_course.subjects).to eq([further_education_subject])
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

FE courses could not currently be created as they would fail validation based on fields they don't require. To solve this - we need to change validation

### Changes proposed in this pull request

- No longer require maths, english, or age range on a FE course
- Set the funding type to "Fee" in build new course/create
- Set the FE Subject on the course in build new course/create

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
