### PR TITLE
[2743] Add v3 /providers/courses endpoint

### DIFF
--- a/app/services/courses/assignable_master_subject_service.rb
+++ b/app/services/courses/assignable_master_subject_service.rb
@@ -13,11 +13,11 @@ module Courses
     def execute(course:)
       case course.level
       when "primary"
-        @primary_subject.all
+        @primary_subject.includes(:financial_incentive).all
       when "secondary"
-        @secondary_subject.all
+        @secondary_subject.includes(:financial_incentive).all
       when "further_education"
-        @further_education_subject.all
+        @further_education_subject.includes(:financial_incentive).all
       end
     end
   end

--- a/config/initializers/api_pagination.rb
+++ b/config/initializers/api_pagination.rb
@@ -1,0 +1,9 @@
+ApiPagination.configure do |config|
+  config.page_param do |params|
+    params.dig(:page, :page)
+  end
+
+  config.per_page_param do |params|
+    params.dig(:page, :per_page) || 10
+  end
+end

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -2,7 +2,7 @@
 
 Kaminari.configure do |config|
   config.default_per_page = 100
-  # config.max_per_page = nil
+  config.max_per_page = 100
   # config.window = 4
   # config.outer_window = 0
   # config.left = 0

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,7 @@
 #                                                api_v2_build_new_course GET    /api/v2/build_new_course(.:format)                                                                                               api/v2/courses#build_new
 #                              api_v3_recruitment_cycle_provider_courses GET    /api/v3/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/courses(.:format)                                    api/v3/courses#index
 #                               api_v3_recruitment_cycle_provider_course GET    /api/v3/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/courses/:code(.:format)                              api/v3/courses#show
+#                                       api_v3_recruitment_cycle_courses GET    /api/v3/recruitment_cycles/:recruitment_cycle_year/providers/courses(.:format)                                                   api/v3/courses#index
 #                                     api_v3_recruitment_cycle_providers GET    /api/v3/recruitment_cycles/:recruitment_cycle_year/providers(.:format)                                                           api/v3/providers#index
 #                                      api_v3_recruitment_cycle_provider GET    /api/v3/recruitment_cycles/:recruitment_cycle_year/providers/:code(.:format)                                                     api/v3/providers#show
 #                                               api_v3_recruitment_cycle GET    /api/v3/recruitment_cycles/:year(.:format)                                                                                       api/v3/recruitment_cycles#show
@@ -176,6 +177,10 @@ Rails.application.routes.draw do
           resources :courses,
                     only: %i[index show],
                     param: :code
+
+          collection do
+            resources :courses, only: %i[index]
+          end
         end
       end
     end

--- a/spec/requests/api/v3/providers/courses/index_spec.rb
+++ b/spec/requests/api/v3/providers/courses/index_spec.rb
@@ -29,12 +29,13 @@ describe "GET v3/providers/:provider_code/courses" do
            applications_open_from: applications_open_from)
   end
 
-  let(:courses_site_status) {
+  let(:courses_site_status) do
     build(:site_status,
           :findable,
           :with_any_vacancy,
           site: create(:site, provider: provider))
-  }
+  end
+
   let(:enrichment)     { build :course_enrichment, :published }
   let(:provider)       { create :provider }
 
@@ -51,187 +52,473 @@ describe "GET v3/providers/:provider_code/courses" do
     end
 
     describe "JSON generated for courses" do
-      let(:request_path) { "/api/v3/recruitment_cycles/#{current_cycle.year}/providers/#{provider.provider_code}/courses" }
+      context "with a specified provider" do
+        let(:request_path) { "/api/v3/recruitment_cycles/#{current_cycle.year}/providers/#{provider.provider_code}/courses" }
 
-      subject { perform_request }
+        subject { perform_request }
 
-      it { should have_http_status(:success) }
+        it { should have_http_status(:success) }
 
-      it "has a data section with the correct attributes" do
-        perform_request
+        it "has a data section with the correct attributes" do
+          perform_request
 
