### PR TITLE
[2704] Add validation for custom age ranges

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -642,13 +642,18 @@ private
   end
 
   def validate_custom_age_range
-    age_range_array = age_range_in_years.split("_")
-    if age_range_array.first.to_i.zero?
-      errors.add(:age_range_in_years_from, "#{age_range_in_years} is invalid. A valid from value must be provided.")
-    elsif age_range_array.last.to_i.zero?
-      errors.add(:age_range_in_years_to, "#{age_range_in_years} is invalid. A valid to value must be provided.")
+    age_range_array = age_range_in_years.split("_to_")
+    error_message = "#{age_range_in_years} is invalid. You must enter a valid age range."
+    if age_range_in_years.length >= 9
+      errors.add(:age_range_in_years, error_message)
+    elsif age_range_array.length != 2
+      errors.add(:age_range_in_years, error_message)
+    elsif age_range_array.first.to_i.zero? || age_range_array.first.to_i > 14 || age_range_array.first.to_i < 3
+      errors.add(:age_range_in_years_from, error_message)
+    elsif age_range_array.last.to_i.zero? || age_range_array.last.to_i < 7 || age_range_array.last.to_i > 18
+      errors.add(:age_range_in_years_to, error_message)
     elsif age_range_array.last.to_i - age_range_array.first.to_i < 4
-      errors.add(:age_range_in_years, "#{age_range_in_years} is an invalid age range. A valid age range must cover 4 or more years.")
+      errors.add(:age_range_in_years, "#{age_range_in_years} is invalid. Your age range must cover 4 years.")
     end
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -642,18 +642,22 @@ private
   end
 
   def validate_custom_age_range
-    age_range_array = age_range_in_years.split("_to_")
+    # This regex checks that a 1 or 2 digit number is selected for the 'to' and 'from' values.
+    # It also checks that the age range is correctly formatted with _to_ in between these values
+    valid_regex_pattern = /^(\d{1,2})_to_(\d{1,2})$/
+    #The below grabs the 'from' and 'to' ages and puts them into variables if the regex is valid
+    from_age, to_age = valid_regex_pattern.match(age_range_in_years).captures if valid_regex_pattern.match(age_range_in_years)
+
     error_message = "#{age_range_in_years} is invalid. You must enter a valid age range."
-    if age_range_in_years.length >= 9
+
+    if !valid_regex_pattern.match(age_range_in_years)
       errors.add(:age_range_in_years, error_message)
-    elsif age_range_array.length != 2
-      errors.add(:age_range_in_years, error_message)
-    elsif age_range_array.first.to_i.zero? || age_range_array.first.to_i > 14 || age_range_array.first.to_i < 3
+    elsif from_age.to_i < 3 || from_age.to_i > 14
       errors.add(:age_range_in_years_from, error_message)
-    elsif age_range_array.last.to_i.zero? || age_range_array.last.to_i < 7 || age_range_array.last.to_i > 18
+    elsif to_age.to_i < 7 || to_age.to_i > 18
       errors.add(:age_range_in_years_to, error_message)
-    elsif age_range_array.last.to_i - age_range_array.first.to_i < 4
-      errors.add(:age_range_in_years, "#{age_range_in_years} is invalid. Your age range must cover 4 years.")
+    elsif to_age.to_i - from_age.to_i < 4
+      errors.add(:age_range_in_years, "#{age_range_in_years} is invalid. Your age range must cover at least 4 years.")
     end
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -172,6 +172,7 @@ class Course < ApplicationRecord
   validate :validate_has_languages, if: :has_the_modern_languages_secondary_subject_type?
   validate :validate_subject_count
   validate :validate_subject_consistency
+  validate :validate_custom_age_range, on: %i[create new], if: -> { age_range_in_years.present? }
 
   validates :name, :profpost_flag, :program_type, :qualification, :start_date, :study_mode, presence: true
   validates :age_range_in_years, presence: true, on: %i[new create], unless: :further_education_course?
