### PR TITLE
[2640] Add validations for course creation

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -27,7 +27,7 @@ module API
         @course.assign_attributes(course_params)
         update_further_education_fields if @course.level == "further_education"
         @course.name = @course.generate_name
-        @course.valid?
+        @course.valid?(:new)
 
         # https://github.com/jsonapi-rb/jsonapi-rails/issues/113
         json_data = JSONAPI::Serializable::Renderer.new.render(
@@ -102,6 +102,7 @@ module API
         has_synced? if should_sync
 
         if @course.errors.empty? && @course.valid?
+          @course.save
           render jsonapi: @course.reload
         else
           render jsonapi_errors: @course.errors, status: :unprocessable_entity
@@ -133,7 +134,7 @@ module API
         update_further_education_fields if @course.level == "further_education"
         @course.name = @course.generate_name
 
-        if @course.save
+        if @course.valid?(:new) && @course.save
           render jsonapi: @course.reload
         else
           render jsonapi_errors: @course.errors, status: :unprocessable_entity
@@ -175,7 +176,6 @@ module API
 
         @course.subjects = Subject.where(id: subject_ids)
         @course.name = @course.generate_name
-        @course.save
       end
 
       def build_provider

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -159,7 +159,7 @@ class Course < ApplicationRecord
   validates :science, inclusion: { in: entry_requirement_options_without_nil_choice }, if: :gcse_science_required?
   validates :enrichments, presence: true, on: :publish
   validates :is_send, inclusion: { in: [true, false] }
-  validates :sites, presence: true, on: :publish
+  validates :sites, presence: true, on: %i[publish create]
   validates :level, presence: { message: "^There is a problem with this course. Contact support to fix it (Error: L)" }, on: :publish
   validates :subjects, presence: true, on: :publish
   validate :validate_enrichment_publishable, on: :publish
@@ -168,7 +168,7 @@ class Course < ApplicationRecord
   validate :validate_course_syncable, on: :sync
   validate :validate_qualification, on: :update
   validate :validate_start_date, on: :update, if: -> { provider.present? && start_date.present? }
-  validate :validate_applications_open_from, on: :update, if: -> { provider.present? }
+  validate :validate_applications_open_from, on: %i[update create], if: -> { provider.present? }
   validate :validate_modern_languages
   validate :validate_subject_count
   validate :validate_subject_consistency
@@ -552,9 +552,17 @@ private
   end
 
   def validate_applications_open_from
-    unless valid_date_range.include?(applications_open_from)
-      errors.add(:applications_open_from, "#{applications_open_from} is not valid for the #{provider.recruitment_cycle.year} cycle. " +
-      "A valid date must be between #{recruitment_cycle.application_start_date} and #{recruitment_cycle.application_end_date}")
+    if applications_open_from.blank?
+      errors.add(:applications_open_from, :blank)
+    elsif !valid_date_range.include?(applications_open_from)
+      chosen_date = applications_open_from.strftime("%d/%m/%Y")
+      start_date = recruitment_cycle.application_start_date.strftime("%d/%m/%Y")
+      end_date = recruitment_cycle.application_end_date.strftime("%d/%m/%Y")
+      errors.add(
+        :applications_open_from,
+        "#{chosen_date} is not valid for the #{provider.recruitment_cycle.year} cycle. " +
+        "A valid date must be between #{start_date} and #{end_date}",
+      )
     end
   end
 
@@ -582,7 +590,10 @@ private
   end
 
   def validate_subject_count
-    return if subjects.empty?
+    if subjects.empty?
+      errors.add(:subjects, :course_creation)
+      return
+    end
 
     case level
     when "primary", "further_education"

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -169,6 +169,7 @@ class Course < ApplicationRecord
   validate :validate_start_date, on: :update, if: -> { provider.present? && start_date.present? }
   validate :validate_applications_open_from, on: %i[update new], if: -> { provider.present? }
   validate :validate_modern_languages
+  validate :validate_has_languages, if: :has_the_modern_languages_secondary_subject_type?
   validate :validate_subject_count
   validate :validate_subject_consistency
 
@@ -542,7 +543,7 @@ private
     if qualification.blank?
       errors.add(:qualification, :blank)
     else
-      errors.add(:qualification, "^#{qualifications_description} is not valid for a #{level.to_s.humanize.downcase} course") unless qualification_options.include?(qualification)
+      errors.add(:qualification, "^#{qualifications_description} is not valid for a #{level.to_s.humanize.downcase} course") unless qualification.in?(qualification_options)
     end
   end
 
@@ -590,6 +591,12 @@ private
     raise "SecondarySubject.modern_languages not found" if SecondarySubject.modern_languages == nil
 
     subjects.any? { |subject| subject&.id == SecondarySubject.modern_languages.id }
+  end
+
+  def validate_has_languages
+    unless has_any_modern_language_subject_type?
+      errors.add(:subjects, :select_a_language)
+    end
   end
 
   def validate_subject_count

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,7 @@ en:
             subjects:
               blank: "^There is a problem with this course. Contact support to fix it (Error: S)"
               course_creation: "^You must pick at least one subject"
+              select_a_language: "^You must pick at least one language"
             study_mode:
               blank: "^You need to pick an option"
             applications_open_from:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,8 +41,17 @@ en:
               blank: "^Complete your course information before publishing"
             sites:
               blank: "^You must pick at least one location for this course"
+            age_range_in_years:
+              blank: "^You need to pick an age range"
+            program_type:
+              blank: "^You need to pick an option"
             subjects:
               blank: "^There is a problem with this course. Contact support to fix it (Error: S)"
+              course_creation: "^You must pick at least one subject"
+            study_mode:
+              blank: "^You need to pick an option"
+            applications_open_from:
+              blank: "^You must say when applications open from"
         course_enrichment:
           attributes:
             salary_details:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,10 @@ en:
               blank: "is missing"
         course:
           attributes:
+            level:
+              blank: "^You need to pick a level"
+            qualification:
+              blank: "^You need to pick an outcome"
             maths:
               inclusion: "^Pick an option for Maths"
             english:

--- a/lib/mcb/editor/courses_editor.rb
+++ b/lib/mcb/editor/courses_editor.rb
@@ -38,10 +38,14 @@ module MCB
           edit(attribute)
         end
 
+        course.subjects = @cli.multiselect(
+          initial_items: course.subjects.to_a,
+          possible_items: course.assignable_subjects,
+        )
+        course.ensure_modern_languages
         puts "\nAbout to create the following course:"
         print_at_most_two_courses
         if @cli.confirm_creation? && try_saving_course
-          edit_subjects
           edit_sites
           edit(:application_opening_date)
           print_summary
@@ -94,7 +98,6 @@ module MCB
           initial_items: course.subjects.to_a,
           possible_items: course.assignable_subjects,
         )
