### PR TITLE
[2709] - Re-enable Redis caching for storing geocoder api responses

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -8,7 +8,7 @@ Geocoder.configure(
   # http_proxy: nil,                  # HTTP proxy server (user:pass@host:port)
   # https_proxy: nil,                 # HTTPS proxy server (user:pass@host:port)
   api_key: Settings.gcp_api_key, # API key for geocoding service
-  # cache: Redis.new(password: Settings.mcbg.redis_password), # cache object (must respond to #[], #[]=, and #del)
+  cache: Redis.new(password: Settings.mcbg.redis_password), # cache object (must respond to #[], #[]=, and #del)
   # cache_prefix: 'geocoder:',  # prefix (string) to use for all cache keys
 
   # Exceptions that should not be rescued by default


### PR DESCRIPTION
### Context
Redis caching for geocoding was turned off recently when we were debugging Postgres connection issues on QA. Just need to enable again

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