@@ -637,6 +638,17 @@ private
       unless FurtherEducationSubject.exists?(id: subjects_excluding_discontinued.map(&:id))
         errors.add(:subjects, "must be further education")
       end
+    end
+  end
+
+  def validate_custom_age_range
+    age_range_array = age_range_in_years.split("_")
+    if age_range_array.first.to_i.zero?
+      errors.add(:age_range_in_years_from, "#{age_range_in_years} is invalid. A valid from value must be provided.")
+    elsif age_range_array.last.to_i.zero?
+      errors.add(:age_range_in_years_to, "#{age_range_in_years} is invalid. A valid to value must be provided.")
+    elsif age_range_array.last.to_i - age_range_array.first.to_i < 4
+      errors.add(:age_range_in_years, "#{age_range_in_years} is an invalid age range. A valid age range must cover 4 or more years.")
     end
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -642,31 +642,7 @@ private
   end
 
   def validate_custom_age_range
-    # This regex checks that a 1 or 2 digit number is selected for the 'to' and 'from' values.
-    # It also checks that the age range is correctly formatted with _to_ in between these values
-    valid_regex_pattern = /^(\d{1,2})_to_(\d{1,2})$/
-    #The below grabs the 'from' and 'to' ages and puts them into variables if the regex is valid
-    from_age, to_age = valid_regex_pattern.match(age_range_in_years).captures if valid_regex_pattern.match(age_range_in_years)
-
-    error_message = "#{age_range_in_years} is invalid. You must enter a valid age range."
-
-    if !valid_regex_pattern.match(age_range_in_years)
-      errors.add(:age_range_in_years, error_message)
-    elsif from_age_invalid?(from_age)
-      errors.add(:age_range_in_years_from, error_message)
-    elsif to_age_invalid?(to_age)
-      errors.add(:age_range_in_years_to, error_message)
-    elsif to_age.to_i - from_age.to_i < 4
-      errors.add(:age_range_in_years, "#{age_range_in_years} is invalid. Your age range must cover at least 4 years.")
-    end
-  end
-
-  def from_age_invalid?(from_age)
-    from_age.to_i < 3 || from_age.to_i > 14
-  end
-
-  def to_age_invalid?(to_age)
-    to_age.to_i < 7 || to_age.to_i > 18
+    Courses::ValidateCustomAgeRangeService.new.execute(age_range_in_years, self)
   end
 
   def valid_date_range

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -652,13 +652,21 @@ private
 
     if !valid_regex_pattern.match(age_range_in_years)
       errors.add(:age_range_in_years, error_message)
-    elsif from_age.to_i < 3 || from_age.to_i > 14
+    elsif from_age_invalid?(from_age)
       errors.add(:age_range_in_years_from, error_message)
-    elsif to_age.to_i < 7 || to_age.to_i > 18
+    elsif to_age_invalid?(to_age)
       errors.add(:age_range_in_years_to, error_message)
     elsif to_age.to_i - from_age.to_i < 4
       errors.add(:age_range_in_years, "#{age_range_in_years} is invalid. Your age range must cover at least 4 years.")
     end
+  end
+
+  def from_age_invalid?(from_age)
+    from_age.to_i < 3 || from_age.to_i > 14
+  end
+
+  def to_age_invalid?(to_age)
+    to_age.to_i < 7 || to_age.to_i > 18
   end
 
   def valid_date_range

