### PR TITLE
[2663] fix mcb bulk sync to find

### DIFF
--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -192,35 +192,17 @@ module MCB
     # The opts passed in are examined determine which opts need to be added,
     # this function essentially just fills in any missing options.
     #
-    #   opts = system_apiv_opts(opts)
+    #   opts = system_api_opts(opts)
     def system_api_opts(opts)
-      # the following lines are necessary to make opts work with double **splats and default values
-      # See the change introduced in https://github.com/ddfreyne/cri/pull/99 (cri 2.15.8)
-      opts = expose_opts_defaults_for_splat(opts, :url, :'max-pages', :token, :all)
-      opts.merge! azure_env_settings_for_opts(**opts)
-
-      if requesting_remote_connection?(**opts)
-        opts[:url] ||= service_root_url(**opts)
-        config = MCB::Azure.get_config(**opts)
-        opts[:token] ||= config["SETTINGS__SYSTEM_AUTHENTICATION_TOKEN"]
-      end
-
-      opts
+      process_opts_for_remote_connection(
+        opts,
+        token: "SETTINGS__SYSTEM_AUTHENTICATION_TOKEN",
+      )
     end
 
     def apiv1_opts(opts)
-      # the following lines are necessary to make opts work with double **splats and default values
-      # See the change introduced in https://github.com/ddfreyne/cri/pull/99 (cri 2.15.8)
-      opts = expose_opts_defaults_for_splat(opts, :url, :'max-pages', :token, :all)
-
-      opts.merge! azure_env_settings_for_opts(**opts)
-
-      if requesting_remote_connection?(**opts)
-        opts[:url] = service_root_url(**opts)
-        opts[:token] = MCB::Azure.get_config(**opts)["AUTHENTICATION_TOKEN"]
-      end
-
-      opts
+      process_opts_for_remote_connection opts,
+                                         token: "AUTHENTICATION_TOKEN"
     end
 
     # Return options necessary to connect to API V2.
@@ -230,12 +212,27 @@ module MCB
     #
     #   opts = apiv2_opts(opts)
     def apiv2_opts(opts)
-      opts = expose_opts_defaults_for_splat(opts, :url, :'max-pages', :token, :all)
-      opts.merge! azure_env_settings_for_opts(**opts)
+      process_opts_for_remote_connection opts,
+                                         token: "AUTHENTICATION_TOKEN"
+    end
 
-      if requesting_remote_connection?(**opts)
-        opts[:url] ||= service_root_url(**opts)
-        opts[:token] ||= MCB::Azure.get_config(**opts)["AUTHENTICATION_TOKEN"]
+    def process_opts_for_remote_connection(opts, **mappings)
+      opts.merge! azure_env_settings_for_opts(**opts)
+      return opts unless requesting_remote_connection?(**opts)
+
+      # "opts[:url] ||= " doesn't work here because opts[:url] will always
+      # have the default value for the URL cmdline option. However,
+      # opts.key?(:url) returns false if the user hasn't provided --url.
+      # See the change introduced in https://github.com/ddfreyne/cri/pull/99
+      # (cri 2.15.8)
+      unless opts.key? :url
+        opts[:url] = service_root_url(**opts)
+      end
+      config = MCB::Azure.get_config(**opts)
+      mappings.each do |to_opt, from_config|
+        unless opts.key? to_opt
+          opts[to_opt] = config[from_config]
+        end
       end
 
       opts
@@ -488,6 +485,17 @@ module MCB
       sleep(sleep)
     end
 
+    # The following utility method is necessary because without processing the
+    # opts like this, default values won't be retrieved when using the splat
+    # operator. See the change introduced in
+    # https://github.com/ddfreyne/cri/pull/99 (cri 2.15.8)
+    def expose_opts_defaults_for_splat(opts, *keys)
+      keys.each do |key|
+        opts[key] = opts[key]
+      end
+      opts
+    end
+
   private
 
     def remove_option_with_arg(argv, *options)
@@ -517,17 +525,6 @@ module MCB
       end
 
       new_url
-    end
-
-    # The following utility method is necessary because without processing the
-    # opts like this, default values won't be retrieved when using the splat
-    # operator. See the change introduced in
-    # https://github.com/ddfreyne/cri/pull/99 (cri 2.15.8)
-    def expose_opts_defaults_for_splat(opts, *keys)
-      keys.each do |key|
-        opts[key] = opts[key]
-      end
-      opts
     end
   end
 end

--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -206,21 +206,26 @@ module MCB
       opts.merge! azure_env_settings_for_opts(**opts)
 
       if requesting_remote_connection?(**opts)
