### PR TITLE
[2702] - Restrict geocode searches to Great Britain (gb)

### DIFF
--- a/app/jobs/geocode_job.rb
+++ b/app/jobs/geocode_job.rb
@@ -3,7 +3,7 @@ class GeocodeJob < ApplicationJob
 
   def perform(klass, id)
     record = klass.classify.safe_constantize.find(id)
-    results = Geocoder.search(record.full_address)
+    results = Geocoder.search(record.full_address, params: { region: "gb" })
     if results.present?
       result = results.first
       record.update!(

--- a/spec/jobs/geocode_job_spec.rb
+++ b/spec/jobs/geocode_job_spec.rb
@@ -34,7 +34,7 @@ describe GeocodeJob, type: :job do
       ]
 
       allow(Geocoder).to receive(:search).and_return(results)
-      expect(Geocoder).to receive(:search).with(site.full_address)
+      expect(Geocoder).to receive(:search).with(site.full_address, params: { region: "gb" })
 
       site.save!
       perform_enqueued_jobs { job }
@@ -49,7 +49,7 @@ describe GeocodeJob, type: :job do
       results = []
 
       allow(Geocoder).to receive(:search).and_return(results)
-      expect(Geocoder).to receive(:search).with(site.full_address)
+      expect(Geocoder).to receive(:search).with(site.full_address, params: { region: "gb" })
 
       site.save!
       perform_enqueued_jobs { job }


### PR DESCRIPTION
### Context
Restrict geocode searches to Great Britain (gb)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
