### PR TITLE
1591 return providers accredited by accrediting provider

### DIFF
--- a/app/controllers/api/v2/accredited_provider_training_providers_controller.rb
+++ b/app/controllers/api/v2/accredited_provider_training_providers_controller.rb
@@ -1,0 +1,29 @@
+module API
+  module V2
+    class AccreditedProviderTrainingProvidersController < ApplicationController
+      before_action :build_recruitment_cycle
+      before_action :build_provider
+
+      def index
+        authorize @provider, :can_list_training_providers?
+        providers = @provider.training_providers
+
+        render jsonapi: providers, include: params[:include]
+      end
+
+    private
+
+      def build_recruitment_cycle
+        @recruitment_cycle = RecruitmentCycle.find_by(
+          year: params[:recruitment_cycle_year],
+        ) || RecruitmentCycle.current_recruitment_cycle
+      end
+
+      def build_provider
+        @provider = @recruitment_cycle.providers.find_by!(
+          provider_code: params[:provider_code].upcase,
+        )
+      end
+    end
+  end
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -86,7 +86,13 @@ class Provider < ApplicationRecord
            primary_key: :provider_code,
            inverse_of: :accrediting_provider
 
+  # the accredited_providers that this provider is a training_provider for
   has_many :accrediting_providers, -> { distinct }, through: :courses
+
+  # the providers that this provider is an accredited_provider for
+  def training_providers
+    Provider.where(id: current_accredited_courses.map(&:provider_id))
+  end
 
   def current_accredited_courses
     accredited_courses.select { |c| c.provider.recruitment_cycle == recruitment_cycle }

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -45,4 +45,5 @@ class ProviderPolicy
   alias_method :update?, :show?
   alias_method :sync_courses_with_search_and_compare?, :show?
   alias_method :build_new?, :show?
+  alias_method :can_list_training_providers?, :show?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@
 #                                                                        PUT    /api/v2/providers/:provider_code/sites/:id(.:format)                                                                             api/v2/sites#update
 #                                                                        GET    /api/v2/providers/:provider_code/recruitment_cycles(.:format)                                                                    api/v2/recruitment_cycles#index
 #                                                                        POST   /api/v2/providers/:code/sync_courses_with_search_and_compare(.:format)                                                           api/v2/providers#sync_courses_with_search_and_compare
+#                                     api_v2_provider_training_providers GET    /api/v2/providers/:provider_code/training_providers(.:format)                                                                    api/v2/accredited_provider_training_providers#index
 #                                                       api_v2_providers GET    /api/v2/providers(.:format)                                                                                                      api/v2/providers#index
 #                                                                        POST   /api/v2/providers(.:format)                                                                                                      api/v2/providers#create
 #                                                        api_v2_provider GET    /api/v2/providers/:code(.:format)                                                                                                api/v2/providers#show
@@ -66,6 +67,7 @@
 #                                                                        PUT    /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/sites/:id(.:format)                                  api/v2/sites#update
 #                   api_v2_recruitment_cycle_provider_recruitment_cycles GET    /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/recruitment_cycles(.:format)                         api/v2/recruitment_cycles#index
 #                                                                        POST   /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:code/sync_courses_with_search_and_compare(.:format)                api/v2/providers#sync_courses_with_search_and_compare
+#                   api_v2_recruitment_cycle_provider_training_providers GET    /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/training_providers(.:format)                         api/v2/accredited_provider_training_providers#index
 #                                     api_v2_recruitment_cycle_providers GET    /api/v2/recruitment_cycles/:recruitment_cycle_year/providers(.:format)                                                           api/v2/providers#index
 #                                      api_v2_recruitment_cycle_provider GET    /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:code(.:format)                                                     api/v2/providers#show
 #                                                                        PATCH  /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:code(.:format)                                                     api/v2/providers#update
@@ -134,6 +136,7 @@ Rails.application.routes.draw do
         resources :sites, only: %i[index update show create]
         resources :recruitment_cycles, only: %i[index]
         post :sync_courses_with_search_and_compare, on: :member
+        get :training_providers, to: "accredited_provider_training_providers#index"
       end
 
       resources :providers,

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -347,6 +347,19 @@ describe Provider, type: :model do
     end
   end
 