-        course.ensure_modern_languages
         course.reload
       end
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -111,18 +111,6 @@ FactoryBot.define do
       end
     end
 
-    before(:create) do |course, evaluator|
-      if evaluator.infer_subjects? && course.subjects.empty?
-        if course.level == "primary"
-          course.subjects << find_or_create(:primary_subject, :primary)
-        elsif course.level == "secondary"
-          course.subjects << find_or_create(:secondary_subject, :science)
-        elsif course.level == "further_education"
-          course.subjects << find_or_create(:further_education_subject)
-        end
-      end
-    end
-
     after(:create) do |course, evaluator|
       # This is important to retain the relationship behaviour between
       # course and it's enrichment
@@ -217,7 +205,7 @@ FactoryBot.define do
     end
 
     trait :skip_validate do
-      to_create {|instance| instance.save(validate: false)}
+      to_create { |instance| instance.save(validate: false) }
     end
   end
 end

--- a/spec/lib/mcb/commands/courses/edit_spec.rb
+++ b/spec/lib/mcb/commands/courses/edit_spec.rb
@@ -78,6 +78,7 @@ describe "mcb courses edit" do
         end
 
         it "ignores providers associated with the next cycle" do
+          CourseSubject.where(course_id: course.id).first.destroy
           provider.destroy
           course.destroy
 

--- a/spec/lib/mcb/editor/courses_editor_spec.rb
+++ b/spec/lib/mcb/editor/courses_editor_spec.rb
@@ -182,7 +182,7 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
       end
     end
 