-        json_response = JSON.parse response.body
-        expect(json_response).to eq(
-          "data" => [{
-            "id" => provider.courses[0].id.to_s,
-            "type" => "courses",
-            "attributes" => {
-              "findable?" => true,
-              "open_for_applications?" => true,
-              "has_vacancies?" => true,
-              "name" => provider.courses[0].name,
-              "course_code" => provider.courses[0].course_code,
-              "start_date" => provider.courses[0].start_date.strftime("%B %Y"),
-              "study_mode" => "full_time",
-              "qualification" => "pgce_with_qts",
-              "description" => "PGCE with QTS full time teaching apprenticeship",
-              "content_status" => "published",
-              "ucas_status" => "running",
-              "funding_type" => "apprenticeship",
-              "is_send?" => true,
-              "level" => "primary",
-              "applications_open_from" => provider.courses[0].applications_open_from.strftime("%Y-%m-%d"),
-              "about_course" => enrichment.about_course,
-              "course_length" => enrichment.course_length,
-              "fee_details" => enrichment.fee_details,
-              "fee_international" => enrichment.fee_international,
-              "fee_uk_eu" => enrichment.fee_uk_eu,
-              "financial_support" => enrichment.financial_support,
-              "how_school_placements_work" => enrichment.how_school_placements_work,
-              "interview_process" => enrichment.interview_process,
-              "other_requirements" => enrichment.other_requirements,
-              "personal_qualities" => enrichment.personal_qualities,
-              "required_qualifications" => enrichment.required_qualifications,
-              "salary_details" => enrichment.salary_details,
-              "last_published_at" => enrichment.last_published_timestamp_utc.iso8601,
-              "about_accrediting_body" => nil,
-              "english" => "must_have_qualification_at_application_time",
-              "maths" => "must_have_qualification_at_application_time",
-                "science" => "must_have_qualification_at_application_time",
-              "provider_code" => provider.provider_code,
-              "recruitment_cycle_year" => current_year.to_s,
-              "gcse_subjects_required" => %w[maths english science],
-              "age_range_in_years" => provider.courses[0].age_range_in_years,
-              "accrediting_provider" => nil,
-              "accrediting_provider_code" => nil,
-            },
-            "relationships" => {
-              "accrediting_provider" => { "meta" => { "included" => false } },
-              "provider" => { "meta" => { "included" => false } },
-              "site_statuses" => { "meta" => { "included" => false } },
-              "sites" => { "meta" => { "included" => false } },
-              "subjects" => { "meta" => { "included" => false } },
-            },
-            "meta" => {
-              "edit_options" => {
-                "entry_requirements" => %w[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test],
-                "qualifications" => %w[qts pgce_with_qts pgde_with_qts],
-                "age_range_in_years" => %w[3_to_7 5_to_11 7_to_11 7_to_14],
-                "start_dates" => [
-                  "October #{previous_year}",
-                  "November #{previous_year}",
-                  "December #{previous_year}",
-                  "January #{current_year}",
-                  "February #{current_year}",
-                  "March #{current_year}",
-                  "April #{current_year}",
-                  "May #{current_year}",
-                  "June #{current_year}",
-                  "July #{current_year}",
-                  "August #{current_year}",
-                  "September #{current_year}",
-                  "October #{current_year}",
-                  "November #{current_year}",
-                  "December #{current_year}",
-                  "January #{next_year}",
-                  "February #{next_year}",
-                  "March #{next_year}",
-                  "April #{next_year}",
-                  "May #{next_year}",
-                  "June #{next_year}",
-                  "July #{next_year}",
-                ],
-                "study_modes" => %w[full_time part_time full_time_or_part_time],
-                "show_is_send" => false,
-                "show_start_date" => false,
-                "show_applications_open" => false,
-                "subjects" => [
-                  {
-                    "id" => "1",
-                    "type" => "subjects",
-                    "attributes" => {
-                      "subject_name" => "Primary",
-                      "subject_code" => "00",
-                      "bursary_amount" => nil,
-                      "early_career_payments" => nil,
-                      "scholarship" => nil,
-                    },
-                   },
-                  {
-                   "id" => "2",
-                   "type" => "subjects",
-                   "attributes" => {
-                     "subject_name" => "Primary with English",
-                     "subject_code" => "01",
-                     "bursary_amount" => nil,
-                     "early_career_payments" => nil,
-                     "scholarship" => nil,
-                   },
-                  },
-                  {
-                   "id" => "3",
-                   "type" => "subjects",
-                   "attributes" => {
-                     "subject_name" => "Primary with geography and history",
-                     "subject_code" => "02",
-                     "bursary_amount" => nil,
-                     "early_career_payments" => nil,
-                     "scholarship" => nil,
-                   },
-                  },
-                  {
-                   "id" => "4",
-                   "type" => "subjects",
-                   "attributes" => {
-                     "subject_name" => "Primary with mathematics",
-                     "subject_code" => "03",
-                     "bursary_amount" => "6000",
-                     "early_career_payments" => nil,
-                     "scholarship" => nil,
-                   },
-                  },
-                  {
-                   "id" => "5",
-                   "type" => "subjects",
-                   "attributes" => {
-                     "subject_name" => "Primary with modern languages",
-                     "subject_code" => "04",
-                     "bursary_amount" => nil,
-                     "early_career_payments" => nil,
-                     "scholarship" => nil,
-                   },
-                  },
-                  {
-                   "id" => "6",
-                   "type" => "subjects",
-                   "attributes" => {
-                     "subject_name" => "Primary with physical education",
-                     "subject_code" => "06",
-                     "bursary_amount" => nil,
-                     "early_career_payments" => nil,
-                     "scholarship" => nil,
-                   },
-                  },
-                  {
-                   "id" => "7",
-                   "type" => "subjects",
-                   "attributes" => {
-                     "subject_name" => "Primary with science",
-                     "subject_code" => "07",
-                     "bursary_amount" => nil,
-                     "early_career_payments" => nil,
-                     "scholarship" => nil,
-},
-                 },
-                ],
-                "modern_languages" => nil,
+          json_response = JSON.parse response.body
+          expect(json_response).to eq(
+            "data" => [{
+              "id" => provider.courses[0].id.to_s,
+              "type" => "courses",
+              "attributes" => {
+                "findable?" => true,
+                "open_for_applications?" => true,
+                "has_vacancies?" => true,
+                "name" => provider.courses[0].name,
+                "course_code" => provider.courses[0].course_code,
+                "start_date" => provider.courses[0].start_date.strftime("%B %Y"),
+                "study_mode" => "full_time",
+                "qualification" => "pgce_with_qts",
+                "description" => "PGCE with QTS full time teaching apprenticeship",
+                "content_status" => "published",
+                "ucas_status" => "running",
+                "funding_type" => "apprenticeship",
+                "is_send?" => true,
+                "level" => "primary",
+                "applications_open_from" => provider.courses[0].applications_open_from.strftime("%Y-%m-%d"),
+                "about_course" => enrichment.about_course,
+                "course_length" => enrichment.course_length,
+                "fee_details" => enrichment.fee_details,
+                "fee_international" => enrichment.fee_international,
+                "fee_uk_eu" => enrichment.fee_uk_eu,
+                "financial_support" => enrichment.financial_support,
+                "how_school_placements_work" => enrichment.how_school_placements_work,
+                "interview_process" => enrichment.interview_process,
+                "other_requirements" => enrichment.other_requirements,
+                "personal_qualities" => enrichment.personal_qualities,
+                "required_qualifications" => enrichment.required_qualifications,
+                "salary_details" => enrichment.salary_details,
+                "last_published_at" => enrichment.last_published_timestamp_utc.iso8601,
+                "about_accrediting_body" => nil,
+                "english" => "must_have_qualification_at_application_time",
+                "maths" => "must_have_qualification_at_application_time",
+                  "science" => "must_have_qualification_at_application_time",
+                "provider_code" => provider.provider_code,
+                "recruitment_cycle_year" => current_year.to_s,
+                "gcse_subjects_required" => %w[maths english science],
+                "age_range_in_years" => provider.courses[0].age_range_in_years,
+                "accrediting_provider" => nil,
+                "accrediting_provider_code" => nil,
               },
+              "relationships" => {
+                "accrediting_provider" => { "meta" => { "included" => false } },
+                "provider" => { "meta" => { "included" => false } },
+                "site_statuses" => { "meta" => { "included" => false } },
+                "sites" => { "meta" => { "included" => false } },
+                "subjects" => { "meta" => { "included" => false } },
+              },
+              "meta" => {
+                "edit_options" => {
+                  "entry_requirements" => %w[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test],
+                  "qualifications" => %w[qts pgce_with_qts pgde_with_qts],
+                  "age_range_in_years" => %w[3_to_7 5_to_11 7_to_11 7_to_14],
+                  "start_dates" => [
+                    "October #{previous_year}",
+                    "November #{previous_year}",
+                    "December #{previous_year}",
+                    "January #{current_year}",
+                    "February #{current_year}",
+                    "March #{current_year}",
+                    "April #{current_year}",
+                    "May #{current_year}",
+                    "June #{current_year}",
+                    "July #{current_year}",
+                    "August #{current_year}",
+                    "September #{current_year}",
+                    "October #{current_year}",
+                    "November #{current_year}",
+                    "December #{current_year}",
+                    "January #{next_year}",
+                    "February #{next_year}",
+                    "March #{next_year}",
+                    "April #{next_year}",
+                    "May #{next_year}",
+                    "June #{next_year}",
+                    "July #{next_year}",
+                  ],
+                  "study_modes" => %w[full_time part_time full_time_or_part_time],
+                  "show_is_send" => false,
+                  "show_start_date" => false,
+                  "show_applications_open" => false,
+                  "subjects" => [
+                    {
+                      "id" => "1",
+                      "type" => "subjects",
+                      "attributes" => {
+                        "subject_name" => "Primary",
+                        "subject_code" => "00",
+                        "bursary_amount" => nil,
+                        "early_career_payments" => nil,
+                        "scholarship" => nil,
+                      },
+                     },
+                    {
+                     "id" => "2",
+                     "type" => "subjects",
+                     "attributes" => {
+                       "subject_name" => "Primary with English",
+                       "subject_code" => "01",
+                       "bursary_amount" => nil,
+                       "early_career_payments" => nil,
+                       "scholarship" => nil,
+                     },
+                    },
+                    {
+                     "id" => "3",
+                     "type" => "subjects",
+                     "attributes" => {
+                       "subject_name" => "Primary with geography and history",
+                       "subject_code" => "02",
+                       "bursary_amount" => nil,
+                       "early_career_payments" => nil,
+                       "scholarship" => nil,
+                     },
+                    },
+                    {
+                     "id" => "4",
+                     "type" => "subjects",
+                     "attributes" => {
+                       "subject_name" => "Primary with mathematics",
+                       "subject_code" => "03",
+                       "bursary_amount" => "6000",
+                       "early_career_payments" => nil,
+                       "scholarship" => nil,
+                     },
+                    },
+                    {
+                     "id" => "5",
+                     "type" => "subjects",
+                     "attributes" => {
+                       "subject_name" => "Primary with modern languages",
+                       "subject_code" => "04",
+                       "bursary_amount" => nil,
+                       "early_career_payments" => nil,
+                       "scholarship" => nil,
+                     },
+                    },
+                    {
+                     "id" => "6",
+                     "type" => "subjects",
+                     "attributes" => {
+                       "subject_name" => "Primary with physical education",
+                       "subject_code" => "06",
+                       "bursary_amount" => nil,
+                       "early_career_payments" => nil,
+                       "scholarship" => nil,
+                     },
+                    },
+                    {
+                     "id" => "7",
+                     "type" => "subjects",
+                     "attributes" => {
+                       "subject_name" => "Primary with science",
+                       "subject_code" => "07",
+                       "bursary_amount" => nil,
+                       "early_career_payments" => nil,
+                       "scholarship" => nil,
+  },
+                   },
+                  ],
+                  "modern_languages" => nil,
+                },
+              },
+            }],
+            "links"  => {
+              "last" => "/api/v3/recruitment_cycles/2020/providers/#{provider.provider_code}/courses?page%5Bpage%5D=1",
             },
-          }],
-          "jsonapi" => {
-            "version" => "1.0",
-          },
-        )
+            "jsonapi" => {
+              "version" => "1.0",
+            },
+          )
+        end
+      end
+
+      context "without a specified provider" do
+        let(:request_path) { "/api/v3/recruitment_cycles/#{current_cycle.year}/providers/courses" }
+
+        subject { perform_request }
+
+        it { should have_http_status(:success) }
+
+        it "has a data section with the correct attributes" do
+          perform_request
+
+          json_response = JSON.parse response.body
+          expect(json_response).to eq(
+            "data" => [{
+              "id" => provider.courses[0].id.to_s,
+              "type" => "courses",
+              "attributes" => {
+                "findable?" => true,
+                "open_for_applications?" => true,
+                "has_vacancies?" => true,
+                "name" => provider.courses[0].name,
+                "course_code" => provider.courses[0].course_code,
+                "start_date" => provider.courses[0].start_date.strftime("%B %Y"),
+                "study_mode" => "full_time",
+                "qualification" => "pgce_with_qts",
+                "description" => "PGCE with QTS full time teaching apprenticeship",
+                "content_status" => "published",
+                "ucas_status" => "running",
+                "funding_type" => "apprenticeship",
+                "is_send?" => true,
+                "level" => "primary",
+                "applications_open_from" => provider.courses[0].applications_open_from.strftime("%Y-%m-%d"),
+                "about_course" => enrichment.about_course,
+                "course_length" => enrichment.course_length,
+                "fee_details" => enrichment.fee_details,
+                "fee_international" => enrichment.fee_international,
+                "fee_uk_eu" => enrichment.fee_uk_eu,
+                "financial_support" => enrichment.financial_support,
+                "how_school_placements_work" => enrichment.how_school_placements_work,
+                "interview_process" => enrichment.interview_process,
+                "other_requirements" => enrichment.other_requirements,
+                "personal_qualities" => enrichment.personal_qualities,
+                "required_qualifications" => enrichment.required_qualifications,
+                "salary_details" => enrichment.salary_details,
+                "last_published_at" => enrichment.last_published_timestamp_utc.iso8601,
+                "about_accrediting_body" => nil,
+                "english" => "must_have_qualification_at_application_time",
+                "maths" => "must_have_qualification_at_application_time",
+                  "science" => "must_have_qualification_at_application_time",
+                "provider_code" => provider.provider_code,
+                "recruitment_cycle_year" => current_year.to_s,
+                "gcse_subjects_required" => %w[maths english science],
+                "age_range_in_years" => provider.courses[0].age_range_in_years,
+                "accrediting_provider" => nil,
+                "accrediting_provider_code" => nil,
+              },
+              "relationships" => {
+                "accrediting_provider" => { "meta" => { "included" => false } },
+                "provider" => { "meta" => { "included" => false } },
+                "site_statuses" => { "meta" => { "included" => false } },
+                "sites" => { "meta" => { "included" => false } },
+                "subjects" => { "meta" => { "included" => false } },
+              },
+              "meta" => {
+                "edit_options" => {
+                  "entry_requirements" => %w[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test],
+                  "qualifications" => %w[qts pgce_with_qts pgde_with_qts],
+                  "age_range_in_years" => %w[3_to_7 5_to_11 7_to_11 7_to_14],
+                  "start_dates" => [
+                    "October #{previous_year}",
+                    "November #{previous_year}",
+                    "December #{previous_year}",
+                    "January #{current_year}",
+                    "February #{current_year}",
+                    "March #{current_year}",
+                    "April #{current_year}",
+                    "May #{current_year}",
+                    "June #{current_year}",
+                    "July #{current_year}",
+                    "August #{current_year}",
+                    "September #{current_year}",
+                    "October #{current_year}",
+                    "November #{current_year}",
+                    "December #{current_year}",
+                    "January #{next_year}",
+                    "February #{next_year}",
+                    "March #{next_year}",
+                    "April #{next_year}",
+                    "May #{next_year}",
+                    "June #{next_year}",
+                    "July #{next_year}",
+                  ],
+                  "study_modes" => %w[full_time part_time full_time_or_part_time],
+                  "show_is_send" => false,
+                  "show_start_date" => false,
+                  "show_applications_open" => false,
+                  "subjects" => [
+                    {
+                      "id" => "1",
+                      "type" => "subjects",
+                      "attributes" => {
+                        "subject_name" => "Primary",
+                        "subject_code" => "00",
+                        "bursary_amount" => nil,
+                        "early_career_payments" => nil,
+                        "scholarship" => nil,
+                      },
+                     },
+                    {
+                     "id" => "2",
+                     "type" => "subjects",
+                     "attributes" => {
+                       "subject_name" => "Primary with English",
+                       "subject_code" => "01",
+                       "bursary_amount" => nil,
+                       "early_career_payments" => nil,
+                       "scholarship" => nil,
+                     },
+                    },
+                    {
+                     "id" => "3",
+                     "type" => "subjects",
+                     "attributes" => {
+                       "subject_name" => "Primary with geography and history",
+                       "subject_code" => "02",
+                       "bursary_amount" => nil,
+                       "early_career_payments" => nil,
+                       "scholarship" => nil,
+                     },
+                    },
+                    {
+                     "id" => "4",
+                     "type" => "subjects",
+                     "attributes" => {
+                       "subject_name" => "Primary with mathematics",
+                       "subject_code" => "03",
+                       "bursary_amount" => "6000",
+                       "early_career_payments" => nil,
+                       "scholarship" => nil,
+                     },
+                    },
+                    {
+                     "id" => "5",
+                     "type" => "subjects",
+                     "attributes" => {
+                       "subject_name" => "Primary with modern languages",
+                       "subject_code" => "04",
+                       "bursary_amount" => nil,
+                       "early_career_payments" => nil,
+                       "scholarship" => nil,
+                     },
+                    },
+                    {
+                     "id" => "6",
+                     "type" => "subjects",
+                     "attributes" => {
+                       "subject_name" => "Primary with physical education",
+                       "subject_code" => "06",
+                       "bursary_amount" => nil,
+                       "early_career_payments" => nil,
+                       "scholarship" => nil,
+                     },
+                    },
+                    {
+                     "id" => "7",
+                     "type" => "subjects",
+                     "attributes" => {
+                       "subject_name" => "Primary with science",
+                       "subject_code" => "07",
+                       "bursary_amount" => nil,
+                       "early_career_payments" => nil,
+                       "scholarship" => nil,
+  },
+                   },
+                  ],
+                  "modern_languages" => nil,
+                },
+              },
+            }],
+            "links"  => {
+              "last" => "/api/v3/recruitment_cycles/2020/providers/courses?page%5Bpage%5D=1",
+            },
+            "jsonapi" => {
+              "version" => "1.0",
+            },
+          )
+        end
+
+        context "pagination" do
+          context "when specifying per_page" do
+            before do
+              6.times do
+                create(:course, :resulting_in_pgce_with_qts, :with_apprenticeship,
+                       level: "primary",
+                       name: "Mathematics",
+                       provider: provider,
+                       start_date: Time.now.utc,
+                       study_mode: :full_time,
+                       subjects: subjects,
+                       is_send: true,
+                       site_statuses: [courses_site_status],
+                       enrichments: [enrichment],
+                       maths: :must_have_qualification_at_application_time,
+                       english: :must_have_qualification_at_application_time,
+                       science: :must_have_qualification_at_application_time,
+                       age_range_in_years: "3_to_7",
+                       applications_open_from: applications_open_from)
+              end
+            end
+
+            context "on the first page" do
+              let(:request_path) { "/api/v3/recruitment_cycles/#{current_cycle.year}/providers/courses?page%5Bpage%5D=1&page%5Bper_page%5D=2" }
+
+              it "links to the next page only" do
+                perform_request
+
+                json_response = JSON.parse response.body
+                expect(json_response["links"]["next"]).to eq("/api/v3/recruitment_cycles/#{current_cycle.year}/providers/courses?page%5Bpage%5D=2&page%5Bper_page%5D=2")
+                expect(json_response["links"].key?("prev")).to eq(false)
+                expect(json_response["links"]["last"]).to eq("/api/v3/recruitment_cycles/#{current_cycle.year}/providers/courses?page%5Bpage%5D=3&page%5Bper_page%5D=2")
+              end
+            end
+
+            context "on the last page" do
+              let(:request_path) { "/api/v3/recruitment_cycles/#{current_cycle.year}/providers/courses?page%5Bpage%5D=4&page%5Bper_page%5D=2" }
+
+              it "links to the previous and next pages" do
+                perform_request
+
+                json_response = JSON.parse response.body
+                expect(json_response["links"].key?("next")).to eq(false)
+                expect(json_response["links"]["prev"]).to eq("/api/v3/recruitment_cycles/#{current_cycle.year}/providers/courses?page%5Bpage%5D=3&page%5Bper_page%5D=2")
+              end
+            end
+
+            context "on the second page" do
+              let(:request_path) { "/api/v3/recruitment_cycles/#{current_cycle.year}/providers/courses?page%5Bpage%5D=2&page%5Bper_page%5D=2" }
+
+              it "links to the previous and next pages" do
+                perform_request
+
+                json_response = JSON.parse response.body
+                expect(json_response["links"]["next"]).to eq("/api/v3/recruitment_cycles/#{current_cycle.year}/providers/courses?page%5Bpage%5D=3&page%5Bper_page%5D=2")
+                expect(json_response["links"]["prev"]).to eq("/api/v3/recruitment_cycles/#{current_cycle.year}/providers/courses?page%5Bpage%5D=1&page%5Bper_page%5D=2")
+                expect(json_response["links"]["last"]).to eq("/api/v3/recruitment_cycles/#{current_cycle.year}/providers/courses?page%5Bpage%5D=3&page%5Bper_page%5D=2")
+              end
+            end
+          end
+
+          context "when not specifying per_page" do
+            before do
+              11.times do
+                create(:course, :resulting_in_pgce_with_qts, :with_apprenticeship,
+                       level: "primary",
+                       name: "Mathematics",
+                       provider: provider,
+                       start_date: Time.now.utc,
+                       study_mode: :full_time,
+                       subjects: subjects,
+                       is_send: true,
+                       site_statuses: [courses_site_status],
+                       enrichments: [enrichment],
+                       maths: :must_have_qualification_at_application_time,
+                       english: :must_have_qualification_at_application_time,
+                       science: :must_have_qualification_at_application_time,
+                       age_range_in_years: "3_to_7",
+                       applications_open_from: applications_open_from)
+              end
+            end
+
+            let(:request_path) { "/api/v3/recruitment_cycles/#{current_cycle.year}/providers/courses?page%5Bpage%5D=1" }
+
+            it "links to the previous and next pages" do
+              perform_request
+
+              json_response = JSON.parse response.body
+              expect(json_response["data"].count).to eq(10)
+            end
+          end
+        end
       end
     end
 


### PR DESCRIPTION
### Context
In order to create the results page for find there must be a way to list all courses regardless of course.

### Changes proposed in this pull request
Create the path /providers/courses, and allow it to be paginated.

### Guidance to review
https://jsonapi.org/format/#fetching-pagination

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