--- a/app/services/courses/validate_custom_age_range_service.rb
+++ b/app/services/courses/validate_custom_age_range_service.rb
@@ -1,0 +1,33 @@
+module Courses
+  class ValidateCustomAgeRangeService
+    def execute(age_range_in_years, course)
+      # This regex checks that a 1 or 2 digit number is selected for the 'to' and 'from' values.
+      # It also checks that the age range is correctly formatted with _to_ in between these values
+      valid_regex_pattern = /^(\d{1,2})_to_(\d{1,2})$/
+      #The below grabs the 'from' and 'to' ages and puts them into variables if the regex is valid
+      from_age, to_age = valid_regex_pattern.match(age_range_in_years).captures if valid_regex_pattern.match(age_range_in_years)
+
+      error_message = "#{age_range_in_years} is invalid. You must enter a valid age range."
+
+      if !valid_regex_pattern.match(age_range_in_years)
+        course.errors.add(:age_range_in_years, error_message)
+      elsif from_age_invalid?(from_age)
+        course.errors.add(:age_range_in_years, error_message)
+      elsif to_age_invalid?(to_age)
+        course.errors.add(:age_range_in_years, error_message)
+      elsif to_age.to_i - from_age.to_i < 4
+        course.errors.add(:age_range_in_years, "#{age_range_in_years} is invalid. Your age range must cover at least 4 years.")
+      end
+    end
+
+  private
+
+    def from_age_invalid?(from_age)
+      from_age.to_i < 3 || from_age.to_i > 14
+    end
+
+    def to_age_invalid?(to_age)
+      to_age.to_i < 7 || to_age.to_i > 18
+    end
+  end
+end

--- a/app/services/courses/validate_custom_age_range_service.rb
+++ b/app/services/courses/validate_custom_age_range_service.rb
@@ -2,28 +2,27 @@ module Courses
   class ValidateCustomAgeRangeService
     def execute(age_range_in_years, course)
       error_message = "#{age_range_in_years} is invalid. You must enter a valid age range."
-      valid_regex_pattern = Regexp.new(/^(?<from>\d{1,2})_to_(?<to>\d{1,2})$/)
+      valid_age_range_regex = Regexp.new(/^(?<from>\d{1,2})_to_(?<to>\d{1,2})$/)
 
-      if valid_regex_pattern.match(age_range_in_years)
-        from_age = get_ages(age_range_in_years, valid_regex_pattern)["from"]
-        to_age = get_ages(age_range_in_years, valid_regex_pattern)["to"]
-      end
-
-      if !valid_regex_pattern.match(age_range_in_years)
+      if valid_age_range_regex.match(age_range_in_years)
+        from_age = get_ages(age_range_in_years, valid_age_range_regex)["from"]
+        to_age = get_ages(age_range_in_years, valid_age_range_regex)["to"]
+        if from_age_invalid?(from_age)
+          course.errors.add(:age_range_in_years, error_message)
+        elsif to_age_invalid?(to_age)
+          course.errors.add(:age_range_in_years, error_message)
+        elsif to_age - from_age < 4
+          course.errors.add(:age_range_in_years, "#{age_range_in_years} is invalid. Your age range must cover at least 4 years.")
+        end
+      else
         course.errors.add(:age_range_in_years, error_message)
-      elsif from_age_invalid?(from_age)
-        course.errors.add(:age_range_in_years, error_message)
-      elsif to_age_invalid?(to_age)
-        course.errors.add(:age_range_in_years, error_message)
-      elsif to_age - from_age < 4
-        course.errors.add(:age_range_in_years, "#{age_range_in_years} is invalid. Your age range must cover at least 4 years.")
       end
     end
 
   private
 
-    def get_ages(age_range_in_years, valid_regex_pattern)
-      valid_regex_pattern.match(age_range_in_years)&.named_captures&.transform_values { |v| v.to_i }
+    def get_ages(age_range_in_years, valid_age_range_regex)
+      valid_age_range_regex.match(age_range_in_years)&.named_captures&.transform_values { |year| year.to_i }
     end
 
     def from_age_invalid?(from_age)

--- a/app/services/courses/validate_custom_age_range_service.rb
+++ b/app/services/courses/validate_custom_age_range_service.rb
@@ -1,13 +1,13 @@
 module Courses
   class ValidateCustomAgeRangeService
     def execute(age_range_in_years, course)
