### PR TITLE
[2697] Include relations that are being lazy loaded to speed up query

### DIFF
--- a/app/controllers/api/v2/organisations_controller.rb
+++ b/app/controllers/api/v2/organisations_controller.rb
@@ -6,8 +6,9 @@ module API
         @organisations = Organisation.all
         if params_includes_provider?
           current_recruitment_cycle = RecruitmentCycle.current
-          @organisations = @organisations.includes(:providers)
+          @organisations = @organisations.includes(:providers, :users, :nctl_organisations, providers: %i[contacts sites courses recruitment_cycle ucas_preferences])
                              .where(provider: { recruitment_cycle_id: current_recruitment_cycle.id })
+
         end
 
         render jsonapi: @organisations, include: params[:include]

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -14,7 +14,6 @@
 #  discarded_at                     :datetime
 #  email                            :text
 #  id                               :integer          not null, primary key
-#  last_published_at                :datetime
 #  latitude                         :float
 #  longitude                        :float
 #  postcode                         :text
@@ -33,7 +32,6 @@
 #
 # Indexes
 #
-#  IX_provider_last_published_at                             (last_published_at)
 #  index_provider_on_changed_at                              (changed_at) UNIQUE
 #  index_provider_on_discarded_at                            (discarded_at)
 #  index_provider_on_latitude_and_longitude                  (latitude,longitude)

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -14,7 +14,6 @@
 #  discarded_at                     :datetime
 #  email                            :text
 #  id                               :integer          not null, primary key
-#  last_published_at                :datetime
 #  latitude                         :float
 #  longitude                        :float
 #  postcode                         :text
@@ -33,7 +32,6 @@
 #
 # Indexes
 #
-#  IX_provider_last_published_at                             (last_published_at)
 #  index_provider_on_changed_at                              (changed_at) UNIQUE
 #  index_provider_on_discarded_at                            (discarded_at)
 #  index_provider_on_latitude_and_longitude                  (latitude,longitude)

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -14,7 +14,6 @@
 #  discarded_at                     :datetime
 #  email                            :text
 #  id                               :integer          not null, primary key
-#  last_published_at                :datetime
 #  latitude                         :float
 #  longitude                        :float
 #  postcode                         :text
@@ -33,7 +32,6 @@
 #
 # Indexes
 #
-#  IX_provider_last_published_at                             (last_published_at)
 #  index_provider_on_changed_at                              (changed_at) UNIQUE
 #  index_provider_on_discarded_at                            (discarded_at)
 #  index_provider_on_latitude_and_longitude                  (latitude,longitude)

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -14,7 +14,6 @@
 #  discarded_at                     :datetime
 #  email                            :text
 #  id                               :integer          not null, primary key
-#  last_published_at                :datetime
 #  latitude                         :float
 #  longitude                        :float
 #  postcode                         :text
@@ -33,7 +32,6 @@
 #
 # Indexes
 #
-#  IX_provider_last_published_at                             (last_published_at)
 #  index_provider_on_changed_at                              (changed_at) UNIQUE
 #  index_provider_on_discarded_at                            (discarded_at)
 #  index_provider_on_latitude_and_longitude                  (latitude,longitude)

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -14,7 +14,6 @@
 #  discarded_at                     :datetime
 #  email                            :text
 #  id                               :integer          not null, primary key
-#  last_published_at                :datetime
 #  latitude                         :float
 #  longitude                        :float
 #  postcode                         :text
@@ -33,7 +32,6 @@
 #
 # Indexes
 #
-#  IX_provider_last_published_at                             (last_published_at)
 #  index_provider_on_changed_at                              (changed_at) UNIQUE
 #  index_provider_on_discarded_at                            (discarded_at)
 #  index_provider_on_latitude_and_longitude                  (latitude,longitude)


### PR DESCRIPTION
### Context
The organisations index page is extremely slow, to the point where it times out when using prod data.

### Changes proposed in this pull request
Reduce the number of queries by ~80%, and speed things up by a factor of ~100.

### Guidance to review
It's still too slow to load the prod data before the server times out.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