-    xdescribe "runs the course creation wizard" do
+    describe "runs the course creation wizard" do
       def run_new_course_wizard(*input_cmds)
         with_stubbed_stdout(stdin: input_cmds.join("\n")) do
           subject.new_course_wizard
@@ -246,9 +246,9 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
             desired_attributes[:level],
             desired_attributes[:course_code],
             "y", # is SEND confirmation
-            "y", # confirm creation
             "[ ] Biology",
             "continue",
+            "y", # confirm creation
             # location selection
             "[ ] #{site_1.location_name}",
             "[ ] #{site_3.location_name}",
@@ -276,9 +276,9 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
             desired_attributes[:level],
             desired_attributes[:course_code],
             "y", # is SEND confirmation
-            "y", # confirm creation
             "[ ] Japanese",
             "continue",
+            "y", # confirm creation
             # location selection
             "[ ] #{site_1.location_name}",
             "[ ] #{site_3.location_name}",
@@ -306,9 +306,9 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
             "primary",
             desired_attributes[:course_code],
             "y", # is SEND confirmation
-            "y", # confirm creation
             "[ ] Primary with mathematics",
             "continue",
+            "y", # confirm creation
             # location selection
             "[ ] #{site_1.location_name}",
             "[ ] #{site_3.location_name}",
@@ -337,9 +337,9 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
             "further_education",
             desired_attributes[:course_code],
             "y", # is SEND confirmation
-            "y", # confirm creation
             "[ ] Further education",
             "continue",
+            "y", # confirm creation
             # location selection
             "[ ] #{site_1.location_name}",
             "[ ] #{site_3.location_name}",
@@ -368,10 +368,9 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
           desired_attributes[:level],
           desired_attributes[:course_code],
           "y", # is SEND confirmation
-          "y", # confirm creation
-          # subject selection
-          "[ ] Mathematics",
+          "[ ] Mathematics", # subject selection
           "continue",
+          "y", # confirm creation
           # location selection
           "[ ] #{site_1.location_name}",
           "[ ] #{site_3.location_name}",
@@ -419,10 +418,9 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
           desired_attributes[:level],
           desired_attributes[:course_code],
           "y", # is SEND confirmation
-          "y", # confirm creation
-          # subject selection
-          "[ ] Mathematics",
+          "[ ] Mathematics", # subject selection
           "continue",
+          "y", # confirm creation
           # location selection
           "[ ] #{site_1.location_name}",
           "[ ] #{site_3.location_name}",
@@ -453,10 +451,10 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
           desired_attributes[:course_code],
           "n", # is SEND
           desired_attributes[:recruitment_cycle],
-          "y", # confirm creation
           # subject selection
           "[ ] Mathematics",
           "continue",
+          "y", # confirm creation
           # location selection
           "[ ] #{site_1.location_name}",
           "[ ] #{site_3.location_name}",
@@ -494,6 +492,8 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
           desired_attributes[:course_code],
           "n", # is SEND
           desired_attributes[:recruitment_cycle],
+          "[ ] Mathematics",
+          "continue",
           "n", # confirm creation
         )[:stdout]
 
@@ -517,6 +517,8 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
           course_code, # a duplicate course code
           "n", # is SEND
           desired_attributes[:recruitment_cycle],
+          "[ ] Mathematics",
+          "continue",
           "y", # confirm creation
         )[:stdout]
 

--- a/spec/lib/mcb/editor/courses_editor_spec.rb
+++ b/spec/lib/mcb/editor/courses_editor_spec.rb
@@ -16,6 +16,7 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
   let(:japanese) { find_or_create(:modern_languages_subject, :japanese) }
   let(:primary_with_mathematics) { find_or_create(:primary_subject, :primary_with_mathematics) }
   let(:biology) { find_or_create(:secondary_subject, :biology) }
+  let(:mathematics) { find_or_create(:secondary_subject, :mathematics) }
   let(:modern_languages) { find_or_create(:secondary_subject, :modern_languages) }
   let(:further_education) { find_or_create(:further_education_subject) }
   let(:current_cycle) { find_or_create :recruitment_cycle }
@@ -50,6 +51,7 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
     japanese
     primary_with_mathematics
     biology
+    mathematics
     further_education
   end
 
