### PR TITLE
Change dev psql user to match production db dumps

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -2,8 +2,8 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: 5
-  username: <%= ENV['DB_USERNAME'] || 'manage_courses_backend' %>
-  password: <%= ENV['DB_PASSWORD'] || 'manage_courses_backend' %>
+  username: <%= ENV['DB_USERNAME'] || 'manage_courses' %>
+  password: <%= ENV['DB_PASSWORD'] || 'manage_courses' %>
   host: <%= ENV['DB_HOSTNAME'] || 'localhost' %>
   port: <%= ENV['DB_PORT'] || '5432' %>
 

--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -370,8 +370,8 @@ module MCB
     def configure_local_database_env
       # values to match database.yml
       ENV["DB_HOSTNAME"] = "localhost"
-      ENV["DB_USERNAME"] = "manage_courses_backend"
-      ENV["DB_PASSWORD"] = "manage_courses_backend"
+      ENV["DB_USERNAME"] = "manage_courses"
+      ENV["DB_PASSWORD"] = "manage_courses"
       ENV["DB_DATABASE"] = "manage_courses_backend_development"
     end
 

--- a/lib/tasks/create_dev_user.rake
+++ b/lib/tasks/create_dev_user.rake
@@ -25,13 +25,13 @@ namespace :db do
   desc "Create the dev user role"
   task :create_dev_user do
     run_sql <<~EOSQL.strip
-      CREATE USER manage_courses_backend WITH SUPERUSER CREATEDB PASSWORD 'manage_courses_backend';
+      CREATE USER manage_courses WITH SUPERUSER CREATEDB PASSWORD 'manage_courses';
     EOSQL
   end
 
   task :drop_dev_user do
     run_sql <<~EOSQL.strip
-      DROP ROLE IF EXISTS manage_courses_backend;
+      DROP ROLE IF EXISTS manage_courses;
     EOSQL
   end
 end

--- a/spec/lib/mcb/commands/az/apps/pg_dump_spec.rb
+++ b/spec/lib/mcb/commands/az/apps/pg_dump_spec.rb
@@ -6,7 +6,7 @@ describe "mcb az apps pg_dump" do
     Timecop.freeze do
       allow(MCB).to receive(:exec_command).with(
         "pg_dump --encoding utf8 --clean --if-exists " \
-        "-h localhost -U manage_courses_backend " \
+        "-h localhost -U manage_courses " \
         "-d manage_courses_backend_development " \
         "--file 'localhost_manage_courses_backend_development_#{Time.now.utc.strftime('%Y%m%d_%H%M%S')}.sql'",
       )

--- a/spec/lib/mcb/commands/db_spec.rb
+++ b/spec/lib/mcb/commands/db_spec.rb
@@ -6,7 +6,7 @@ describe "mcb db" do
     allow(MCB).to receive(:exec_command).with(
       "psql",
       "-h", "localhost",
-      "-U", "manage_courses_backend",
+      "-U", "manage_courses",
       "-d", "manage_courses_backend_development"
     )
 


### PR DESCRIPTION
This will remove a step for onboarding new developers when restoring a
sanitized backup of production data.

The production db uses `manage_courses` as a username, and that is encoded
in the production databaes dumps, without this patch you get errors
restoring the production db dumps because the `manage_coures` role does
not exist, meaning you have notice in the scrollback and manually create
the role.

This patch will mean all devs will have to re-run `rake db:setup` and
optionally manually drop the old role.

### Context

Onboarding new dev

### Changes proposed in this pull request

* rename dev psql role from `manage_courses_backend` to `manage_courses`

### Guidance to review

* Try it out locally
* :ship:

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally