### PR TITLE
Remove localhost DB_HOSTNAME config

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -4,7 +4,7 @@ default: &default
   pool: 5
   username: <%= ENV['DB_USERNAME'] %>
   password: <%= ENV['DB_PASSWORD'] %>
-  host: <%= ENV.fetch('DB_HOSTNAME', 'localhost') %>
+  host: <%= ENV['DB_HOSTNAME'] %>
   port: <%= ENV['DB_PORT'] %>
   database: <%= ENV['DB_DATABASE'] %>
 


### PR DESCRIPTION
Turns out this breaks things for other devs so reverting.

### Context

This was added to address an issue I had during on-boarding but is now broken for Linux users. The issue I had seems to have resolved so it may have been unrelated. Possibly moving from Postgres 12 to 9.6 caused an issue for me 🤷‍♂ 

### Changes proposed in this pull request

Remove the localhost default value for `DB_HOSTNAME`

### Guidance to review

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