@@ -321,7 +323,7 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
         end
 
         it "only shows further education subjects if further education level is selected" do
-          run_new_course_wizard(
+          output = run_new_course_wizard(
             desired_attributes[:title],
             desired_attributes[:qualification],
             desired_attributes[:study_mode],

--- a/spec/lib/mcb/editor/courses_editor_spec.rb
+++ b/spec/lib/mcb/editor/courses_editor_spec.rb
@@ -182,7 +182,7 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
       end
     end
 
-    describe "runs the course creation wizard" do
+    xdescribe "runs the course creation wizard" do
       def run_new_course_wizard(*input_cmds)
         with_stubbed_stdout(stdin: input_cmds.join("\n")) do
           subject.new_course_wizard
@@ -323,7 +323,7 @@ describe MCB::Editor::CoursesEditor, :needs_audit_user do
         end
 
         it "only shows further education subjects if further education level is selected" do
-          output = run_new_course_wizard(
+          run_new_course_wizard(
             desired_attributes[:title],
             desired_attributes[:qualification],
             desired_attributes[:study_mode],

--- a/spec/models/concerns/courses/edit_options_spec.rb
+++ b/spec/models/concerns/courses/edit_options_spec.rb
@@ -15,7 +15,7 @@ describe Course, type: :model do
 
     context "secondary level" do
       context "with the modern language subject" do
-        let(:course) { create(:course, level: "secondary", subjects: [find(:secondary_subject, :modern_languages)]) }
+        let(:course) { create(:course, level: "secondary", subjects: [find(:secondary_subject, :modern_languages), find(:modern_languages_subject, :french)]) }
 
         it "returns modern languages subjects" do
           expect(course.available_modern_languages).to(

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -137,6 +137,23 @@ describe Course, type: :model do
           expect(error.first).to include("You must pick at least one subject")
         end
 
+        context "With modern languages as a subject" do
+          let(:course) { Course.new(provider: provider, subjects: [modern_languages]) }
+
+          it "Requires a language to be selected" do
+            error = errors[:subjects]
+            expect(error).not_to be_empty
+            expect(error.first).to include("You must pick at least one language")
+          end
+
+          it "Does not add an error if a language is selected" do
+            course.subjects << french
+            course.valid?(:new)
+            error = course.errors.messages[:subjects]
+            expect(error).to be_empty
+          end
+        end
+
         it "Requires an age range" do
           error = errors[:age_range_in_years]
           expect(error).not_to be_empty
@@ -544,7 +561,7 @@ describe Course, type: :model do
       let(:subject_discontinued) { create :discontinued_subject }
       let(:subject_without_code) { create :primary_subject, :primary, subject_code: nil }
       let(:course) do
-        create :course, subjects: [subject, modern_languages, subject_discontinued]
+        create :course, subjects: [subject, subject_discontinued]
       end
 
       it "returns none-discontinued subjects that have a code present" do
@@ -1010,7 +1027,7 @@ describe Course, type: :model do
 
   context "bursaries and scholarships" do
     let!(:financial_incentive) { create(:financial_incentive, subject: modern_languages, bursary_amount: 255, scholarship: 1415, early_career_payments: 32) }
-    subject { create(:course, level: "secondary", subjects: [modern_languages]) }
+    subject { create(:course, :skip_validate, level: "secondary", subjects: [modern_languages]) }
 
     it { should have_bursary }
     it { should have_scholarship_and_bursary }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -111,6 +111,59 @@ describe Course, type: :model do
     end
 
     describe "valid?" do
+      fcontext "A new course" do
+        let(:provider) { build(:provider) }
+        let(:course) { Course.new(provider: provider) }
+        let(:errors) { course.errors.messages }
+        before { course.valid? }
+
+        it "Requires a subject" do
+          error = errors[:subjects]
+          expect(error).not_to be_empty
+          expect(error.first).to include("You must pick at least one subject")
+        end
+
+        it "Requires an age range" do
+          error = errors[:age_range_in_years]
+          expect(error).not_to be_empty
+          expect(error.first).to include("You need to pick an age range")
+        end
+
+        it "Requires a program type to have been specified" do
+          error = errors[:program_type]
+          expect(error).not_to be_empty
+          expect(error.first).to include("You need to pick an option")
+        end
+
+        it "Requires a study mode" do
+          error = errors[:study_mode]
+          expect(error).not_to be_empty
+          expect(error.first).to include("You need to pick an option")
+        end
+
+        context "Applications open" do
+          it "Empty" do
+            error = errors[:applications_open_from]
+            expect(error).not_to be_empty
+            expect(error.first).to include("You must say when applications open")
+          end
+
+          it "A date outside of the current recruitment cycle" do
+            course.applications_open_from = course.recruitment_cycle.application_start_date - 1
+            course.valid?
+            error = course.errors.messages[:applications_open_from]
+            expect(error).not_to be_empty
+            expect(error.first).to include("is not valid")
+          end
+        end
+
+        it "Requires at least one location" do
+          error = errors[:sites]
+          expect(error).not_to be_empty
+          expect(error.first).to include("You must pick at least one location")
+        end
+      end
+
       context "A further education course" do
         let(:course) { build(:course, level: "further_education") }
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -45,7 +45,7 @@ describe Course, type: :model do
       level: "secondary",
       name: "Biology",
       course_code: "3X9F",
-      subjects: [ find_or_create(:secondary_subject, :biology) ]
+      subjects: [find_or_create(:secondary_subject, :biology)],
     )
   end
   let(:subject) { course }
@@ -278,7 +278,7 @@ describe Course, type: :model do
         it "Should give an error for the subjects" do
           expect(subject.errors.full_messages).to match_array([
             "There is a problem with this course. Contact support to fix it (Error: S)",
-            "You must pick at least one subject"
+            "You must pick at least one subject",
           ])
         end
       end
@@ -1256,7 +1256,7 @@ describe Course, type: :model do
         :skip_validate,
         infer_subjects?: false,
         subjects: courses_subjects,
-        site_statuses: [site_status]
+        site_statuses: [site_status],
       )
     end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -324,9 +324,8 @@ describe Provider, type: :model do
       let(:suspended_site_status) { create(:site_status, :suspended, site: site) }
       let(:syncable_course) { create(:course, :infer_level, site_statuses: [findable_site_status_1], subjects: [dfe_subject]) }
       let(:suspended_course) { create(:course, :infer_level, site_statuses: [suspended_site_status], subjects: [dfe_subject]) }
-      let(:invalid_subject_course) { create(:course, :infer_level, level: "primary", site_statuses: [findable_site_status_2], subjects: []) }
 
-      subject { create(:provider, courses: [syncable_course, suspended_course, invalid_subject_course], sites: [site]) }
+      subject { create(:provider, courses: [syncable_course, suspended_course], sites: [site]) }
 
       its(:syncable_courses) { should eq [syncable_course] }
     end

--- a/spec/requests/api/v2/build_new_course_spec.rb
+++ b/spec/requests/api/v2/build_new_course_spec.rb
@@ -143,6 +143,27 @@ describe "/api/v2/build_new_course", type: :request do
                 },
               },
               {
+                "title" => "Invalid sites",
+                "detail" => "You must pick at least one location for this course",
+                "source" => {
+                  "pointer" => "/data/attributes/sites",
+                },
+              },
+              {
+                "title" => "Invalid qualification",
+                "detail" => "You need to pick an outcome",
+                "source" => {
+                  "pointer" => "/data/attributes/qualification",
+                },
+              },
+              {
+                "title" => "Invalid applications_open_from",
+                "detail" => "You must say when applications open from",
+                "source" => {
+                  "pointer" => "/data/attributes/applications_open_from",
+                },
+              },
+              {
                 "title" => "Invalid subjects",
                 "detail" => "You must pick at least one subject",
                 "source" => {
@@ -168,13 +189,6 @@ describe "/api/v2/build_new_course", type: :request do
                 "detail" => "You need to pick an option",
                 "source" => {
                   "pointer" => "/data/attributes/program_type",
-                },
-              },
-              {
-                "title" => "Invalid qualification",
-                "detail" => "You need to pick an outcome",
-                "source" => {
-                  "pointer" => "/data/attributes/qualification",
                 },
               },
               {
@@ -215,14 +229,22 @@ describe "/api/v2/build_new_course", type: :request do
     let(:params) do
       { course: {} }
     end
+    let(:json_response) { parse_response(response) }
 
-    it "returns a new course with errors" do
-      response = do_get params
+    before { do_get params }
+
+    it "Returns an 200 status" do
       expect(response).to have_http_status(:ok)
-      json_response = parse_response(response)
+    end
+
+    it "returns a new course with the correct attribtues" do
       expected = course_jsonapi
       expected["data"]["attributes"]["name"] = ""
-      expected["data"]["errors"] = [
+      expect(json_response["data"]["attributes"]).to eq(course_jsonapi["data"]["attributes"])
+    end
+
+    it "returns a new course with the correct errors" do
+      expected_errors = [
               {
                 "title" => "Invalid maths",
                 "detail" => "Pick an option for Maths",
@@ -300,9 +322,23 @@ describe "/api/v2/build_new_course", type: :request do
                   "pointer" => "/data/attributes/level",
                 },
               },
+              {
+                "title" => "Invalid sites",
+                "detail" => "You must pick at least one location for this course",
+                "source" => {
+                  "pointer" => "/data/attributes/sites",
+                },
+              },
+              {
+                "title" => "Invalid applications_open_from",
+                "detail" => "You must say when applications open from",
+                "source" => {
+                  "pointer" => "/data/attributes/applications_open_from",
+                },
+              },
         ]
 
-      expect(json_response).to eq expected
+      expect(json_response["data"]["errors"]).to match_array(expected_errors)
     end
   end
 
@@ -318,14 +354,17 @@ describe "/api/v2/build_new_course", type: :request do
         qualification: "qts",
         funding_type: "fee",
         subjects_ids: subjects.map(&:id),
+        sites_ids: [sites.map(&:id)],
         level: :primary,
         age_range_in_years: "3_to_7",
+        applications_open_from: provider.recruitment_cycle.application_start_date,
         } }
     end
 
+    let(:sites) { [create(:site, provider: provider)] }
     let(:subjects) { [find_or_create(:primary_subject, :primary_with_mathematics)] }
     let(:course) do
-      Course.new({ provider: provider, subjects: subjects }.merge(params[:course].slice!(:subjects_ids)))
+      Course.new({ provider: provider, subjects: subjects, sites: sites }.merge(params[:course].slice!(:subjects_ids, :sites_ids)))
     end
 
     it "returns a matching course with no errors" do

--- a/spec/requests/api/v2/build_new_course_spec.rb
+++ b/spec/requests/api/v2/build_new_course_spec.rb
@@ -143,6 +143,13 @@ describe "/api/v2/build_new_course", type: :request do
                 },
               },
               {
+                "title" => "Invalid subjects",
+                "detail" => "You must pick at least one subject",
+                "source" => {
+                  "pointer" => "/data/attributes/subjects",
+                },
+              },
+              {
                 "title" => "Invalid name",
                 "detail" => "Name can't be blank",
                 "source" => {
@@ -158,14 +165,14 @@ describe "/api/v2/build_new_course", type: :request do
               },
               {
                 "title" => "Invalid program_type",
-                "detail" => "Program type can't be blank",
+                "detail" => "You need to pick an option",
                 "source" => {
                   "pointer" => "/data/attributes/program_type",
                 },
               },
               {
                 "title" => "Invalid qualification",
-                "detail" => "Qualification can't be blank",
+                "detail" => "You need to pick an outcome",
                 "source" => {
                   "pointer" => "/data/attributes/qualification",
                 },
@@ -179,21 +186,21 @@ describe "/api/v2/build_new_course", type: :request do
               },
               {
                 "title" => "Invalid study_mode",
-                "detail" => "Study mode can't be blank",
+                "detail" => "You need to pick an option",
                 "source" => {
                   "pointer" => "/data/attributes/study_mode",
                 },
               },
               {
                 "title" => "Invalid age_range_in_years",
-                "detail" => "Age range in years can't be blank",
+                "detail" => "You need to pick an age range",
                 "source" => {
                   "pointer" => "/data/attributes/age_range_in_years",
                 },
               },
               {
                 "title" => "Invalid level",
-                "detail" => "Level can't be blank",
+                "detail" => "You need to pick a level",
                 "source" => {
                   "pointer" => "/data/attributes/level",
                 },
@@ -231,6 +238,13 @@ describe "/api/v2/build_new_course", type: :request do
                 },
               },
               {
+                "title" => "Invalid subjects",
+                "detail" => "You must pick at least one subject",
+                "source" => {
+                  "pointer" => "/data/attributes/subjects",
+                },
+              },
+              {
                 "title" => "Invalid name",
                 "detail" => "Name can't be blank",
                 "source" => {
@@ -246,14 +260,14 @@ describe "/api/v2/build_new_course", type: :request do
               },
               {
                 "title" => "Invalid program_type",
-                "detail" => "Program type can't be blank",
+                "detail" => "You need to pick an option",
                 "source" => {
                   "pointer" => "/data/attributes/program_type",
                 },
               },
               {
                 "title" => "Invalid qualification",
-                "detail" => "Qualification can't be blank",
+                "detail" => "You need to pick an outcome",
                 "source" => {
                   "pointer" => "/data/attributes/qualification",
                 },
@@ -267,21 +281,21 @@ describe "/api/v2/build_new_course", type: :request do
               },
               {
                 "title" => "Invalid study_mode",
-                "detail" => "Study mode can't be blank",
+                "detail" => "You need to pick an option",
                 "source" => {
                   "pointer" => "/data/attributes/study_mode",
                 },
               },
               {
                 "title" => "Invalid age_range_in_years",
-                "detail" => "Age range in years can't be blank",
+                "detail" => "You need to pick an age range",
                 "source" => {
                   "pointer" => "/data/attributes/age_range_in_years",
                 },
               },
               {
                 "title" => "Invalid level",
-                "detail" => "Level can't be blank",
+                "detail" => "You need to pick a level",
                 "source" => {
                   "pointer" => "/data/attributes/level",
                 },

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -164,7 +164,6 @@ describe "Publish API v2", type: :request do
         it "has validation errors" do
           expect(json_data.map { |error| error["detail"] }).to match_array([
             "Complete your course information before publishing",
-            "There is a problem with this course. Contact support to fix it (Error: S)",
             "You must pick at least one location for this course",
           ])
         end
@@ -190,13 +189,11 @@ describe "Publish API v2", type: :request do
               "Enter a course length",
               "Give details about the fee for UK and EU students",
               "Enter details about the qualifications needed",
-              "There is a problem with this course. Contact support to fix it (Error: S)",
             ])
           end
 
           it "has validation error pointers" do
             expect(json_data.map { |error| error["source"]["pointer"] }).to match_array([
-              nil,
               "/data/attributes/about_course",
               "/data/attributes/how_school_placements_work",
               "/data/attributes/course_length",
@@ -227,7 +224,6 @@ describe "Publish API v2", type: :request do
               "Enter a course length",
               "Give details about the salary for this course",
               "Enter details about the qualifications needed",
-              "There is a problem with this course. Contact support to fix it (Error: S)",
             ])
           end
         end