-      # This regex checks that a 1 or 2 digit number is selected for the 'to' and 'from' values.
-      # It also checks that the age range is correctly formatted with _to_ in between these values
-      valid_regex_pattern = /^(\d{1,2})_to_(\d{1,2})$/
-      #The below grabs the 'from' and 'to' ages and puts them into variables if the regex is valid
-      from_age, to_age = valid_regex_pattern.match(age_range_in_years).captures if valid_regex_pattern.match(age_range_in_years)
-
       error_message = "#{age_range_in_years} is invalid. You must enter a valid age range."
+      valid_regex_pattern = Regexp.new(/^(?<from>\d{1,2})_to_(?<to>\d{1,2})$/)
+
+      if valid_regex_pattern.match(age_range_in_years)
+        from_age = get_ages(age_range_in_years, valid_regex_pattern)["from"]
+        to_age = get_ages(age_range_in_years, valid_regex_pattern)["to"]
+      end
 
       if !valid_regex_pattern.match(age_range_in_years)
         course.errors.add(:age_range_in_years, error_message)
@@ -15,19 +15,23 @@ module Courses
         course.errors.add(:age_range_in_years, error_message)
       elsif to_age_invalid?(to_age)
         course.errors.add(:age_range_in_years, error_message)
-      elsif to_age.to_i - from_age.to_i < 4
+      elsif to_age - from_age < 4
         course.errors.add(:age_range_in_years, "#{age_range_in_years} is invalid. Your age range must cover at least 4 years.")
       end
     end
 
   private
 
+    def get_ages(age_range_in_years, valid_regex_pattern)
+      valid_regex_pattern.match(age_range_in_years)&.named_captures&.transform_values { |v| v.to_i }
+    end
+
     def from_age_invalid?(from_age)
-      from_age.to_i < 3 || from_age.to_i > 14
+      from_age < 3 || from_age > 14
     end
 
     def to_age_invalid?(to_age)
-      to_age.to_i < 7 || to_age.to_i > 18
+      to_age < 7 || to_age > 18
     end
   end
 end

--- a/spec/requests/api/v2/providers/courses/create/age_range_in_years_spec.rb
+++ b/spec/requests/api/v2/providers/courses/create/age_range_in_years_spec.rb
@@ -7,8 +7,9 @@ describe "POST /providers/:provider_code/courses/:course_code" do
       class: {
         Course: API::V2::SerializableCourse,
         PrimarySubject: API::V2::SerializableSubject,
+        Site: API::V2::SerializableSite,
       },
-      include: %i[subjects],
+      include: %i[subjects sites],
     )
 
     post "/api/v2/recruitment_cycles/#{recruitment_cycle.year}/providers/" \
@@ -20,7 +21,7 @@ describe "POST /providers/:provider_code/courses/:course_code" do
   end
 
   let(:organisation)      { create :organisation }
-  let(:provider)          { create :provider, organisations: [organisation], recruitment_cycle: recruitment_cycle }
+  let(:provider)          { create :provider, organisations: [organisation], recruitment_cycle: recruitment_cycle, sites: [site] }
   let(:recruitment_cycle) { find_or_create :recruitment_cycle }
   let(:user)              { create :user, organisations: [organisation] }
   let(:payload)           { { email: user.email } }
@@ -30,8 +31,10 @@ describe "POST /providers/:provider_code/courses/:course_code" do
     build :course,
           provider: provider,
           age_range_in_years: age_range_in_years,
-          subjects: [subject]
+          subjects: [subject],
+          sites: [site]
   }
+  let(:site) { build(:site) }
   let(:subject) { find_or_create(:primary_subject) }
 
 
@@ -57,7 +60,7 @@ describe "POST /providers/:provider_code/courses/:course_code" do
 
     it "returns an error" do
       expect(json_data.count).to eq 1
-      expect(response.body).to include "Age range in years can't be blank"
+      expect(response.body).to include "You need to pick an age range"
     end
   end
 
@@ -71,7 +74,7 @@ describe "POST /providers/:provider_code/courses/:course_code" do
       it "should return an error stating valid age ranges must be 4 years or greater" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(json_data.count).to eq 1
