### PR TITLE
[2664] - Fix display of test results in azure portal

### DIFF
--- a/.azure_parallel
+++ b/.azure_parallel
@@ -1,0 +1,5 @@
+--require spec_helper
+--no-profile
+--format documentation
+--format RspecJunitFormatter
+--out rspec-output/rspec-output<%= ENV['TEST_ENV_NUMBER'] %>.xml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,15 +41,23 @@ steps:
     dockerHubImageName: $(imageName)
     CC_TEST_REPORTER_ID: $(ccReporterID)
 - script: |
+    set -x
     $DOCKER_OVERRIDE exec -T web /bin/sh -c 'bundle config --local disable_exec_load true'
     $DOCKER_OVERRIDE exec -T web /bin/sh -c 'bundle exec rake parallel:setup'
-    $DOCKER_OVERRIDE exec -T web /bin/sh -c 'bundle exec rake "parallel:spec[,,--format progress --format RspecJunitFormatter --out rspec-results.xml --no-profile]"'
+    $DOCKER_OVERRIDE exec -T web /bin/sh -c 'bundle exec rake "parallel:spec[,, -O .azure_parallel]"'
+
   displayName: 'Execute tests'
   env:
     DOCKER_OVERRIDE: $(dockerOverride)
     dockerHubUsername: $(dockerHubUsername)
     dockerHubImageName: $(imageName)
     CC_TEST_REPORTER_ID: $(ccReporterID)
+- task: PublishTestResults@2
+  condition: succeededOrFailed()
+  inputs:
+    testRunner: JUnit
+    testResultsFiles: 'rspec-output/*.xml'
+    failedTaskOnFailedTest: true
 - script: |
     $DOCKER_OVERRIDE exec -T web /bin/sh -c "bundle exec rubocop app config db lib spec --format clang"
   displayName: 'Execute linters'
@@ -135,9 +143,3 @@ steps:
   displayName: 'Publish Artifact'
   inputs:
     PathtoPublish: '$(build.artifactstagingdirectory)'
-- task: PublishTestResults@2
-  condition: succeededOrFailed()
-  inputs:
-    testRunner: JUnit
-    testResultsFiles: '*.xml'
-    failedTaskOnFailedTest: true


### PR DESCRIPTION
### Context

Inspired by @timabell 's trip down the rabbit hole - https://github.com/DFE-Digital/manage-courses-frontend/pull/823

When switching over parallel tests, it ended up breaking publishing of test results in Azure. This was because:

* The xml file wasn't copied out of the container so azure DevOps couldn't find it.
* Multiple processes wrote to the same xml file, sometimes making it invalid xml.

### Changes proposed in this pull request

* Show test results sooner
* Fix display of test results in azure portal

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
