### PR TITLE
[2714] Remove admin users from organisations

### DIFF
--- a/db/migrate/20191220161244_remove_admin_users_from_organisations.rb
+++ b/db/migrate/20191220161244_remove_admin_users_from_organisations.rb
@@ -1,0 +1,9 @@
+class RemoveAdminUsersFromOrganisations < ActiveRecord::Migration[6.0]
+  def change
+    admin_users = User.where("email ~ ?", "@(digital\.){0,1}education\.gov\.uk$")
+
+    admin_users.each do |user|
+      user.organisations = []
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_16_113352) do
+ActiveRecord::Schema.define(version: 2019_12_20_161244) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"


### PR DESCRIPTION
### Context
We have an admin flag on users

### Changes proposed in this pull request
Remove all associated organisations from users flagged as admin 

### Guidance to review
- Ensure all users with the admin flag do not have any organisations
- Ensure all other users still have their associated organisations

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