+  describe "training_providers" do
+    let(:accredited_provider) { create(:provider, :accredited_body) }
+    let(:training_provider1) { create(:provider) }
+    let(:training_provider2) { create(:provider) }
+
+    let!(:course1) { create(:course, accrediting_provider: accredited_provider, provider: training_provider1) }
+    let!(:course2) { create(:course, provider: training_provider2) }
+
+    subject { accredited_provider.training_providers }
+
+    it { is_expected.to contain_exactly(training_provider1) }
+  end
+
   describe "#before_create" do
     describe "#set_defaults" do
       let(:provider) { build :provider }

--- a/spec/requests/api/v2/providers/accredited_body_get_providers_spec.rb
+++ b/spec/requests/api/v2/providers/accredited_body_get_providers_spec.rb
@@ -1,0 +1,194 @@
+require "rails_helper"
+
+describe "AccreditedBody API v2", type: :request do
+  describe "GET /providers" do
+    let(:user) { create(:user, organisations: [organisation]) }
+    let(:organisation) { create(:organisation) }
+    let(:recruitment_cycle) { find_or_create :recruitment_cycle }
+    let(:payload) { { email: user.email } }
+    let(:token) do
+      JWT.encode payload,
+                 Settings.authentication.secret,
+                 Settings.authentication.algorithm
+    end
+    let(:credentials) do
+      ActionController::HttpAuthentication::Token.encode_credentials(token)
+    end
+
+    let!(:course) do
+      create(:course, provider: delivering_provider1, accrediting_provider: accredited_provider)
+    end
+    let!(:course2) do
+      create(:course, provider: delivering_provider2, accrediting_provider: accredited_provider)
+    end
+
+    let(:delivering_provider1) { create(:provider) }
+    let(:delivering_provider2) { create(:provider) }
+    let(:accredited_provider) {
+      create(:provider,
+             organisations: [organisation],
+             recruitment_cycle: recruitment_cycle)
+    }
+
+    let(:json_response) { JSON.parse(response.body) }
+    let(:request_path) { "/api/v2/recruitment_cycles/#{recruitment_cycle.year}/providers/#{accredited_provider.provider_code}/training_providers" }
+
+    def perform_request
+      get request_path, headers: { "HTTP_AUTHORIZATION" => credentials }
+    end
+
+    subject do
+      perform_request
+
+      response
+    end
+
+    it_behaves_like "Unauthenticated, unauthorised, or not accepted T&Cs"
+
+    describe "JSON generated for a providers" do
+      it "has a data section with the correct attributes" do
+        perform_request
+
+        expect(json_response).to eq(
+          "data" => [
+            {
+              "id" => delivering_provider1.id.to_s,
+              "type" => "providers",
+              "attributes" => {
+                "provider_code" => delivering_provider1.provider_code,
+                "provider_name" => delivering_provider1.provider_name,
+                "accredited_body?" => delivering_provider1.accredited_body?,
+                "can_add_more_sites?" => delivering_provider1.can_add_more_sites?,
+                "accredited_bodies" => [
+                  {
+                    "provider_name" => accredited_provider.provider_name,
+                    "provider_code" => accredited_provider.provider_code,
+                    "description" => "",
+                  },
+                ],
+                "train_with_us" => delivering_provider1.train_with_us,
+                "train_with_disability" => delivering_provider1.train_with_disability,
+                "latitude" => delivering_provider1.latitude,
+                "longitude" => delivering_provider1.longitude,
+                "address1" => delivering_provider1.address1,
+                "address2" => delivering_provider1.address2,
+                "address3" => delivering_provider1.address3,
+                "address4" => delivering_provider1.address4,
+                "postcode" => delivering_provider1.postcode,
+                "region_code" => delivering_provider1.region_code,
+                "telephone" => delivering_provider1.telephone,
+                "email" => delivering_provider1.email,
+                "website" => delivering_provider1.website,
+                "recruitment_cycle_year" => delivering_provider1.recruitment_cycle.year,
+                "admin_contact" => nil,
+                "utt_contact" => nil,
+                "web_link_contact" => nil,
+                "fraud_contact" => nil,
+                "finance_contact" => nil,
+                "gt12_contact" => nil,
+                "application_alert_contact" => nil,
+                "type_of_gt12" => nil,
+                "send_application_alerts" => nil,
+              },
+              "relationships" => {
+                "sites" => {
+                  "meta" => {
+                    "included" => false,
+                  },
+                }, "courses" => {
+                    "meta" => {
+                      "count" => 1,
+                    },
+                  }
+              },
+            },
+            {
+              "id" => delivering_provider2.id.to_s,
+              "type" => "providers",
+              "attributes" => {
+                "provider_code" => delivering_provider2.provider_code,
+                "provider_name" => delivering_provider2.provider_name,
+                "accredited_body?" => delivering_provider2.accredited_body?,
+                "can_add_more_sites?" => delivering_provider2.can_add_more_sites?,
+                "accredited_bodies" => [
+                  {
+                    "provider_name" => accredited_provider.provider_name,
+                    "provider_code" => accredited_provider.provider_code,
+                    "description" => "",
+                  },
+                ],
+                "train_with_us" => delivering_provider2.train_with_us,
+                "train_with_disability" => delivering_provider2.train_with_disability,
+                "latitude" => delivering_provider2.latitude,
+                "longitude" => delivering_provider2.longitude,
+                "address1" => delivering_provider2.address1,
+                "address2" => delivering_provider2.address2,
+                "address3" => delivering_provider2.address3,
+                "address4" => delivering_provider2.address4,
+                "postcode" => delivering_provider2.postcode,
+                "region_code" => delivering_provider2.region_code,
+                "telephone" => delivering_provider2.telephone,
+                "email" => delivering_provider2.email,
+                "website" => delivering_provider2.website,
+                "recruitment_cycle_year" => delivering_provider2.recruitment_cycle.year,
+                "admin_contact" => nil,
+                "utt_contact" => nil,
+                "web_link_contact" => nil,
+                "fraud_contact" => nil,
+                "finance_contact" => nil,
+                "gt12_contact" => nil,
+                "application_alert_contact" => nil,
+                "type_of_gt12" => nil,
+                "send_application_alerts" => nil,
+              },
+              "relationships" => {
+                "sites" => {
+                  "meta" => {
+                    "included" => false,
+                  },
+                }, "courses" => {
+                    "meta" => {
+                      "count" => 1,
+                    },
+                  }
+              },
+            },
+          ],
+          "jsonapi" => {
+            "version" => "1.0",
+          },
+        )
+      end
+    end
+
+    context "with two recruitment cycles" do
+      let(:next_recruitment_cycle) { create :recruitment_cycle, :next }
+
+      let!(:course3) { create(:course, provider: delivering_provider3, accrediting_provider: next_accredited_provider) }
+      let(:delivering_provider3) { create(:provider, recruitment_cycle: next_recruitment_cycle) }
+
+      let(:next_accredited_provider) {
+        create :provider,
+               organisations: [organisation],
+               provider_code: accredited_provider.provider_code,
+               recruitment_cycle: next_recruitment_cycle,
+               year_code: next_recruitment_cycle.year
+      }
+
+      describe "making a request for the next recruitment cycle" do
+        let(:request_path) {
+          "/api/v2/recruitment_cycles/#{next_recruitment_cycle.year}/providers/#{accredited_provider.provider_code}/training_providers"
+        }
+
+        it "only returns data for the next recruitment cycle" do
+          perform_request
+
+          expect(json_response["data"].count).to eq 1
+          expect(json_response["data"].first)
+            .to have_attribute("recruitment_cycle_year")
+            .with_value(next_recruitment_cycle.year)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
We are adding a page that lists all of the providers that deliver courses for a particular accredited provider.

### Changes proposed in this pull request

* Add `/api/v2/recruitment_cycles/<year>/providers/<provider_code/training_providers` route
* Add `AccreditedProviderTrainingProvidersController` to serve that URL ^
* Add `Provider#training_providers` method

### Guidance to review

The language is a bit tricky here. We've gone with 'training provider' being a provider that doesn't have it's own accreditation but delivers courses on behalf of an 'accredited provider' (a provider that does. Both of these are represented as a `Provider` object.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