-        expect(response.body).to include "#{age_range_in_years} " + error_message
+        expect(response.body).to include "#{age_range_in_years} #{error_message}"
       end
     end
 
@@ -81,7 +84,7 @@ describe "POST /providers/:provider_code/courses/:course_code" do
       it "should return an error stating valid age ranges must be 4 years or greater" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(json_data.count).to eq 1
-        expect(response.body).to include "#{age_range_in_years} " + error_message
+        expect(response.body).to include "#{age_range_in_years} #{error_message}"
       end
     end
 
@@ -91,7 +94,7 @@ describe "POST /providers/:provider_code/courses/:course_code" do
       it "should return an error stating valid age ranges must be 4 years or greater" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(json_data.count).to eq 1
-        expect(response.body).to include "#{age_range_in_years} " + error_message
+        expect(response.body).to include "#{age_range_in_years} #{error_message}"
       end
     end
 
@@ -101,7 +104,7 @@ describe "POST /providers/:provider_code/courses/:course_code" do
       it "should return an error stating that there is an invalid from year" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(json_data.count).to eq 1
-        expect(response.body).to include "#{age_range_in_years} " + error_message
+        expect(response.body).to include "#{age_range_in_years} #{error_message}"
       end
     end
 
@@ -111,7 +114,7 @@ describe "POST /providers/:provider_code/courses/:course_code" do
       it "should return an error stating that there is an invalid from year" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(json_data.count).to eq 1
-        expect(response.body).to include "#{age_range_in_years} " + error_message
+        expect(response.body).to include "#{age_range_in_years} #{error_message}"
       end
     end
   end

--- a/spec/requests/api/v2/providers/courses/create/age_range_in_years_spec.rb
+++ b/spec/requests/api/v2/providers/courses/create/age_range_in_years_spec.rb
@@ -1,0 +1,98 @@
+describe "POST /providers/:provider_code/courses/:course_code" do
+  let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+
+  before do
+    jsonapi_data = jsonapi_renderer.render(
+      course,
+      class: {
+        Course: API::V2::SerializableCourse,
+        PrimarySubject: API::V2::SerializableSubject,
+      },
+      include: %i[subjects],
+    )
+
+    post "/api/v2/recruitment_cycles/#{recruitment_cycle.year}/providers/" \
+            "#{course.provider.provider_code}/courses",
+         headers: { "HTTP_AUTHORIZATION" => credentials },
+         params: {
+           _jsonapi: { data: jsonapi_data[:data] },
+         }
+  end
+
+  let(:organisation)      { create :organisation }
+  let(:provider)          { create :provider, organisations: [organisation], recruitment_cycle: recruitment_cycle }
+  let(:recruitment_cycle) { find_or_create :recruitment_cycle }
+  let(:user)              { create :user, organisations: [organisation] }
+  let(:payload)           { { email: user.email } }
+  let(:token)             { build_jwt :apiv2, payload: payload }
+
+  let(:course)            {
+    build :course,
+          provider: provider,
+          age_range_in_years: age_range_in_years,
+          subjects: [subject]
+  }
+  let(:subject) { find_or_create(:primary_subject) }
+
+
+  let(:age_range_in_years) { "3_to_7" }
+
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+  let(:json_data) { JSON.parse(response.body)["errors"] }
+
+  context "with a valid age range" do
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it "age_range_in_years attribute to the correct value" do
+      expect(Course.first.age_range_in_years).to eq(age_range_in_years)
+    end
+  end
+
+  context "when nil" do
+    let(:age_range_in_years) { nil }
+
+    it "returns an error" do
+      expect(json_data.count).to eq 1
+      expect(response.body).to include "Age range in years can't be blank"
+    end
+  end
+
+  context "an invalid age range" do
+    context "with an age range of less than 4 years" do
+      let(:age_range_in_years) { "4_to_6" }
+      let(:error_message) { "is an invalid age range. A valid age range must cover 4 or more years." }
+
+      it "should return an error stating valid age ranges must be 4 years or greater" do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_data.count).to eq 1
+        expect(response.body).to include "#{age_range_in_years} " + error_message
+      end
+    end
+
+    context "with an age range that does not include a valid from age range value" do
+      let(:age_range_in_years) { "to_6" }
+      let(:error_message) { "is invalid. A valid from value must be provided." }
+
+      it "should return an error stating that there is an invalid from year" do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_data.count).to eq 1
+        expect(response.body).to include "#{age_range_in_years} " + error_message
+      end
+    end
+
+    context "with an age range that does not include a valid to age range value" do
+      let(:age_range_in_years) { "2_to" }
+      let(:error_message) { "is invalid. A valid to value must be provided." }
+
+      it "should return an error stating that there is an invalid from year" do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_data.count).to eq 1
+        expect(response.body).to include "#{age_range_in_years} " + error_message
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/providers/courses/create/age_range_in_years_spec.rb
+++ b/spec/requests/api/v2/providers/courses/create/age_range_in_years_spec.rb
@@ -66,7 +66,7 @@ describe "POST /providers/:provider_code/courses/:course_code" do
 
     context "with an age range of with a gap of less than 4 years" do
       let(:age_range_in_years) { "5_to_8" }
