### PR TITLE
[2678] Add timestamps to tables without them

### DIFF
--- a/app/models/course_subject.rb
+++ b/app/models/course_subject.rb
@@ -3,8 +3,10 @@
 # Table name: course_subject
 #
 #  course_id  :integer
+#  created_at :datetime
 #  id         :integer          not null, primary key
 #  subject_id :integer
+#  updated_at :datetime
 #
 # Indexes
 #

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -2,10 +2,12 @@
 #
 # Table name: subject
 #
+#  created_at   :datetime
 #  id           :bigint           not null, primary key
 #  subject_code :text
 #  subject_name :text
 #  type         :text
+#  updated_at   :datetime
 #
 # Indexes
 #

--- a/app/models/subjects/discontinued_subject.rb
+++ b/app/models/subjects/discontinued_subject.rb
@@ -2,10 +2,12 @@
 #
 # Table name: subject
 #
+#  created_at   :datetime
 #  id           :bigint           not null, primary key
 #  subject_code :text
 #  subject_name :text
 #  type         :text
+#  updated_at   :datetime
 #
 # Indexes
 #

--- a/app/models/subjects/further_education_subject.rb
+++ b/app/models/subjects/further_education_subject.rb
@@ -2,10 +2,12 @@
 #
 # Table name: subject
 #
+#  created_at   :datetime
 #  id           :bigint           not null, primary key
 #  subject_code :text
 #  subject_name :text
 #  type         :text
+#  updated_at   :datetime
 #
 # Indexes
 #

--- a/app/models/subjects/modern_languages_subject.rb
+++ b/app/models/subjects/modern_languages_subject.rb
@@ -2,10 +2,12 @@
 #
 # Table name: subject
 #
+#  created_at   :datetime
 #  id           :bigint           not null, primary key
 #  subject_code :text
 #  subject_name :text
 #  type         :text
+#  updated_at   :datetime
 #
 # Indexes
 #

--- a/app/models/subjects/primary_subject.rb
+++ b/app/models/subjects/primary_subject.rb
@@ -2,10 +2,12 @@
 #
 # Table name: subject
 #
+#  created_at   :datetime
 #  id           :bigint           not null, primary key
 #  subject_code :text
 #  subject_name :text
 #  type         :text
+#  updated_at   :datetime
 #
 # Indexes
 #

--- a/app/models/subjects/secondary_subject.rb
+++ b/app/models/subjects/secondary_subject.rb
@@ -2,10 +2,12 @@
 #
 # Table name: subject
 #
+#  created_at   :datetime
 #  id           :bigint           not null, primary key
 #  subject_code :text
 #  subject_name :text
 #  type         :text
+#  updated_at   :datetime
 #
 # Indexes
 #

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -2,10 +2,12 @@
 #
 # Table name: subject
 #
+#  created_at   :datetime
 #  id           :bigint           not null, primary key
 #  subject_code :text
 #  subject_name :text
 #  type         :text
+#  updated_at   :datetime
 #
 # Indexes
 #

--- a/db/migrate/20191223134441_add_timestamps_to_subjects.rb
+++ b/db/migrate/20191223134441_add_timestamps_to_subjects.rb
@@ -1,0 +1,7 @@
+class AddTimestampsToSubjects < ActiveRecord::Migration[6.0]
+  def change
+    change_table :subject, bulk: true do |t|
+      t.timestamps(null: true)
+    end
+  end
+end

--- a/db/migrate/20191223135644_add_timestamps_to_course_subjects.rb
+++ b/db/migrate/20191223135644_add_timestamps_to_course_subjects.rb
@@ -1,0 +1,7 @@
+class AddTimestampsToCourseSubjects < ActiveRecord::Migration[6.0]
+  def change
+    change_table :course_subject, bulk: true do |t|
+      t.timestamps(null: true)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_20_161244) do
+ActiveRecord::Schema.define(version: 2019_12_23_135644) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -127,6 +127,8 @@ ActiveRecord::Schema.define(version: 2019_12_20_161244) do
   create_table "course_subject", id: :serial, force: :cascade do |t|
     t.integer "course_id"
     t.integer "subject_id"
+    t.datetime "created_at", precision: 6
+    t.datetime "updated_at", precision: 6
     t.index ["course_id", "subject_id"], name: "index_course_subject_on_course_id_and_subject_id", unique: true
     t.index ["course_id"], name: "index_course_subject_on_course_id"
     t.index ["subject_id"], name: "index_course_subject_on_subject_id"
@@ -270,6 +272,8 @@ ActiveRecord::Schema.define(version: 2019_12_20_161244) do
     t.text "type"
     t.text "subject_code"
     t.text "subject_name"
+    t.datetime "created_at", precision: 6
+    t.datetime "updated_at", precision: 6
     t.index ["subject_name"], name: "index_subject_on_subject_name"
   end
 

--- a/spec/models/course_subject_spec.rb
+++ b/spec/models/course_subject_spec.rb
@@ -3,8 +3,10 @@
 # Table name: course_subject
 #
 #  course_id  :integer
+#  created_at :datetime
 #  id         :integer          not null, primary key
 #  subject_id :integer
+#  updated_at :datetime
 #
 # Indexes
 #

--- a/spec/models/secondary_subject_spec.rb
+++ b/spec/models/secondary_subject_spec.rb
@@ -2,10 +2,12 @@
 #
 # Table name: subject
 #
+#  created_at   :datetime
 #  id           :bigint           not null, primary key
 #  subject_code :text
 #  subject_name :text
 #  type         :text
+#  updated_at   :datetime
 #
 # Indexes
 #

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -2,10 +2,12 @@
 #
 # Table name: subject
 #
+#  created_at   :datetime
 #  id           :bigint           not null, primary key
 #  subject_code :text
 #  subject_name :text
 #  type         :text
+#  updated_at   :datetime
 #
 # Indexes
 #

--- a/spec/serializers/subject_serializer_spec.rb
+++ b/spec/serializers/subject_serializer_spec.rb
@@ -2,10 +2,12 @@
 #
 # Table name: subject
 #
+#  created_at   :datetime
 #  id           :bigint           not null, primary key
 #  subject_code :text
 #  subject_name :text
 #  type         :text
+#  updated_at   :datetime
 #
 # Indexes
 #


### PR DESCRIPTION
### Context
A number of tables with being flagged by rubocop as missing timestamps, this adds timestamps to those tables.

### Changes proposed in this pull request
Add timestamps to the tables `course_subject` and `subject`

### Guidance to review
These timestamps are nullable in because no data for them currently exists, an alternate solution would be to set the date to the epoch.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
