### PR TITLE
Add default DB_HOSTNAME

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -4,7 +4,7 @@ default: &default
   pool: 5
   username: <%= ENV['DB_USERNAME'] %>
   password: <%= ENV['DB_PASSWORD'] %>
-  host: <%= ENV['DB_HOSTNAME'] %>
+  host: <%= ENV.fetch('DB_HOSTNAME', 'localhost') %>
   port: <%= ENV['DB_PORT'] %>
   database: <%= ENV['DB_DATABASE'] %>
 

--- a/lib/mcb/commands/users/grant.rb
+++ b/lib/mcb/commands/users/grant.rb
@@ -2,7 +2,7 @@ summary "Attach a user to an organisation/provider in the DB. Will prompt to cre
 param :id_or_email_or_sign_in_id
 option :p, "provider_code", "provider code",
        argument: :optional, transform: ->(code) { code.upcase }
-usage "grant --admin <user_id/email/sign_in_user_id> -p <provider_code>"
+usage "grant <user_id/email/sign_in_user_id> -p <provider_code>"
 
 run do |opts, args, _cmd|
   MCB.init_rails(opts)


### PR DESCRIPTION
### Context
A couple of issues I had getting the app running locally during on boarding.

### Changes proposed in this pull request

* Default the DB_HOSTNAME to `localhost`. This avoids having to set the env var to run things locally in dev and test.
* Remove the `--admin` option from the usage guidance in MCB as it was removed in 021ec535

### Checklist

- [ ] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
