### PR TITLE
[2750] Check self_accredited course by looking at provider

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -394,7 +394,7 @@ class Course < ApplicationRecord
   end
 
   def self_accredited?
-    accrediting_provider.blank?
+    provider.accredited_body?
   end
 
   def to_s

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -161,8 +161,12 @@ FactoryBot.define do
       qualification { :pgde }
     end
 
+    trait :self_accredited do
+      association(:provider, factory: %i[provider accredited_body])
+    end
+
     trait :with_accrediting_provider do
-      association(:accrediting_provider, factory: :provider)
+      association(:accrediting_provider, factory: %i[provider accredited_body])
     end
 
     trait :with_higher_education do

--- a/spec/models/course/assign_program_type_spec.rb
+++ b/spec/models/course/assign_program_type_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Course, type: :model do
       end
 
       context "a self accredited course" do
-        let(:subject) { create(:course) }
+        let(:subject) { create(:course, :self_accredited) }
 
         it "should add an error to the course object" do
           expect(subject.errors.count).to eq 1
@@ -45,7 +45,7 @@ RSpec.describe Course, type: :model do
       end
 
       context "a HEIs self accredited courses" do
-        let(:subject) { create(:course) }
+        let(:subject) { create(:course, :self_accredited) }
         its(:program_type) { should eq("higher_education_programme") }
       end
     end

--- a/spec/models/course/funding_type_spec.rb
+++ b/spec/models/course/funding_type_spec.rb
@@ -1,8 +1,7 @@
 RSpec.describe Course, type: :model do
   describe "#funding_type" do
     describe "self accredited salary" do
-      let(:provider) { create(:provider) }
-      let(:course) { create(:course, provider: provider) }
+      let(:course) { create(:course, :self_accredited) }
 
       it "adds an error" do
         course.funding_type = "salary"

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1463,15 +1463,15 @@ describe Course, type: :model do
   end
 
   describe "#self_accredited?" do
-    let(:provider) { build(:provider) }
+    subject { create(:course, provider: provider) }
 
     context "when self accredited" do
-      subject { create(:course, provider: provider) }
+      let(:provider) { build(:provider, :accredited_body) }
       its(:self_accredited?) { should be_truthy }
     end
 
-    context "when self accredited" do
-      subject { create(:course, :with_accrediting_provider, provider: provider) }
+    context "when not self accredited" do
+      let(:provider) { build(:provider) }
       its(:self_accredited?) { should be_falsey }
     end
   end

--- a/spec/requests/api/v2/providers/courses/create_spec.rb
+++ b/spec/requests/api/v2/providers/courses/create_spec.rb
@@ -161,6 +161,7 @@ describe "Course POST #create API V2", type: :request do
     end
 
     context "When the course is a further education course" do
+      let(:provider) { create(:provider, :accredited_body, organisations: [organisation]) }
       let(:course) do
         build(
           :course,

--- a/spec/services/courses/assign_program_type_service_spec.rb
+++ b/spec/services/courses/assign_program_type_service_spec.rb
@@ -13,7 +13,8 @@ describe Courses::AssignProgramTypeService do
     let(:funding_type) { "salary" }
 
     context "and the course is not self_accredited" do
-      let(:course) { create(:course, :with_accrediting_provider) }
+      let(:provider) { create(:provider, accrediting_provider: "N") }
+      let(:course) { create(:course, :with_accrediting_provider, provider: provider) }
 
       it "should return :school_direct_salaried_training_programme" do
         expect(course.program_type).to eq("school_direct_salaried_training_programme")
@@ -21,6 +22,7 @@ describe Courses::AssignProgramTypeService do
     end
 
     context "when the course is self accredited" do
+      let(:course) { create(:course, :self_accredited) }
       it "an error should be added to the course object" do
         expect(course.errors["program_type"].first).to eq("Salary is not valid for a self accredited course")
       end


### PR DESCRIPTION
### Context

Salaried courses could not be created by non-accredited providers. This was due to the `self_accredited?` method depending on the `accreditng_provider` association which was not set yet.

### Changes proposed in this pull request

- Change `self_accredited?` to look at the provider type of the course's provider

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