-      let(:error_message) { "is invalid. Your age range must cover 4 years." }
+      let(:error_message) { "is invalid. Your age range must cover at least 4 years." }
 
       it "should return an error stating valid age ranges must be 4 years or greater" do
         expect(response).to have_http_status(:unprocessable_entity)

--- a/spec/requests/api/v2/providers/courses/create/age_range_in_years_spec.rb
+++ b/spec/requests/api/v2/providers/courses/create/age_range_in_years_spec.rb
@@ -62,9 +62,31 @@ describe "POST /providers/:provider_code/courses/:course_code" do
   end
 
   context "an invalid age range" do
-    context "with an age range of less than 4 years" do
-      let(:age_range_in_years) { "4_to_6" }
-      let(:error_message) { "is an invalid age range. A valid age range must cover 4 or more years." }
+    let(:error_message) { "is invalid. You must enter a valid age range." }
+
+    context "with an age range of with a gap of less than 4 years" do
+      let(:age_range_in_years) { "5_to_8" }
+      let(:error_message) { "is invalid. Your age range must cover 4 years." }
+
+      it "should return an error stating valid age ranges must be 4 years or greater" do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_data.count).to eq 1
+        expect(response.body).to include "#{age_range_in_years} " + error_message
+      end
+    end
+
+    context "with a from value that does not fall within the valid age range" do
+      let(:age_range_in_years) { "1_to_15" }
+
+      it "should return an error stating valid age ranges must be 4 years or greater" do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_data.count).to eq 1
+        expect(response.body).to include "#{age_range_in_years} " + error_message
+      end
+    end
+
+    context "with a to value that does not fall within the valid age range" do
+      let(:age_range_in_years) { "7_to_19" }
 
       it "should return an error stating valid age ranges must be 4 years or greater" do
         expect(response).to have_http_status(:unprocessable_entity)
@@ -75,7 +97,6 @@ describe "POST /providers/:provider_code/courses/:course_code" do
 
     context "with an age range that does not include a valid from age range value" do
       let(:age_range_in_years) { "to_6" }
-      let(:error_message) { "is invalid. A valid from value must be provided." }
 
       it "should return an error stating that there is an invalid from year" do
         expect(response).to have_http_status(:unprocessable_entity)
@@ -86,7 +107,6 @@ describe "POST /providers/:provider_code/courses/:course_code" do
 
     context "with an age range that does not include a valid to age range value" do
       let(:age_range_in_years) { "2_to" }
-      let(:error_message) { "is invalid. A valid to value must be provided." }
 
       it "should return an error stating that there is an invalid from year" do
         expect(response).to have_http_status(:unprocessable_entity)

