### PR TITLE
[2403] Remove content_status and last_published_date from provider

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -14,7 +14,6 @@
 #  discarded_at                     :datetime
 #  email                            :text
 #  id                               :integer          not null, primary key
-#  last_published_at                :datetime
 #  latitude                         :float
 #  longitude                        :float
 #  postcode                         :text
@@ -33,7 +32,6 @@
 #
 # Indexes
 #
-#  IX_provider_last_published_at                             (last_published_at)
 #  index_provider_on_changed_at                              (changed_at) UNIQUE
 #  index_provider_on_discarded_at                            (discarded_at)
 #  index_provider_on_latitude_and_longitude                  (latitude,longitude)
@@ -219,11 +217,6 @@ class Provider < ApplicationRecord
     ]
 
     attributes.slice(*attribute_names)
-  end
-
-  # NOTE: This can be removed, it should not be in use any more
-  def content_status
-    :published
   end
 
   # This reflects the fact that organisations should actually be a has_one.

--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -4,7 +4,7 @@ module API
       type "providers"
 
       attributes :provider_code, :provider_name, :accredited_body?, :can_add_more_sites?,
-                 :content_status, :accredited_bodies, :train_with_us, :train_with_disability,
+                 :accredited_bodies, :train_with_us, :train_with_disability,
                  :latitude, :longitude
 
       attribute :address1 do
@@ -45,10 +45,6 @@ module API
 
       attribute :recruitment_cycle_year do
         @object.recruitment_cycle.year
-      end
-
-      attribute :last_published_at do
-        @object.last_published_at&.iso8601
       end
 
       attribute :admin_contact do

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -14,7 +14,6 @@
 #  discarded_at                     :datetime
 #  email                            :text
 #  id                               :integer          not null, primary key
-#  last_published_at                :datetime
 #  latitude                         :float
 #  longitude                        :float
 #  postcode                         :text
@@ -33,7 +32,6 @@
 #
 # Indexes
 #
-#  IX_provider_last_published_at                             (last_published_at)
 #  index_provider_on_changed_at                              (changed_at) UNIQUE
 #  index_provider_on_discarded_at                            (discarded_at)
 #  index_provider_on_latitude_and_longitude                  (latitude,longitude)

--- a/db/migrate/20191216113352_remove_provider_last_published_at.rb
+++ b/db/migrate/20191216113352_remove_provider_last_published_at.rb
@@ -1,0 +1,7 @@
+# rubocop:disable Rails/ReversibleMigration
+class RemoveProviderLastPublishedAt < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :provider, :last_published_at
+  end
+end
+# rubocop:enable Rails/ReversibleMigration

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_21_134242) do
+ActiveRecord::Schema.define(version: 2019_12_16_113352) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -207,7 +207,6 @@ ActiveRecord::Schema.define(version: 2019_11_21_134242) do
     t.datetime "created_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.text "accrediting_provider"
-    t.datetime "last_published_at"
     t.datetime "changed_at", default: -> { "timezone('utc'::text, now())" }, null: false
     t.integer "recruitment_cycle_id", null: false
     t.datetime "discarded_at"
@@ -218,7 +217,6 @@ ActiveRecord::Schema.define(version: 2019_11_21_134242) do
     t.float "longitude"
     t.index ["changed_at"], name: "index_provider_on_changed_at", unique: true
     t.index ["discarded_at"], name: "index_provider_on_discarded_at"
-    t.index ["last_published_at"], name: "IX_provider_last_published_at"
     t.index ["latitude", "longitude"], name: "index_provider_on_latitude_and_longitude"
     t.index ["recruitment_cycle_id", "provider_code"], name: "index_provider_on_recruitment_cycle_id_and_provider_code", unique: true
   end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -14,7 +14,6 @@
 #  discarded_at                     :datetime
 #  email                            :text
 #  id                               :integer          not null, primary key
-#  last_published_at                :datetime
 #  latitude                         :float
 #  longitude                        :float
 #  postcode                         :text
@@ -33,7 +32,6 @@
 #
 # Indexes
 #
-#  IX_provider_last_published_at                             (last_published_at)
 #  index_provider_on_changed_at                              (changed_at) UNIQUE
 #  index_provider_on_discarded_at                            (discarded_at)
 #  index_provider_on_latitude_and_longitude                  (latitude,longitude)

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -14,7 +14,6 @@
 #  discarded_at                     :datetime
 #  email                            :text
 #  id                               :integer          not null, primary key
