### PR TITLE
[2677] Remove PE from potential subjects if user is not an admin

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -31,6 +31,12 @@ module API
           include: [:subjects, :sites, :accrediting_provider, :provider, provider: [:sites]],
         )
 
+        if !@current_user.admin?
+          json_data[:data][:meta][:edit_options][:subjects]&.reject! do |subject|
+            subject[:attributes][:subject_name] == "Physical education"
+          end
+        end
+
         json_data[:data][:errors] = []
 
         @course.errors.messages.each do |error_key, _|


### PR DESCRIPTION
### Context

PE courses should not be able to be created by non-admin users via the UI.

### Changes proposed in this pull request

- Remove PE from the list of potential subjects from the build new course endpoint.


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
