### PR TITLE
[2700] add "set -x" to the azure pipeline jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,19 +15,24 @@ variables:
 
 steps:
 - script: |
+    set -x
     GIT_SHORT_SHA=$(echo $(Build.SourceVersion) | cut -c 1-7)
     docker_path=$(dockerHubUsername)/$(imageName)
     docker_bg_find_sync_path=$(dockerHubUsername)/$(imageNameBgFindSync)
     docker_bg_geocode_path=$(dockerHubUsername)/$(imageNameBgGeoCode)
+    set +x # We confuse VSTS if we trace these commands
     echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
     echo "##vso[task.setvariable variable=docker_path;]$docker_path"
     echo "##vso[task.setvariable variable=docker_bg_find_sync_path;]$docker_bg_find_sync_path"
     echo "##vso[task.setvariable variable=docker_bg_geocode_path;]$docker_bg_geocode_path"
   displayName: 'Set version number'
 
-- script: docker pull $(docker_path):latest || true
+- script: |
+    set -x
+    docker pull $(docker_path):latest || true
   displayName: "Pull latest docker image to cache"
 - script: |
+    set -x
     $DOCKER_OVERRIDE build
     $DOCKER_OVERRIDE up --no-build -d
     $DOCKER_OVERRIDE exec -T web /bin/sh -c "./wait-for-command.sh -c 'nc -z db 5432' -s 0 -t 20"
@@ -59,6 +64,7 @@ steps:
     testResultsFiles: 'rspec-output/*.xml'
     failedTaskOnFailedTest: true
 - script: |
+    set -x
     $DOCKER_OVERRIDE exec -T web /bin/sh -c "bundle exec rubocop app config db lib spec --format clang"
   displayName: 'Execute linters'
   env:
@@ -66,6 +72,7 @@ steps:
     dockerHubUsername: $(dockerHubUsername)
     dockerHubImageName: $(imageName)
 - script: |
+    set -x
     $DOCKER_OVERRIDE exec -T web /bin/sh -c "bundle exec rake cc:report"
   displayName: 'Execute Code Climate reporter'
   env:
@@ -75,6 +82,7 @@ steps:
     CC_TEST_REPORTER_ID: $(ccReporterID)
     AGENT_JOBSTATUS: $(Agent.JobStatus)
 - script: |
+    set -x
     $DOCKER_OVERRIDE exec -T web /bin/sh -c "bundle exec rake brakeman"
   displayName: 'Execute Brakeman static analysis'
   env:


### PR DESCRIPTION
### Context

The Azure DevOps pipelines don't display what commands are running so it can be hard to understand what's happening just from the output.

### Changes proposed in this pull request

Add `set -x` to all the steps' jobs in the build pipeline to enable built-in shell tracing.

### Guidance to review

:shipit:

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