-#  last_published_at                :datetime
 #  latitude                         :float
 #  longitude                        :float
 #  postcode                         :text
@@ -33,7 +32,6 @@
 #
 # Indexes
 #
-#  IX_provider_last_published_at                             (last_published_at)
 #  index_provider_on_changed_at                              (changed_at) UNIQUE
 #  index_provider_on_discarded_at                            (discarded_at)
 #  index_provider_on_latitude_and_longitude                  (latitude,longitude)

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -72,7 +72,6 @@ describe "Providers API", type: :request do
                region_code: :london,
                accrediting_provider: "Y",
                scheme_member: "Y",
-               last_published_at: DateTime.now.utc,
                ucas_preferences: ucas_preferences,
                contacts: contacts,
                sites: [site])
@@ -129,7 +128,6 @@ describe "Providers API", type: :request do
                region_code: :south_west,
                accrediting_provider: "N",
                scheme_member: "N",
-               last_published_at: DateTime.now.utc,
                ucas_preferences: ucas_preferences2,
                contacts: contacts2,
                sites: [site2])

--- a/spec/requests/api/v2/providers/update_spec.rb
+++ b/spec/requests/api/v2/providers/update_spec.rb
@@ -119,9 +119,7 @@ describe "PATCH /providers/:provider_code" do
       it "doesn't permit #{attribute}" do
         update_provider[attribute] = if(attribute == :recruitment_cycle_id)
                                        next_cycle.id
-
                                      else
-
                                        value
                                      end
         perform_request(update_provider)
@@ -140,7 +138,6 @@ describe "PATCH /providers/:provider_code" do
     include_examples "does not allow assignment", :created_at,           Time.zone.now
     include_examples "does not allow assignment", :updated_at,           Time.zone.now
     include_examples "does not allow assignment", :accrediting_provider, :accredited_body
-    include_examples "does not allow assignment", :last_published_at,    Time.zone.now
     include_examples "does not allow assignment", :changed_at,           Time.zone.now
 
     let!(:next_cycle) { find_or_create(:recruitment_cycle, :next) }

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -251,8 +251,6 @@ describe "Providers API v2", type: :request do
             "email" => provider.email,
             "website" => provider.website,
             "recruitment_cycle_year" => provider.recruitment_cycle.year,
-            "content_status" => provider.content_status.to_s,
-            "last_published_at" => provider.last_published_at,
             "accredited_bodies" => [{
               "provider_code" => accrediting_provider.provider_code,
               "provider_name" => accrediting_provider.provider_name,
@@ -335,8 +333,6 @@ describe "Providers API v2", type: :request do
               "email" => provider.email,
               "website" => provider.website,
               "recruitment_cycle_year" => provider.recruitment_cycle.year,
-              "content_status" => provider.content_status.to_s,
-              "last_published_at" => provider.last_published_at,
               "accredited_bodies" => [{
                 "provider_code" => accrediting_provider.provider_code,
                 "provider_name" => accrediting_provider.provider_name,

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -14,7 +14,6 @@
 #  discarded_at                     :datetime
 #  email                            :text
 #  id                               :integer          not null, primary key
-#  last_published_at                :datetime
 #  latitude                         :float
 #  longitude                        :float
 #  postcode                         :text
@@ -33,7 +32,6 @@
 #
 # Indexes
 #
-#  IX_provider_last_published_at                             (last_published_at)
 #  index_provider_on_changed_at                              (changed_at) UNIQUE
 #  index_provider_on_discarded_at                            (discarded_at)
 #  index_provider_on_latitude_and_longitude                  (latitude,longitude)

--- a/spec/serializers/search_and_compare/course_serializer_spec.rb
+++ b/spec/serializers/search_and_compare/course_serializer_spec.rb
@@ -96,7 +96,6 @@ describe SearchAndCompare::CourseSerializer do
 
       let(:provider_enrichment) do
         {
-          last_published_at: 1.day.ago,
           address1: "c/o Claverdon Primary School",
           address2: "Breach Lane",
           address3: "Claverdon",


### PR DESCRIPTION
### Context
Provider enrichments are no longer in use, these fields are leftover from them.

### Changes proposed in this pull request
Remove any references to providers' `content_status` or `last_published_date` and correct any tests broken by this.

### Guidance to review
Needs to be checked by @fofr but things seem to still work.  

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