-        opts[:url] ||= MCB::Azure.get_urls(**opts).first
+        opts[:url] ||= service_root_url(**opts)
         opts[:token] ||= MCB::Azure.get_config(**opts)["AUTHENTICATION_TOKEN"]
       end
 
       opts
     end
 
+    # Get the correct URL for the service specified with the given options.
+    def service_root_url(**opts)
+      MCB::Azure.get_urls(**opts)
+        .grep(%r{^https://.*\.(education|service)\.gov\.uk$})
+        .first
+    end
+
     # Return the base url to the API V2 for the given opts.
     #
     # <tt>opts</tt> should be filled-in using <tt>apiv2_opts</tt>
     def apiv2_base_url(opts)
-      url = MCB::Azure.get_urls(**opts)
-        .grep(/^https.*gov\.uk$/)
-        .first
-      "#{url}/api/v2"
+      root_url = service_root_url(opts)
+      "#{root_url}/api/v2"
     end
 
     def display_pages_received(page:, max_pages:, next_url:)

--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -194,6 +194,8 @@ module MCB
     #
     #   opts = system_apiv_opts(opts)
     def system_api_opts(opts)
+      # the following lines are necessary to make opts work with double **splats and default values
+      # See the change introduced in https://github.com/ddfreyne/cri/pull/99 (cri 2.15.8)
       opts = expose_opts_defaults_for_splat(opts, :url, :'max-pages', :token, :all)
       opts.merge! azure_env_settings_for_opts(**opts)
 
@@ -214,7 +216,7 @@ module MCB
       opts.merge! azure_env_settings_for_opts(**opts)
 
       if requesting_remote_connection?(**opts)
-        opts[:url] = MCB::Azure.get_urls(**opts).first
+        opts[:url] = service_root_url(**opts)
         opts[:token] = MCB::Azure.get_config(**opts)["AUTHENTICATION_TOKEN"]
       end
 

--- a/lib/mcb/azure.rb
+++ b/lib/mcb/azure.rb
@@ -1,6 +1,6 @@
 module MCB
   module Azure
-    @config = {}
+    @configs = {}
 
     def self.get_subs
       raw_json = MCB::run_command "az account list"
@@ -25,16 +25,16 @@ module MCB
 
     def self.get_config(webapp:, rgroup: nil, subscription: nil, **_opts)
       config_key = "#{subscription}-#{rgroup}-#{webapp}"
-      unless @config.key? config_key
+      unless @configs.key? config_key
         rgroup ||= rgroup_for_app(webapp)
         cmd = "az webapp config appsettings list -g \"#{rgroup}\" -n \"#{webapp}\""
         cmd += " --subscription \"#{subscription}\"" if subscription
         raw_json = MCB::run_command(cmd)
-        @config[config_key] = JSON.parse(raw_json)
+        @configs[config_key] = JSON.parse(raw_json)
                                  .map { |c| [c["name"], c["value"]] }
                                  .to_h
       end
-      @config[config_key]
+      @configs[config_key]
     end
 
     def self.get_urls(webapp:, rgroup: nil, subscription: nil, **_opts)

--- a/lib/mcb/commands/api.rb
+++ b/lib/mcb/commands/api.rb
@@ -1,0 +1,10 @@
+name "api"
+summary "Commands that target the system API endpoint"
+
+option :u, :url, "set the base url to connect to",
+       argument: :required,
+       default: "http://localhost:3001"
+option :t, "token", "set the authorization token",
+       argument: :required,
+       default: "Ge32"
+instance_eval(&MCB.remote_connect_options)

--- a/lib/mcb/commands/api/bulk_sync_to_find.rb
+++ b/lib/mcb/commands/api/bulk_sync_to_find.rb
@@ -1,20 +1,13 @@
 name "bulk_sync_to_find"
 summary "Bulk sync all course to Find"
 usage "bulk_sync_to_find"
-option :u, "url", "set the base url to connect to",
-       argument: :required
-option nil, :email, "the email to encode",
-       argument: :required,
-       default: -> { MCB.config[:email] }
-option :t, "token", "set the authorization token",
-       argument: :required
 
 run do |opts, _args, _cmd|
-  opts = MCB.apiv2_opts(opts)
+  opts = MCB.system_api_opts(opts)
 
   base_url = get_url_from_opts(opts)
   url = "#{base_url}/api/system/sync"
-  token = get_token_from_opts(opts)
+  token = opts[:token]
 
   require "httparty"
 
@@ -27,12 +20,9 @@ end
 def init_rails(opts)
   # Since this is an API connection, we don't want to connect to the remote
   # Rails instance, so remove <tt>webapp</tt> from the opts to
-  # <tt>init_rails</tt>. Also, <tt>email</tt> will get in the way as
-  # <tt>init_rails</tt> will try to setup auditing, and the user we're
-  # generating a token for may not exist locally.
+  # <tt>init_rails</tt>
   rails_opts = opts.dup
   rails_opts.delete(:webapp)
-  rails_opts.delete(:email)
   MCB.init_rails(**rails_opts)
 end
 

--- a/lib/mcb/commands/apiv1/courses/find.rb
+++ b/lib/mcb/commands/apiv1/courses/find.rb
@@ -25,6 +25,8 @@ run do |opts, args, _cmd|
 
   verbose "looking for provider '#{provider_code}' course '#{course_code}'"
 
+  opts = MCB.expose_opts_defaults_for_splat(opts, :url, :'max-pages', :token, :all)
+
   (course, last_context) = find_course(provider_code, course_code, opts)
 
   if course.nil?

--- a/lib/mcb/commands/apiv1/courses/list.rb
+++ b/lib/mcb/commands/apiv1/courses/list.rb
@@ -10,6 +10,8 @@ run do |opts, _args, _cmd|
   opts = MCB.apiv1_opts(opts)
   last_context = nil
 
+  opts = MCB.expose_opts_defaults_for_splat(opts, :url, :'max-pages', :token, :all)
+
   table = Terminal::Table.new headings: %w[Code Name Provider\ Code Provider\ Name] do |t|
     MCB.each_v1_course(opts).each do |course, context|
       last_context = context

--- a/lib/mcb/commands/apiv1/providers/find.rb
+++ b/lib/mcb/commands/apiv1/providers/find.rb
@@ -21,6 +21,8 @@ run do |opts, args, _cmd|
 
   verbose "looking for provider #{args[:code]}"
 
+  opts = MCB.expose_opts_defaults_for_splat(opts, :url, :'max-pages', :token, :all)
+
   (provider, last_context) = find_provider(args[:code], opts)
 
   if provider.nil?

--- a/lib/mcb/commands/apiv1/providers/list.rb
+++ b/lib/mcb/commands/apiv1/providers/list.rb
@@ -12,6 +12,8 @@ run do |opts, _args, _cmd|
   opts = MCB.apiv1_opts(opts)
   last_context = nil
 
+  opts = MCB.expose_opts_defaults_for_splat(opts, :url, :'max-pages', :token, :all)
+
   table = Terminal::Table.new headings: %w[Code Name] do |t|
     MCB.each_v1_provider(opts).each do |provider, context|
       last_context = context

--- a/spec/lib/mcb/azure_spec.rb
+++ b/spec/lib/mcb/azure_spec.rb
@@ -108,7 +108,7 @@ describe MCB::Azure do
     end
 
     it "only runs az once, caching the response" do
-      MCB::Azure.instance_eval { @config&.clear }
+      MCB::Azure.instance_eval { @configs&.clear }
 
       MCB::Azure.get_config(webapp: "some-app", rgroup: "some-rgroup")
 

--- a/spec/lib/mcb/azure_spec.rb
+++ b/spec/lib/mcb/azure_spec.rb
@@ -82,15 +82,19 @@ describe MCB::Azure do
         ]
       EOCONFIG
     end
-
-    subject { MCB::Azure.get_config(webapp: "some-app", rgroup: "some-rgroup") }
+    let(:expected_response) do
+      {
+        "SETTING_ONE" => "UNO",
+        "SETTING_TWO" => "DUO",
+      }
+    end
 
     before :each do
       allow(MCB).to receive(:run_command).and_return(config_json)
     end
 
     it "runs az" do
-      subject
+      MCB::Azure.get_config(webapp: "some-app", rgroup: "some-rgroup")
       expect(MCB).to(
         have_received(:run_command).with(
           'az webapp config appsettings list -g "some-rgroup" -n "some-app"',
@@ -98,7 +102,25 @@ describe MCB::Azure do
       )
     end
 
-    it { should eq("SETTING_ONE" => "UNO", "SETTING_TWO" => "DUO") }
+    it "returns the correct values" do
+      config = MCB::Azure.get_config(webapp: "some-app", rgroup: "some-rgroup")
+      expect(config).to eq expected_response
+    end
+
+    it "only runs az once, caching the response" do
+      MCB::Azure.instance_eval { @config&.clear }
+
+      MCB::Azure.get_config(webapp: "some-app", rgroup: "some-rgroup")
+
+      config = MCB::Azure.get_config(webapp: "some-app", rgroup: "some-rgroup")
+
+      expect(config).to eq expected_response
+      expect(MCB).to(
+        have_received(:run_command).with(
+          'az webapp config appsettings list -g "some-rgroup" -n "some-app"',
+        ).once,
+      )
+    end
   end
 
   describe ".get_urls" do

--- a/spec/lib/mcb/commands/api/bulk_sync_to_find_spec.rb
+++ b/spec/lib/mcb/commands/api/bulk_sync_to_find_spec.rb
@@ -1,13 +1,17 @@
 require "spec_helper"
 require "mcb_helper"
 
-describe "mcb apiv2 bulk_sync_to_find" do
+describe "mcb api bulk_sync_to_find" do
   it "returns a plain-text JSON string" do
     sync_request = stub_request(:post, "http://localhost:3001/api/system/sync")
                      .with(headers: { "Authorization" => "Bearer Ge32" })
 
     with_stubbed_stdout do
-      $mcb.run(%w[apiv2 bulk_sync_to_find])
+      begin
+        $mcb.run(%w[api bulk_sync_to_find])
+      rescue SystemExit
+        raise "SystemExit not allowed"
+      end
     end
 
     expect(sync_request).to have_been_made

--- a/spec/lib/mcb_spec.rb
+++ b/spec/lib/mcb_spec.rb
@@ -148,6 +148,30 @@ describe "mcb command" do
     end
   end
 
+  describe ".service_root_url" do
+    let(:opts) do
+      {
+        webapp: "weebapp",
+        rgroup: "rezgrp",
+        subscription: "sub6",
+      }
+    end
+
+    it "returns the first https url on service.gov.uk" do
+      allow(MCB::Azure).to(
+        receive(:get_urls).with(opts).and_return(
+          %w[http://svc.azure.net
+             https://svc.azure.net
+             http://svc.service.gov.uk
+             https://svc.service.gov.uk],
+        ),
+      )
+
+      expect(MCB.service_root_url(opts))
+        .to eq "https://svc.service.gov.uk"
+    end
+  end
+
   describe ".apiv2_base_url" do
     let(:opts) do
       {
@@ -157,13 +181,10 @@ describe "mcb command" do
       }
     end
 
-    it "returns the first https url on gov.uk" do
-      allow(MCB::Azure).to(
-        receive(:get_urls).with(opts).and_return(
-          %w[http://svc.azure.net
-             https://svc.azure.net
-             http://svc.service.gov.uk
-             https://svc.service.gov.uk],
+    it "adds the api v2 path to the service root url" do
+      allow(MCB).to(
+        receive(:service_root_url).with(opts).and_return(
+          "https://svc.service.gov.uk",
         ),
       )
 

--- a/spec/lib/mcb_spec.rb
+++ b/spec/lib/mcb_spec.rb
@@ -116,6 +116,14 @@ describe "mcb command" do
     end
   end
 
+  describe ".system_api_opts" do
+    it "sets the webapp"
+    it "sets the rgroup"
+    it "sets the subscription"
+    it "sets the url"
+    it "sets the token"
+  end
+
   describe ".apiv1_opts" do
     context "with the -E flag" do
       let(:opts) { { env: "low-cal" } }

--- a/spec/support/with_stubbed_stdout.rb
+++ b/spec/support/with_stubbed_stdout.rb
@@ -51,8 +51,10 @@ def run(stdin: nil, stderr: nil)
     $stdin = StringIO.new(stdin)
   end
 
-  allow_any_instance_of(Binding).to receive(:pry)
-                                      .and_raise("Cannot use pry with stubbed stdout")
+  allow_any_instance_of(Binding).to(
+    receive(:pry)
+      .and_raise("Cannot use pry with stubbed stdout, set WITHOUT_STUBBED_STDOUT"),
+  )
 
   yield
 


### PR DESCRIPTION
### Context

The `mcb apiv2 bulk_sync_to_find` was using the wrong token, because it was added as an `apiv2` command when it's actually in the "system" api.

### Changes proposed in this pull request

Move `bulk_sync_to_find` to the right namespace (just `api` instead of `apiv2`) and add support for getting configuration for the system API.

### Guidance to review

The method `system_api_opts` is just a copy of `apiv1_opts`, but it should be refactored to pull out logic that is shared between those methods, and `apiv2_opts`. I'll do that as a separate PR to keep this one smaller.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
