### PR TITLE
[2767] mcb - add flag to allow geocode of invalid sites

### DIFF
--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -479,10 +479,12 @@ module MCB
 
     def geocode(obj:, sleep:, force: false)
       obj.geocode
-      obj.save!(validate: !force)
-
       verbose "Geocoded #{obj.class}:#{obj.id} - #{obj}. " \
               "New lat/long #{obj.latitude},#{obj.latitude} for full_address '#{obj.full_address}'"
+
+      saved = obj.save(validate: !force)
+      warn "Saving failed for #{obj.class}:#{obj.id} - #{obj}. Error: #{obj.errors}" unless saved
+
       sleep(sleep)
     end
 

--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -477,9 +477,10 @@ module MCB
       argv.empty? || (argv.first == "-E" && argv.length == 2)
     end
 
-    def geocode(obj:, sleep:)
+    def geocode(obj:, sleep:, force: false)
       obj.geocode
-      obj.save
+      obj.save!(validate: !force)
+
       verbose "Geocoded #{obj.class}:#{obj.id} - #{obj}. " \
               "New lat/long #{obj.latitude},#{obj.latitude} for full_address '#{obj.full_address}'"
       sleep(sleep)

--- a/lib/mcb/commands/sites/geocode.rb
+++ b/lib/mcb/commands/sites/geocode.rb
@@ -3,6 +3,7 @@ summary "Batch geocode Sites"
 usage "geocode [options] [<id>...]"
 option :s, "sleep", "time to sleep between each request", argument: :optional, default: 0.25, transform: method(:Float)
 option :b, "batch_size", "batch size", argument: :optional, default: 100, transform: method(:Integer)
+flag :f, "force", "Geocode even if the rest of the site has validation errors"
 
 instance_eval(&MCB.remote_connect_options)
 
@@ -19,13 +20,13 @@ run do |opts, args, _cmd|
     Site
       .where(id: args.to_a)
       .find_each(batch_size: opts[:batch_size]) do |site|
-        MCB.geocode(obj: site, sleep: opts[:sleep])
+        MCB.geocode(obj: site, sleep: opts[:sleep], force: opts[:force])
       end
   else
     Site
       .not_geocoded
       .find_each(batch_size: opts[:batch_size]) do |site|
-        MCB.geocode(obj: site, sleep: opts[:sleep])
+        MCB.geocode(obj: site, sleep: opts[:sleep], force: opts[:force])
       end
   end
 end

--- a/spec/lib/mcb/commands/sites/geocode_spec.rb
+++ b/spec/lib/mcb/commands/sites/geocode_spec.rb
@@ -58,7 +58,6 @@ describe "mcb geocode" do
       end
 
       it "geocodes the site" do
-
         expect(MCB).to receive(:geocode).with(obj: invalid_site, sleep: default_sleep, force: true).and_call_original
 
         expect { execute_cmd(arguments: ["-f", invalid_site.id]) }

--- a/spec/lib/mcb/commands/sites/geocode_spec.rb
+++ b/spec/lib/mcb/commands/sites/geocode_spec.rb
@@ -24,7 +24,7 @@ describe "mcb geocode" do
     let(:default_sleep) { 0.25 }
 
     it "geocodes all Sites not currently geocoded" do
-      expect(MCB).to receive(:geocode).with(obj: site_one, sleep: default_sleep).and_call_original
+      expect(MCB).to receive(:geocode).with(obj: site_one, sleep: default_sleep, force: false).and_call_original
 
       expect { execute_cmd }
         .to change { site_one.reload.longitude }.from(nil).to(-0.1204749)
@@ -32,7 +32,7 @@ describe "mcb geocode" do
     end
 
     it "geocodes Sites by id" do
-      expect(MCB).to receive(:geocode).with(obj: site_two, sleep: default_sleep).and_call_original
+      expect(MCB).to receive(:geocode).with(obj: site_two, sleep: default_sleep, force: false).and_call_original
 
       expect { execute_cmd(arguments: [site_two.id]) }
         .to change { site_two.reload.latitude }.from(nil).to(51.4524877)
@@ -40,6 +40,31 @@ describe "mcb geocode" do
 
       expect(site_one.reload.latitude).to be(nil)
       expect(site_one.reload.longitude).to be(nil)
+    end
+
+    context "invalid site" do
+      let(:invalid_site) do
+        invalid_site = build(:site, provider: provider, postcode: "this is not a postcode")
+        invalid_site.save!(validate: false)
+        invalid_site
+      end
+
+      it "geocodes all sites" do
+        expect(MCB).to receive(:geocode).with(obj: invalid_site, sleep: default_sleep, force: true).and_call_original
+
+        expect { execute_cmd(arguments: ["-f"]) }
+          .to change { invalid_site.reload.latitude }.from(nil).to(51.4524877)
+                .and change { invalid_site.reload.longitude }.from(nil).to(-0.1204749)
+      end
+
+      it "geocodes the site" do
+
+        expect(MCB).to receive(:geocode).with(obj: invalid_site, sleep: default_sleep, force: true).and_call_original
+
+        expect { execute_cmd(arguments: ["-f", invalid_site.id]) }
+          .to change { invalid_site.reload.latitude }.from(nil).to(51.4524877)
+                .and change { invalid_site.reload.longitude }.from(nil).to(-0.1204749)
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
There are around 800 (out of 16000) Sites that are not currently geocoded. This because these Sites cannot be updated due to validation issues (e.g. they were imported from legacy with invalid attributes e.g. partial postcode or duplicate Site name). 

#### To do

- Update the mcb geocode tasks (Sites and Providers) to skip validation then re-geocode all Sites (and Providers) with nil lat and long on each environment. 

#### Success

* We update the lat and log for invalid sites as a one-off process.
* Command is repeatable in case we need.

### Tech Notes

* This is changing prod data so let's make sure it's covered with tests.

### Changes proposed in this pull request

* mcb - add flag to allow geocode of invalid sites

### Guidance to review

Geocode a single site

    bin/mcb sites geocode 11216495 -v -f

Geocode all the sites without lat long

    bin/mcb sites geocode -v -f

See the update help with new `-f` flag

    mcb sites geocode --help

(`-v` for verbose so you can see what it did)

Use rails console to check sites before/after

```ruby
s = Site.where(latitude: nil).sample
```

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally