### PR TITLE
[2513] Change environment variable from SETTINGS__ to PTT_API__

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ file
 ```
 
 ```bash
-export SETTINGS__FILE__BASED__SETTINGS__ENV1="machine wins"
+export PTT_API__FILE__BASED__PTT_API__ENV1="machine wins"
 ```
 
 ```ruby

--- a/azure/template.json
+++ b/azure/template.json
@@ -400,31 +400,31 @@
                 "value": "[parameters('sentryDSNBackend')]"
               },
               {
-                "name": "SETTINGS__AUTHENTICATION__SECRET",
+                "name": "PTT_API__AUTHENTICATION__SECRET",
                 "value": "[parameters('settingsAuthenticationSecret')]"
               },
               {
-                "name": "SETTINGS__MANAGE_API__SECRET",
+                "name": "PTT_API__MANAGE_API__SECRET",
                 "value": "[parameters('settingsManageApiSecret')]"
               },
               {
-                "name": "SETTINGS__SEARCH_API__SECRET",
+                "name": "PTT_API__SEARCH_API__SECRET",
                 "value": "[parameters('settingsSearchApiSecret')]"
               },
               {
-                "name": "SETTINGS__GOVUK_NOTIFY__API_KEY",
+                "name": "PTT_API__GOVUK_NOTIFY__API_KEY",
                 "value": "[parameters('govukNotifyApiKey')]"
               },
               {
-                "name": "SETTINGS__GOVUK_NOTIFY__WELCOME_EMAIL_TEMPLATE_ID",
+                "name": "PTT_API__GOVUK_NOTIFY__WELCOME_EMAIL_TEMPLATE_ID",
                 "value": "[parameters('govukNotifyWelcomeEmailTemplateId')]"
               },
               {
-                "name": "SETTINGS__SYSTEM_AUTHENTICATION_TOKEN",
+                "name": "PTT_API__SYSTEM_AUTHENTICATION_TOKEN",
                 "value": "[parameters('mcbeSystemAuthenticationToken')]"
               },
               {
-                "name": "SETTINGS__MCBG__REDIS_PASSWORD",
+                "name": "PTT_API__MCBG__REDIS_PASSWORD",
                 "value": "[concat(listKeys(resourceId('Microsoft.Cache/Redis', parameters('redisCacheName')), '2018-03-01').primaryKey)]"
               },
               {
@@ -436,15 +436,15 @@
                 "value": "0"
               },
               {
-                "name": "SETTINGS__LOGSTASH__HOST",
+                "name": "PTT_API__LOGSTASH__HOST",
                 "value": "[parameters('logstashHost')]"
               },
               {
-                "name": "SETTINGS__LOGSTASH__PORT",
+                "name": "PTT_API__LOGSTASH__PORT",
                 "value": "[parameters('logstashPort')]"
               },
               {
-                "name": "SETTINGS__GCP_API_KEY",
+                "name": "PTT_API__GCP_API_KEY",
                 "value": "[parameters('googleCloudPlatformAPIKey')]"
               }
             ]
@@ -728,15 +728,15 @@
                 "secureValue": "[parameters('sentryDSNContainers')[copyIndex()]]"
               },
               {
-                "name": "SETTINGS__AUTHENTICATION__SECRET",
+                "name": "PTT_API__AUTHENTICATION__SECRET",
                 "secureValue": "[parameters('settingsAuthenticationSecret')]"
               },
               {
-                "name": "SETTINGS__SEARCH_API__SECRET",
+                "name": "PTT_API__SEARCH_API__SECRET",
                 "secureValue": "[parameters('settingsSearchApiSecret')]"
               },
               {
-                "name": "SETTINGS__MCBG__REDIS_PASSWORD",
+                "name": "PTT_API__MCBG__REDIS_PASSWORD",
                 "secureValue": "[concat(listKeys(resourceId('Microsoft.Cache/Redis', parameters('redisCacheName')), '2018-03-01').primaryKey)]"
               },
               {
@@ -744,15 +744,15 @@
                 "value": "[concat ('rediss://',parameters('redisCacheName'),'.redis.cache.windows.net:6380')]"
               },
               {
-                "name": "SETTINGS__LOGSTASH__HOST",
+                "name": "PTT_API__LOGSTASH__HOST",
                 "secureValue": "[parameters('logstashHost')]"
               },
               {
-                "name": "SETTINGS__LOGSTASH__PORT",
+                "name": "PTT_API__LOGSTASH__PORT",
                 "secureValue": "[parameters('logstashPort')]"
               },
               {
-                "name": "SETTINGS__GCP_API_KEY",
+                "name": "PTT_API__GCP_API_KEY",
                 "secureValue": "[parameters('googleCloudPlatformAPIKey')]"
               }
             ]

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -21,7 +21,7 @@ Config.setup do |config|
 
   # Define ENV variable prefix deciding which variables to load into config.
   #
-  config.env_prefix = "SETTINGS"
+  config.env_prefix = "PTT_API"
 
   # What string to use as level separator for settings loaded from ENV variables. Default value of '.' works well
   # with Heroku, but you might want to change it for example for '__' to easy override settings from command line, where

--- a/lib/mcb/azure.rb
+++ b/lib/mcb/azure.rb
@@ -57,14 +57,14 @@ module MCB
     end
 
     def self.configure_redis(app_config)
-      %w[REDIS_URL SETTINGS__MCBG__REDIS_PASSWORD].each do |env_var|
+      %w[REDIS_URL PTT_API__MCBG__REDIS_PASSWORD].each do |env_var|
         ENV[env_var] = app_config.fetch(env_var)
       end
     end
 
     def self.configure_env(app_config)
       ENV.update(
-        app_config.select { |e| e.start_with?("SETTINGS__") },
+        app_config.select { |e| e.start_with?("PTT_API__") },
       )
     end
 

--- a/spec/lib/mcb/azure_spec.rb
+++ b/spec/lib/mcb/azure_spec.rb
@@ -169,15 +169,15 @@ describe MCB::Azure do
   end
 
   describe ".configure_env" do
-    it "sets all the SETTINGS__ env vars from the app config" do
+    it "sets all the PTT_API__ env vars from the app config" do
       allow(ENV).to receive(:update)
       MCB::Azure.configure_env(
-        "SETTINGS__FOO" => "bar",
+        "PTT_API__FOO" => "bar",
         "some_random_kind_of_yak" => "shaving",
       )
       expect(ENV).to(
         have_received(:update).with(
-          "SETTINGS__FOO" => "bar",
+          "PTT_API__FOO" => "bar",
         ),
       )
     end

--- a/spec/lib/mcb/commands/db_spec.rb
+++ b/spec/lib/mcb/commands/db_spec.rb
@@ -23,8 +23,8 @@ describe "mcb db" do
         "PG_USERNAME"                            => "azuser",
         "PG_PASSWORD"                            => "azpass",
         "REDIS_URL"                              => "https://redisurl",
-        "SETTINGS__MCBG__REDIS_PASSWORD"         => "redispass",
-        "RAILS_ENV"                              => "qa",
+        "PTT_API__MCBG__REDIS_PASSWORD" => "redispass",
+        "RAILS_ENV" => "qa",
       }
 
       azure_qa_settings = { webapp: "s121d01-mcbe-as",


### PR DESCRIPTION
### Context
Our applications currently make use of a number of variables, as such it is easy to confuse which environment variable is for which application.

### Changes proposed in this pull request
Any environment variable previously prefixed with `SETTINGS__` will now be prefixed by `MCBE__`

### Guidance to review
This will need changes to azure I presume. @rizzkhan1   
  
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