--- a/spec/requests/api/v2/providers/courses/publishable_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publishable_spec.rb
@@ -76,7 +76,6 @@ describe "Publishable API v2", type: :request do
           expect(json_data.map { |error| error["detail"] }).to match_array([
             "Complete your course information before publishing",
             "You must pick at least one location for this course",
-            "There is a problem with this course. Contact support to fix it (Error: S)",
           ])
         end
       end
@@ -95,9 +94,8 @@ describe "Publishable API v2", type: :request do
           it { should have_http_status(:unprocessable_entity) }
 
           it "has validation error details" do
-            expect(json_data.count).to eq 6
+            expect(json_data.count).to eq 5
             expect(json_data.map { |error| error["detail"] }).to match_array([
-              "There is a problem with this course. Contact support to fix it (Error: S)",
               "Enter details about this course",
               "Enter a course length",
               "Give details about the fee for UK and EU students",
@@ -108,7 +106,6 @@ describe "Publishable API v2", type: :request do
 
           it "has validation error pointers" do
             expect(json_data.map { |error| error["source"]["pointer"] }).to match_array([
-              nil,
               "/data/attributes/about_course",
               "/data/attributes/how_school_placements_work",
               "/data/attributes/course_length",

--- a/spec/requests/api/v2/providers/courses/update_application_open_from_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_application_open_from_spec.rb
@@ -79,8 +79,11 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
       it "returns an error" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(json_data.count).to eq 1
-        expect(response.body).to include("#{updated_applications_open_from[:applications_open_from]} is not valid for the #{provider.recruitment_cycle.year} cycle. " +
-            "A valid date must be between #{provider.recruitment_cycle.application_start_date} and #{provider.recruitment_cycle.application_end_date}")
+        chosen_date = updated_applications_open_from[:applications_open_from].strftime("%d/%m/%Y")
+        start_date = provider.recruitment_cycle.application_start_date.strftime("%d/%m/%Y")
+        end_date = provider.recruitment_cycle.application_end_date.strftime("%d/%m/%Y")
+        expect(response.body).to include("#{chosen_date} is not valid for the #{provider.recruitment_cycle.year} cycle. " +
+                                         "A valid date must be between #{start_date} and #{end_date}")
       end
     end
   end
@@ -98,8 +101,11 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
       it "returns an error" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(json_data.count).to eq 1
-        expect(response.body).to include("#{updated_applications_open_from[:applications_open_from]} is not valid for the #{provider.recruitment_cycle.year} cycle. " +
-            "A valid date must be between #{provider.recruitment_cycle.application_start_date} and #{provider.recruitment_cycle.application_end_date}")
+        chosen_date = updated_applications_open_from[:applications_open_from].strftime("%d/%m/%Y")
+        start_date = provider.recruitment_cycle.application_start_date.strftime("%d/%m/%Y")
+        end_date = provider.recruitment_cycle.application_end_date.strftime("%d/%m/%Y")
+        expect(response.body).to include("#{chosen_date} is not valid for the #{provider.recruitment_cycle.year} cycle. " +
+                                         "A valid date must be between #{start_date} and #{end_date}")
       end
     end
   end

--- a/spec/requests/api/v2/providers/sync_courses_with_search_and_compare_spec.rb
+++ b/spec/requests/api/v2/providers/sync_courses_with_search_and_compare_spec.rb
@@ -14,7 +14,7 @@ describe "Courses API v2", type: :request do
   let(:suspended_site_status) { build(:site_status, :suspended, site: site) }
   let(:syncable_course) { create(:course, :infer_level, site_statuses: [findable_site_status_1], subjects: [dfe_subject]) }
   let(:suspended_course) { create(:course, :infer_level, site_statuses: [suspended_site_status], subjects: [dfe_subject]) }
-  let(:invalid_subject_course) { create(:course, :infer_level, site_statuses: [findable_site_status_2], subjects: [non_dfe_subject]) }
+  let(:invalid_subject_course) { create(:course, level: :secondary, site_statuses: [findable_site_status_2], subjects: [non_dfe_subject, find_or_create(:modern_languages_subject, :french)]) }
   let(:provider) do
     create(:provider,
            organisations: [organisation],

--- a/spec/services/courses/assignable_subject_service_spec.rb
+++ b/spec/services/courses/assignable_subject_service_spec.rb
@@ -29,7 +29,7 @@ describe Courses::AssignableSubjectService do
     let!(:arabic) { find_or_create(:modern_languages_subject, subject_name: "French").becomes(ModernLanguagesSubject) }
 
     it "returns subjects other than modern language", without_subjects: true do
-      course = create(:course, level: "secondary")
+      course = build(:course, level: "secondary", infer_subjects?: false)
       expect(service.execute(course: course)).to match_array([biology, arabic])
     end
   end


### PR DESCRIPTION
### Context

The `build_new` endpoint for course creation needs additional validations - this is to enable us to ensure we have correct data being created.

### Changes proposed in this pull request

- Add a new validation scope for `:new`
  - The reason for the additional scope was that currently a lot of tests fail when adding some of them to `on: :create` - this could be mitigated in the future but I wanted to minimise the changes in this PR
- Add new validations to courses 

### Guidance to review

- Check out `2640-create-a-course-validation-changes` on MCFE (or master if it is merged)
- Run through the course creation for an accredited body and attempt to submit without any data
  - **Note** the Frontend for age ranges with a custom age range is not handled yet as this needs additional work to remove the validation from the frontend

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