--- a/spec/services/courses/validate_custom_age_range_service_spec.rb
+++ b/spec/services/courses/validate_custom_age_range_service_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+describe Courses::ValidateCustomAgeRangeService do
+  let(:service) { described_class.new }
+  let(:course) { build(:course, age_range_in_years: age_range_in_years) }
+  let(:execute_service) { service.execute(age_range_in_years, course) }
+
+  before do
+    execute_service
+  end
+
+
+  context "with a valid age range" do
+    let(:age_range_in_years) { "4_to_8" }
+    it "age_range_in_years attribute to the correct value" do
+      expect(course.errors.count).to eq(0)
+    end
+  end
+
+  context "an invalid age range" do
+    let(:error_message) { "is invalid. You must enter a valid age range." }
+
+    context "with an age range of with a gap of less than 4 years" do
+      let(:age_range_in_years) { "5_to_8" }
+      let(:error_message) { "is invalid. Your age range must cover at least 4 years." }
+
+      it "should return an error stating valid age ranges must be 4 years or greater" do
+        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years} " + error_message
+      end
+    end
+
+    context "with a from value that does not fall within the valid age range" do
+      let(:age_range_in_years) { "1_to_15" }
+
+      it "should return an error" do
+        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years} " + error_message
+      end
+    end
+
+    context "with a to value that does not fall within the valid age range" do
+      let(:age_range_in_years) { "7_to_19" }
+
+      it "should return an error stating valid age ranges must be 4 years or greater" do
+        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years} " + error_message
+      end
+    end
+
+    context "with an age range that does not include a valid from age range value" do
+      let(:age_range_in_years) { "to_6" }
+
+      it "should return an error stating that there is an invalid from year" do
+        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years} " + error_message
+      end
+    end
+
+    context "with an age range that does not include a valid to age range value" do
+      let(:age_range_in_years) { "2_to" }
+
+      it "should return an error stating that there is an invalid from year" do
+        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years} " + error_message
+      end
+    end
+  end
+end

--- a/spec/services/courses/validate_custom_age_range_service_spec.rb
+++ b/spec/services/courses/validate_custom_age_range_service_spec.rb
@@ -25,7 +25,7 @@ describe Courses::ValidateCustomAgeRangeService do
       let(:error_message) { "is invalid. Your age range must cover at least 4 years." }
 
       it "should return an error stating valid age ranges must be 4 years or greater" do
-        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years} " + error_message
+        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years} #{error_message}"
       end
     end
 
@@ -33,7 +33,7 @@ describe Courses::ValidateCustomAgeRangeService do
       let(:age_range_in_years) { "1_to_15" }
 
       it "should return an error" do
-        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years} " + error_message
+        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years} #{error_message}"
       end
     end
 
@@ -41,7 +41,7 @@ describe Courses::ValidateCustomAgeRangeService do
       let(:age_range_in_years) { "7_to_19" }
 
       it "should return an error stating valid age ranges must be 4 years or greater" do
-        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years} " + error_message
+        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years} #{error_message}"
       end
     end
 
@@ -49,7 +49,7 @@ describe Courses::ValidateCustomAgeRangeService do
       let(:age_range_in_years) { "to_6" }
 
       it "should return an error stating that there is an invalid from year" do
-        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years} " + error_message
+        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years} #{error_message}"
       end
     end
 
@@ -57,7 +57,7 @@ describe Courses::ValidateCustomAgeRangeService do
       let(:age_range_in_years) { "2_to" }
 
       it "should return an error stating that there is an invalid from year" do
-        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years} " + error_message
+        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years} #{error_message}"
       end
     end
   end


### PR DESCRIPTION
### Context

We need a validation on the course that checks that custom age ranges are valid for the new and create actions.

It must do three things:
1. Check if the age ranges are 4 or more years apart
2. Check that the from value is valid (so in 3_to_7 that 3 is an integer)
3. Check that the to value is valid (so in 3_to_7 that 7 is an integer)

### Changes proposed in this pull request
- Add a validation that is triggered on the new and create course endpoints that does the above.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
